### PR TITLE
Remove free trial — pay to activate from day one

### DIFF
--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -442,8 +442,7 @@ async function completeOnboarding(phone: string, u: any, budget: string, budgetL
     programmeWeek: 1,
     programmeDayInWeek: 1,
     programmeStartDate: new Date(),
-    subscriptionStatus: "trial",
-    betaBypassUntil: new Date(Date.now() + 7 * 86_400_000),
+    subscriptionStatus: "inactive",
     onboardingState: "COMPLETE",
     ...(referralCode && !u.referralCode ? { referralCode } : {}),
   }).where(eq(users.phoneNumber, phone));
@@ -489,9 +488,14 @@ async function completeOnboarding(phone: string, u: any, budget: string, budgetL
       : `${gymName || "The gym"} is your tool. How you use it decides everything.`;
 
   const name = u.name || "there";
-  const msg1 = `${name}, your programme is live. *7 days free — let's go.*\n\n${goalHook[defaultGoal] || goalHook.fat_loss}\n\n*Your targets:*\n• ${calorieTarget} kcal/day · ${proteinTarget}g protein\n• ${stepsLabel} steps/day — non-negotiable\n• ${trainingDays} training sessions/week\n\n${trainingHook}${ageNote}${refCodeLine}`;
-  const msg2 = `*Day 1 starts now.*\n\n${firstWorkout}\n\nSend *done* when you finish. I will log it.`;
-  const msg3 = `${shoppingPreview}\n\nTell me what you had to eat today — even if it was not perfect. That is how we start.\n\n_After the trial: R149/month — R5/day. Cancel anytime._`;
+  const appUrl = process.env.APP_URL || "https://kamlifecoach.co.za";
+  const merchantId = process.env.PAYFAST_MERCHANT_ID;
+  const cleanPhoneOnb = u.phoneNumber.replace(/^whatsapp:/, "").replace(/\D/g, "");
+  const payLinkOnb = merchantId ? `${appUrl}/api/payfast/link?phone=${encodeURIComponent(cleanPhoneOnb)}` : appUrl;
+
+  const msg1 = `${name}, your programme is built.\n\n${goalHook[defaultGoal] || goalHook.fat_loss}\n\n*Your targets:*\n• ${calorieTarget} kcal/day · ${proteinTarget}g protein\n• ${stepsLabel} steps/day — non-negotiable\n• ${trainingDays} training sessions/week\n\n${trainingHook}${ageNote}${refCodeLine}`;
+  const msg2 = `*Day 1 is ready.*\n\n${firstWorkout}`;
+  const msg3 = `${shoppingPreview}\n\n*Activate to start coaching — R149/month, cancel anytime:*\n${payLinkOnb}\n\n_R5/day. Less than a coffee. POPIA protected. Cancel by replying *cancel*._`;
   return `${msg1}\n\n---\n\n${msg2}\n\n---\n\n${msg3}`;
 }
 
