### PR TITLE
Record successful engine mutations in turn ledger

### DIFF
--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -5,6 +5,7 @@ import { eq, and } from "drizzle-orm";
 import twilio from "twilio";
 import { classifyMediaFailure } from "../coach-guardrails";
 import { detectEscalation, escalationSLA, isSyntheticTestClient } from "../safety-detection";
+import { currentRuntimeDecision } from "../understanding/state";
 
 // Standalone escalation check — exported so handleMessage can call it early, before any handler
 // returns. Does NOT create a chatHistory row; only creates the escalations record + coach alert.
@@ -183,12 +184,22 @@ export async function recordTurn(reply: string): Promise<void> {
   const t = turnStore.getStore();
   if (!t?.userId) return;
   try {
+    const decision = currentRuntimeDecision();
+    const stateRead = decision
+      ? {
+          ...t.stateRead,
+          decisionState: decision.state,
+          decisionEvidence: decision.evidence,
+          meaningfulProblem: decision.meaningfulProblem,
+          hasMinimumUsefulQuestion: decision.hasMinimumUsefulQuestion,
+        }
+      : t.stateRead;
     await db.insert(turnLedger).values({
       userId: t.userId,
       inputType: t.inputType,
       inputText: t.inputText,
       resolvedDay: t.resolvedDay,
-      stateRead: Object.keys(t.stateRead).length ? t.stateRead : null,
+      stateRead: Object.keys(stateRead).length ? stateRead : null,
       mutations: t.mutations.length ? t.mutations : null,
       reply: (reply || "").slice(0, 4000),
       replyMs: Date.now() - t.startedAt,

--- a/server/understanding/executor.ts
+++ b/server/understanding/executor.ts
@@ -25,6 +25,7 @@
 import { type CoachAction, type ToolOutcome, refsAreLabels, actionFingerprint, shouldAutoExecute, writesState, describeAction, actionNumberIsClientReported, explicitMealSlot } from "./actions";
 import { neverSilentLine } from "../reply-hygiene";
 import { sastHour } from "../sast";
+import { turnMutation } from "../handlers/chat-log";
 
 export interface ExecuteContext {
   user: any;
@@ -42,7 +43,7 @@ export interface ExecuteContext {
    *  fallback, logged when it fires, not the normal path. */
   engineReply?: string;
   /** Resuming a parked action after an explicit "yes". The number was already checked
-   *  against the message that proposed it, and "yes" carries no digits of its own. */
+   * against the message that proposed it, and "yes" carries no digits of its own. */
   preConfirmed?: boolean;
 }
 
@@ -140,7 +141,10 @@ export async function executeAction(action: CoachAction, ctx: ExecuteContext): P
   // 4. PERFORM — delegate to the proven handler. Fingerprint on SUCCESS only.
   try {
     const reply = await perform(action, ctx);
-    if (writesState(action.type)) markDone(fingerprint);
+    if (writesState(action.type)) {
+      markDone(fingerprint);
+      turnMutation(`${describeAction(action)} → performed`);
+    }
     return { ...base, performed: writesState(action.type), reply: reply || "" };
   } catch (e) {
     console.error(`[EXECUTOR] ${action.type} failed:`, (e as Error)?.message || e);


### PR DESCRIPTION
## Purpose
Complete the forensic turn record for engine actions by recording successful state mutations at the existing executor boundary.

## Changes
- Reuse the existing `turnMutation()` hook from `handlers/chat-log.ts`.
- Record only successful state writes after their proven handler returns.
- Leave confirmation, duplicate, dry-run, refused-number, and failed executions distinct and unrecorded as mutations.

## Why
The turn ledger now stores the canonical decision, but its mutation list still only captured a rare multi-intent handoff. The executor is the single place that knows whether a state-changing action actually happened.

## Scope
One existing module owner, no schema migration, no new routing, no prompt/model changes, no architecture-budget raise.