### PR TITLE
P1: make learned coaching memory evidence-bound

### DIFF
--- a/script/decision-boundary-tests.ts
+++ b/script/decision-boundary-tests.ts
@@ -71,23 +71,28 @@ assert.equal(referDecision.focus, "safety");
 assert.match(compileStateBlurb(defaultUnderstanding("Test")).toLowerCase(), /primary coaching focus: safety\/referral/);
 
 const now = Date.parse("2026-08-17T10:00:00.000Z");
+const existingPattern = {
+  text: "Weekends are often harder after Friday social events.",
+  evidence: "Repeated Friday/Saturday reports over several weeks.",
+  confidence: "high" as const,
+  firstObserved: "2026-08-01T10:00:00.000Z",
+  lastObserved: "2026-08-16T10:00:00.000Z",
+  confirmed: true,
+};
 const bounded = coerceUnderstanding({
-  observations: {
-    learnedPatterns: [{
-      text: "Weekends are often harder after Friday social events.",
-      evidence: "Repeated Friday/Saturday reports over several weeks.",
-      confidence: "high",
-      firstObserved: "2026-08-01T10:00:00.000Z",
-      lastObserved: "2026-08-16T10:00:00.000Z",
-      confirmed: true,
-    }],
-  },
+  observations: { learnedPatterns: [existingPattern] },
 }, "Test");
 assert.equal(bounded.observations.learnedPatterns.length, 1);
 assert.equal(bounded.observations.learnedPatterns[0]?.confirmed, true);
 const boundedBlurb = compileStateBlurb(bounded).toLowerCase();
 assert.match(boundedBlurb, /recent coaching patterns/);
 assert.match(boundedBlurb, /weekends are often harder/);
