### PR TITLE
Harden launch blockers: auth, rate limiter, scheduler, body size

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { Switch, Route, Redirect } from "wouter";
 import { queryClient } from "./lib/queryClient";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
@@ -17,10 +17,18 @@ import ABTests from "@/pages/ab-tests";
 import PaymentSuccess from "@/pages/payment-success";
 import PaymentCancel from "@/pages/payment-cancel";
 import Login from "@/pages/login";
-import { isAuthenticated } from "@/lib/auth";
 
 function AuthGuard({ component: Component }: { component: React.ComponentType }) {
-  if (!isAuthenticated()) return <Redirect to="/login" />;
+  const { data: isAuth, isLoading } = useQuery<boolean>({
+    queryKey: ["/api/auth/check"],
+    queryFn: () =>
+      fetch("/api/auth/check", { credentials: "include" }).then((r) => r.ok),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  if (isLoading) return null;
+  if (!isAuth) return <Redirect to="/login" />;
   return <Component />;
 }
 

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,17 +1,13 @@
-const KEY = "kamlife_dashboard_token";
+const SESSION_HINT = "kamlife_session";
 
-export function getToken(): string | null {
-  return localStorage.getItem(KEY);
+export function markLoggedIn(): void {
+  sessionStorage.setItem(SESSION_HINT, "1");
 }
 
-export function setToken(token: string): void {
-  localStorage.setItem(KEY, token);
+export function markLoggedOut(): void {
+  sessionStorage.removeItem(SESSION_HINT);
 }
 
-export function clearToken(): void {
-  localStorage.removeItem(KEY);
-}
-
-export function isAuthenticated(): boolean {
-  return !!getToken();
+export function hasSessionHint(): boolean {
+  return !!sessionStorage.getItem(SESSION_HINT);
 }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,12 +1,7 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
-import { getToken } from "./auth";
 
 export function authHeaders(extra?: Record<string, string>): Record<string, string> {
-  const token = getToken();
-  return {
-    ...(token ? { "x-dashboard-key": token } : {}),
-    ...extra,
-  };
+  return { ...extra };
 }
 
 async function throwIfResNotOk(res: Response) {

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useLocation } from "wouter";
-import { setToken } from "@/lib/auth";
+import { markLoggedIn } from "@/lib/auth";
+import { queryClient } from "@/lib/queryClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,14 +21,19 @@ export default function Login() {
       const res = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ password }),
       });
+      if (res.status === 429) {
+        setError("Too many failed attempts — try again in 15 minutes");
+        return;
+      }
       if (!res.ok) {
         setError("Invalid password");
         return;
       }
-      const { token } = await res.json();
-      setToken(token);
+      markLoggedIn();
+      queryClient.setQueryData(["/api/auth/check"], true);
       navigate("/dashboard");
     } catch {
       setError("Connection error — try again");

--- a/server/index.ts
+++ b/server/index.ts
@@ -258,6 +258,12 @@ async function runMigrations(): Promise<void> {
       content TEXT NOT NULL,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
     )`,
+
+    `CREATE TABLE IF NOT EXISTS rate_limits (
+      phone TEXT PRIMARY KEY,
+      window_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      hit_count INTEGER NOT NULL DEFAULT 1
+    )`,
   ];
 
   let created = 0;
@@ -348,11 +354,19 @@ declare module "http" {
   }
 }
 
+// Progress photo uploads can be up to ~8MB base64 — allow a larger body for that path.
+// All other JSON endpoints get a tight 100kb cap to bound attack surface.
+app.use(
+  "/api/users",
+  express.json({
+    limit: "10mb",
+    verify: (req: any, _res, buf) => { req.rawBody = buf; },
+  }),
+);
 app.use(
   express.json({
-    verify: (req, _res, buf) => {
-      req.rawBody = buf;
-    },
+    limit: "100kb",
+    verify: (req: any, _res, buf) => { if (!req.rawBody) req.rawBody = buf; },
   }),
 );
 
@@ -483,7 +497,7 @@ async function activateCoachAccount(): Promise<void> {
     listenOptions,
     () => {
       log(`serving on port ${port}`);
-      initScheduler();
+      initScheduler().catch(e => console.error("[STARTUP] Scheduler init failed:", e));
       initFoodsTable().catch(e => console.error("[STARTUP] Foods init failed:", e));
       initMemoryTable().catch(e => console.error("[STARTUP] Memory init failed:", e));
       initMealLogsTable().catch(e => console.error("[STARTUP] Meal logs init failed:", e));

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6511,15 +6511,8 @@ CRITICAL RULES — these are non-negotiable:
 
 // ============================================================
 // RATE LIMITER — 15 messages per phone per 60 seconds
+// DB-backed so limits survive server restarts / multi-instance deploys.
 // ============================================================
-
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, val] of rateLimitMap.entries()) {
-    if (now > val.resetAt) rateLimitMap.delete(key);
-  }
-}, 5 * 60 * 1000);
 
 // ============================================================
 // VOICE NOTE FAILURE TRACKER — escalate to "please type" after 3 failures
@@ -6548,17 +6541,29 @@ export function clearVoiceFailure(userId: string): void {
   voiceFailureMap.delete(userId);
 }
 
-function checkRateLimit(phone: string): boolean {
-  const now = Date.now();
-  const window = 60 * 1000;
-  const entry = rateLimitMap.get(phone);
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(phone, { count: 1, resetAt: now + window });
-    return true;
+async function checkRateLimit(phone: string): Promise<boolean> {
+  try {
+    const result = await pool.query<{ hit_count: number }>(`
+      INSERT INTO rate_limits (phone, window_start, hit_count)
+      VALUES ($1, NOW(), 1)
+      ON CONFLICT (phone) DO UPDATE SET
+        hit_count = CASE
+          WHEN rate_limits.window_start > NOW() - INTERVAL '60 seconds'
+            THEN rate_limits.hit_count + 1
+          ELSE 1
+        END,
+        window_start = CASE
+          WHEN rate_limits.window_start > NOW() - INTERVAL '60 seconds'
+            THEN rate_limits.window_start
+          ELSE NOW()
+        END
+      RETURNING hit_count
+    `, [phone]);
+    return result.rows[0].hit_count <= 15;
+  } catch (e) {
+    console.error("[RATE_LIMIT] DB error — allowing request:", e);
+    return true; // fail open rather than blocking legitimate users
   }
-  if (entry.count >= 15) return false;
-  entry.count++;
-  return true;
 }
 
 // ============================================================

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,38 +1,128 @@
-import type { Express } from "express";
+import type { Express, Request } from "express";
 import crypto from "crypto";
 
-/**
- * Admin auth middleware — timing-safe key comparison.
- * Single key: COACH_DASHBOARD_KEY, sent via x-dashboard-key header.
- */
-export function requireAdminKey(req: any, res: any, next: any) {
-  const key = process.env.COACH_DASHBOARD_KEY;
-  if (!key) {
-    console.error("[AUTH] COACH_DASHBOARD_KEY env var is not set — admin access blocked");
-    return res.status(503).json({ message: "Dashboard not configured" });
-  }
-  const provided = (req.headers["x-dashboard-key"] as string) || "";
-  let match = false;
-  try {
-    match = provided.length === key.length && crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(key));
-  } catch {
-    match = false;
-  }
-  if (!match) return res.status(401).json({ message: "Unauthorized" });
-  next();
+function createSessionToken(secret: string): string {
+  const exp = Date.now() + 24 * 60 * 60 * 1000;
+  const payload = `admin:${exp}`;
+  const sig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  return `${payload}.${sig}`;
 }
 
-/**
- * Register auth routes (login).
- */
+function verifySessionToken(token: string, secret: string): boolean {
+  const dot = token.lastIndexOf(".");
+  if (dot === -1) return false;
+  const payload = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  try {
+    const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+    if (sig.length !== expected.length) return false;
+    if (!crypto.timingSafeEqual(Buffer.from(sig, "hex"), Buffer.from(expected, "hex"))) return false;
+  } catch {
+    return false;
+  }
+  const colonIdx = payload.indexOf(":");
+  if (colonIdx === -1) return false;
+  return Date.now() < parseInt(payload.slice(colonIdx + 1), 10);
+}
+
+function parseCookies(req: Request): Record<string, string> {
+  const header = (req.headers.cookie as string) || "";
+  const result: Record<string, string> = {};
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    const v = part.slice(eq + 1).trim();
+    if (k) result[k] = decodeURIComponent(v);
+  }
+  return result;
+}
+
+export function requireAdminKey(req: any, res: any, next: any) {
+  const secret = process.env.COACH_DASHBOARD_KEY;
+  if (!secret) {
+    console.error("[AUTH] COACH_DASHBOARD_KEY not set — admin blocked");
+    return res.status(503).json({ message: "Dashboard not configured" });
+  }
+
+  // 1. httpOnly cookie — React dashboard
+  const cookies = parseCookies(req);
+  if (cookies.admin_session && verifySessionToken(cookies.admin_session, secret)) return next();
+
+  // 2. Header fallback — server-rendered /coach page uses x-dashboard-key directly
+  const provided = (req.headers["x-dashboard-key"] as string) || "";
+  if (provided.length > 0 && provided.length === secret.length) {
+    try {
+      if (crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(secret))) return next();
+    } catch {}
+  }
+
+  return res.status(401).json({ message: "Unauthorized" });
+}
+
+// Brute-force protection for the login endpoint (in-memory, per IP)
+const loginAttempts = new Map<string, { count: number; lockedUntil: number }>();
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of loginAttempts.entries()) {
+    if (now > entry.lockedUntil + 60_000) loginAttempts.delete(ip);
+  }
+}, 5 * 60_000);
+
 export function registerAuthRoutes(app: Express) {
   app.post("/api/auth/login", (req: any, res: any) => {
-    const key = process.env.COACH_DASHBOARD_KEY;
-    if (!key) return res.status(503).json({ message: "Dashboard not configured — set COACH_DASHBOARD_KEY env var" });
+    const secret = process.env.COACH_DASHBOARD_KEY;
+    if (!secret) return res.status(503).json({ message: "Dashboard not configured — set COACH_DASHBOARD_KEY env var" });
+
+    const ip: string = (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() || req.socket?.remoteAddress || "unknown";
+    const now = Date.now();
+    const attempt = loginAttempts.get(ip);
+    if (attempt && now < attempt.lockedUntil) {
+      return res.status(429).json({ message: "Too many failed attempts — try again in 15 minutes" });
+    }
+    if (attempt && now >= attempt.lockedUntil) loginAttempts.delete(ip);
+
     const { password } = req.body || {};
-    if (!password || password !== key) {
+    let match = false;
+    try {
+      match =
+        typeof password === "string" &&
+        password.length === secret.length &&
+        crypto.timingSafeEqual(Buffer.from(password), Buffer.from(secret));
+    } catch {}
+
+    if (!match) {
+      const entry = loginAttempts.get(ip) ?? { count: 0, lockedUntil: 0 };
+      entry.count += 1;
+      if (entry.count >= 5) entry.lockedUntil = now + 15 * 60_000;
+      loginAttempts.set(ip, entry);
       return res.status(401).json({ message: "Invalid password" });
     }
-    return res.json({ success: true, token: password });
+
+    loginAttempts.delete(ip);
+    const token = createSessionToken(secret);
+    res.cookie("admin_session", token, {
+      httpOnly: true,
+      sameSite: "strict" as const,
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 24 * 60 * 60 * 1000,
+      path: "/",
+    });
+    return res.json({ success: true });
+  });
+
+  app.get("/api/auth/check", (req: any, res: any) => {
+    const secret = process.env.COACH_DASHBOARD_KEY;
+    if (!secret) return res.status(503).json({ message: "Dashboard not configured" });
+    const cookies = parseCookies(req);
+    if (cookies.admin_session && verifySessionToken(cookies.admin_session, secret)) {
+      return res.json({ authenticated: true });
+    }
+    return res.status(401).json({ authenticated: false });
+  });
+
+  app.post("/api/auth/logout", (_req: any, res: any) => {
+    res.clearCookie("admin_session", { path: "/" });
+    return res.json({ success: true });
   });
 }

--- a/server/routes/types.ts
+++ b/server/routes/types.ts
@@ -8,5 +8,5 @@ export interface RouteDeps {
   requireAdminKey: (req: any, res: any, next: any) => void;
   handleMessage: (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[]) => Promise<string>;
   logChat: (userId: string, messageIn: string, messageOut: string, intent: string) => Promise<void>;
-  checkRateLimit: (phone: string) => boolean;
+  checkRateLimit: (phone: string) => Promise<boolean>;
 }

--- a/server/routes/whatsapp.ts
+++ b/server/routes/whatsapp.ts
@@ -82,7 +82,7 @@ export function registerWhatsAppRoutes(app: Express, deps: Pick<RouteDeps, "hand
       // Rate limiter
       const rawPhoneEarly = (req.body.From || "") as string;
       const phoneKey = rawPhoneEarly.replace(/^(whatsapp:)\s+/, "$1+");
-      if (!checkRateLimit(phoneKey)) {
+      if (!await checkRateLimit(phoneKey)) {
         return res.type("text/xml").send(`<?xml version="1.0" encoding="UTF-8"?><Response><Message>Too many messages. Wait 60 seconds.</Message></Response>`);
       }
 

--- a/server/scheduler.ts
+++ b/server/scheduler.ts
@@ -1,7 +1,7 @@
 import cron from "node-cron";
 import twilio from "twilio";
 import { isTwilioCircuitOpen, recordTwilioSuccess, recordTwilioFailure, sastDayStart } from "./utils";
-import { db } from "./db";
+import { db, pool } from "./db";
 import { users, chatHistory, stepLogs, workoutLogs, weightLogs, mealLogs, sentProactive, escalations } from "../shared/schema";
 import { eq, gte, lte, and, lt, desc, asc, or, sql, count } from "drizzle-orm";
 import { readFileSync, writeFileSync, existsSync } from "fs";
@@ -2637,11 +2637,28 @@ cron.schedule("0 8 * * 6", async () => {
 
 let schedulerInitialised = false;
 
-export function initScheduler(): void {
+export async function initScheduler(): Promise<void> {
   if (schedulerInitialised) {
     console.log("[SCHEDULER] Already initialised — skipping duplicate registration");
     return;
   }
+
+  // PostgreSQL session-level advisory lock — only one replica runs the scheduler.
+  // Lock is released automatically when the DB connection closes (on server shutdown).
+  // Lock ID 8675309 is an arbitrary stable integer unique to this scheduler.
+  try {
+    const { rows } = await pool.query<{ pg_try_advisory_lock: boolean }>(
+      "SELECT pg_try_advisory_lock(8675309)"
+    );
+    if (!rows[0].pg_try_advisory_lock) {
+      console.log("[SCHEDULER] Another instance holds the leader lock — cron jobs skipped on this replica");
+      return;
+    }
+    console.log("[SCHEDULER] Acquired leader lock — this replica will run all cron jobs");
+  } catch (e) {
+    console.warn("[SCHEDULER] Could not acquire advisory lock — starting scheduler anyway:", e);
+  }
+
   schedulerInitialised = true;
 
   // Catch-up removed: Railway filesystem is ephemeral — state file lost on every deploy


### PR DESCRIPTION
Fixes all non-payment launch blockers identified in the audit.

- Admin auth: httpOnly cookie with HMAC signature, 24h expiry, brute-force lockout
- Rate limiter: DB-backed (survives restarts), replaces in-memory Map
- Scheduler: PostgreSQL advisory lock so only one replica runs cron jobs
- Body size: 100kb global cap, 10mb for photo upload routes

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNm14M9Roq7Q82xyXWwgDV)_