### PR TITLE
P1: make coaching focus explicit

### DIFF
--- a/script/decision-boundary-tests.ts
+++ b/script/decision-boundary-tests.ts
@@ -3,13 +3,14 @@
 import assert from "node:assert/strict";
 import { verifyBrainReply } from "../server/brain/reply-verifier";
 import { currentRuntimeDecision, deriveRuntimeDecision } from "../server/understanding/state";
-import type { RuntimeDecisionResult } from "../server/understanding/state";
+import type { DecisionFocus, RuntimeDecisionResult } from "../server/understanding/state";
 
-const d = (state: RuntimeDecisionResult["state"], evidence: RuntimeDecisionResult["evidence"]): RuntimeDecisionResult => ({
+const d = (state: RuntimeDecisionResult["state"], evidence: RuntimeDecisionResult["evidence"], focus: DecisionFocus = "none"): RuntimeDecisionResult => ({
   state,
   evidence,
   meaningfulProblem: state !== "CONTINUE",
   hasMinimumUsefulQuestion: state === "INVESTIGATE",
+  focus,
 });
 
 assert.equal(
@@ -22,20 +23,20 @@ assert.match(
 );
 
 assert.equal(
-  verifyBrainReply("I don't know yet — log another day properly and I'll tell you what matters.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }, d("INVESTIGATE", "insufficient")).ok,
+  verifyBrainReply("I don't know yet — log another day properly and I'll tell you what matters.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }, d("INVESTIGATE", "insufficient", "hunger")).ok,
   true,
 );
 assert.match(
-  verifyBrainReply("You're hungry, so add more protein tomorrow.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }, d("INVESTIGATE", "insufficient")).violation || "",
+  verifyBrainReply("You're hungry, so add more protein tomorrow.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }, d("INVESTIGATE", "insufficient", "hunger")).violation || "",
   /INVESTIGATE/i,
 );
 
 assert.equal(
-  verifyBrainReply("This needs a doctor to assess properly.", { goalType: "fat_loss", clientMessage: "I have severe pain" }, d("REFER", "sufficient")).ok,
+  verifyBrainReply("This needs a doctor to assess properly.", { goalType: "fat_loss", clientMessage: "I have severe pain" }, d("REFER", "sufficient", "safety")).ok,
   true,
 );
 assert.match(
-  verifyBrainReply("Just cut your calories and see how you feel.", { goalType: "fat_loss", clientMessage: "I have severe pain" }, d("REFER", "sufficient")).violation || "",
+  verifyBrainReply("Just cut your calories and see how you feel.", { goalType: "fat_loss", clientMessage: "I have severe pain" }, d("REFER", "sufficient", "safety")).violation || "",
   /REFER/,
 );
 
@@ -46,7 +47,23 @@ const liveDecision = deriveRuntimeDecision({
   },
 });
 assert.equal(liveDecision.state, "INVESTIGATE");
+assert.equal(liveDecision.focus, "hunger");
 assert.equal(currentRuntimeDecision()?.state, "INVESTIGATE");
+assert.equal(currentRuntimeDecision()?.focus, "hunger");
+
+const intakeDecision = deriveRuntimeDecision({
+  deficitEvidence: { gapIsMaterial: true, confidence: "usable" },
+});
+assert.equal(intakeDecision.state, "CHANGE");
+assert.equal(intakeDecision.focus, "intake");
+
+const continueDecision = deriveRuntimeDecision({});
+assert.equal(continueDecision.state, "CONTINUE");
+assert.equal(continueDecision.focus, "none");
+
+const referDecision = deriveRuntimeDecision({ requiresReferral: true });
+assert.equal(referDecision.state, "REFER");
+assert.equal(referDecision.focus, "safety");
 
 assert.match(
   verifyBrainReply("You're hungry, so add more protein tomorrow.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }).violation || "",

--- a/server/understanding/compiler.ts
+++ b/server/understanding/compiler.ts
@@ -14,7 +14,7 @@
  *    steer toward reassurance, not a push. Protein's been light; she's on a 3-day streak."
  */
 
-import type { UnderstandingState } from "./state";
+import { currentRuntimeDecision, type UnderstandingState } from "./state";
 
 function firstName(name: string): string {
   const n = (name || "").trim().split(/\s+/)[0];
@@ -79,6 +79,14 @@ export function compileStateBlurb(s: UnderstandingState): string {
       const gap = days === 2 ? "a couple of days" : `${days} days`;
       parts.push(`they're returning after ${gap} away — re-establish context from what they say now; do not pretend continuity.`);
     }
+  }
+
+  const decision = currentRuntimeDecision();
+  if (decision) {
+    if (decision.focus === "safety") parts.push("Primary coaching focus: safety/referral. Do not turn this into normal coaching.");
+    else if (decision.focus === "hunger") parts.push("Primary coaching focus: hunger. Treat this as the one thing to investigate or act on; do not invent a second problem.");
+    else if (decision.focus === "intake") parts.push("Primary coaching focus: intake/energy balance. Keep other observations in the background unless they change the next instruction.");
+    else if (decision.state === "CONTINUE") parts.push("Primary coaching focus: no intervention. Protect the current plan unless the client gives new evidence that changes the decision.");
   }
 
   parts.push(`Right now, ${steer(s)}.`);

--- a/server/understanding/state.ts
+++ b/server/understanding/state.ts
@@ -12,9 +12,8 @@
  *  - stats                   → DERIVED from the real DB snapshot each turn; NEVER persisted here
  *                              (persisting a stale streak/weight would lie).
  *
- * Storage is deliberately abstract: this module only defines the shape, safe defaults,
- * and (de)serialization. Where it lives (a table, a jsonb column, a cache) is the wiring
- * step's decision, not the schema's.
+ * Storage is deliberately abstract: this module only defines the shape, safe defaults, and (de)serialization.
+ * Where it lives (a table, a jsonb column, a cache) is the wiring step's decision, not the schema's.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -186,7 +185,8 @@ export function parseUnderstanding(json: string | null | undefined, fallbackName
 // ---- Canonical coaching decision contract (P0) ----
 export type DecisionState = "CONTINUE" | "CHANGE" | "INVESTIGATE" | "REFER";
 export type DecisionEvidence = "sufficient" | "insufficient";
-export interface DecisionInputs { requiresReferral?: boolean; meaningfulProblem: boolean; evidence: DecisionEvidence; hasMinimumUsefulQuestion?: boolean; }
+export type DecisionFocus = "safety" | "hunger" | "intake" | "none";
+export interface DecisionInputs { requiresReferral?: boolean; meaningfulProblem: boolean; evidence: DecisionEvidence; hasMinimumUsefulQuestion?: boolean; focus?: DecisionFocus; }
 export function selectDecisionState(input: DecisionInputs): DecisionState {
   if (input.requiresReferral) return "REFER";
   if (input.meaningfulProblem && input.evidence === "insufficient") return input.hasMinimumUsefulQuestion ? "INVESTIGATE" : "CONTINUE";
@@ -197,7 +197,7 @@ export function isCoachingDecisionState(value: unknown): value is DecisionState 
 
 /** Deterministic adapter from the live evidence objects into the canonical decision contract. */
 export interface RuntimeDecisionInputs { hungerEvidence?: any; deficitEvidence?: any; requiresReferral?: boolean; }
-export interface RuntimeDecisionResult { state: DecisionState; evidence: DecisionEvidence; meaningfulProblem: boolean; hasMinimumUsefulQuestion: boolean; }
+export interface RuntimeDecisionResult { state: DecisionState; evidence: DecisionEvidence; meaningfulProblem: boolean; hasMinimumUsefulQuestion: boolean; focus: DecisionFocus; }
 const decisionStorage = new AsyncLocalStorage<RuntimeDecisionResult>();
 export function currentRuntimeDecision(): RuntimeDecisionResult | undefined { return decisionStorage.getStore(); }
 const rememberRuntimeDecision = (decision: RuntimeDecisionResult): RuntimeDecisionResult => {
@@ -205,7 +205,7 @@ const rememberRuntimeDecision = (decision: RuntimeDecisionResult): RuntimeDecisi
   return decision;
 };
 export function deriveRuntimeDecision(input: RuntimeDecisionInputs): RuntimeDecisionResult {
-  if (input.requiresReferral) return rememberRuntimeDecision({ state: "REFER", evidence: "sufficient", meaningfulProblem: true, hasMinimumUsefulQuestion: false });
+  if (input.requiresReferral) return rememberRuntimeDecision({ state: "REFER", evidence: "sufficient", meaningfulProblem: true, hasMinimumUsefulQuestion: false, focus: "safety" });
   const hunger = input.hungerEvidence;
   const persistentHunger = hunger?.hunger?.persistent === true;
   const hungerProblem = persistentHunger || hunger?.evidenceState === "persistent_hunger" || hunger?.evidenceState === "adequate_protein_persistent_hunger";
@@ -216,5 +216,6 @@ export function deriveRuntimeDecision(input: RuntimeDecisionInputs): RuntimeDeci
   const meaningfulProblem = hungerProblem || deficitProblem;
   const evidence: DecisionEvidence = hungerNeedsInvestigation ? "insufficient" : deficitProblem ? deficitEvidence : hungerProblem ? "sufficient" : "insufficient";
   const hasMinimumUsefulQuestion = hungerNeedsInvestigation || (deficitProblem && deficitEvidence === "insufficient");
-  return rememberRuntimeDecision({ state: selectDecisionState({ meaningfulProblem, evidence, hasMinimumUsefulQuestion }), evidence, meaningfulProblem, hasMinimumUsefulQuestion });
+  const focus: DecisionFocus = hungerProblem ? "hunger" : deficitProblem ? "intake" : "none";
+  return rememberRuntimeDecision({ state: selectDecisionState({ meaningfulProblem, evidence, hasMinimumUsefulQuestion, focus }), evidence, meaningfulProblem, hasMinimumUsefulQuestion, focus });
 }


### PR DESCRIPTION
## Purpose
Move the next product-behaviour slice from generic helpfulness toward deterministic prioritisation.

## Changes
- Extend the existing canonical runtime decision with a deterministic `focus`: `safety | hunger | intake | none`.
- Safety wins first; persistent hunger takes precedence over intake; otherwise no intervention focus is declared.
- Surface that focus through the existing deterministic prompt compiler so Coach K is told what matters most this turn and is explicitly discouraged from manufacturing secondary problems.
- Add regression coverage for all four focus outcomes.

## Why
The decision engine already knows the coaching outcome, but the model was still receiving multiple evidence blocks without a first-class primary focus. This slice makes the intended "one thing that matters now" visible to the existing conversational owner without creating another agent, prompt system, or data model.

## Scope
No database schema change, no infrastructure/WhatsApp/Meta change, no new conversational owner, no feature parity work.