### PR TITLE
Revert bulk voice notes — cost unacceptable at scale

### DIFF
--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -8,7 +8,6 @@ import {
 } from "../shared";
 import { selectVariantMessage, recordDelivery } from "../../ab";
 import { getKamlifeProgramme } from "../../programme";
-import { generateVoiceNote } from "../../tts";
 
 export async function runMorningCheckin(): Promise<void> {
   console.log("[SCHEDULER] JOB: Morning check-in");
@@ -259,21 +258,6 @@ export async function runMorningCheckin(): Promise<void> {
 
       if (canSendProactive(client.id)) {
         await sendWhatsApp(phone, parts.join(" "));
-
-        // Voice note — short spoken opener, sent immediately after the text
-        try {
-          const proteinNote = totalProtLogged >= proteinTarget * 0.9
-            ? `Protein target hit yesterday.`
-            : totalProtLogged > 0
-              ? `${Math.round(proteinTarget - totalProtLogged)}g protein short yesterday. Fix it today.`
-              : `No food logged yesterday. Log breakfast now.`;
-          const trainingNote = isTodayTrainingDay ? `Training day today. Get it done.` : `Rest day. Stay on food and steps.`;
-          const streakNote = wStreak >= 3 ? `${wStreak}-session streak — protect it.` : "";
-          const voiceScript = `Morning ${name}. ${streakNote} ${proteinNote} ${trainingNote}`.replace(/\s+/g, " ").trim();
-          const voiceUrl = await generateVoiceNote(voiceScript);
-          if (voiceUrl) await sendWhatsApp(phone, "", voiceUrl);
-        } catch (voiceErr) { console.warn("[TTS] Morning voice note failed:", voiceErr); }
-
         recordProactiveSend(client.id);
       }
     } catch (err) {

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -6,7 +6,6 @@ import {
   todaySAST, thisWeekUTC, hasRunToday,
 } from "../shared";
 import { getShoppingList, formatShoppingList } from "../../shopping-lists";
-import { generateVoiceNote } from "../../tts";
 
 export async function runFridayWeekendStrategy(): Promise<void> {
   console.log("[SCHEDULER] JOB: Friday weekend strategy");
@@ -137,28 +136,6 @@ export async function runSundayWeeklyReport(): Promise<void> {
       else lines.push(``, `${name}, below your best but you are still here. That matters. Reset Sunday night and go again Monday.`);
 
       await sendWhatsApp(client.phoneNumber, lines.join("\n"));
-
-      // Voice note — short spoken summary, sent right after the text report
-      try {
-        const winLine = completedSessions >= plannedSessions
-          ? `${completedSessions} sessions — target hit.`
-          : completedSessions > 0
-            ? `${completedSessions} out of ${plannedSessions} sessions done.`
-            : `No sessions logged this week.`;
-        const fixLine = completedSessions < plannedSessions
-          ? `This week — ${plannedSessions - completedSessions} more session${plannedSessions - completedSessions !== 1 ? "s" : ""} than last.`
-          : proteinHitRate < 60
-            ? `Protein at every meal this week — that is the focus.`
-            : `Maintain the consistency. Same output or better.`;
-        const closeLine = totalScore >= 85
-          ? `This is what results look like. Same energy.`
-          : totalScore >= 60
-            ? `Solid week. One more push and you are in the top tier.`
-            : `You are still here. Reset tonight and go again Monday.`;
-        const voiceScript = `${name}. Week ${weekNum} done. Score: ${totalScore} out of 100. ${winLine} ${fixLine} ${closeLine}`;
-        const voiceUrl = await generateVoiceNote(voiceScript);
-        if (voiceUrl) await sendWhatsApp(client.phoneNumber, "", voiceUrl);
-      } catch (voiceErr) { console.warn("[TTS] Weekly voice note failed:", voiceErr); }
 
       try {
         const budgetTier = client.weeklyFoodBudget || "100_300";


### PR DESCRIPTION
Removes TTS calls from morning check-in and weekly report. At 1000 clients those fire thousands of API calls per day. Voice stays on low-frequency milestone events only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9VUk8xPspuoLo1pLDj9vc)_