### PR TITLE
Fix corrupted project: restore dependencies and missing imports

### DIFF
--- a/server/handlers/checks.ts
+++ b/server/handlers/checks.ts
@@ -1,6 +1,7 @@
 import { db } from "../db";
 import { chatHistory, mealLogs, workoutLogs, stepLogs, exerciseLogs } from "../../shared/schema";
 import { eq, desc, and, gte, sql } from "drizzle-orm";
+import { sastDayStart } from "../utils";
 
 export const JUNK_WORDS = [
   "kfc", "kota", "fat cake", "magwinya", "vetkoek", "chips", "niknaks", "cool drink", "coke", "fanta",

--- a/server/handlers/weight.ts
+++ b/server/handlers/weight.ts
@@ -3,6 +3,7 @@ import { users, weightLogs } from "../../shared/schema";
 import { eq, and, gte, asc } from "drizzle-orm";
 import { calculateTargets } from "../targets";
 import { storeMemory } from "../memory";
+import { sastDayStart } from "../utils";
 
 export async function handleWeightLog(
   phone: string,

--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -5,7 +5,7 @@ import { buildFullProgramme, getKamlifeProgramme } from "./programme";
 import { calculateTargets } from "./targets";
 import { askCoachK } from "./gpt";
 import { getShoppingList, formatShoppingList } from "./shopping-lists";
-import { getDisplayName } from "./utils";
+import { getDisplayName, sastDayStart } from "./utils";
 
 // ============================================================
 // MENU TEXT — context-aware


### PR DESCRIPTION
## Summary
- Restored all npm dependencies (`node_modules` only had `typescript` installed)
- Added missing `sastDayStart` import to `server/handlers/checks.ts`, `server/handlers/weight.ts`, and `server/onboarding.ts`
- `npm run check` now passes cleanly with zero TypeScript errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNm14M9Roq7Q82xyXWwgDV)_