@@ -508,7 +512,7 @@ export async function handleOnboarding(user: any, message: string, phone: string
   // ---- START — lead with value, keep legal minimal ----
   if (state === "START") {
     await db.update(users).set({ onboardingState: "ASK_POPIA" }).where(eq(users.phoneNumber, phone));
-    return `Coach K here. Real SA fitness coaching — personalised programme, food guidance, daily accountability. All on WhatsApp. No app to download.\n\n7-day free trial. Then R149/month — cancel anytime.\n\n_I'm AI, not a human coach or doctor. If you have any health conditions, check with your doctor before starting. Your info is stored under POPIA — only used for your coaching, never sold. Reply *delete my data* anytime._\n\nReply *yes* to build your programme.`;
+    return `Coach K here. Real SA fitness coaching — personalised programme, food guidance, daily accountability. All on WhatsApp. No app to download.\n\nR149/month — R5/day. Cancel anytime.\n\n_I'm AI, not a human coach or doctor. If you have any health conditions, check with your doctor before starting. Your info is stored under POPIA — only used for your coaching, never sold. Reply *delete my data* anytime._\n\nReply *yes* to build your programme.`;
   }
 
   // ---- ASK_POPIA ----

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -175,30 +175,6 @@ async function handleMessage(phone: string, message: string, mediaUrl?: string, 
     user.subscriptionStatus = "active";
   }
 
-  // ---- TRIAL EXPIRY CHECK — convert expired trials to inactive with a clear message ----
-  if (user.subscriptionStatus === "trial") {
-    const trialEnd = user.betaBypassUntil ? new Date(user.betaBypassUntil) : null;
-    if (trialEnd && trialEnd < new Date()) {
-      // Trial expired — convert to inactive and tell the user
-      await db.update(users).set({ subscriptionStatus: "inactive", betaBypassUntil: null }).where(eq(users.phoneNumber, phone));
-      user.subscriptionStatus = "inactive";
-      const appUrl = process.env.APP_URL || "https://kamlifecoach.co.za";
-      const merchantId = process.env.PAYFAST_MERCHANT_ID;
-      const cleanPhone = phone.replace(/^whatsapp:/, "").replace(/\D/g, "");
-      const payLink = merchantId
-        ? `${appUrl}/api/payfast/link?phone=${encodeURIComponent(cleanPhone)}`
-        : null;
-      const name = user.name || "there";
-      const workouts = user.totalWorkoutsCompleted || 0;
-      const payPart = payLink
-        ? `*R149/month — cancel anytime:*\n${payLink}\n\nR5/day. Reply *pay* anytime to get your link.`
-        : `Reply *pay* and we will send you the payment link directly. R149/month — cancel anytime.`;
-      const trialEndReply = `${name}, your 7-day free trial has ended.${workouts > 0 ? `\n\nYou completed ${workouts} workout${workouts > 1 ? "s" : ""} — that's real momentum.` : ""}\n\nEverything is saved — your programme, progress, and targets. Subscribe to keep coaching going.\n\n${payPart}`;
-      await logChat(user.id, message, trialEndReply, "TRIAL_EXPIRED");
-      return trialEndReply;
-    }
-  }
-
   // ---- SUBSCRIPTION GATE — inactive users get free basic tier, premium features gated ----
   // FREE (always available): food logging, step tracking, water, weight, basic Q&A, meal diary
   // PREMIUM (requires subscription): workout programmes, shopping lists, full coaching, meal plans
@@ -218,8 +194,8 @@ async function handleMessage(phone: string, message: string, mediaUrl?: string, 
     if (isPremiumRequest) {
       const workouts = user.totalWorkoutsCompleted || 0;
       const gateReply = workouts === 0
-        ? `Your programme is built, ${name} — subscribe to unlock it.\n\nFood tracking is free forever. Workouts, shopping lists, and full coaching are *R149/month — cancel anytime.*\n\n${payLink}\n\n_POPIA protected. Data never sold. Cancel by replying *cancel*._`
-        : `${name}, reactivate to get your workouts, shopping lists, and full coaching back.\n\n*R149/month — cancel anytime:* ${payLink}\n\nFood tracking and steps stay free. Data saved for 90 days.`;
+        ? `${name}, your programme is ready — activate to start.\n\n*R149/month — R5/day. Cancel anytime:*\n${payLink}`
+        : `${name}, reactivate to get your workouts, shopping lists, and full coaching back.\n\n*R149/month — cancel anytime:*\n${payLink}\n\nYour ${workouts} session${workouts !== 1 ? "s" : ""} and all progress are saved.`;
       await logChat(user.id, message, gateReply, "SUBSCRIPTION_GATE");
       return gateReply;
     }

--- a/server/scheduler/jobs/business.ts
+++ b/server/scheduler/jobs/business.ts
@@ -96,10 +96,10 @@ export async function runSignupNudge(): Promise<void> {
       if (isNewSignup && created) {
         const daysSince = Math.floor((Date.now() - created.getTime()) / 86_400_000);
         const workouts = client.totalWorkoutsCompleted || 0;
-        if (daysSince === 5 && client.subscriptionStatus === "trial") {
-          await sendCriticalAlert(client.phoneNumber, `${name}, 2 days left on your free trial.${workouts > 0 ? ` You've done ${workouts} session${workouts > 1 ? "s" : ""} — that's real progress.` : ""}\n\nKeep everything — workouts, food coaching, daily accountability.\n\n*R149/month — cancel anytime:*\n${payLink}\n\nR5/day. Less than a KFC streetwise.`);
-        } else if (daysSince === 7 && client.subscriptionStatus === "trial") {
-          await sendCriticalAlert(client.phoneNumber, `${name} — last day of your trial. Tomorrow coaching stops unless you subscribe.\n\nYour programme, targets, and progress are saved. Pay now and nothing changes — Day ${(client.programmeDayInWeek || 1) + 1} drops tomorrow morning.\n\n*R149/month:*\n${payLink}`);
+        if (daysSince === 1 && client.subscriptionStatus === "inactive") {
+          await sendCriticalAlert(client.phoneNumber, `${name}, your programme is built and ready.\n\n${workouts === 0 ? "Day 1 is waiting." : `${workouts} session${workouts > 1 ? "s" : ""} logged.`} Activate now and coaching starts immediately.\n\n*R149/month — cancel anytime:*\n${payLink}\n\nR5/day.`);
+        } else if (daysSince === 3 && client.subscriptionStatus === "inactive") {
+          await sendCriticalAlert(client.phoneNumber, `${name}, your programme is still here.\n\nEvery day you wait is a day behind. R149/month — R5/day:\n${payLink}`);
         }
       } else if (!isNewSignup && cancelled) {
         const daysSinceCancelled = Math.floor((Date.now() - cancelled.getTime()) / 86_400_000);


### PR DESCRIPTION
Removes the 7-day free trial entirely. Users see their full programme on signup (that's the pitch), then must pay to interact with coaching.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9VUk8xPspuoLo1pLDj9vc)_