### PR TITLE
Retention loop, cancel save flow, photo comparison, referral

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { MessageCircle, CheckCircle, TrendingUp, Shield, Zap, Users, Star, ChevronRight, Phone, Crown } from "lucide-react";
+import { MessageCircle, CheckCircle, TrendingUp, Shield, Zap, Users, Star, ChevronRight, Phone } from "lucide-react";
 import { motion } from "framer-motion";
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
@@ -80,7 +80,7 @@ export default function LandingPage() {
             >
               <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
                 <MessageCircle className="w-5 h-5 mr-2" />
-                Start Free Trial — from R149/month
+                Start Free Trial — R149/month
               </a>
             </Button>
             <Button size="lg" variant="outline" className="h-14 px-8 rounded-2xl text-base border-2" asChild>
@@ -92,7 +92,7 @@ export default function LandingPage() {
           </div>
 
           <p className="text-sm text-muted-foreground">
-            From R149/month · Cancel anytime · Day 1 sent immediately on payment
+            R149/month · Cancel anytime · Day 1 sent immediately on payment
           </p>
         </motion.div>
 
@@ -188,114 +188,49 @@ export default function LandingPage() {
 
       {/* Pricing */}
       <section className="py-24 px-4 bg-muted/30">
-        <div className="max-w-5xl mx-auto text-center">
-          <h2 className="text-4xl font-bold font-display mb-4">Choose your level</h2>
-          <p className="text-muted-foreground mb-12">All plans on WhatsApp. No app needed. Cancel anytime.</p>
+        <div className="max-w-lg mx-auto text-center">
+          <h2 className="text-4xl font-bold font-display mb-4">One plan. Everything included.</h2>
+          <p className="text-muted-foreground mb-12">WhatsApp only. No app needed. Cancel anytime.</p>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-start">
-
-            {/* Basic */}
-            <div className="bg-card rounded-3xl border border-border p-8 relative overflow-hidden text-left">
-              <div className="text-sm font-semibold text-muted-foreground mb-2">Basic</div>
-              <div className="flex items-end gap-1 mb-1">
-                <span className="text-5xl font-bold font-display">R149</span>
-                <span className="text-muted-foreground mb-2">/month</span>
-              </div>
-              <p className="text-muted-foreground text-sm mb-6">R3.30/day — less than a taxi fare</p>
-              <ul className="space-y-3 mb-8">
-                {[
-                  "Personalised workout programme",
-                  "SA meal plans at Shoprite prices",
-                  "Daily WhatsApp check-ins",
-                  "Step & food logging",
-                  "Weekly Sunday report",
-                  "Braai & takeout guides",
-                ].map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-sm">
-                    <CheckCircle className="w-4 h-4 text-emerald-500 mt-0.5 shrink-0" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <Button className="w-full rounded-2xl" asChild>
-                <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
-                  <MessageCircle className="w-4 h-4 mr-2" />
-                  Start Basic
-                </a>
-              </Button>
+          <div className="bg-card rounded-3xl border-2 border-primary p-10 relative overflow-hidden text-left shadow-xl shadow-primary/10">
+            <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-primary to-emerald-500 rounded-t-3xl" />
+            <div className="flex items-center justify-between mb-4">
+              <div className="text-sm font-semibold text-primary uppercase tracking-wide">KamLife Coach</div>
+              <span className="text-xs font-bold bg-primary text-white px-3 py-1 rounded-full">Beta price</span>
             </div>
-
-            {/* Pro — most popular */}
-            <div className="bg-card rounded-3xl border-2 border-primary p-8 relative overflow-hidden text-left shadow-xl shadow-primary/10">
-              <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-primary to-emerald-500 rounded-t-3xl" />
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-sm font-semibold text-primary">Pro</div>
-                <span className="text-xs font-bold bg-primary text-white px-2 py-0.5 rounded-full">Most popular</span>
-              </div>
-              <div className="flex items-end gap-1 mb-1">
-                <span className="text-5xl font-bold font-display">R199</span>
-                <span className="text-muted-foreground mb-2">/month</span>
-              </div>
-              <p className="text-muted-foreground text-sm mb-6">R6.60/day — less than a Nando's quarter</p>
-              <ul className="space-y-3 mb-8">
-                {[
-                  "Everything in Basic",
-                  "Weekly coach review of your logs",
-                  "Progress photo analysis",
-                  "Personalised monthly check-in call",
-                  "Priority response within 2 hours",
-                  "Custom meal swaps for your budget",
-                ].map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-sm">
-                    <CheckCircle className="w-4 h-4 text-primary mt-0.5 shrink-0" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <Button size="lg" className="w-full h-12 rounded-2xl font-bold" asChild>
-                <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
-                  <MessageCircle className="w-4 h-4 mr-2" />
-                  Start Pro
-                </a>
-              </Button>
+            <div className="flex items-end gap-1 mb-1">
+              <span className="text-6xl font-bold font-display">R149</span>
+              <span className="text-muted-foreground mb-2 text-lg">/month</span>
             </div>
-
-            {/* Premium */}
-            <div className="bg-card rounded-3xl border border-border p-8 relative overflow-hidden text-left">
-              <div className="flex items-center gap-2 mb-2">
-                <Crown className="w-4 h-4 text-amber-500" />
-                <div className="text-sm font-semibold text-amber-500">Premium</div>
-              </div>
-              <div className="flex items-end gap-1 mb-1">
-                <span className="text-5xl font-bold font-display">R349</span>
-                <span className="text-muted-foreground mb-2">/month</span>
-              </div>
-              <p className="text-muted-foreground text-sm mb-6">Full coaching experience</p>
-              <ul className="space-y-3 mb-8">
-                {[
-                  "Everything in Pro",
-                  "Weekly personal voice note from Coach Kam",
-                  "Unlimited WhatsApp voice replies",
-                  "Injury rehab protocol",
-                  "Supplement & blood work guidance",
-                  "Direct line — replies within 30 minutes",
-                ].map((item) => (
-                  <li key={item} className="flex items-start gap-2 text-sm">
-                    <CheckCircle className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <Button variant="outline" className="w-full rounded-2xl border-2" asChild>
-                <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
-                  <Crown className="w-4 h-4 mr-2" />
-                  Start Premium
-                </a>
-              </Button>
-            </div>
-
+            <p className="text-muted-foreground text-sm mb-8">R3.30/day — less than a taxi fare. Cancel anytime.</p>
+            <ul className="space-y-3 mb-10">
+              {[
+                "Personalised workout programme — gym or home",
+                "SA meal plans at Shoprite & Boxer prices",
+                "Daily WhatsApp coaching — 24/7",
+                "Food & calorie logging by chat",
+                "Step tracking & weekly progress reports",
+                "Braai, kota, and takeout coaching",
+                "Injury modifications and medical condition support",
+                "Supplement advice — honest, SA-priced",
+                "7-day free trial — Day 1 sent immediately",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-2 text-sm">
+                  <CheckCircle className="w-4 h-4 text-emerald-500 mt-0.5 shrink-0" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <Button size="lg" className="w-full h-14 rounded-2xl font-bold text-base" asChild>
+              <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
+                <MessageCircle className="w-5 h-5 mr-2" />
+                Start your free trial
+              </a>
+            </Button>
+            <p className="text-xs text-muted-foreground text-center mt-4">7 days free · Then R149/month · Cancel anytime on WhatsApp</p>
           </div>
-          <p className="text-sm text-muted-foreground mt-6">All plans: cancel anytime · Day 1 workout sent immediately on payment · Refer a friend and you both get one month free</p>
+
+          <p className="text-sm text-muted-foreground mt-6">Refer a friend and you both get one month free</p>
         </div>
       </section>
 
@@ -340,7 +275,7 @@ export default function LandingPage() {
         <div className="max-w-2xl mx-auto">
           <h2 className="text-4xl font-bold font-display mb-4">Start today. Results in week one.</h2>
           <p className="text-primary-foreground/80 text-lg mb-8">
-            3 questions and your programme is built. Day 1 delivered the moment you pay. From R149/month.
+            3 questions and your programme is built. Day 1 delivered the moment you pay. R149/month.
           </p>
           <Button size="lg" variant="secondary" className="h-14 px-10 rounded-2xl text-base font-bold" asChild>
             <a href={WA_LINK} target="_blank" rel="noopener noreferrer">
@@ -348,7 +283,7 @@ export default function LandingPage() {
               Start Coaching on WhatsApp
             </a>
           </Button>
-          <p className="text-primary-foreground/60 text-sm mt-4">From R149/month · Cancel anytime · No app needed</p>
+          <p className="text-primary-foreground/60 text-sm mt-4">R149/month · Cancel anytime · No app needed</p>
         </div>
       </section>
 
@@ -361,7 +296,7 @@ export default function LandingPage() {
             </div>
             <span className="font-semibold text-foreground">KamLife Coach</span>
           </div>
-          <p>Built for South Africa 🇿🇦 · POPIA compliant · From R149/month</p>
+          <p>Built for South Africa 🇿🇦 · POPIA compliant · R149/month</p>
           <Link href="/login" className="hover:text-foreground transition-colors">Coach Login</Link>
         </div>
       </footer>

--- a/script/integration-tests.ts
+++ b/script/integration-tests.ts
@@ -212,6 +212,78 @@ test("classifyMediaFailure: unknown → FAIL with stage prefix", () => {
   assert.ok(r.includes("FAIL") && r.startsWith("FOOD_VISION"));
 });
 
+// ── Progress photo upload validation (mirrors admin.ts logic) ────────────────
+
+const ALLOWED_PHOTO_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"]);
+const PHOTO_MAX_BYTES = 8 * 1024 * 1024;
+
+function validateProgressPhotoUpload(body: { base64?: string; contentType?: string }): { status: number; error?: string } {
+  if (!body.base64) return { status: 400, error: "base64 image data is required" };
+  if (!ALLOWED_PHOTO_TYPES.has(body.contentType || "")) {
+    return { status: 415, error: "Unsupported image type. Use jpeg, png, webp, or heic." };
+  }
+  const cleaned = (body.base64 || "").replace(/^data:[^;]+;base64,/, "");
+  const sizeBytes = Buffer.byteLength(cleaned, "base64");
+  if (sizeBytes > PHOTO_MAX_BYTES) return { status: 413, error: "Image must be under 8MB" };
+  return { status: 200 };
+}
+
+test("photo upload: missing base64 → 400", () => {
+  const r = validateProgressPhotoUpload({ contentType: "image/jpeg" });
+  assert.equal(r.status, 400);
+});
+test("photo upload: unsupported MIME image/gif → 415", () => {
+  const r = validateProgressPhotoUpload({ base64: "abc", contentType: "image/gif" });
+  assert.equal(r.status, 415);
+});
+test("photo upload: unsupported MIME application/pdf → 415", () => {
+  const r = validateProgressPhotoUpload({ base64: "abc", contentType: "application/pdf" });
+  assert.equal(r.status, 415);
+});
+test("photo upload: oversize payload → 413", () => {
+  // 8MB + 1 byte of base64 data
+  const oversizeB64 = Buffer.alloc(PHOTO_MAX_BYTES + 1).toString("base64");
+  const r = validateProgressPhotoUpload({ base64: oversizeB64, contentType: "image/jpeg" });
+  assert.equal(r.status, 413);
+});
+test("photo upload: valid jpeg within size limit → 200", () => {
+  const smallB64 = Buffer.alloc(100).toString("base64");
+  const r = validateProgressPhotoUpload({ base64: smallB64, contentType: "image/jpeg" });
+  assert.equal(r.status, 200);
+});
+test("photo upload: valid webp → 200", () => {
+  const r = validateProgressPhotoUpload({ base64: "abc", contentType: "image/webp" });
+  assert.equal(r.status, 200);
+});
+test("photo upload: data URI prefix stripped before size check", () => {
+  const payload = "data:image/jpeg;base64," + Buffer.alloc(100).toString("base64");
+  const r = validateProgressPhotoUpload({ base64: payload, contentType: "image/jpeg" });
+  assert.equal(r.status, 200, "data URI prefix should be stripped — small payload should pass");
+});
+test("photo upload: heic content type accepted", () => {
+  const r = validateProgressPhotoUpload({ base64: "abc", contentType: "image/heic" });
+  assert.equal(r.status, 200);
+});
+
+// ── Proactive send pause switch ───────────────────────────────────────────────
+
+function isProactivePausedTest(env: string | undefined): boolean {
+  return env === "true";
+}
+
+test("proactive pause: PROACTIVE_PAUSED=true → paused", () => {
+  assert.equal(isProactivePausedTest("true"), true);
+});
+test("proactive pause: PROACTIVE_PAUSED=false → not paused", () => {
+  assert.equal(isProactivePausedTest("false"), false);
+});
+test("proactive pause: PROACTIVE_PAUSED=undefined → not paused", () => {
+  assert.equal(isProactivePausedTest(undefined), false);
+});
+test("proactive pause: PROACTIVE_PAUSED=1 (wrong value) → not paused", () => {
+  assert.equal(isProactivePausedTest("1"), false);
+});
+
 // ── Results ──────────────────────────────────────────────────────────────────
 
 console.log(`\nintegration-tests: ${passed}/${passed + failed} passed`);

--- a/server/coach-prompt.ts
+++ b/server/coach-prompt.ts
@@ -110,22 +110,33 @@ R100 week: Eggs 12 pack R45. Pilchards 3 tins R36. Cabbage R8. Onions R8. Pap 2k
 R200 week: Add frozen chicken 1kg R40. Brown bread R14. Oats R15. Sweet potato R12.
 Shoprite and Boxer always first. Protein per rand: pilchards, eggs, chicken thighs, beans, mince. In that order.
 
-CALORIE-DENSE NUTRITIOUS FOODS — COACH WITH CONTEXT, NEVER ALARM:
-These foods are GOOD. They belong in any healthy diet. A fat loss client eating avocado, peanut butter, or banana is making a SMART CHOICE. Your job is to acknowledge that and give context, not create fear.
+CALORIE-DENSE FOODS — GOAL-AWARE COACHING, NEVER SHAMING:
+These are genuinely healthy foods. Your coaching response depends entirely on the client's goal. Never eliminate them. Never shame. But always give the right portion intelligence for their goal.
 
-- Avocado: Healthy fat, keeps clients full, supports hormones. On fat loss: "Solid choice — healthy fat and satisfying. Track the portion and it fits your plan perfectly." NEVER suggest swapping it out. NEVER say "quarter avo max."
-- Peanut butter: Protein + healthy fat combo. On fat loss: "Good protein and fat — earns its place. The 2-tbsp portion is right." On muscle gain: encourage it. NEVER suggest swapping to cottage cheese unless client specifically asks for lower-calorie alternatives.
-- Banana: Great natural carb. Ideal pre-workout fuel. On fat loss: "Natural carb — best timing is before a workout. Factor the 90 kcal into your total and move on." On muscle gain: "Perfect carb for training." NEVER say "banana → apple instead."
-- Nuts/peanuts: Healthy fat and protein. On fat loss: "Good snack — just log the portion accurately, they're calorie-dense." NOT "skip nuts."
-- Cooking oil: Acknowledge it. If client is using excessive amounts, coach portion gently — one sentence, not a lecture.
-- Eggs, full cream milk, butter: Real food. Log accurately. No alarm needed.
+FAT LOSS CLIENTS — these foods are good but calorie-dense. Portion matters:
+- Peanut butter: 1 tbsp = 95 kcal. Most people eat 3 tablespoons thinking it is healthy. For fat loss: "Good choice — just measure 1 tablespoon. Two tablespoons is already 190 kcal and it adds up fast." One sentence on portion. Not a lecture.
+- Avocado: Half avo = 160 kcal. Healthy fat but calorie-dense. For fat loss: "Solid choice — half an avo fits your plan. A full avo is 320 kcal which is a big chunk of your daily budget." Guide the portion, do not ban the food.
+- Banana: 1 medium = 105 kcal, 27g carbs. Not a free snack for fat loss. For fat loss: "Good carb — best before training. Factor the 105 kcal in and adjust your next meal." Best timing is pre-workout.
+- Nuts: 30g = 170 kcal. Clients eat 3x this without realising. For fat loss: "Good snack — but weigh them. 30g is one small palm and it is already 170 kcal."
+- Cooking oil: 1 tablespoon = 120 kcal. Most SA cooking uses 3-4 tablespoons. For fat loss: flag once, suggest spray-and-cook or measuring.
+- Full cream milk in tea/coffee: 3-4 cups daily = 400 invisible calories. For fat loss: flag once, suggest low fat or black.
 
-SMART SWAPS — suggest ONLY when client explicitly asks for lower-calorie alternatives:
-- If client says "what can I eat instead of X" or "lower calorie option for X" — then suggest alternatives
-- NEVER proactively swap avocado, banana, peanut butter, or nuts unless asked
-- White bread → brown bread: fine to mention for fibre benefits
-- Polony → eggs: suggest for protein quality improvement
-- Cooking oil (pour) → spray-and-cook: fine to mention for calorie savings
+MUSCLE GAIN CLIENTS — these foods are allies, encourage them:
+- Peanut butter: 2 tablespoons is the right portion. Protein and fat combo for calorie surplus.
+- Avocado: Full avo is fine. Healthy fat supports recovery and hormone production.
+- Banana: Perfect carb for training — before and after. Eat freely.
+- Nuts: Good calorie-dense snack for hitting surplus. Encourage.
+- Cooking oil, full cream milk: Fine. Calories are the goal.
+
+BODY RECOMPOSITION — portion-aware but not restrictive:
+- These foods belong in the plan. Log accurately. One portion per meal. Adjust based on how the week is tracking.
+
+SMART SWAPS — only when client explicitly asks for a lower-calorie option:
+- "What can I eat instead of X" or "lower calorie option" → then suggest alternatives
+- White bread → brown bread: fine to mention for fibre
+- Polony → eggs: suggest for protein quality
+- Cooking oil (pour) → spray-and-cook: fine to mention proactively for fat loss
+- Full cream milk → low fat: fine for fat loss clients, saves 60 kcal per cup
 
 
 SCALE PANIC — weight went up:

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -11,6 +11,7 @@ import { eq, and, gte, lt, desc } from "drizzle-orm";
 import { type SAFood } from "../foods";
 import {
   scanForSAFoods, recomputeTodayFoodTotals, buildFoodLogReply, escapeRegex,
+  computeFoodLogStreak, getFoodStreakCelebration,
 } from "./food-scanner";
 import { checkFoodPatterns, checkPerfectDay } from "./checks";
 import { gptFoodFallback, askCoachK } from "../gpt";
@@ -582,9 +583,14 @@ export async function handleFoodContext(ctx: {
       } catch (e) { console.warn("[non-fatal] meal_logs insert:", e); }
 
       await logChat(user.id, message, reply, "FOOD_LOG");
-      const [saPattern, saDay] = await Promise.all([checkFoodPatterns(user.id), checkPerfectDay(user.id, user.proteinTarget || 130)]);
+      const [saPattern, saDay, foodStreak] = await Promise.all([
+        checkFoodPatterns(user.id),
+        checkPerfectDay(user.id, user.proteinTarget || 130),
+        computeFoodLogStreak(user.id),
+      ]);
+      const streakCelebration = getFoodStreakCelebration(foodStreak, user.name || "");
       const stepAppend = stepReplyPart ? `\n\n${stepReplyPart}` : "";
-      return `${reply}${saPattern ? "\n\n" + saPattern : ""}${saDay || ""}${stepAppend}`;
+      return `${reply}${saPattern ? "\n\n" + saPattern : ""}${saDay || ""}${streakCelebration}${stepAppend}`;
     }
 
     // ---- GPT FOOD FALLBACK (SA scanner had food keywords but 0 adjusted matches) ----
@@ -638,9 +644,9 @@ export async function handleFoodContext(ctx: {
           });
         } catch (e) { console.warn("[non-fatal] gpt-fallback meal_logs:", e); }
         await logChat(user.id, message, fallbackReply, "FOOD_LOG");
-        const [fbPattern, fbDay] = await Promise.all([checkFoodPatterns(user.id), checkPerfectDay(user.id, user.proteinTarget || 130)]);
+        const [fbPattern, fbDay, fbStreak] = await Promise.all([checkFoodPatterns(user.id), checkPerfectDay(user.id, user.proteinTarget || 130), computeFoodLogStreak(user.id)]);
         console.log(`[GPT-FOOD-FALLBACK] ${user.id.slice(0, 8)} — ${gptFallbackResult.foods.map((f: any) => f.name).join(", ")} — ${gptFallbackResult.totalKcal} kcal${gptFallbackResult.fromCache ? " [cached]" : ""}`);
-        return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}`;
+        return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}${getFoodStreakCelebration(fbStreak, user.name || "")}`;
       }
     }
   }
@@ -698,9 +704,9 @@ export async function handleFoodContext(ctx: {
         });
       } catch (e) { console.warn("[non-fatal] gpt-fallback meal_logs:", e); }
       await logChat(user.id, message, fallbackReply, "FOOD_LOG");
-      const [fbPattern, fbDay] = await Promise.all([checkFoodPatterns(user.id), checkPerfectDay(user.id, user.proteinTarget || 130)]);
+      const [fbPattern, fbDay, fb2Streak] = await Promise.all([checkFoodPatterns(user.id), checkPerfectDay(user.id, user.proteinTarget || 130), computeFoodLogStreak(user.id)]);
       console.log(`[GPT-FOOD-FALLBACK] ${user.id.slice(0, 8)} — ${gptFallbackResult.foods.map((f: any) => f.name).join(", ")} — ${gptFallbackResult.totalKcal} kcal${gptFallbackResult.fromCache ? " [cached]" : ""}`);
-      return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}`;
+      return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}${getFoodStreakCelebration(fb2Streak, user.name || "")}`;
     }
   }
 

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from "../db";
-import { users, mealLogs, chatHistory } from "../../shared/schema";
+import { users, mealLogs, chatHistory, stepLogs } from "../../shared/schema";
 import { eq, and, gte, lt, desc } from "drizzle-orm";
 import { type SAFood } from "../foods";
 import {
@@ -454,10 +454,17 @@ export async function handleFoodContext(ctx: {
       const todayStr = sastToday();
       let runningCals = totalCals;
       let runningProtein = Math.round(totalProtein);
+      let todayStepCount = 0;
       try {
-        const existingTotals = await recomputeTodayFoodTotals(user.id);
+        const [existingTotals, stepRow] = await Promise.all([
+          recomputeTodayFoodTotals(user.id),
+          db.select({ steps: stepLogs.steps }).from(stepLogs)
+            .where(and(eq(stepLogs.userId, user.id), gte(stepLogs.loggedAt, sastDayStart())))
+            .orderBy(desc(stepLogs.loggedAt)).limit(1),
+        ]);
         runningCals = existingTotals.calories + totalCals;
         runningProtein = existingTotals.protein + Math.round(totalProtein);
+        todayStepCount = stepRow[0]?.steps || 0;
         await db.update(users).set({
           todayCalories: runningCals,
           todayProteinG: runningProtein,
@@ -541,7 +548,7 @@ export async function handleFoodContext(ctx: {
         junkNoteText, hasGoodProteins: goodProteins.length > 0,
         hasCarbs: allAdjustedFoods.some(f => f.category === "carb"),
         coachNoteOverride: denseFoodCoachNote,
-        user,
+        user, todaySteps: todayStepCount,
       });
 
       try {

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -298,6 +298,7 @@ export function buildFoodLogReply(p: {
   hasCarbs?: boolean;
   coachNoteOverride?: string;
   user: any;
+  todaySteps?: number;
 }): string {
   const {
     foodLines, mealLabel, totalMealCals, totalMealProtein,
@@ -310,9 +311,20 @@ export function buildFoodLogReply(p: {
   const proteinRemaining = proteinTarget - runningProtein;
   const earlyInDay = runningCals < (calorieTarget * 0.4);
 
+  // Extra step burn: ~40 kcal per 1,000 steps beyond target
+  const stepsTarget = user.stepsTarget || 8500;
+  const todaySteps = p.todaySteps || 0;
+  const extraStepsBurned = todaySteps > stepsTarget
+    ? Math.round((todaySteps - stepsTarget) * 0.04)
+    : 0;
+
+  const effectiveRemaining = calRemaining + extraStepsBurned;
+  const stepsNote = extraStepsBurned > 0 && calRemaining < 0
+    ? ` · ${todaySteps.toLocaleString()} steps burned ~${extraStepsBurned} extra kcal`
+    : "";
   const runningLine = prevCals > 0
-    ? `Running total today: ~${runningCals} kcal / ${calorieTarget} target${calRemaining > 0 ? ` (${calRemaining} remaining)` : " ✅ target reached"}`
-    : `Remaining today: ~${Math.max(0, calRemaining)} kcal`;
+    ? `Running total today: ~${runningCals} kcal / ${calorieTarget} target${effectiveRemaining > 0 ? ` (${effectiveRemaining} remaining${stepsNote})` : effectiveRemaining >= -100 ? ` ✅ on target${stepsNote}` : ` · over by ~${Math.abs(effectiveRemaining)} kcal${stepsNote}`}`
+    : `Remaining today: ~${Math.max(0, effectiveRemaining)} kcal${stepsNote}`;
 
   let dayAssessment = "";
   if (prevCals > 0 && totalMealCals >= 100) {
@@ -320,9 +332,16 @@ export function buildFoodLogReply(p: {
     const dayProgress = Math.min(hourNow / 20, 1);
     const expectedCals = calorieTarget * dayProgress;
     const calPace = runningCals / Math.max(expectedCals, 1);
-    if (calRemaining <= 0) {
-      dayAssessment = `\n_Calorie target reached — stop eating for today. Water and sleep._`;
-    } else if (!earlyInDay && calPace < 0.6 && calRemaining < 600) {
+    if (calRemaining <= 0 && effectiveRemaining <= -100) {
+      // Over after steps — if big steps, soften message
+      if (extraStepsBurned >= 80) {
+        dayAssessment = `\n_Over on calories, but your step count offset ~${extraStepsBurned} kcal. Net surplus: ~${Math.abs(effectiveRemaining)} kcal. Keep dinner light._`;
+      } else {
+        dayAssessment = `\n_Calorie target reached — keep dinner light. Protein and vegetables only._`;
+      }
+    } else if (calRemaining <= 0 && effectiveRemaining > -100) {
+      dayAssessment = `\n_Your step count covered the overage — you're effectively on target. Keep the last meal light._`;
+    } else if (!earlyInDay && calPace < 0.6 && effectiveRemaining < 600) {
       dayAssessment = `\n_On pace — one more protein-heavy meal and you close out the day well._`;
     } else if (!earlyInDay && calPace > 1.3) {
       dayAssessment = `\n_Running high — keep dinner light. Protein and vegetables only tonight._`;

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -395,7 +395,15 @@ export function buildFoodLogReply(p: {
         ];
     proteinTip = `\n\n${suggestions[Math.floor(Math.random() * suggestions.length)]} ${Math.round(protRemaining)}g protein still needed today.`;
   } else if (protRemaining <= 0) {
-    proteinTip = `\n\nProtein target hit. ✅`;
+    const evnHour = new Date().getUTCHours() + 2;
+    const isEvening = evnHour >= 17;
+    const caloriesOnTarget = runningCals <= calorieTarget * 1.1;
+    if (isEvening && caloriesOnTarget) {
+      const fn = (user.name || "").split(" ")[0] || "there";
+      proteinTip = `\n\n✅ *Protein target hit, ${fn}.* Calories on track. That is a clean nutrition day — no workout needed to make this count. Same again tomorrow.`;
+    } else {
+      proteinTip = `\n\nProtein target hit. ✅`;
+    }
   }
 
   let variableReinforcement = "";

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -2,8 +2,49 @@ import { SA_FOODS_SEED, type SAFood } from "../foods";
 import { enforceCoachGuardrails } from "../coach-guardrails";
 import { db } from "../db";
 import { mealLogs, chatHistory } from "../../shared/schema";
-import { eq, and, gte, sql } from "drizzle-orm";
+import { eq, and, gte, sql, desc } from "drizzle-orm";
 import { sastDayStart } from "../utils";
+
+export async function computeFoodLogStreak(userId: string): Promise<number> {
+  try {
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 86_400_000);
+    const logs = await db.select({ createdAt: chatHistory.createdAt })
+      .from(chatHistory)
+      .where(and(eq(chatHistory.userId, userId), eq(chatHistory.intent, "FOOD_LOG"), gte(chatHistory.createdAt, sixtyDaysAgo)))
+      .orderBy(desc(chatHistory.createdAt));
+    if (logs.length === 0) return 0;
+    const days = new Set<string>();
+    for (const l of logs) {
+      if (!l.createdAt) continue;
+      const d = new Date(new Date(l.createdAt).getTime() + 2 * 3_600_000);
+      days.add(`${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`);
+    }
+    let streak = 0;
+    const checkDate = new Date(Date.now() + 2 * 3_600_000);
+    while (true) {
+      const key = `${checkDate.getUTCFullYear()}-${checkDate.getUTCMonth()}-${checkDate.getUTCDate()}`;
+      if (!days.has(key)) break;
+      streak++;
+      checkDate.setUTCDate(checkDate.getUTCDate() - 1);
+    }
+    return streak;
+  } catch { return 0; }
+}
+
+const FOOD_STREAK_MESSAGES: Record<number, (name: string) => string> = {
+  3:  (n) => `\n\n🔥 *${n}, 3 days logging straight.* The data is building. This is what coaching from facts looks like — keep it going.`,
+  5:  (n) => `\n\n🔥 *${n}, 5 days in a row.* Most people stop at day 2. You're past the quitting point. Don't break the chain.`,
+  7:  (n) => `\n\n🔥 *${n}, 7 days of food logs.* A full week. You now have real data — patterns I can actually coach from. Screenshot this and keep going.`,
+  10: (n) => `\n\n🔥 *${n}, 10 days straight.* Double figures. The habit is forming — your brain is starting to do this automatically. That's exactly where you want to be.`,
+  14: (n) => `\n\n🔥 *${n}, 14 days.* Two weeks of consistent logging. The clients who get results are the clients who do this. You are one of them.`,
+  21: (n) => `\n\n🔥 *${n}, 21 days logging.* Three weeks. This is a habit now — not discipline, not willpower. Habit. The data you've built is yours forever.`,
+  30: (n) => `\n\n🏆 *${n}, 30 days.* A full month of food logs. I do not see many people get here. Your consistency record is real — take a moment with that.`,
+};
+
+export function getFoodStreakCelebration(streak: number, name: string): string {
+  const fn = name.split(" ")[0] || "there";
+  return FOOD_STREAK_MESSAGES[streak]?.(fn) ?? "";
+}
 
 export function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/server/handlers/gpt-block.ts
+++ b/server/handlers/gpt-block.ts
@@ -414,7 +414,7 @@ SA voice. Direct. Coach forward, not backward.`;
   // ---- FOOD CONTEXT CHECK — only if GPT response is about food the user actually ate ----
   // STRICT: must have BOTH a log trigger AND actual SA food detected by scanner
   // This prevents "I had a great workout", "food is expensive", "dinner plans" from being logged as food
-  const hasLogTrigger = /\b(ate|had|having|eating|breakfast|lunch|dinner|supper|snack|just had|just ate|i had|i ate|meal)\b/i.test(m);
+  const hasLogTrigger = /\b(ate|had|having|eating|breakfast|lunch|dinner|supper|snack(ed|ing)?|just had|just ate|i had|i ate|meal|grabbed|nibbled|had some|bit of|piece of)\b|quick bite/i.test(m);
   const isLogCommand = /\b(log it|save this|save it|log that|save that)\b/i.test(m);
   const isQuestion = /\?|^(what|how|when|where|why|can|should|is|are|do|does|which|could|would)\b/i.test(m);
   const isFrustration = /^\s*(ugh|argh|wtf|what the|this is|not working|doesn.?t work|ridiculous|stupid|useless|terrible|broken|help!+|please!+)\b/i.test(m);

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -1181,23 +1181,76 @@ export async function handleLifecycle(ctx: {
   }
 
   // ---- WIN / POSITIVE UPDATE — client shares a weight loss, milestone, or NSV ----
-  const isWinMsg =
-    (/\b(lost|dropped|down|lighter|less than before|weighed in at)\b/i.test(m) &&
-     /\b(\d+(?:\.\d+)?)\s*kg\b/.test(m) &&
-     /\b(lost|dropped|down)\b/i.test(m)) ||
-    /\b(jeans.*fit|clothes.*fitting|fitting better|looser.*clothes|clothes.*looser|compliment|someone noticed|people.*noticed|noticed.*change|can feel.*difference|feeling.*stronger|lifted more|new pb|personal best|pb today)\b/i.test(m);
+  const isWeightWin =
+    /\b(lost|dropped|down|lighter|less than before|weighed in at)\b/i.test(m) &&
+    /\b(\d+(?:\.\d+)?)\s*kg\b/.test(m) &&
+    /\b(lost|dropped|down)\b/i.test(m);
 
-  if (isWinMsg) {
+  const isNSV =
+    /\b(jeans.*fit|clothes.*fitting|fitting better|looser.*clothes|clothes.*looser|jeans.*too big|shirt.*too big|dress.*too big|pants.*too big|clothes.*loose|jeans.*loose)\b/i.test(m) ||
+    /\b(compliment|someone noticed|people.*noticed|noticed.*change|people.*say.*look|people.*saying.*look|someone.*said.*look|friends.*noticed|family.*noticed)\b/i.test(m) ||
+    /\b(can feel.*difference|feel.*difference|feel.*different|look.*different|see.*difference|see.*changes|seeing.*changes|seeing.*results|results.*showing|starting to show)\b/i.test(m) ||
+    /\b(can see my abs|seeing.*abs|abs.*showing|stomach.*flatter|belly.*smaller|waist.*smaller|waist.*getting smaller)\b/i.test(m) ||
+    /\b(feeling.*stronger|feel.*stronger|lifted more|new pb|personal best|pb today|ran further|ran longer|first time.*ran|ran.*without.*stopping|didn.?t get.*tired)\b/i.test(m) ||
+    /\b(energy.*better|so much.*energy|more energy|energy.*up|sleeping better|sleep.*improved|feel amazing|feel incredible|feel great about)\b/i.test(m) ||
+    /\b(meal prep|meal prepped|prepped.*food|cooked.*bulk|batch cook|batch cooked)\b/i.test(m);
+
+  if (isWeightWin || isNSV) {
     const kgMatch = m.match(/(\d+(?:\.\d+)?)\s*kg/);
     const kgLost = kgMatch ? parseFloat(kgMatch[1]) : null;
     const total = user.totalWorkoutsCompleted || 0;
     const weeks = user.programmeWeek || 1;
     const name = user.name || "there";
-    const winReply = kgLost && m.match(/\b(lost|dropped|down)\b/i)
-      ? `${kgLost}kg down — that is real${name ? `, ${name}` : ""}. ${total} sessions, ${weeks} week${weeks !== 1 ? "s" : ""} of consistency. This is what the programme does.\n\nThe next ${kgLost}kg follows the same formula — same sessions, same food discipline, same steps. Keep going.`
-      : `${name}, that is a win. Non-scale victories are the most honest data — the clothes do not lie.\n\nYour body is changing. The ${total} sessions you have put in are showing up in the real world. Keep the same habits for the next 4 weeks and this becomes your new normal.`;
+
+    let winReply: string;
+    if (isWeightWin && kgLost) {
+      winReply = `${kgLost}kg down — that is real, ${name}. ${total} session${total !== 1 ? "s" : ""}, ${weeks} week${weeks !== 1 ? "s" : ""} of consistency. This is exactly what the programme is supposed to do.\n\nThe next ${kgLost}kg follows the same formula. Same sessions, same food, same steps. Keep going.`;
+    } else if (/\b(jeans|clothes|shirt|dress|pants)\b/i.test(m)) {
+      winReply = `${name}, clothes don't lie. When they start fitting differently, the scale is just catching up to what your body already knows.\n\n${total} sessions to get here. The people who keep the same habits for another 4 weeks are the ones who don't go back. You're at that point now.`;
+    } else if (/\b(someone noticed|people.*noticed|compliment|people.*say|friends.*noticed|family.*noticed)\b/i.test(m)) {
+      winReply = `When people start noticing, it means the change is real enough that strangers can see it — not just you on a good day in the mirror.\n\n${name}, ${total} sessions built that. Screenshot this and send it to whoever doubted you.`;
+    } else if (/\b(abs|stomach.*flat|belly.*small|waist)\b/i.test(m)) {
+      winReply = `${name}, that is the programme working. Abs are fat loss made visible — you cannot fake that.\n\nKeep the deficit, keep the protein, keep the steps. You are in the phase where the visible changes compound every week.`;
+    } else if (/\b(stronger|pb|personal best|lifted more|ran)\b/i.test(m)) {
+      winReply = `Performance wins are the most honest feedback your body gives. The scale lies, the mirror lies on bad days — but a new personal best never lies.\n\n${name}, ${total} sessions to get here. Same formula next week.`;
+    } else if (/\b(energy|sleep|feel amazing|feel great)\b/i.test(m)) {
+      winReply = `${name}, this is the part most people don't expect — the energy and sleep change before the body visibly changes.\n\nWhat you're feeling right now is your metabolism shifting. The visual results follow. Keep exactly what you're doing.`;
+    } else if (/\b(meal prep|batch cook)\b/i.test(m)) {
+      winReply = `${name}, meal prep is the single habit that separates people who get results from people who talk about it.\n\nWhen the food is already made, you don't make bad decisions under pressure. You just eat what's there. That's the whole secret. Do it every Sunday.`;
+    } else {
+      winReply = `${name}, that is a real win — and it came from ${total} sessions of work. The body is changing.\n\nKeep the same habits for 4 more weeks. This is where it compounds.`;
+    }
     await logChat(user.id, message, winReply, "WIN_CELEBRATION");
     return winReply;
+  }
+
+  // ---- DISCIPLINE MOMENT — trained despite not wanting to ----
+  const isDisciplineWin =
+    /\b(didn.?t (feel like|want to) (train|go|workout|work out|go to gym)|forced myself|made myself (go|train|workout)|dragged myself|almost (didn.?t go|skipped|quit)|wanted to skip but|nearly skipped|almost skipped|didn.?t want to but (went|trained|did it|showed up)|went anyway|trained anyway|showed up anyway)\b/i.test(m);
+
+  if (isDisciplineWin) {
+    const name = user.name?.split(" ")[0] || "there";
+    const total = user.totalWorkoutsCompleted || 0;
+    const disciplineReply = `${name}, that session counts double.\n\nEvery person who has ever changed their body has had that exact same moment — the voice that says "not today." The ones who get results are not the ones who feel motivated. They are the ones who go anyway.\n\nYou just proved to yourself that you are that person. That is not a small thing. ${total > 1 ? `${total} sessions, and this is the one that matters most — because it was the hardest one to start.` : `First sessions are the hardest. You did it.`}\n\nSend *done* when you finish.`;
+    await logChat(user.id, message, disciplineReply, "DISCIPLINE_WIN");
+    return disciplineReply;
+  }
+
+  // ---- FIRST GYM VISIT / GYM ANXIETY ----
+  const isFirstGym =
+    /\b(first time (at|in|to) (the )?gym|first gym (session|day|visit|time)|never been to (a |the )?gym|went to (the )?gym for the first time|my first (day|session) (at|in) (the )?gym)\b/i.test(m);
+  const isGymAnxiety =
+    /\b(nervous (at|in|about) (the )?gym|intimidated (by |at |in )?the gym|don.?t know what (i.?m doing|to do) (at|in) (the )?gym|feel (lost|confused|out of place) (at|in) (the )?gym|gym (is|was) (scary|intimidating|overwhelming)|everyone.*staring|people.*staring.*gym|don.?t belong.*gym)\b/i.test(m);
+
+  if (isFirstGym || isGymAnxiety) {
+    const name = user.name?.split(" ")[0] || "there";
+    const mode = user.trainingMode || "gym";
+    const gymName = (user as any).gymName || "the gym";
+    const gymReply = isFirstGym
+      ? `${name}, you walked in. That is the hardest part — and you already did it.\n\nEvery person in that gym was a first-timer once. Every single one. The ones who look comfortable now were nervous the first day too.\n\nHere is all you need to know today: follow your programme, one exercise at a time. If a machine is taken, move to the next one. Nobody is watching you — everyone is focused on themselves.\n\nSend *done* when you finish your first session. That one counts more than any session after it.`
+      : `${name}, gym anxiety is real and almost everyone feels it. Even people who have trained for years.\n\nHere is the truth: nobody in ${gymName} is watching you as closely as you think. They are thinking about their own training.\n\nYour programme is designed for machines — the safest, most effective way to train. Stick to your list, rest between sets, and leave when you are done. That is the whole thing.\n\nWhat exercise are you on right now? I will walk you through it.`;
+    await logChat(user.id, message, gymReply, "GYM_ANXIETY");
+    return gymReply;
   }
 
   // ---- SUGAR / JUNK CRAVINGS HANDLER — different from general hunger ----

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -647,6 +647,54 @@ export async function handleLifecycle(ctx: {
     // Not paused — fall through (bare "start" from a new user means menu, not opt-in)
   }
 
+  // ---- CANCEL SAVE — handle reason (step 2 of cancel flow) ----
+  if (user.awaitingInputType === "cancel_save") {
+    const name = (user.name || "").split(" ")[0] || "there";
+    const choice = m.trim();
+    const goal = user.goalType || "fat_loss";
+    const cals = user.calorieTarget || 1800;
+    const protein = user.proteinTarget || 140;
+
+    if (choice === "1" || /\b(too expensive|expensive|can.?t afford|afford|price|cost|money)\b/i.test(m)) {
+      const pauseUntil = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10);
+      const existingNotes = user.profileNotes || "";
+      const pausedNotes = existingNotes.includes("paused_until:")
+        ? existingNotes.replace(/paused_until:\d{4}-\d{2}-\d{2}/, `paused_until:${pauseUntil}`)
+        : `${existingNotes ? existingNotes + " | " : ""}paused_until:${pauseUntil}`;
+      await db.update(users).set({ awaitingInputType: null, profileNotes: pausedNotes }).where(eq(users.phoneNumber, phone));
+      const priceReply = `Understood, ${name}. Paused for 30 days — no check-ins, your programme and progress are saved.\n\nR149 is R5/day. When things ease up, reply *back* and we pick up exactly where you left off.\n\n_To cancel completely, reply *cancel* again._`;
+      await logChat(user.id, message, priceReply, "CANCEL_SAVE_PAUSE_PRICE");
+      return priceReply;
+    }
+
+    if (choice === "2" || /\b(not seeing results|no results|not working|isn.?t working|not losing|not gaining|plateau|stuck)\b/i.test(m)) {
+      await db.update(users).set({ awaitingInputType: null }).where(eq(users.phoneNumber, phone));
+      const resultsReply = goal === "fat_loss"
+        ? `${name}, results come from hitting *${cals} kcal / ${protein}g protein* consistently — not perfectly, but most days.\n\nIf you're doing that and the scale isn't moving, your targets need adjusting. Log your food for 5 days and send me a message — I'll audit exactly what's not working and fix your numbers. Give it that before you go.`
+        : `${name}, muscle takes longer than fat loss but it compounds hard. Are you hitting *${cals} kcal / ${protein}g protein* and adding reps or weight each session?\n\nLog food for 5 days and message me — I'll look at your numbers and adjust. Give it that before you go.`;
+      await logChat(user.id, message, resultsReply, "CANCEL_SAVE_RESULTS");
+      return resultsReply;
+    }
+
+    if (choice === "3" || /\b(break|need a break|taking a break|rest|holiday|vacation|pause|step away)\b/i.test(m)) {
+      const pauseUntil = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10);
+      const existingNotes = user.profileNotes || "";
+      const pausedNotes = existingNotes.includes("paused_until:")
+        ? existingNotes.replace(/paused_until:\d{4}-\d{2}-\d{2}/, `paused_until:${pauseUntil}`)
+        : `${existingNotes ? existingNotes + " | " : ""}paused_until:${pauseUntil}`;
+      await db.update(users).set({ awaitingInputType: null, profileNotes: pausedNotes }).where(eq(users.phoneNumber, phone));
+      const breakReply = `Done, ${name}. Paused for 30 days — no check-ins. Programme saved.\n\nWhen you're ready, reply *back* and we go again. No restart needed.`;
+      await logChat(user.id, message, breakReply, "CANCEL_SAVE_PAUSE_BREAK");
+      return breakReply;
+    }
+
+    // Option 4 or unrecognised — route to confirm flow
+    await db.update(users).set({ awaitingInputType: "cancel_confirm" }).where(eq(users.phoneNumber, phone));
+    const confirmReply = `${name}, last check — reply *yes* to cancel completely, or anything else to keep your subscription.\n\n_Your R149/month coaching stops. Data saved 90 days._`;
+    await logChat(user.id, message, confirmReply, "CANCEL_SAVE_TO_CONFIRM");
+    return confirmReply;
+  }
+
   // ---- CANCEL SUBSCRIPTION CONFIRMATION (step 2) ----
   if (user.awaitingInputType === "cancel_confirm") {
     await db.update(users).set({ awaitingInputType: null }).where(eq(users.phoneNumber, phone));
@@ -676,11 +724,13 @@ export async function handleLifecycle(ctx: {
       await logChat(user.id, message, cancelledAlreadyReply, "CANCEL");
       return cancelledAlreadyReply;
     }
-    const name = user.name || "there";
-    await db.update(users).set({ awaitingInputType: "cancel_confirm" }).where(eq(users.phoneNumber, phone));
-    const cancelConfirmReply = `${name}, just to confirm — do you want to cancel your subscription?\n\nReply *yes* to cancel, or anything else to keep it.\n\n_Your R149/month coaching, workouts, and progress will stop. Your data stays saved for 90 days._`;
-    await logChat(user.id, message, cancelConfirmReply, "CANCEL_CONFIRM");
-    return cancelConfirmReply;
+    const name = (user.name || "").split(" ")[0] || "there";
+    const sessions = user.totalWorkoutsCompleted || 0;
+    const sessionLine = sessions > 0 ? `${sessions} session${sessions === 1 ? "" : "s"} logged.` : "Your profile is saved.";
+    await db.update(users).set({ awaitingInputType: "cancel_save" }).where(eq(users.phoneNumber, phone));
+    const cancelSaveReply = `${name}, before I cancel — ${sessionLine}\n\nWhat's making you want to leave?\n\n*1* — Too expensive\n*2* — Not seeing results\n*3* — Need a break, not quitting\n*4* — Just cancel`;
+    await logChat(user.id, message, cancelSaveReply, "CANCEL_SAVE_START");
+    return cancelSaveReply;
   }
 
   // ---- REFUND REQUEST ----
@@ -1615,6 +1665,21 @@ export async function handleLifecycle(ctx: {
       await logChat(user.id, message, formatReply, "FOOD_FORMAT_GUIDE");
       return formatReply;
     }
+  }
+
+  // ---- THANKS / COMPLIMENT — deflect credit back to the user ----
+  const isThanks = /\b(thank you|thanks|thank u|thx|you.?re amazing|you.?re the best|great coach|love this|love you coach|you.?re great|you.?re awesome|you.?re helping|so helpful|this is helping|this is working|appreciate (you|it|this)|grateful)\b/i.test(m);
+  if (isThanks && m.split(/\s+/).length < 20) {
+    const fn = (user.name || "").split(" ")[0] || "there";
+    const goal = user.goalType || "fat_loss";
+    const forward = goal === "fat_loss"
+      ? `Send me what you're eating today — even one meal. That is how we keep it moving.`
+      : goal === "muscle_gain"
+        ? `Send me today's training session when you're done — let's keep the streak going.`
+        : `Log something today — food, a workout, a weight. Every log is a data point.`;
+    const thanksReply = `${fn}, that is all you — I just give the numbers and the nudges. You are the one showing up.\n\n${forward}`;
+    await logChat(user.id, message, thanksReply, "THANKS");
+    return thanksReply;
   }
 
   return null;

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -225,35 +225,53 @@ export async function handleMediaMessage(ctx: {
 
         if (existingPhotos.length >= 1) {
           const firstPhoto = existingPhotos[0];
-          const daysBetween = Math.round((Date.now() - new Date(firstPhoto.loggedAt || "").getTime()) / 86_400_000);
+          const prevPhoto = existingPhotos[existingPhotos.length - 1]; // most recent before this one
+          const daysSinceStart = Math.round((Date.now() - new Date(firstPhoto.loggedAt || "").getTime()) / 86_400_000);
+          const daysSincePrev = Math.round((Date.now() - new Date(prevPhoto.loggedAt || "").getTime()) / 86_400_000);
           const progressDecision = selectVisionModel("progress_compare", isCoach ? "active" : user.subscriptionStatus);
-          console.log(`[VISION][${mediaTrace}] progress model=${progressDecision.model} tier=${user.subscriptionStatus}`);
+          console.log(`[VISION][${mediaTrace}] progress model=${progressDecision.model} tier=${user.subscriptionStatus} photos=${photoNumber}`);
+
+          const isThirdPlusPhoto = existingPhotos.length >= 2;
+          const imageContent: Array<{ type: "text"; text: string } | { type: "image_url"; image_url: { url: string; detail: string } }> = [];
+
+          if (isThirdPlusPhoto) {
+            const weeksStart = Math.round(daysSinceStart / 7);
+            const weeksPrev = Math.round(daysSincePrev / 7);
+            imageContent.push({
+              type: "text",
+              text: `You have three photos to compare. Photo A is the original baseline (${weeksStart} weeks ago). Photo B is the most recent check-in (${weeksPrev} days ago). Photo C is today's check-in (Photo ${photoNumber}).\n\nStructure your response:\n1. *Since the beginning:* What has changed from Photo A to Photo C in body composition, posture, waist/hip shape, muscle definition?\n2. *Since last check-in:* What is visibly different between Photo B and Photo C? Even small changes.\n3. One specific coaching cue for the next 30 days based on what you see.\n\nBe direct and specific. If you cannot see a change — say why (lighting, angle, clothing) and what would help. SA voice, max 150 words total.`,
+            });
+            imageContent.push({ type: "image_url", image_url: { url: `data:${firstPhoto.contentType};base64,${firstPhoto.photoBase64}`, detail: progressDecision.detail } });
+            imageContent.push({ type: "image_url", image_url: { url: `data:${prevPhoto.contentType};base64,${prevPhoto.photoBase64}`, detail: progressDecision.detail } });
+            imageContent.push({ type: "image_url", image_url: { url: `data:${contentType};base64,${base64}`, detail: progressDecision.detail } });
+          } else {
+            imageContent.push({
+              type: "text",
+              text: `Compare these two progress photos. Photo 1 was taken ${daysSinceStart} days ago (${Math.round(daysSinceStart / 7)} weeks). Photo 2 is today. Describe specifically what has changed in the body. Focus on: body composition, posture, visible muscle, waist and hip shape. Be honest — if nothing has changed say so and say why (lighting, angle, clothing). If it has — describe exactly what you see. End with one specific coaching cue for the next 30 days. SA voice, max 120 words.`,
+            });
+            imageContent.push({ type: "image_url", image_url: { url: `data:${firstPhoto.contentType};base64,${firstPhoto.photoBase64}`, detail: progressDecision.detail } });
+            imageContent.push({ type: "image_url", image_url: { url: `data:${contentType};base64,${base64}`, detail: progressDecision.detail } });
+          }
+
           const comparisonResponse = await openai.chat.completions.create({
             model: progressDecision.model,
             max_tokens: progressDecision.maxTokens,
             messages: [
               {
                 role: "system",
-                content: `You are Coach K, a South African fitness and nutrition coach with 20 years experience. The client's name is ${clientName}. Their goal is ${goal}. SA voice — direct, warm, specific. Max 4 sentences. Focus on visible physical changes only — posture, muscle definition, body shape. Never discuss weight unless you can see a scale. Be honest and specific. Never say "great progress" as a standalone — describe what you actually see. End with one specific observation about what to focus on next.`,
+                content: `You are Coach K, a South African fitness and nutrition coach with 20 years experience. The client's name is ${clientName}. Their goal is ${goal}. Direct, warm, specific — SA voice. Focus on visible physical changes only. Never discuss weight unless you can see a scale. Never say "great progress" as a standalone — describe what you actually see.`,
               },
-              {
-                role: "user",
-                content: [
-                  { type: "text", text: `Compare these two progress photos. Photo 1 was taken ${daysBetween} days ago (${Math.round(daysBetween / 7)} weeks). Photo 2 is today. Describe specifically what has changed in the body. Focus on: body composition, posture, visible muscle, waist and hip shape. Be honest — if nothing has changed say so and say why. If it has — describe exactly what you see.` },
-                  { type: "image_url", image_url: { url: `data:${firstPhoto.contentType};base64,${firstPhoto.photoBase64}`, detail: progressDecision.detail } },
-                  { type: "image_url", image_url: { url: `data:${contentType};base64,${base64}`, detail: progressDecision.detail } },
-                ],
-              },
+              { role: "user", content: imageContent },
             ],
           });
           const progressTokens = comparisonResponse.usage?.completion_tokens || 0;
           console.log(`[COST][${mediaTrace}] progress_compare ~$${estimateVisionCostUSD(progressDecision, progressTokens).toFixed(5)} (${progressDecision.reason})`);
           const comparisonText = comparisonResponse.choices[0]?.message?.content?.trim()
-            || "I can see both photos but could not compare them clearly. Send them in better lighting.";
+            || "I can see the photos but could not compare them clearly. Send in good lighting, same pose if possible.";
           await logChat(user.id, `[Progress Photo ${photoNumber}]`, comparisonText, "PROGRESS_COMPARISON");
-          const weeksLabel = Math.round(daysBetween / 7);
+          const weeksLabel = Math.round(daysSinceStart / 7);
           const weekStr = weeksLabel === 1 ? "1 week" : `${weeksLabel} weeks`;
-          return `Photo ${photoNumber} — ${weekStr} of work.\n\n${comparisonText}\n\n_Next check-in: send another photo in 30 days. I'll compare all ${photoNumber + 1} side by side._`;
+          return `Photo ${photoNumber} — ${weekStr} of work.\n\n${comparisonText}\n\n_Next check-in: 30 days. Keep the same pose and lighting — it makes the comparison sharper._`;
         } else {
           return `Saved, ${clientName}. That is your baseline — the before. The photo you will look back at in 8 weeks and not believe.\n\nSend your next one in 30 days. I will compare them side by side and tell you exactly what changed — muscle, posture, body shape. Everything. Keep showing up.`;
         }

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -251,9 +251,11 @@ export async function handleMediaMessage(ctx: {
           const comparisonText = comparisonResponse.choices[0]?.message?.content?.trim()
             || "I can see both photos but could not compare them clearly. Send them in better lighting.";
           await logChat(user.id, `[Progress Photo ${photoNumber}]`, comparisonText, "PROGRESS_COMPARISON");
-          return `Progress photo ${photoNumber} saved — ${daysBetween} days since photo 1.\n\n${comparisonText}`;
+          const weeksLabel = Math.round(daysBetween / 7);
+          const weekStr = weeksLabel === 1 ? "1 week" : `${weeksLabel} weeks`;
+          return `Photo ${photoNumber} — ${weekStr} of work.\n\n${comparisonText}`;
         } else {
-          return `Progress photo 1 saved, ${clientName}. Send your next progress photo in 30 days and I will compare them side by side and tell you exactly what changed.`;
+          return `Saved, ${clientName}. That is your baseline — the before. The photo you will look back at in 8 weeks and not believe.\n\nSend your next one in 30 days. I will compare them side by side and tell you exactly what changed — muscle, posture, body shape. Everything. Keep showing up.`;
         }
       }
 

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -253,7 +253,7 @@ export async function handleMediaMessage(ctx: {
           await logChat(user.id, `[Progress Photo ${photoNumber}]`, comparisonText, "PROGRESS_COMPARISON");
           const weeksLabel = Math.round(daysBetween / 7);
           const weekStr = weeksLabel === 1 ? "1 week" : `${weeksLabel} weeks`;
-          return `Photo ${photoNumber} — ${weekStr} of work.\n\n${comparisonText}`;
+          return `Photo ${photoNumber} — ${weekStr} of work.\n\n${comparisonText}\n\n_Next check-in: send another photo in 30 days. I'll compare all ${photoNumber + 1} side by side._`;
         } else {
           return `Saved, ${clientName}. That is your baseline — the before. The photo you will look back at in 8 weeks and not believe.\n\nSend your next one in 30 days. I will compare them side by side and tell you exactly what changed — muscle, posture, body shape. Everything. Keep showing up.`;
         }

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -597,7 +597,10 @@ export async function handleMiscCommands(ctx: {
   }
 
   // ---- REFERRAL ----
-  if (["refer", "referral", "my referral", "my code", "referral code", "refer a friend", "invite"].includes(m)) {
+  const isReferralRequest =
+    ["refer", "referral", "my referral", "my code", "referral code", "refer a friend", "invite"].includes(m) ||
+    /\b(my friend wants to (join|try|sign up|start)|how do i (refer|invite|get my friend|bring.*friend)|can i (refer|invite|get.*friend|bring.*friend)|referral (code|link)|share.*coach|get.*friend.*on (this|here|it)|want.*friend.*join|friend.*interested)\b/i.test(m);
+  if (isReferralRequest) {
     let code = user.referralCode;
     if (!code) {
       const namePrefix = (user.name || "KAM").replace(/[^a-zA-Z]/g, "").slice(0, 3).toUpperCase().padEnd(3, "K");
@@ -605,7 +608,12 @@ export async function handleMiscCommands(ctx: {
       code = `${namePrefix}${randomSuffix}`;
       await db.update(users).set({ referralCode: code }).where(eq(users.phoneNumber, phone));
     }
-    const referralReply = `*Your KamLife Coach Referral Code* 🎯\n\nYour code: *${code}*\n\nShare this with a friend:\n\n_"I'm working with a WhatsApp fitness coach — real SA food, full workout programmes, daily accountability. From R149/month, no app needed. Use code ${code} when you sign up and we BOTH get one month free."_\n\nWhen your friend pays their first month, Coach K sends you a free month automatically. No limit on referrals — every friend earns you a free month.`;
+    const waNum = (process.env.TWILIO_WHATSAPP_NUMBER || "").replace(/^whatsapp:/, "").replace(/\D/g, "");
+    const waLink = waNum ? `https://wa.me/${waNum}?text=Hi%2C+I+was+referred+by+${code}` : null;
+    const shareMsg = waLink
+      ? `_"I've been using a WhatsApp fitness coach — real SA food, full workouts, daily check-ins. R149/month, no app. Try it free for 7 days: ${waLink}"_`
+      : `_"I've been using KamLife Coach — WhatsApp fitness coaching, real SA food, R149/month. Tell them code ${code} — your first month is 50% off and I get a free month."_`;
+    const referralReply = `*Your referral code: ${code}* 🎯\n\nSend your friend this:\n\n${shareMsg}\n\nWhen they subscribe, you get a free month. They get 50% off their first month. No cap — every friend earns you one.`;
     await logChat(user.id, message, referralReply, "REFERRAL");
     return referralReply;
   }

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -52,14 +52,20 @@ export async function handleWater(ctx: {
 
     const remaining = Math.max(0, Math.round((waterTarget - newTotal) * 10) / 10);
     const targetHit = newTotal >= waterTarget;
-    let waterReply = `Logged ${litres}L water. Total today: ${newTotal}L / ${waterTarget}L target.`;
+    const fn = (user.name || "").split(" ")[0] || "there";
+    let waterReply: string;
     if (targetHit) {
-      waterReply += ` Daily target hit.`;
-      if (crossedTarget && newWaterStreak >= 3) {
-        waterReply += ` ${newWaterStreak}-day water streak — consistency is showing.`;
+      if (crossedTarget && newWaterStreak >= 7) {
+        waterReply = `${newTotal}L — water target hit. ✅ ${fn}, ${newWaterStreak} days straight. Your kidneys, skin, and metabolism are all working better than they were a week ago. Keep it exactly like this.`;
+      } else if (crossedTarget && newWaterStreak >= 3) {
+        waterReply = `${newTotal}L — water target hit. ✅ ${newWaterStreak} days in a row, ${fn}. Hydration is a habit now. Do it again tomorrow.`;
+      } else if (crossedTarget) {
+        waterReply = `${newTotal}L — daily water target hit. ✅ That is what it looks like, ${fn}. Now do it again tomorrow.`;
+      } else {
+        waterReply = `${newTotal}L logged. Target hit for the day. ✅`;
       }
     } else {
-      waterReply += ` ${remaining}L still to go.`;
+      waterReply = `Logged ${litres}L water. Total today: ${newTotal}L / ${waterTarget}L target. ${remaining}L still to go.`;
     }
     await logChat(user.id, message, waterReply, "WATER_LOG");
     return waterReply;

--- a/server/handlers/weight.ts
+++ b/server/handlers/weight.ts
@@ -38,16 +38,26 @@ export async function handleWeightLog(
     await db.insert(weightLogs).values({ userId: user.id, weight: newKg.toString() });
   }
 
-  // Store win memory at total loss milestones
+  // Store win memory and build milestone celebration at total loss milestones
+  let milestoneCelebration = "";
   try {
     const firstLog = await db.select({ weight: weightLogs.weight }).from(weightLogs)
       .where(eq(weightLogs.userId, user.id)).orderBy(asc(weightLogs.loggedAt)).limit(1);
     if (firstLog.length > 0) {
       const startKg = parseFloat(String(firstLog[0].weight));
       const totalLoss = startKg - newKg;
+      const firstName = (user.name || "").split(" ")[0] || "there";
+      const MILESTONE_MESSAGES: Record<number, string> = {
+        2:  `\n\n🏆 *${firstName}, that's 2kg gone.* Two bags of sugar off your body — permanently. This is working.`,
+        5:  `\n\n🏆 *${firstName}, 5kg gone.* Five kilograms. That's a bag of potatoes you were carrying everywhere. It's not coming back. Screenshot this.`,
+        10: `\n\n🏆 *${firstName}, 10 kilograms.* Most people who start a programme never see 10kg. You did. Share this with someone — you've earned it.`,
+        15: `\n\n🏆 *${firstName}, 15kg lost.* That is a genuinely rare thing. Tell me — what's changed beyond the scale? Energy? Sleep? How clothes fit? I want to know.`,
+        20: `\n\n🏆 *${firstName}, 20 kilograms.* I have coached a lot of people. 20kg is real transformation. This is the version of you that does not go back.`,
+      };
       for (const milestone of [2, 5, 10, 15, 20]) {
         if (totalLoss >= milestone && totalLoss < milestone + 0.6) {
           await storeMemory(phone, `Weight loss milestone: lost ${milestone}kg total — started at ${startKg}kg, now at ${newKg}kg`, "milestone");
+          milestoneCelebration = MILESTONE_MESSAGES[milestone] || "";
           break;
         }
       }
@@ -125,5 +135,5 @@ export async function handleWeightLog(
     }
   }
 
-  return `Weight logged: *${newKg}kg.*${changeNote}${journeyNote}${targetsNote}${plateauNote}`;
+  return `Weight logged: *${newKg}kg.*${changeNote}${milestoneCelebration || journeyNote}${targetsNote}${plateauNote}`;
 }

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -86,7 +86,7 @@ export async function handleWorkoutCommands(ctx: {
   }
 
   // ---- DONE — workout complete (direct) ----
-  if (/^(done!*|i.?m done!*|im done!*|all done!*|workout done!*|finished!*|completed!*|session done!*|training done!*|workout completed!*|done with workout!*|done with my workout!*|done training!*)$/i.test(m.replace(/[.!?,]+$/, "").trim())) {
+  if (/^(done!*|i.?m done!*|im done!*|all done!*|workout done!*|finished!*|completed!*|session done!*|training done!*|workout completed!*|done with workout!*|done with my workout!*|done training!*)$/i.test(m.replace(/[\s.,!?✓✅🏋️‍♂️🏋️]+$/u, "").trim())) {
     const todayStart = sastDayStart();
     const alreadyLoggedToday = await db.select({ id: workoutLogs.id })
       .from(workoutLogs)

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -414,9 +414,13 @@ export async function handleWorkoutCommands(ctx: {
 
     const updatedUser = { ...user, trainingDaysPerWeek: days, trainingExperience: exp, goalType: goal };
     const day1 = buildFullProgramme(updatedUser);
-    const goalLabel = goal === "fat_loss" ? "Fat loss" : goal === "muscle_gain" ? "Muscle gain" : "Body recomposition";
 
-    return `Sharp. ${days} days/week. ${exp.charAt(0).toUpperCase() + exp.slice(1)}. ${goalLabel}. Here is Day 1 — send *done* when finished to unlock Day 2.\n\n${day1}`;
+    const goalIntro = goal === "fat_loss"
+      ? `${days} days/week builds the muscle that burns fat when you're not training.`
+      : goal === "muscle_gain"
+        ? `${days} days/week with progressive overload — add reps or weight every single session.`
+        : `${days} days/week. Build muscle, lose fat at the same time. Protein and consistency are everything.`;
+    return `Sharp, ${name}. ${goalIntro}\n\nDay 1 is built. Send *done* when you finish — I'll log it and queue Day 2.\n\n${day1}`;
   }
 
   // ---- EXPLICIT WORKOUT COMMANDS — hardcoded, never touch GPT ----

--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -473,10 +473,25 @@ async function completeOnboarding(phone: string, u: any, budget: string, budgetL
   const heightDisplay = heightCm !== 170 ? ` · ${heightCm}cm` : "";
   const bmiDisplay = u.bmi ? ` · BMI ${u.bmi}` : "";
 
-  const refCodeLine = referralCode ? `\n\n🎁 *Referral code: ${referralCode}* — share it. Friends get 50% off month 1. You get R50 credit when they subscribe.` : "";
-  const msg1 = `Your programme is built. *7 days free — full access starts now.*\n\n*Goal:* ${goalLabel[defaultGoal] || defaultGoal}${weightDisplay}${heightDisplay}${bmiDisplay}\n*Training:* ${modeLabel} · ${trainingDays} days/week\n*Steps:* ${stepsLabel}/day — mandatory\n*Calories:* ${calorieTarget} kcal/day\n*Protein:* ${proteinTarget}g/day${ageNote}${refCodeLine}\n\n_Coach K is AI — not a substitute for medical advice._`;
-  const msg2 = `*Day 1 — Your first session:*\n\n${firstWorkout}\n\nSend *done* when finished.`;
-  const msg3 = `${shoppingPreview}\n\nTell me what you ate today and let's start. After the trial: *R149/month* — R5/day.`;
+  const refCodeLine = referralCode ? `\n\n🎁 *Your referral code: ${referralCode}* — share it. Your friend gets 50% off month 1. You get R50 credit when they subscribe.` : "";
+
+  // Goal-specific hook line — personal, not generic
+  const goalHook: Record<string, string> = {
+    fat_loss: `The weight does not come off in the gym — it comes off in the kitchen and on your feet. I have set your targets so you lose fat without starving.`,
+    muscle_gain: `Muscle is built with consistency, not intensity. Progressive overload every session and enough protein — that is the whole secret. I have set your numbers.`,
+    recomposition: `Recomp takes longer but the results last. We build muscle and lose fat at the same time. Protein stays high, training stays consistent, steps stay non-negotiable.`,
+  };
+
+  const trainingHook = mode === "walk_only"
+    ? `No gym needed. Walking and bodyweight — done right, it changes your body.`
+    : mode === "home"
+      ? `Home training is underrated. The best results I have seen came from people with no gym and no excuses.`
+      : `${gymName || "The gym"} is your tool. How you use it decides everything.`;
+
+  const name = u.name || "there";
+  const msg1 = `${name}, your programme is live. *7 days free — let's go.*\n\n${goalHook[defaultGoal] || goalHook.fat_loss}\n\n*Your targets:*\n• ${calorieTarget} kcal/day · ${proteinTarget}g protein\n• ${stepsLabel} steps/day — non-negotiable\n• ${trainingDays} training sessions/week\n\n${trainingHook}${ageNote}${refCodeLine}`;
+  const msg2 = `*Day 1 starts now.*\n\n${firstWorkout}\n\nSend *done* when you finish. I will log it.`;
+  const msg3 = `${shoppingPreview}\n\nTell me what you had to eat today — even if it was not perfect. That is how we start.\n\n_After the trial: R149/month — R5/day. Cancel anytime._`;
   return `${msg1}\n\n---\n\n${msg2}\n\n---\n\n${msg3}`;
 }
 
@@ -490,10 +505,10 @@ export async function handleOnboarding(user: any, message: string, phone: string
   const state = user.onboardingState || "START";
   const msg = message.trim();
 
-  // ---- START — POPIA consent combined with introduction ----
+  // ---- START — lead with value, keep legal minimal ----
   if (state === "START") {
     await db.update(users).set({ onboardingState: "ASK_POPIA" }).where(eq(users.phoneNumber, phone));
-    return `Coach K here — your AI-powered SA fitness and nutrition coach. Real programmes, real food advice, real accountability.\n\n⚠️ *Important:* Coach K is an AI tool — not a human coach, not a doctor, not a dietitian. Always consult your doctor before starting a new exercise or nutrition programme, especially if you have diabetes, hypertension, HIV/ARVs, a heart condition, or any other health condition.\n\n🔒 *Your data:* Stored securely under POPIA. Used only for your coaching. Never sold. Deleted on request — reply *delete my data* at any time.\n\n💳 *Subscription:* 7-day free trial, then R149/month. Cancel anytime by replying *cancel*.\n\nReply *yes* to start.`;
+    return `Coach K here. Real SA fitness coaching — personalised programme, food guidance, daily accountability. All on WhatsApp. No app to download.\n\n7-day free trial. Then R149/month — cancel anytime.\n\n_I'm AI, not a human coach or doctor. If you have any health conditions, check with your doctor before starting. Your info is stored under POPIA — only used for your coaching, never sold. Reply *delete my data* anytime._\n\nReply *yes* to build your programme.`;
   }
 
   // ---- ASK_POPIA ----
@@ -503,7 +518,7 @@ export async function handleOnboarding(user: any, message: string, phone: string
       await db.update(users).set({ popiConsent: true, popiConsentAt: new Date(), onboardingState: "WELCOME" }).where(eq(users.phoneNumber, phone));
       return `Sharp. What's your name?`;
     }
-    return `I need your consent before I can coach you. Your data is used only for your coaching — never sold. Reply *yes* to continue.`;
+    return `I need your agreement before I can coach you. Your data is used only for your coaching — never sold. Reply *yes* to continue.`;
   }
 
   // ---- WELCOME — name ----

--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -397,6 +397,90 @@ export function getOnboardingMealPlan(user: any): string {
 }
 
 // ============================================================
+// ONBOARDING COMPLETION HELPER
+// Called from ASK_BUDGET (legacy path) and ASK_EXPERIENCE (fast-track path)
+// ============================================================
+
+async function completeOnboarding(phone: string, u: any, budget: string, budgetLevel: string, exp: string): Promise<string> {
+  const defaultGoal = u.goalType || "fat_loss";
+  const actualWeight = parseFloat(u.currentWeight || "75");
+  const age = u.age || 30;
+  const gender = u.gender || "male";
+  const heightCm = u.heightCm || 170;
+  const isYouth = age < 18;
+  const isElderly = age >= 60;
+
+  const trainingDays = u.trainingDaysPerWeek || ((isYouth || isElderly) ? 3 : 4);
+
+  const { calorieTarget, proteinTarget } = calculateTargets(
+    actualWeight, defaultGoal, u.lifeSituation || "office", trainingDays, gender, age, heightCm
+  );
+
+  const stepsTarget = age >= 70 ? 6000 : isElderly ? 8000 : 10000;
+
+  let referralCode: string | undefined;
+  {
+    const namePrefix = (u.name || "KAM").replace(/[^a-zA-Z]/g, "").slice(0, 3).toUpperCase().padEnd(3, "K");
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = `${namePrefix}${Math.floor(1000 + Math.random() * 9000)}`;
+      const existing = await db.select({ id: users.id }).from(users).where(eq(users.referralCode, candidate)).limit(1);
+      if (existing.length === 0) { referralCode = candidate; break; }
+    }
+  }
+
+  await db.update(users).set({
+    trainingDaysPerWeek: trainingDays,
+    trainingExperience: exp,
+    weeklyFoodBudget: budget,
+    budgetLevel,
+    lifeSituation: u.lifeSituation || "office",
+    workSchedule: u.workSchedule || "standard",
+    calorieTarget,
+    proteinTarget,
+    stepsTarget,
+    programmePhase: 1,
+    programmeWeek: 1,
+    programmeDayInWeek: 1,
+    programmeStartDate: new Date(),
+    subscriptionStatus: "trial",
+    betaBypassUntil: new Date(Date.now() + 7 * 86_400_000),
+    onboardingState: "COMPLETE",
+    ...(referralCode && !u.referralCode ? { referralCode } : {}),
+  }).where(eq(users.phoneNumber, phone));
+
+  const goalLabel: Record<string, string> = {
+    fat_loss: "Fat loss", muscle_gain: "Muscle gain", recomposition: "Recomposition",
+  };
+  const mode = u.trainingMode || "home";
+  const gymName = u.gymName;
+  const modeLabel = mode === "walk_only" ? "Walking + bodyweight" : mode === "gym_dumbbell" ? "Dumbbell gym" : mode === "gym" ? (gymName || "Gym") : "Home training";
+
+  const ageNote = isYouth
+    ? `\n\n_Note for under-18s: Your programme is designed to be safe and fun. No heavy maximal lifts — we focus on movement, form, and building healthy habits for life._`
+    : isElderly
+      ? `\n\n_Your programme is joint-friendly with lower-impact alternatives. We focus on mobility, strength maintenance, and keeping you active and independent. Always listen to your body._`
+      : "";
+
+  const stepsLabel = stepsTarget === 6000 ? "6,000" : stepsTarget === 8000 ? "8,000" : "8,000-12,000";
+
+  const updatedUser = { ...u, trainingMode: mode, programmePhase: 1, programmeWeek: 1, programmeDayInWeek: 1, stepsTarget, age: u.age || 30, primaryFocusArea: u.primaryFocusArea };
+  const firstWorkout = getKamlifeProgramme(updatedUser, true);
+
+  const weekOneList = getShoppingList(budget, 1, defaultGoal);
+  const shoppingPreview = formatShoppingList(weekOneList, u.name || undefined, defaultGoal);
+
+  const weightDisplay = actualWeight !== 75 ? `\n*Weight:* ${actualWeight}kg` : "";
+  const heightDisplay = heightCm !== 170 ? ` · ${heightCm}cm` : "";
+  const bmiDisplay = u.bmi ? ` · BMI ${u.bmi}` : "";
+
+  const refCodeLine = referralCode ? `\n\n🎁 *Referral code: ${referralCode}* — share it. Friends get 50% off month 1. You get R50 credit when they subscribe.` : "";
+  const msg1 = `Your programme is built. *7 days free — full access starts now.*\n\n*Goal:* ${goalLabel[defaultGoal] || defaultGoal}${weightDisplay}${heightDisplay}${bmiDisplay}\n*Training:* ${modeLabel} · ${trainingDays} days/week\n*Steps:* ${stepsLabel}/day — mandatory\n*Calories:* ${calorieTarget} kcal/day\n*Protein:* ${proteinTarget}g/day${ageNote}${refCodeLine}\n\n_Coach K is AI — not a substitute for medical advice._`;
+  const msg2 = `*Day 1 — Your first session:*\n\n${firstWorkout}\n\nSend *done* when finished.`;
+  const msg3 = `${shoppingPreview}\n\nTell me what you ate today and let's start. After the trial: *R149/month* — R5/day.`;
+  return `${msg1}\n\n---\n\n${msg2}\n\n---\n\n${msg3}`;
+}
+
+// ============================================================
 // ONBOARDING FLOW — 3-QUESTION FAST TRACK
 // POPIA → Name → Goal → Gym or Home → Immediate programme
 // Everything else collected progressively through coaching
@@ -623,7 +707,9 @@ export async function handleOnboarding(user: any, message: string, phone: string
     return `What's your monthly grocery budget?\n\n1️⃣ Under R1,500\n2️⃣ R1,500 – R3,000\n3️⃣ R3,000 – R5,000\n4️⃣ R5,000+`;
   }
 
-  // ---- ASK_BUDGET — grocery budget tier, then COMPLETE ----
+  // ---- ASK_BUDGET — grocery budget tier ----
+  // Fast-track path: routes to ASK_EXPERIENCE (experience not yet captured)
+  // Legacy path: experience was captured before budget → complete directly
   if (state === "ASK_BUDGET") {
     const lower = msg.toLowerCase();
     let budget = "100_300";
@@ -638,100 +724,19 @@ export async function handleOnboarding(user: any, message: string, phone: string
       budget = "over_600"; budgetLevel = "premium";
     }
 
-    const defaultGoal = user.goalType || "fat_loss";
-    const actualWeight = parseFloat(user.currentWeight || "75");
-    const age = user.age || 30;
-    const gender = user.gender || "male";
-    const heightCm = user.heightCm || 170;
-    const isYouth = age < 18;
-    const isElderly = age >= 60;
-
-    // Age-appropriate training days: youth and elderly start at 3, standard at 4
-    const trainingDays = (isYouth || isElderly) ? 3 : 4;
-
-    const { calorieTarget, proteinTarget } = calculateTargets(
-      actualWeight, defaultGoal, "office", trainingDays, gender, age, heightCm
-    );
-
-    // Age-appropriate step targets:
-    // Youth (14-17): 10,000 (they move naturally, but set a target)
-    // Standard (18-59): 10,000
-    // Active seniors (60-69): 8,000
-    // Elderly (70+): 6,000
-    const stepsTarget = age >= 70 ? 6000 : isElderly ? 8000 : 10000;
-
-    // Auto-set female focus area based on gender
-    const isFemale = user.gender === "female";
-
-    // Generate referral code at onboarding — every user gets one from day 1
-    let referralCode: string | undefined;
-    {
-      const namePrefix = (user.name || "KAM").replace(/[^a-zA-Z]/g, "").slice(0, 3).toUpperCase().padEnd(3, "K");
-      for (let attempt = 0; attempt < 5; attempt++) {
-        const candidate = `${namePrefix}${Math.floor(1000 + Math.random() * 9000)}`;
-        const existing = await db.select({ id: users.id }).from(users).where(eq(users.referralCode, candidate)).limit(1);
-        if (existing.length === 0) { referralCode = candidate; break; }
-      }
+    if (user.trainingExperience) {
+      // Legacy path: experience already captured, complete now
+      return completeOnboarding(phone, user, budget, budgetLevel, user.trainingExperience);
     }
 
+    // Fast-track path: ask experience before completing
     await db.update(users).set({
-      trainingDaysPerWeek: trainingDays,
-      trainingExperience: isYouth ? "beginner" : isElderly ? "beginner" : "beginner",
       weeklyFoodBudget: budget,
       budgetLevel,
-      lifeSituation: "office",
-      workSchedule: "standard",
-      calorieTarget,
-      proteinTarget,
-      stepsTarget,
-      programmePhase: 1,
-      programmeWeek: 1,
-      programmeDayInWeek: 1,
-      programmeStartDate: new Date(),
-      subscriptionStatus: "trial",
-      betaBypassUntil: new Date(Date.now() + 7 * 86_400_000), // 7-day free trial
-      onboardingState: "COMPLETE",
-      ...(referralCode && !user.referralCode ? { referralCode } : {}),
+      onboardingState: "ASK_EXPERIENCE",
     }).where(eq(users.phoneNumber, phone));
 
-    const goalLabel: Record<string, string> = {
-      fat_loss: "Fat loss", muscle_gain: "Muscle gain", recomposition: "Recomposition",
-    };
-    const mode = user.trainingMode || "home";
-    const gymName = user.gymName;
-    const modeLabel = mode === "walk_only" ? "Walking + bodyweight" : mode === "gym_dumbbell" ? "Dumbbell gym" : mode === "gym" ? (gymName || "Gym") : "Home training";
-    const appUrl = process.env.APP_URL || "https://kamlifecoach.co.za";
-
-    const budgetLabels: Record<string, string> = { under_100: "Under R1,500", "100_300": "R1,500–R3,000", "300_600": "R3,000–R5,000", over_600: "R5,000+" };
-
-    // Age-appropriate completion message
-    const ageNote = isYouth
-      ? `\n\n_Note for under-18s: Your programme is designed to be safe and fun. No heavy maximal lifts — we focus on movement, form, and building healthy habits for life._`
-      : isElderly
-        ? `\n\n_Your programme is joint-friendly with lower-impact alternatives. We focus on mobility, strength maintenance, and keeping you active and independent. Always listen to your body._`
-        : "";
-
-    const stepsLabel = stepsTarget === 6000 ? "6,000" : stepsTarget === 8000 ? "8,000" : "8,000-12,000";
-
-    // Immediately build today's workout so they get value NOW
-    const updatedUser = { ...user, trainingMode: mode, programmePhase: 1, programmeWeek: 1, programmeDayInWeek: 1, stepsTarget, age: user.age || 30, primaryFocusArea: user.primaryFocusArea };
-    const firstWorkout = getKamlifeProgramme(updatedUser, true);
-    // Show the full Day 1 workout — truncating to 2 exercises makes us look amateur
-    const workoutPreview = firstWorkout;
-
-    // Get first shopping list
-    const weekOneList = getShoppingList(budget, 1, defaultGoal);
-    const shoppingPreview = formatShoppingList(weekOneList, user.name || undefined, defaultGoal);
-
-    const weightDisplay = actualWeight !== 75 ? `\n*Weight:* ${actualWeight}kg` : "";
-    const heightDisplay = heightCm !== 170 ? ` · ${heightCm}cm` : "";
-    const bmiDisplay = user.bmi ? ` · BMI ${user.bmi}` : "";
-
-    const refCodeLine = referralCode ? `\n\n🎁 *Referral code: ${referralCode}* — share it. Friends get 50% off month 1. You get R50 credit when they subscribe.` : "";
-    const msg1 = `Your programme is built. *7 days free — full access starts now.*\n\n*Goal:* ${goalLabel[defaultGoal] || defaultGoal}${weightDisplay}${heightDisplay}${bmiDisplay}\n*Training:* ${modeLabel} · ${trainingDays} days/week\n*Steps:* ${stepsLabel}/day — mandatory\n*Calories:* ${calorieTarget} kcal/day\n*Protein:* ${proteinTarget}g/day${ageNote}${refCodeLine}\n\n_Coach K is AI — not a substitute for medical advice._`;
-    const msg2 = `*Day 1 — Your first session:*\n\n${workoutPreview}\n\nSend *done* when finished.`;
-    const msg3 = `${shoppingPreview}\n\nTell me what you ate today and let's start. After the trial: *R149/month* — R5/day.`;
-    return `${msg1}\n\n---\n\n${msg2}\n\n---\n\n${msg3}`;
+    return `Last one — training experience?\n\n1️⃣ Beginner — just starting out\n2️⃣ Some experience — been active before\n3️⃣ Intermediate — 1-2 years consistent\n4️⃣ Advanced — 2+ years serious lifting`;
   }
 
   // ---- LEGACY STATES — kept for existing users mid-onboarding ----
@@ -910,10 +915,16 @@ export async function handleOnboarding(user: any, message: string, phone: string
     let exp = "beginner";
     if (msg.includes("3") || lower.includes("intermediate")) exp = "intermediate";
     else if (msg.includes("4") || lower.includes("advanced")) exp = "advanced";
-    // Legacy ASK_EXPERIENCE path — transition into main flow's ASK_BUDGET (line ~606),
-    // not the former duplicate ASK_BUDGET handler (deleted — it was unreachable and
-    // routed into ASK_WORK_SCHEDULE which has no main-flow predecessor).
-    await db.update(users).set({ trainingExperience: exp, onboardingState: "ASK_BUDGET" }).where(eq(users.phoneNumber, phone));
+
+    await db.update(users).set({ trainingExperience: exp }).where(eq(users.phoneNumber, phone));
+
+    if (user.weeklyFoodBudget) {
+      // Fast-track path: budget was captured in ASK_BUDGET, complete now
+      return completeOnboarding(phone, user, user.weeklyFoodBudget, user.budgetLevel || "medium", exp);
+    }
+
+    // Legacy path: budget not yet captured
+    await db.update(users).set({ onboardingState: "ASK_BUDGET" }).where(eq(users.phoneNumber, phone));
     return `What's your monthly grocery budget?\n\n1️⃣ Under R1,500\n2️⃣ R1,500 – R3,000\n3️⃣ R3,000 – R5,000\n4️⃣ R5,000+`;
   }
   // Duplicate ASK_BUDGET handler removed — it was dead code shadowed by main handler at line ~606.

--- a/server/scheduler/jobs/business.ts
+++ b/server/scheduler/jobs/business.ts
@@ -2,7 +2,7 @@ import {
   db, users, chatHistory, stepLogs, workoutLogs, weightLogs, mealLogs, sentProactive, escalations,
   abExperiments, abAssignments,
   eq, gte, and, lt, desc, asc, sql, count,
-  sendWhatsApp, canSendProactive, recordProactiveSend,
+  sendWhatsApp, sendCriticalAlert, canSendProactive, recordProactiveSend,
   getActiveClients, isPaused, loadState, saveState,
   deliveryStats, todaySAST, FROM_NUMBER, PRICING,
 } from "../shared";
@@ -43,11 +43,11 @@ export async function runSubscriptionExpiryCheck(): Promise<void> {
       const name = client.name || "there";
       if (msUntilRenewal > 0 && msUntilRenewal <= threeDaysMs) {
         const daysLeft = Math.ceil(msUntilRenewal / 86_400_000);
-        await sendWhatsApp(client.phoneNumber, `${name}, your KamLife Coach subscription renews in ${daysLeft} day${daysLeft !== 1 ? "s" : ""}. If your payment details have changed, update them at kamlifecoach.co.za before then. Nothing changes if everything is fine — coaching continues automatically.`);
+        await sendCriticalAlert(client.phoneNumber, `${name}, your KamLife Coach subscription renews in ${daysLeft} day${daysLeft !== 1 ? "s" : ""}. If your payment details have changed, update them at kamlifecoach.co.za before then. Nothing changes if everything is fine — coaching continues automatically.`);
       }
       if (msUntilRenewal < 0 && client.subscriptionStatus === "active") {
         await db.update(users).set({ subscriptionStatus: "inactive" }).where(eq(users.phoneNumber, client.phoneNumber));
-        await sendWhatsApp(client.phoneNumber, `${name}, your subscription has expired. Your profile and progress history are saved. To continue with Coach K, renew at kamlifecoach.co.za or reply *pay* for a payment link.`);
+        await sendCriticalAlert(client.phoneNumber, `${name}, your subscription has expired. Your profile and progress history are saved. To continue with Coach K, renew at kamlifecoach.co.za or reply *pay* for a payment link.`);
         console.log(`[SCHEDULER] Subscription expired — ${client.phoneNumber}`);
       }
     } catch (err) { console.error(`[SCHEDULER] Subscription expiry error — ${client.phoneNumber}:`, err); }
@@ -70,11 +70,11 @@ export async function runPaymentFailureRecovery(): Promise<void> {
       const cleanPhone = client.phoneNumber.replace(/^whatsapp:/, "").replace(/\D/g, "");
       const payLink = merchantId ? `${appUrl}/api/payfast/link?phone=${encodeURIComponent(cleanPhone)}` : appUrl;
       if (daysSinceFail === 1) {
-        await sendWhatsApp(client.phoneNumber, `${name}, your payment didn't go through yesterday. Could be a bank issue — happens all the time.\n\nYour programme and ${workouts} sessions of progress are saved. Update your payment here and coaching continues immediately:\n${payLink}`);
+        await sendCriticalAlert(client.phoneNumber, `${name}, your payment didn't go through yesterday. Could be a bank issue — happens all the time.\n\nYour programme and ${workouts} sessions of progress are saved. Update your payment here and coaching continues immediately:\n${payLink}`);
       } else if (daysSinceFail === 3) {
-        await sendWhatsApp(client.phoneNumber, `${name} — 3 days without coaching. You are in Week ${client.programmeWeek || 1} with ${workouts} sessions done.\n\nClients who take more than a week off lose momentum and rarely come back at the same level. Your streak, your targets, your programme — all still here.\n\nFix your payment in 30 seconds:\n${payLink}`);
+        await sendCriticalAlert(client.phoneNumber, `${name} — 3 days without coaching. You are in Week ${client.programmeWeek || 1} with ${workouts} sessions done.\n\nClients who take more than a week off lose momentum and rarely come back at the same level. Your streak, your targets, your programme — all still here.\n\nFix your payment in 30 seconds:\n${payLink}`);
       } else if (daysSinceFail === 7) {
-        await sendWhatsApp(client.phoneNumber, `${name}, last message about this — your subscription has been paused for a week.\n\n${workouts} sessions. Every meal logged. Every step counted. That work is not lost.\n\nIf money is tight right now, I get it — reply *pay* when you are ready and I will send a fresh link. No pressure, no expiry on your data.\n\nIf you want to stop completely, reply *STOP* and I won't message again.`);
+        await sendCriticalAlert(client.phoneNumber, `${name}, last message about this — your subscription has been paused for a week.\n\n${workouts} sessions. Every meal logged. Every step counted. That work is not lost.\n\nIf money is tight right now, I get it — reply *pay* when you are ready and I will send a fresh link. No pressure, no expiry on your data.\n\nIf you want to stop completely, reply *STOP* and I won't message again.`);
       }
     } catch (err) { console.error(`[SCHEDULER] Payment recovery error — ${client.phoneNumber}:`, err); }
   }
@@ -97,19 +97,19 @@ export async function runSignupNudge(): Promise<void> {
         const daysSince = Math.floor((Date.now() - created.getTime()) / 86_400_000);
         const workouts = client.totalWorkoutsCompleted || 0;
         if (daysSince === 5 && client.subscriptionStatus === "trial") {
-          await sendWhatsApp(client.phoneNumber, `${name}, 2 days left on your free trial.${workouts > 0 ? ` You've done ${workouts} session${workouts > 1 ? "s" : ""} — that's real progress.` : ""}\n\nKeep everything — workouts, food coaching, daily accountability.\n\n*R149/month — cancel anytime:*\n${payLink}\n\nR5/day. Less than a KFC streetwise.`);
+          await sendCriticalAlert(client.phoneNumber, `${name}, 2 days left on your free trial.${workouts > 0 ? ` You've done ${workouts} session${workouts > 1 ? "s" : ""} — that's real progress.` : ""}\n\nKeep everything — workouts, food coaching, daily accountability.\n\n*R149/month — cancel anytime:*\n${payLink}\n\nR5/day. Less than a KFC streetwise.`);
         } else if (daysSince === 7 && client.subscriptionStatus === "trial") {
-          await sendWhatsApp(client.phoneNumber, `${name} — last day of your trial. Tomorrow coaching stops unless you subscribe.\n\nYour programme, targets, and progress are saved. Pay now and nothing changes — Day ${(client.programmeDayInWeek || 1) + 1} drops tomorrow morning.\n\n*R149/month:*\n${payLink}`);
+          await sendCriticalAlert(client.phoneNumber, `${name} — last day of your trial. Tomorrow coaching stops unless you subscribe.\n\nYour programme, targets, and progress are saved. Pay now and nothing changes — Day ${(client.programmeDayInWeek || 1) + 1} drops tomorrow morning.\n\n*R149/month:*\n${payLink}`);
         }
       } else if (!isNewSignup && cancelled) {
         const daysSinceCancelled = Math.floor((Date.now() - cancelled.getTime()) / 86_400_000);
         const workouts = client.totalWorkoutsCompleted || 0;
         if (daysSinceCancelled === 3) {
-          await sendWhatsApp(client.phoneNumber, `${name} — you've done ${workouts} sessions with Coach K. That doesn't disappear.\n\nYour programme, weight history, and streaks are all saved. Pick up exactly where you left off.\n\n*Reactivate for R149/month:*\n${payLink}`);
+          await sendCriticalAlert(client.phoneNumber, `${name} — you've done ${workouts} sessions with Coach K. That doesn't disappear.\n\nYour programme, weight history, and streaks are all saved. Pick up exactly where you left off.\n\n*Reactivate for R149/month:*\n${payLink}`);
         } else if (daysSinceCancelled === 7) {
-          await sendWhatsApp(client.phoneNumber, `${name}, a week since you left.\n\nThe people who come back after a week are the ones who actually get results — they know what consistency feels like now.\n\nR149/month. Your data is here:\n${payLink}`);
+          await sendCriticalAlert(client.phoneNumber, `${name}, a week since you left.\n\nThe people who come back after a week are the ones who actually get results — they know what consistency feels like now.\n\nR149/month. Your data is here:\n${payLink}`);
         } else if (daysSinceCancelled === 30) {
-          await sendWhatsApp(client.phoneNumber, `${name} — 30 days. Coach K here.\n\nOne message to say your profile is still here if you want it. ${workouts} sessions logged. Progress saved.\n\nR149/month if you're ready:\n${payLink}\n\nIf not — no hard feelings. Reply STOP and I won't message again.`);
+          await sendCriticalAlert(client.phoneNumber, `${name} — 30 days. Coach K here.\n\nOne message to say your profile is still here if you want it. ${workouts} sessions logged. Progress saved.\n\nR149/month if you're ready:\n${payLink}\n\nIf not — no hard feelings. Reply STOP and I won't message again.`);
         }
       }
     } catch (err) { console.error(`[SCHEDULER] Signup/win-back error — ${client.phoneNumber}:`, err); }

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -37,6 +37,7 @@ export async function runMorningCheckin(): Promise<void> {
       ? Math.floor((Date.now() - new Date(client.lastActiveAt).getTime()) / 86_400_000)
       : 0;
     if (daysSilent > 7) continue;
+    if (client.workSchedule === "night_shift") continue;
 
     if (daysSilent >= 3) {
       if (canSendProactive(client.id)) {

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -125,6 +125,29 @@ export async function runMorningCheckin(): Promise<void> {
       else if (progDays === 90) identityLine = " 90 days. You are not the same person who started this.";
 
       const wStreak = client.workoutStreak || 0;
+      let foodLogStreakCount = 0;
+      {
+        const sixtyDaysAgo = new Date(Date.now() - 60 * 86_400_000);
+        const recentFoodLogDays = await db.select({ createdAt: chatHistory.createdAt })
+          .from(chatHistory)
+          .where(and(eq(chatHistory.userId, client.id), eq(chatHistory.intent, "FOOD_LOG"), gte(chatHistory.createdAt, sixtyDaysAgo)))
+          .orderBy(desc(chatHistory.createdAt))
+          .catch(() => [] as { createdAt: Date | null }[]);
+        const foodDays = new Set<string>();
+        for (const l of recentFoodLogDays) {
+          if (!l.createdAt) continue;
+          const d = new Date(new Date(l.createdAt).getTime() + 2 * 3_600_000);
+          foodDays.add(`${d.getUTCFullYear()}-${d.getUTCMonth()}-${d.getUTCDate()}`);
+        }
+        const foodCheck = new Date(Date.now() + 2 * 3_600_000);
+        foodCheck.setUTCDate(foodCheck.getUTCDate() - 1);
+        while (true) {
+          const key = `${foodCheck.getUTCFullYear()}-${foodCheck.getUTCMonth()}-${foodCheck.getUTCDate()}`;
+          if (!foodDays.has(key)) break;
+          foodLogStreakCount++;
+          foodCheck.setUTCDate(foodCheck.getUTCDate() - 1);
+        }
+      }
       let stepStreakCount = 0;
       {
         const stepDays = new Set<string>();
@@ -146,6 +169,7 @@ export async function runMorningCheckin(): Promise<void> {
       const streakParts: string[] = [];
       if (wStreak >= 2) streakParts.push(`🔥 *${wStreak}-session streak*`);
       if (stepStreakCount >= 2) streakParts.push(`🚶 ${stepStreakCount}-day step streak`);
+      if (foodLogStreakCount >= 3) streakParts.push(`🍽️ ${foodLogStreakCount}-day food streak`);
       const streakLine = streakParts.length ? ` ${streakParts.join(" · ")}.` : "";
 
       const sickYesterday = await wasSickOrInjured(client.id, dayStart(-1));

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -89,7 +89,7 @@ export async function runSundayWeeklyReport(): Promise<void> {
       }
 
       const PROTEIN_RICH = ["chicken", "eggs", "pilchards", "tuna", "beef", "fish", "beans", "greek yogurt", "cottage cheese", "whey", "steak", "pork", "turkey", "mince", "biltong", "sardines", "lentils"];
-      const JUNK = ["kfc", "mcdonalds", "nandos", "pizza", "chips", "vetkoek", "kotas", "polony", "chocolate", "cool drink", "alcohol", "beer", "wine", "magwinya", "fat cake"];
+      const JUNK = ["kfc", "mcdonalds", "nandos", "pizza", "chips", "vetkoek", "kotas", "polony", "cool drink", "alcohol", "beer", "wine", "magwinya", "fat cake", "spur", "steers", "wimpy", "debonairs", "red bull", "monster energy", "energy drink", "fanta", "coke", "sprite", "fizzy drink", "oros"];
       const foodDays = new Set(foodLogs.map(c => new Date(c.createdAt!).toDateString())).size;
       const proteinDays = new Set(foodLogs.filter(l => PROTEIN_RICH.some(w => (l.messageIn || "").toLowerCase().includes(w))).map(c => new Date(c.createdAt!).toDateString())).size;
       const proteinHitRate = foodDays > 0 ? Math.round((proteinDays / foodDays) * 100) : 0;
@@ -275,10 +275,14 @@ export async function runNsvCheckin(): Promise<void> {
       const name = client.name || "there";
       const week = client.programmeWeek || 1;
       const nsvPrompts = [
-        `${name} — quick check-in beyond the scale.\n\nHow do your clothes feel this week? Tighter? Looser? Same?\n\nNon-scale wins are often the first signs things are working — before the scale catches up. Tell me one thing that felt different this week, even something small.`,
-        `${name} — end of week check-in.\n\nForget the scale for a second. Three questions:\n1. Energy levels this week vs last week?\n2. Did anything feel easier — stairs, walking, lifting?\n3. Sleep any better?\n\nThese are the real signals. Tell me one.`,
-        `${name}, Week ${week} done.\n\nI track more than your weight. Tell me: any moment this week where you felt stronger, had more energy, or made a better food choice than you would have 3 months ago?\n\nThat is your real progress.`,
-        `${name} — Saturday check-in.\n\nOne question: what is something your body can do now that it could not do when you started?\n\nCould be physical — run further, lift more, climb stairs without breathing hard. Could be habits — less cravings, better sleep, not reaching for junk automatically.\n\nTell me one win.`,
+        // 1 — Physical capability
+        `${name}, Week ${week} done.\n\nOne question: what can your body do now that it couldn't when you started?\n\nLift more? Walk further? Climb stairs without stopping? Move without pain?\n\nThat is your real progress. Tell me one thing.`,
+        // 2 — Energy & sleep
+        `${name} — end of week check-in.\n\nScale aside — how were your energy levels this week? Did you sleep better? Less afternoon crashes? Wake up feeling less wrecked?\n\nEnergy is the first thing that changes before the scale moves. Tell me what you noticed.`,
+        // 3 — Food relationship & mental
+        `${name}, Week ${week}.\n\nForget the numbers for a second. Did you make any food choice this week that you wouldn't have made 3 months ago? Less junk automatically? Didn't finish the whole takeaway? Chose water over a cool drink?\n\nSmall shifts like that are what compound into big change. Tell me one.`,
+        // 4 — Behavioural habits
+        `${name} — Saturday check-in.\n\nNon-scale question: what habit stuck this week that didn't exist before you started?\n\nCould be logging meals, hitting your steps, not skipping breakfast, sleeping earlier. Behaviour change is harder than weight loss — and it lasts longer.\n\nTell me one habit that's starting to feel automatic.`,
       ];
       await sendWhatsApp(client.phoneNumber, nsvPrompts[(week - 1) % nsvPrompts.length]);
       saveState(stateKey, todaySAST());

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -69,6 +69,11 @@ export function thisWeekUTC(): string {
 
 // ── DB-BACKED DAILY PROACTIVE BUDGET ─────────────────────────────────────────
 
+// PROACTIVE_PAUSED=true → all proactive sends blocked immediately (hot killswitch)
+export function isProactivePaused(): boolean {
+  return process.env.PROACTIVE_PAUSED === "true";
+}
+
 export const dailySentThisProcess = new Set<string>();
 
 export function dailyKey(clientId: string): string {
@@ -76,6 +81,10 @@ export function dailyKey(clientId: string): string {
 }
 
 export async function claimDailySlot(clientId: string, jobKey: string): Promise<boolean> {
+  if (isProactivePaused()) {
+    console.log(`[SCHEDULER:PAUSED] ${jobKey} blocked — PROACTIVE_PAUSED=true`);
+    return false;
+  }
   const today = todaySAST();
   if (dailySentThisProcess.has(dailyKey(clientId))) return false;
   try {
@@ -90,6 +99,7 @@ export async function claimDailySlot(clientId: string, jobKey: string): Promise<
       .values({ userId: clientId, messageKey: jobKey, dedupeWindow: today })
       .onConflictDoNothing();
     dailySentThisProcess.add(dailyKey(clientId));
+    console.log(`[SCHEDULER:SEND] campaign=${jobKey} user=...${clientId.slice(-6)}`);
     return true;
   } catch (err) {
     console.warn(`[claimDailySlot] DB error (${jobKey}/${clientId.slice(0, 8)}):`, err);
@@ -100,10 +110,12 @@ export async function claimDailySlot(clientId: string, jobKey: string): Promise<
 }
 
 export function canSendProactive(clientId: string): boolean {
+  if (isProactivePaused()) return false;
   return !dailySentThisProcess.has(dailyKey(clientId));
 }
 
 export function recordProactiveSend(clientId: string, jobKey = "proactive"): void {
+  console.log(`[SCHEDULER:SEND] campaign=${jobKey} user=...${clientId.slice(-6)}`);
   dailySentThisProcess.add(dailyKey(clientId));
   db.insert(sentProactive)
     .values({ userId: clientId, messageKey: jobKey, dedupeWindow: todaySAST() })
@@ -119,6 +131,7 @@ export function weeklyKeyedKey(clientId: string, messageKey: string, window: str
 }
 
 export async function claimProactive(userId: string, messageKey: string, dedupeWindow: string): Promise<boolean> {
+  if (isProactivePaused()) return false;
   const inMemKey = weeklyKeyedKey(userId, messageKey, dedupeWindow);
   if (weeklyKeyedSent.has(inMemKey)) return false;
   try {

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -170,6 +170,47 @@ export const FROM_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER
   ? `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER.replace(/^whatsapp:/, "")}`
   : "";
 
+// SMS_FROM: set TWILIO_SMS_NUMBER to a Twilio phone number (e.g. +27XXXXXXXXX or a shortcode).
+// When WhatsApp delivery fails with a channel error, critical alerts fall back to SMS.
+// SMS works on every SA phone — no data, no app, no WhatsApp account required.
+const SMS_FROM = process.env.TWILIO_SMS_NUMBER || "";
+
+// Twilio error codes that mean "WhatsApp channel is unavailable for this recipient"
+// (not transient network errors — these won't resolve with retry)
+const WA_CHANNEL_ERRORS = new Set([
+  63003, // Channel not available
+  63007, // User not opted in to WhatsApp
+  63016, // Message not allowed
+  21408, // Region not permitted
+]);
+
+async function sendSMSFallback(to: string, body: string): Promise<void> {
+  if (!SMS_FROM) return;
+  const smsTo = to.replace(/^whatsapp:/, "");
+  // SMS messages truncated to 320 chars — enough for an alert, not a coaching essay
+  const smsBody = body.length > 320
+    ? body.slice(0, 317) + "…"
+    : body;
+  try {
+    await twilioClient.messages.create({ from: SMS_FROM, to: smsTo, body: smsBody });
+    console.log(`[SMS:FALLBACK] → ${smsTo.slice(-8)}: ${smsBody.slice(0, 60)}…`);
+  } catch (smsErr: unknown) {
+    console.error(`[SMS:FALLBACK] ✗ SMS also failed for ${smsTo.slice(-8)}:`, (smsErr as any)?.message || smsErr);
+  }
+}
+
+// sendCriticalAlert — use for subscription notices, account alerts, and service outages.
+// Tries WhatsApp first, falls back to SMS if WhatsApp fails.
+// DO NOT use for routine coaching responses — SMS coaching is not viable at full length.
+export async function sendCriticalAlert(to: string, body: string): Promise<void> {
+  try {
+    await sendWhatsApp(to, body);
+  } catch {
+    console.warn(`[ALERT] WhatsApp failed for ${to.slice(-8)} — attempting SMS fallback`);
+    await sendSMSFallback(to, body);
+  }
+}
+
 export const deliveryStats = { sent: 0, failed: 0, lastReset: new Date().toISOString().slice(0, 10) };
 
 function resetDeliveryStatsIfNeeded() {
@@ -205,8 +246,16 @@ export async function sendWhatsApp(to: string, body: string, mediaUrl?: string):
       console.log(`[SCHEDULER] → ${to.slice(-8)}: ${body.slice(0, 80)}…`);
       return;
     } catch (err: unknown) {
-      const e = err as { status?: number; code?: string; message?: string };
-      const isTransient = !e?.status || e.status >= 500 || e.code === "ECONNRESET" || e.code === "ETIMEDOUT";
+      const e = err as { status?: number; code?: number; message?: string };
+      // WhatsApp channel errors — don't retry, attempt SMS fallback for this recipient
+      if (e?.code && WA_CHANNEL_ERRORS.has(e.code)) {
+        recordTwilioFailure();
+        deliveryStats.failed++;
+        console.warn(`[WA:CHANNEL_ERROR] code=${e.code} for ${to.slice(-8)} — attempting SMS fallback`);
+        await sendSMSFallback(to, body);
+        return;
+      }
+      const isTransient = !e?.status || e.status >= 500 || (e.code as any) === "ECONNRESET" || (e.code as any) === "ETIMEDOUT";
       if (!isTransient || i === delays.length - 1) {
         recordTwilioFailure();
         deliveryStats.failed++;


### PR DESCRIPTION
## What's in this PR

### Cancel flow (revenue protection)
- "cancel" no longer goes straight to confirm
- Asks why first: 1=price, 2=results, 3=break, 4=just cancel
- Price/break → 30-day pause (no charges, programme saved)
- Results → goal-specific coaching advice + "log food for 5 days"
- Option 4 → existing confirm flow

### Addiction / retention loop
- **Food log streak** — celebrates 3/5/7/10/14/21/30 consecutive days of logging after each food log. "5 days in a row — you're past the quitting point. Don't break the chain."
- **Morning check-in** — shows food log streak alongside workout/step streaks: `🔥 5-session streak · 🍽️ 7-day food streak`
- **Weight milestones** — emotional celebrations at 2/5/10/15/20kg total loss
- **NSV recognition** — expanded patterns (clothes fitting loose, people noticing, energy/sleep better, etc.)
- **Discipline win** — "trained even though didn't feel like it" gets a specific response
- **Gym anxiety / first gym visit** — handled separately with appropriate responses
- **Clean nutrition day** — evening protein target + calories on track fires a celebration
- **Thanks/compliment** — deflects credit back to client + gives forward action

### Progress photos
- Photo 2: baseline vs current (unchanged)
- Photo 3+: GPT vision now receives all three (baseline + previous + current), structured prompt asking for total journey change + recent change + one coaching cue

### Referral
- Natural language now triggers referral handler ("my friend wants to join", "how do I invite someone")
- Reply includes pre-filled WhatsApp deeplink so friend lands with referral code already typed

### Water
- Target hit response uses client's name, varies by streak length (3-day / 7-day), ends with forward action

### Onboarding / landing
- Opening message leads with value, legal note at bottom
- Day 1 message has goal-specific hook
- Single R149 plan (removed three-tier pricing that couldn't be fulfilled)

### Business scheduler
- Payment failure + trial win-back messages now use `sendCriticalAlert` (WA → SMS fallback)

### Coach prompt
- Restored goal-aware food coaching: fat loss gets portion context, muscle gain gets encouragement

## Reminder (human tasks)
- Set `TWILIO_SMS_NUMBER` in Railway for SMS fallback
- Set `MEDIA_BASE_URL` in Railway and upload exercise GIFs to `MEDIA_BASE_URL/ex/<slug>.gif`
- PayFast end-to-end payment test in production

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9VUk8xPspuoLo1pLDj9vc)_