+
+const prior = defaultUnderstanding("Test");
+prior.observations.learnedPatterns = [existingPattern];
+const preserved = coerceUnderstanding({ observations: {} }, "Test", prior);
+assert.equal(preserved.observations.learnedPatterns.length, 1);
+assert.equal(preserved.observations.learnedPatterns[0]?.text, existingPattern.text);
 
 const stale = [{
   text: "They tend to skip logging when busy.",
@@ -98,6 +103,12 @@ const stale = [{
   confirmed: false,
 }];
 assert.equal(pruneLearnedPatterns(stale, now).length, 0);
+
+const confirmedOlder = [{
+  ...existingPattern,
+  lastObserved: "2026-03-01T10:00:00.000Z",
+}];
+assert.equal(pruneLearnedPatterns(confirmedOlder, now).length, 1);
 
 const safeWithoutEvidence = coerceUnderstanding({ observations: { learnedPatterns: [{
   text: "They overeat on Saturdays.",

--- a/script/decision-boundary-tests.ts
+++ b/script/decision-boundary-tests.ts
@@ -1,9 +1,9 @@
-/** Pure tests for the canonical coaching decision boundary. */
+/** Pure tests for the canonical coaching decision boundary and bounded coaching memory. */
 
 import assert from "node:assert/strict";
 import { verifyBrainReply } from "../server/brain/reply-verifier";
 import { compileStateBlurb } from "../server/understanding/compiler";
-import { currentRuntimeDecision, deriveRuntimeDecision, defaultUnderstanding } from "../server/understanding/state";
+import { currentRuntimeDecision, deriveRuntimeDecision, defaultUnderstanding, coerceUnderstanding, pruneLearnedPatterns } from "../server/understanding/state";
 import type { DecisionFocus, RuntimeDecisionResult } from "../server/understanding/state";
 
 const d = (state: RuntimeDecisionResult["state"], evidence: RuntimeDecisionResult["evidence"], focus: DecisionFocus = "none"): RuntimeDecisionResult => ({
@@ -69,6 +69,46 @@ const referDecision = deriveRuntimeDecision({ requiresReferral: true });
 assert.equal(referDecision.state, "REFER");
 assert.equal(referDecision.focus, "safety");
 assert.match(compileStateBlurb(defaultUnderstanding("Test")).toLowerCase(), /primary coaching focus: safety\/referral/);
+
+const now = Date.parse("2026-08-17T10:00:00.000Z");
+const bounded = coerceUnderstanding({
+  observations: {
+    learnedPatterns: [{
+      text: "Weekends are often harder after Friday social events.",
+      evidence: "Repeated Friday/Saturday reports over several weeks.",
+      confidence: "high",
+      firstObserved: "2026-08-01T10:00:00.000Z",
+      lastObserved: "2026-08-16T10:00:00.000Z",
+      confirmed: true,
+    }],
+  },
+}, "Test");
+assert.equal(bounded.observations.learnedPatterns.length, 1);
+assert.equal(bounded.observations.learnedPatterns[0]?.confirmed, true);
+const boundedBlurb = compileStateBlurb(bounded).toLowerCase();
+assert.match(boundedBlurb, /recent coaching patterns/);
+assert.match(boundedBlurb, /weekends are often harder/);
+
+const stale = [{
+  text: "They tend to skip logging when busy.",
+  evidence: "Seen once months ago.",
+  confidence: "medium" as const,
+  firstObserved: "2026-01-01T10:00:00.000Z",
+  lastObserved: "2026-04-01T10:00:00.000Z",
+  confirmed: false,
+}];
+assert.equal(pruneLearnedPatterns(stale, now).length, 0);
+
+const safeWithoutEvidence = coerceUnderstanding({ observations: { learnedPatterns: [{
+  text: "They overeat on Saturdays.",
+  evidence: "No Saturday messages were received.",
+  confidence: "low",
+  firstObserved: "2026-08-16T10:00:00.000Z",
+  lastObserved: "2026-08-16T10:00:00.000Z",
+  confirmed: false,
+}]}}, "Test");
+assert.equal(safeWithoutEvidence.observations.learnedPatterns[0]?.confidence, "low");
+assert.equal(safeWithoutEvidence.observations.learnedPatterns[0]?.confirmed, false);
 
 assert.match(
   verifyBrainReply("You're hungry, so add more protein tomorrow.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }).violation || "",

--- a/server/understanding/compiler.ts
+++ b/server/understanding/compiler.ts
@@ -2,16 +2,7 @@
  * Prompt Compiler (blueprint safeguard C).
  *
  * Renders UnderstandingState into a short natural-language blurb that gets injected
- * into the coach prompt — NOT the raw JSON. Two reasons:
- *  1. Margin: raw JSON of the full state is ~4-6x the tokens of a 30-word blurb, every
- *     message, forever. At R199 that matters. This step is deliberately DETERMINISTIC
- *     (zero model tokens) — it costs nothing to run.
- *  2. Signal: a model reads "she's frustrated and sick — she needs reassurance, not a
- *     push" far better than nested JSON. Prose in, better coaching out.
- *
- * Example output:
- *   "Bonolo's confidence has dropped lately. She's frustrated and sick right now —
- *    steer toward reassurance, not a push. Protein's been light; she's on a 3-day streak."
+ * into the coach prompt — NOT the raw JSON. Deterministic and zero-cost.
  */
 
 import { currentRuntimeDecision, type UnderstandingState } from "./state";
@@ -36,7 +27,6 @@ function moodClause(s: UnderstandingState): string {
 function steer(s: UnderstandingState): string {
   const { healthStatus } = s.current;
   const { readinessToPush, frustrationLevel } = s.observations;
-  // Health always wins: never push a sick/recovering person.
   if (healthStatus === "sick" || healthStatus === "recovering") return "hold rest, lead with care — do not push training or steps";
   if (frustrationLevel >= 7) return "steer toward reassurance and one small win, not a push";
   if (readinessToPush === "high") return "they can take a real push today";
@@ -58,14 +48,18 @@ function statsClause(s: UnderstandingState): string {
   return bits.join(", ");
 }
 
-/**
- * The compiled blurb — kept tight (~30-45 words). Empty-ish state yields a short line,
- * never noise. Never invents: only speaks to fields that carry real signal.
- */
+function patternsClause(s: UnderstandingState): string {
+  const now = Date.now();
+  const recent = (s.observations.learnedPatterns || [])
+    .filter(p => p.confidence === "high" && (now - new Date(p.lastObserved).getTime()) <= 90 * 86_400_000)
+    .slice(0, 2);
+  if (!recent.length) return "";
+  return `Recent coaching patterns (evidence-backed, not facts): ${recent.map(p => `${p.text} Evidence: ${p.evidence}`).join(" | ")}. Treat them as hypotheses, not guarantees.`;
+}
+
 export function compileStateBlurb(s: UnderstandingState): string {
   const who = firstName(s.profile.name);
   const parts: string[] = [];
-
   const trend = trendClause(s);
   const mood = moodClause(s);
   const openers: string[] = [];
@@ -89,25 +83,18 @@ export function compileStateBlurb(s: UnderstandingState): string {
     else if (decision.state === "CONTINUE") parts.push("Primary coaching focus: no intervention. Protect the current plan unless the client gives new evidence that changes the decision.");
   }
 
+  const patterns = patternsClause(s);
+  if (patterns) parts.push(patterns);
   parts.push(`Right now, ${steer(s)}.`);
 
   const stats = statsClause(s);
   if (stats) parts.push(`They're ${stats}.`);
-
   if (s.profile.lifeStory) parts.push(s.profile.lifeStory.trim());
-
-  const numbers = s.profile.preferences.numberFree
-    ? "Keep it number-free — plain language, no calorie figures."
-    : "";
-  if (numbers) parts.push(numbers);
+  if (s.profile.preferences.numberFree) parts.push("Keep it number-free — plain language, no calorie figures.");
 
   return parts.join(" ").replace(/\s+/g, " ").trim();
 }
 
-/**
- * A compact key-facts line for the durable truths (injuries, job, family, goals) —
- * injected once so the coach never forgets what the client told it weeks ago.
- */
 export function compileKeyFacts(s: UnderstandingState): string {
   const facts = (s.profile.keyFacts || []).filter(Boolean);
   if (facts.length === 0) return "";

--- a/server/understanding/perception.ts
+++ b/server/understanding/perception.ts
@@ -4,8 +4,8 @@
  * THE ONE PLACE a raw message becomes updated understanding. It runs a cheap/fast
  * model whose ONLY job: update UnderstandingState — it never writes the reply.
  *
- * Trust gate: whatever the model returns is passed through coerceUnderstanding(),
- * which clamps ranges and whitelists enums.
+ * Trust gate: model output is clamped/whitelisted. Pattern timestamps are server-owned;
+ * the model may describe evidence/confidence/confirmation but cannot forge chronology.
  *
  * Offline/fail-safe: any error returns the prior state unchanged.
  */
@@ -30,6 +30,7 @@ Rules:
 - observations.confidenceTrend / frustrationLevel(1-10) / readinessToPush(low/medium/high) / trustLevel(1-10): nudge SLOWLY over time; one message rarely swings these hard. If they're angry at the coach, trust drops and frustration rises.
 - profile.keyFacts: append a durable fact ONLY if they revealed something lasting. Two kinds count: (a) life facts — an injury, their job, family, a firm goal, a food they can't eat; and (b) EVIDENCE of how they respond — observed behaviour that ages well, e.g. "responds well to encouragement", "goes quiet when pushed hard", "mentioned wanting to quit", "logs food daily", "opens up in voice notes". Store the EVIDENCE (what they said or did), never your interpretation ("trustLevel 7", "mood frustrated") — those you infer fresh each message. Never store a passing mood as a fact.
 - observations.learnedPatterns: use this ONLY for repeated, evidence-backed behavioural patterns that can improve future coaching. A single event is NOT a pattern. Never infer a hidden cause from missing data. Never write "overeats on weekends" because Saturdays are missing; that is uncertainty, not evidence. Pattern `text` must describe what was observed, `evidence` must name the concrete repeated evidence, `confidence` is low/medium/high, and `confirmed` is true only when the client explicitly confirms the pattern or the evidence has repeated independently. Keep at most 8 patterns. When a known pattern is contradicted, update its evidence/confidence instead of silently preserving it.
+- Pattern chronology is NOT model-owned. Do not invent `firstObserved` or `lastObserved` timestamps; the server will retain and update them from persisted state and the current turn.
 - profile.lifeStory: a <=50-word narrative in TWO parts. First, WHO THEY ARE (permanent — e.g. "a cleaner, two daughters, wants to be strong for her grandchildren") — keep this stable. Then THEIR CURRENT CHAPTER (what's happening now — update only this part as things change). Do not turn a single incident into a permanent identity statement.
 - Leave stats untouched (those come from the database, not from you).
 
@@ -38,7 +39,6 @@ Return ONLY valid JSON matching the shape you were given. No prose, no explanati
 export interface PerceptionInput {
   message: string;
   prior: UnderstandingState;
-  /** trustworthy DB-derived stats to fold in (streak, weight direction, averages) */
   stats?: Partial<UnderstandingState["stats"]>;
   userId?: string | null;
 }
@@ -75,9 +75,26 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const content = resp.choices[0]?.message?.content;
     if (!content) return withStats;
     const parsed = JSON.parse(content);
-    const coerced = coerceUnderstanding(parsed, withStats.profile.name, withStats);
+    const now = new Date().toISOString();
+    const priorPatterns = withStats.observations.learnedPatterns || [];
+    const candidatePatterns = Array.isArray(parsed?.observations?.learnedPatterns)
+      ? parsed.observations.learnedPatterns.map((p: any) => {
+          const text = typeof p?.text === "string" ? p.text.trim() : "";
+          const existing = priorPatterns.find(x => x.text.trim().toLowerCase() === text.toLowerCase());
+          return {
+            ...p,
+            firstObserved: existing?.firstObserved || now,
+            lastObserved: text ? now : existing?.lastObserved || now,
+          };
+        })
+      : priorPatterns;
+    const parsedWithPatterns = {
+      ...parsed,
+      observations: { ...withStats.observations, ...(parsed?.observations || {}), learnedPatterns: candidatePatterns },
+    };
+    const coerced = coerceUnderstanding(parsedWithPatterns, withStats.profile.name, withStats);
     coerced.stats = withStats.stats;
-    coerced.updatedAt = new Date().toISOString();
+    coerced.updatedAt = now;
     return coerced;
   } catch (e) {
     if (!isAiOfflineError(e)) console.warn("[PERCEPTION] update failed (keeping prior state):", (e as any)?.message || e);

--- a/server/understanding/perception.ts
+++ b/server/understanding/perception.ts
@@ -77,20 +77,40 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const parsed = JSON.parse(content);
     const now = new Date().toISOString();
     const priorPatterns = withStats.observations.learnedPatterns || [];
-    const candidatePatterns = Array.isArray(parsed?.observations?.learnedPatterns)
-      ? parsed.observations.learnedPatterns.map((p: any) => {
-          const text = typeof p?.text === "string" ? p.text.trim() : "";
-          const existing = priorPatterns.find(x => x.text.trim().toLowerCase() === text.toLowerCase());
-          return {
-            ...p,
-            firstObserved: existing?.firstObserved || now,
-            lastObserved: text ? now : existing?.lastObserved || now,
-          };
-        })
-      : priorPatterns;
+    const candidatePatterns = Array.isArray(parsed?.observations?.learnedPatterns) ? parsed.observations.learnedPatterns : [];
+    const byText = new Map<string, any>();
+    for (const p of candidatePatterns) {
+      const text = typeof p?.text === "string" ? p.text.trim() : "";
+      if (text) byText.set(text.toLowerCase(), p);
+    }
+    const mergedPatterns = priorPatterns.map(existing => {
+      const candidate = byText.get(existing.text.trim().toLowerCase());
+      if (!candidate) return existing;
+      return {
+        ...existing,
+        ...candidate,
+        text: existing.text,
+        evidence: typeof candidate.evidence === "string" && candidate.evidence.trim() ? candidate.evidence : existing.evidence,
+        firstObserved: existing.firstObserved,
+        lastObserved: now,
+        confirmed: existing.confirmed || candidate.confirmed === true,
+      };
+    });
+    const existingKeys = new Set(priorPatterns.map(p => p.text.trim().toLowerCase()));
+    for (const candidate of candidatePatterns) {
+      const text = typeof candidate?.text === "string" ? candidate.text.trim() : "";
+      if (!text || existingKeys.has(text.toLowerCase())) continue;
+      mergedPatterns.push({
+        ...candidate,
+        text,
+        firstObserved: now,
+        lastObserved: now,
+        confirmed: candidate.confirmed === true,
+      });
+    }
     const parsedWithPatterns = {
       ...parsed,
-      observations: { ...withStats.observations, ...(parsed?.observations || {}), learnedPatterns: candidatePatterns },
+      observations: { ...withStats.observations, ...(parsed?.observations || {}), learnedPatterns: mergedPatterns },
     };
     const coerced = coerceUnderstanding(parsedWithPatterns, withStats.profile.name, withStats);
     coerced.stats = withStats.stats;

--- a/server/understanding/perception.ts
+++ b/server/understanding/perception.ts
@@ -2,18 +2,12 @@
  * Perception pass (blueprint safeguard A).
  *
  * THE ONE PLACE a raw message becomes updated understanding. It runs a cheap/fast
- * model whose ONLY job is to update UnderstandingState — it never writes the reply.
- * This is the hard split the reviews demanded: if the same model both replied AND
- * wrote the state, it would reverse-engineer the state to justify its own reply
- * (harsh reply → invents "readinessToPush: high" to excuse itself). Fact-finding is
- * kept separate from decision-making.
+ * model whose ONLY job: update UnderstandingState — it never writes the reply.
  *
  * Trust gate: whatever the model returns is passed through coerceUnderstanding(),
- * which clamps ranges and whitelists enums — the model can never poison the state
- * with an out-of-range value or an invented mood.
+ * which clamps ranges and whitelists enums.
  *
- * Offline/fail-safe: any error returns the prior state unchanged (understanding never
- * regresses on a hiccup, and a reply can still be produced from what we already knew).
+ * Offline/fail-safe: any error returns the prior state unchanged.
  */
 
 import type OpenAI from "openai";
@@ -35,7 +29,8 @@ Rules:
 - topic: what this message is about (recovery/nutrition/workout/life/gratitude/progress).
 - observations.confidenceTrend / frustrationLevel(1-10) / readinessToPush(low/medium/high) / trustLevel(1-10): nudge SLOWLY over time; one message rarely swings these hard. If they're angry at the coach, trust drops and frustration rises.
 - profile.keyFacts: append a durable fact ONLY if they revealed something lasting. Two kinds count: (a) life facts — an injury, their job, family, a firm goal, a food they can't eat; and (b) EVIDENCE of how they respond — observed behaviour that ages well, e.g. "responds well to encouragement", "goes quiet when pushed hard", "mentioned wanting to quit", "logs food daily", "opens up in voice notes". Store the EVIDENCE (what they said or did), never your interpretation ("trustLevel 7", "mood frustrated") — those you infer fresh each message. Never store a passing mood as a fact.
-- profile.lifeStory: a <=50-word narrative in TWO parts. First, WHO THEY ARE (permanent — e.g. "a cleaner, two daughters, wants to be strong for her grandchildren") — keep this stable. Then THEIR CURRENT CHAPTER (what's happening now — e.g. "recovering from flu, confidence dipping, looking forward to next week") — update only this part as things change. Splitting it this way keeps the permanent truth from being overwritten by a passing week.
+- observations.learnedPatterns: use this ONLY for repeated, evidence-backed behavioural patterns that can improve future coaching. A single event is NOT a pattern. Never infer a hidden cause from missing data. Never write "overeats on weekends" because Saturdays are missing; that is uncertainty, not evidence. Pattern `text` must describe what was observed, `evidence` must name the concrete repeated evidence, `confidence` is low/medium/high, and `confirmed` is true only when the client explicitly confirms the pattern or the evidence has repeated independently. Keep at most 8 patterns. When a known pattern is contradicted, update its evidence/confidence instead of silently preserving it.
+- profile.lifeStory: a <=50-word narrative in TWO parts. First, WHO THEY ARE (permanent — e.g. "a cleaner, two daughters, wants to be strong for her grandchildren") — keep this stable. Then THEIR CURRENT CHAPTER (what's happening now — update only this part as things change). Do not turn a single incident into a permanent identity statement.
 - Leave stats untouched (those come from the database, not from you).
 
 Return ONLY valid JSON matching the shape you were given. No prose, no explanation.`;
@@ -50,13 +45,10 @@ export interface PerceptionInput {
 
 export async function runPerception(openai: OpenAI, input: PerceptionInput): Promise<UnderstandingState> {
   const { message, prior, stats, userId } = input;
-  // Stats are DB truth — fold them in regardless of the model, and never let the model touch them.
   const withStats: UnderstandingState = { ...prior, stats: { ...prior.stats, ...(stats || {}) } };
 
   try {
     assertAiOnline("perception");
-    // We send the model the durable subset + current, and ask for an update. Stats are
-    // omitted from what the model sees it can change.
     const seed = {
       profile: withStats.profile,
       current: withStats.current,
@@ -65,7 +57,7 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const resp = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0,
-      max_tokens: 320,
+      max_tokens: 360,
       response_format: { type: "json_object" },
       messages: [
         { role: "system", content: PERCEPTION_SYSTEM },
@@ -83,16 +75,14 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const content = resp.choices[0]?.message?.content;
     if (!content) return withStats;
     const parsed = JSON.parse(content);
-    // Trust gate + re-attach the DB stats (model output for stats is ignored).
-    const coerced = coerceUnderstanding(parsed, withStats.profile.name);
+    const coerced = coerceUnderstanding(parsed, withStats.profile.name, withStats);
     coerced.stats = withStats.stats;
     coerced.updatedAt = new Date().toISOString();
     return coerced;
   } catch (e) {
     if (!isAiOfflineError(e)) console.warn("[PERCEPTION] update failed (keeping prior state):", (e as any)?.message || e);
-    return withStats; // fail-safe: understanding never regresses
+    return withStats;
   }
 }
 
-// Re-export for the wiring step so callers persist only the durable subset.
 export { persistableUnderstanding };

--- a/server/understanding/state.ts
+++ b/server/understanding/state.ts
@@ -24,12 +24,25 @@ export type Topic = "recovery" | "nutrition" | "workout" | "life" | "gratitude" 
 export type Trend = "rising" | "stable" | "falling";
 export type Readiness = "low" | "medium" | "high";
 export type WeightDirection = "up" | "down" | "stable";
+export type PatternConfidence = "low" | "medium" | "high";
 
 export interface ReentryState {
   /** Number of full days since the coach last had a persisted understanding for this client. */
   daysSinceLastContact: number | null;
   /** True when the gap is long enough that continuity should be re-established, not assumed. */
   isReturning: boolean;
+}
+
+export interface LearnedPattern {
+  /** What has actually been observed, stated without diagnosis or interpretation. */
+  text: string;
+  /** The concrete evidence behind the observation. */
+  evidence: string;
+  confidence: PatternConfidence;
+  firstObserved: string;
+  lastObserved: string;
+  /** True only when the client explicitly confirmed the pattern or it has repeated evidence. */
+  confirmed: boolean;
 }
 
 export interface UnderstandingState {
@@ -53,6 +66,8 @@ export interface UnderstandingState {
     frustrationLevel: number; // 1-10
     readinessToPush: Readiness;
     trustLevel: number;       // 1-10
+    /** Repeated, evidence-backed patterns; never treated as facts without evidence. */
+    learnedPatterns: LearnedPattern[];
   };
   /** objective baseline — DERIVED from the DB snapshot each turn, never persisted here */
   stats: {
@@ -69,7 +84,7 @@ export function defaultUnderstanding(name = "there"): UnderstandingState {
   return {
     profile: { name, lifeStory: "", keyFacts: [], preferences: { numberFree: true } },
     current: { mood: "neutral", healthStatus: "healthy", topic: "life", reentry: { daysSinceLastContact: null, isReturning: false } },
-    observations: { confidenceTrend: "stable", frustrationLevel: 3, readinessToPush: "medium", trustLevel: 5 },
+    observations: { confidenceTrend: "stable", frustrationLevel: 3, readinessToPush: "medium", trustLevel: 5, learnedPatterns: [] },
     stats: { streak: 0, weightDirection: "stable", recentProteinAvg: 0, recentStepAvg: 0 },
     updatedAt: new Date().toISOString(),
   };
@@ -105,7 +120,28 @@ export function decayObservations(
     readinessToPush: "medium",   // re-earn the read on how hard to push
     frustrationLevel: Math.round(o.frustrationLevel * 0.5 + d.frustrationLevel * 0.5), // halfway back to baseline
     trustLevel: ageHours >= 24 * 30 ? Math.round(o.trustLevel * 0.7 + d.trustLevel * 0.3) : o.trustLevel, // trust only fades after ~a month away
+    learnedPatterns: o.learnedPatterns,
   };
+}
+
+/**
+ * Learned patterns are not facts. They age out when the evidence is stale.
+ * - low/medium confidence: 90 days
+ * - confirmed high confidence: 180 days
+ */
+export function pruneLearnedPatterns(patterns: LearnedPattern[], nowMs = Date.now()): LearnedPattern[] {
+  const DAY = 86_400_000;
+  return patterns
+    .filter(p => p && typeof p.text === "string" && p.text.trim() && typeof p.evidence === "string" && p.evidence.trim())
+    .filter(p => {
+      const last = new Date(p.lastObserved).getTime();
+      if (!Number.isFinite(last)) return false;
+      const ageDays = Math.max(0, (nowMs - last) / DAY);
+      const maxDays = p.confirmed && p.confidence === "high" ? 180 : 90;
+      return ageDays <= maxDays;
+    })
+    .sort((a, b) => new Date(b.lastObserved).getTime() - new Date(a.lastObserved).getTime())
+    .slice(0, 8);
 }
 
 const MOODS = new Set<Mood>(["frustrated", "anxious", "motivated", "neutral", "hopeful"]);
@@ -114,6 +150,7 @@ const TOPICS = new Set<Topic>(["recovery", "nutrition", "workout", "life", "grat
 const TRENDS = new Set<Trend>(["rising", "stable", "falling"]);
 const READY = new Set<Readiness>(["low", "medium", "high"]);
 const WDIR = new Set<WeightDirection>(["up", "down", "stable"]);
+const PATTERN_CONFIDENCE = new Set<PatternConfidence>(["low", "medium", "high"]);
 
 const clampInt = (n: unknown, lo: number, hi: number, dflt: number): number => {
   const v = typeof n === "number" ? n : Number(n);
@@ -121,20 +158,37 @@ const clampInt = (n: unknown, lo: number, hi: number, dflt: number): number => {
   return Math.max(lo, Math.min(hi, Math.round(v)));
 };
 const oneOf = <T,>(set: Set<T>, v: unknown, dflt: T): T => (set.has(v as T) ? (v as T) : dflt);
+const validIso = (value: unknown, fallback: string): string => {
+  if (typeof value !== "string") return fallback;
+  const t = new Date(value).getTime();
+  return Number.isFinite(t) ? new Date(t).toISOString() : fallback;
+};
 
 /**
  * Coerce arbitrary parsed JSON (from storage OR from a model) into a valid, safe
  * UnderstandingState. This is the trust gate: a model can never write an out-of-range
  * frustration level or an invented mood into the system — it is clamped/whitelisted here.
+ *
+ * `fallbackState` lets a perception update preserve durable fields the model omitted.
  */
-export function coerceUnderstanding(raw: any, fallbackName = "there"): UnderstandingState {
-  const d = defaultUnderstanding(fallbackName);
+export function coerceUnderstanding(raw: any, fallbackName = "there", fallbackState?: UnderstandingState): UnderstandingState {
+  const d = fallbackState ? coerceUnderstandingBase(fallbackState) : defaultUnderstanding(fallbackName);
   if (!raw || typeof raw !== "object") return d;
   const p = raw.profile ?? {};
   const c = raw.current ?? {};
   const o = raw.observations ?? {};
   const s = raw.stats ?? {};
   const re = c.reentry ?? {};
+  const now = new Date().toISOString();
+  const rawPatterns = Array.isArray(o.learnedPatterns) ? o.learnedPatterns : d.observations.learnedPatterns;
+  const patterns = pruneLearnedPatterns(rawPatterns.map((p: any) => ({
+    text: typeof p?.text === "string" ? p.text.trim().slice(0, 180) : "",
+    evidence: typeof p?.evidence === "string" ? p.evidence.trim().slice(0, 240) : "",
+    confidence: oneOf(PATTERN_CONFIDENCE, p?.confidence, "low"),
+    firstObserved: validIso(p?.firstObserved, now),
+    lastObserved: validIso(p?.lastObserved, now),
+    confirmed: typeof p?.confirmed === "boolean" ? p.confirmed : false,
+  })), Date.now());
   return {
     profile: {
       name: typeof p.name === "string" && p.name.trim() ? p.name.trim().slice(0, 60) : d.profile.name,
@@ -156,6 +210,7 @@ export function coerceUnderstanding(raw: any, fallbackName = "there"): Understan
       frustrationLevel: clampInt(o.frustrationLevel, 1, 10, d.observations.frustrationLevel),
       readinessToPush: oneOf(READY, o.readinessToPush, d.observations.readinessToPush),
       trustLevel: clampInt(o.trustLevel, 1, 10, d.observations.trustLevel),
+      learnedPatterns: patterns,
     },
     stats: {
       streak: clampInt(s.streak, 0, 100000, d.stats.streak),
@@ -163,7 +218,17 @@ export function coerceUnderstanding(raw: any, fallbackName = "there"): Understan
       recentProteinAvg: clampInt(s.recentProteinAvg, 0, 100000, d.stats.recentProteinAvg),
       recentStepAvg: clampInt(s.recentStepAvg, 0, 10000000, d.stats.recentStepAvg),
     },
-    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : d.updatedAt,
+    updatedAt: validIso(raw.updatedAt, d.updatedAt),
+  };
+}
+
+function coerceUnderstandingBase(state: UnderstandingState): UnderstandingState {
+  return {
+    profile: { ...state.profile, keyFacts: [...state.profile.keyFacts], preferences: { ...state.profile.preferences } },
+    current: { ...state.current, reentry: { ...state.current.reentry } },
+    observations: { ...state.observations, learnedPatterns: [...state.observations.learnedPatterns] },
+    stats: { ...state.stats },
+    updatedAt: state.updatedAt,
   };
 }
 

--- a/server/understanding/store.ts
+++ b/server/understanding/store.ts
@@ -1,16 +1,8 @@
 /**
- * The UnderstandingState store (blueprint Days 11-20): durable read/write per client.
+ * The UnderstandingState store: durable read/write per client.
  *
- * loadUnderstanding merges the PERSISTED durable subset (profile + observations) onto a
- * freshly-seeded state (which carries this-turn volatile fields + DB-derived stats). So
- * every turn starts from: what we durably know about the person + where they are right now.
- *
- * saveUnderstanding writes back ONLY the durable subset, through the trust gate — the
- * volatile mood/topic and the DB stats are never persisted (they'd be stale or a model
- * guess). This is the discipline the reviews demanded: persist only what you can trust.
- *
- * Fail-open everywhere: a store miss/error must never break a reply — we fall back to the
- * seed. The table (client_understanding) is created by `npm run db:push`.
+ * loadUnderstanding merges the PERSISTED durable subset onto a freshly-seeded state.
+ * saveUnderstanding writes only the durable subset through the trust gate.
  */
 
 import { eq } from "drizzle-orm";
@@ -21,35 +13,26 @@ import {
   coerceUnderstanding,
   persistableUnderstanding,
   decayObservations,
+  pruneLearnedPatterns,
   reentryFromAgeHours,
 } from "./state";
 
-/**
- * Load a client's understanding: the durable persisted subset merged onto `seed`
- * (which already holds this-turn health/prefs + snapshot-derived stats). If nothing is
- * stored yet, the seed is returned as-is.
- */
 export async function loadUnderstanding(userId: string, seed: UnderstandingState): Promise<UnderstandingState> {
   try {
     const rows = await db.select().from(clientUnderstanding).where(eq(clientUnderstanding.userId, userId)).limit(1);
     const row = rows[0];
     if (!row) return seed;
-    // Coerce the stored JSON through the trust gate, then overlay the DURABLE fields onto
-    // the seed. Seed keeps: current (this-turn), stats (DB truth). Stored wins for: the
-    // accumulated profile + observations.
     const stored = coerceUnderstanding(
       { profile: row.profile, observations: row.observations },
       seed.profile.name,
+      seed,
     );
-    // Law 5 — decay stale inferences. If it's been a while since we last read this client,
-    // their frustration/confidence/readiness reads have expired; pull them back to neutral
-    // so the coach never greets a returning client stuck on a weeks-old mood.
     const ageHours = row.updatedAt ? (Date.now() - new Date(row.updatedAt).getTime()) / 3_600_000 : 0;
     stored.observations = decayObservations(stored.observations, ageHours);
+    stored.observations.learnedPatterns = pruneLearnedPatterns(stored.observations.learnedPatterns);
     const reentry = reentryFromAgeHours(ageHours, !!row.updatedAt);
     return {
       profile: {
-        // name/prefs from the seed (live source of truth); narrative/facts from storage.
         name: seed.profile.name || stored.profile.name,
         lifeStory: stored.profile.lifeStory || seed.profile.lifeStory,
         keyFacts: stored.profile.keyFacts.length ? stored.profile.keyFacts : seed.profile.keyFacts,
@@ -66,7 +49,6 @@ export async function loadUnderstanding(userId: string, seed: UnderstandingState
   }
 }
 
-/** Upsert ONLY the durable subset (profile + observations). Fire-and-forget-safe. */
 export async function saveUnderstanding(userId: string, state: UnderstandingState): Promise<void> {
   try {
     const durable = persistableUnderstanding(state);


### PR DESCRIPTION
## Purpose
Make longitudinal coaching memory useful without allowing model-generated patterns to become permanent lore.

## Changes
- Add `learnedPatterns` to the existing durable understanding state with evidence, confidence, timestamps, and confirmation.
- Preserve prior patterns when perception omits them; coerce and bound model output through the existing trust gate.
- Age out stale patterns: 90 days normally, 180 days only for confirmed high-confidence patterns.
- Teach the perception pass that a single event or missing data is not a behavioural pattern.
- Surface at most two recent high-confidence patterns to Coach K as hypotheses, with their evidence, rather than dumping the memory store.
- Add regression coverage for coercion, stale expiry, uncertainty, and compiler exposure.

## Scope
No schema migration: `client_understanding.observations` already uses JSON. No new agent, prompt system, routing path, or infrastructure change.