### PR TITLE
revert: restore last known-green production line

### DIFF
--- a/docs/ROLLBACK-NOTE.md
+++ b/docs/ROLLBACK-NOTE.md
@@ -1,0 +1,1 @@
+Temporary engineering note: revert the learned-pattern memory slice to restore the last known-green production line. The memory implementation remains preserved on its source branch for re-application as a smaller, independently verified slice after the Railway failure is understood.

--- a/script/decision-boundary-tests.ts
+++ b/script/decision-boundary-tests.ts
@@ -1,9 +1,9 @@
-/** Pure tests for the canonical coaching decision boundary and bounded coaching memory. */
+/** Pure tests for the canonical coaching decision boundary. */
 
 import assert from "node:assert/strict";
 import { verifyBrainReply } from "../server/brain/reply-verifier";
 import { compileStateBlurb } from "../server/understanding/compiler";
-import { currentRuntimeDecision, deriveRuntimeDecision, defaultUnderstanding, coerceUnderstanding, pruneLearnedPatterns } from "../server/understanding/state";
+import { currentRuntimeDecision, deriveRuntimeDecision, defaultUnderstanding } from "../server/understanding/state";
 import type { DecisionFocus, RuntimeDecisionResult } from "../server/understanding/state";
 
 const d = (state: RuntimeDecisionResult["state"], evidence: RuntimeDecisionResult["evidence"], focus: DecisionFocus = "none"): RuntimeDecisionResult => ({
@@ -69,57 +69,6 @@ const referDecision = deriveRuntimeDecision({ requiresReferral: true });
 assert.equal(referDecision.state, "REFER");
 assert.equal(referDecision.focus, "safety");
 assert.match(compileStateBlurb(defaultUnderstanding("Test")).toLowerCase(), /primary coaching focus: safety\/referral/);
-
-const now = Date.parse("2026-08-17T10:00:00.000Z");
-const existingPattern = {
-  text: "Weekends are often harder after Friday social events.",
-  evidence: "Repeated Friday/Saturday reports over several weeks.",
-  confidence: "high" as const,
-  firstObserved: "2026-08-01T10:00:00.000Z",
-  lastObserved: "2026-08-16T10:00:00.000Z",
-  confirmed: true,
-};
-const bounded = coerceUnderstanding({
-  observations: { learnedPatterns: [existingPattern] },
-}, "Test");
-assert.equal(bounded.observations.learnedPatterns.length, 1);
-assert.equal(bounded.observations.learnedPatterns[0]?.confirmed, true);
-const boundedBlurb = compileStateBlurb(bounded).toLowerCase();
-assert.match(boundedBlurb, /recent coaching patterns/);
-assert.match(boundedBlurb, /weekends are often harder/);
-
-const prior = defaultUnderstanding("Test");
-prior.observations.learnedPatterns = [existingPattern];
-const preserved = coerceUnderstanding({ observations: {} }, "Test", prior);
-assert.equal(preserved.observations.learnedPatterns.length, 1);
-assert.equal(preserved.observations.learnedPatterns[0]?.text, existingPattern.text);
-
-const stale = [{
-  text: "They tend to skip logging when busy.",
-  evidence: "Seen once months ago.",
-  confidence: "medium" as const,
-  firstObserved: "2026-01-01T10:00:00.000Z",
-  lastObserved: "2026-04-01T10:00:00.000Z",
-  confirmed: false,
-}];
-assert.equal(pruneLearnedPatterns(stale, now).length, 0);
-
-const confirmedOlder = [{
-  ...existingPattern,
-  lastObserved: "2026-03-01T10:00:00.000Z",
-}];
-assert.equal(pruneLearnedPatterns(confirmedOlder, now).length, 1);
-
-const safeWithoutEvidence = coerceUnderstanding({ observations: { learnedPatterns: [{
-  text: "They overeat on Saturdays.",
-  evidence: "No Saturday messages were received.",
-  confidence: "low",
-  firstObserved: "2026-08-16T10:00:00.000Z",
-  lastObserved: "2026-08-16T10:00:00.000Z",
-  confirmed: false,
-}]}}, "Test");
-assert.equal(safeWithoutEvidence.observations.learnedPatterns[0]?.confidence, "low");
-assert.equal(safeWithoutEvidence.observations.learnedPatterns[0]?.confirmed, false);
 
 assert.match(
   verifyBrainReply("You're hungry, so add more protein tomorrow.", { goalType: "fat_loss", clientMessage: "I'm always hungry" }).violation || "",

--- a/server/understanding/compiler.ts
+++ b/server/understanding/compiler.ts
@@ -2,7 +2,16 @@
  * Prompt Compiler (blueprint safeguard C).
  *
  * Renders UnderstandingState into a short natural-language blurb that gets injected
- * into the coach prompt — NOT the raw JSON. Deterministic and zero-cost.
+ * into the coach prompt — NOT the raw JSON. Two reasons:
+ *  1. Margin: raw JSON of the full state is ~4-6x the tokens of a 30-word blurb, every
+ *     message, forever. At R199 that matters. This step is deliberately DETERMINISTIC
+ *     (zero model tokens) — it costs nothing to run.
+ *  2. Signal: a model reads "she's frustrated and sick — she needs reassurance, not a
+ *     push" far better than nested JSON. Prose in, better coaching out.
+ *
+ * Example output:
+ *   "Bonolo's confidence has dropped lately. She's frustrated and sick right now —
+ *    steer toward reassurance, not a push. Protein's been light; she's on a 3-day streak."
  */
 
 import { currentRuntimeDecision, type UnderstandingState } from "./state";
@@ -48,18 +57,10 @@ function statsClause(s: UnderstandingState): string {
   return bits.join(", ");
 }
 
-function patternsClause(s: UnderstandingState): string {
-  const now = Date.now();
-  const recent = (s.observations.learnedPatterns || [])
-    .filter(p => p.confidence === "high" && (now - new Date(p.lastObserved).getTime()) <= 90 * 86_400_000)
-    .slice(0, 2);
-  if (!recent.length) return "";
-  return `Recent coaching patterns (evidence-backed, not facts): ${recent.map(p => `${p.text} Evidence: ${p.evidence}`).join(" | ")}. Treat them as hypotheses, not guarantees.`;
-}
-
 export function compileStateBlurb(s: UnderstandingState): string {
   const who = firstName(s.profile.name);
   const parts: string[] = [];
+
   const trend = trendClause(s);
   const mood = moodClause(s);
   const openers: string[] = [];
@@ -83,14 +84,17 @@ export function compileStateBlurb(s: UnderstandingState): string {
     else if (decision.state === "CONTINUE") parts.push("Primary coaching focus: no intervention. Protect the current plan unless the client gives new evidence that changes the decision.");
   }
 
-  const patterns = patternsClause(s);
-  if (patterns) parts.push(patterns);
   parts.push(`Right now, ${steer(s)}.`);
 
   const stats = statsClause(s);
   if (stats) parts.push(`They're ${stats}.`);
+
   if (s.profile.lifeStory) parts.push(s.profile.lifeStory.trim());
-  if (s.profile.preferences.numberFree) parts.push("Keep it number-free — plain language, no calorie figures.");
+
+  const numbers = s.profile.preferences.numberFree
+    ? "Keep it number-free — plain language, no calorie figures."
+    : "";
+  if (numbers) parts.push(numbers);
 
   return parts.join(" ").replace(/\s+/g, " ").trim();
 }

--- a/server/understanding/perception.ts
+++ b/server/understanding/perception.ts
@@ -2,12 +2,18 @@
  * Perception pass (blueprint safeguard A).
  *
  * THE ONE PLACE a raw message becomes updated understanding. It runs a cheap/fast
- * model whose ONLY job: update UnderstandingState — it never writes the reply.
+ * model whose ONLY job is to update UnderstandingState — it never writes the reply.
+ * This is the hard split the reviews demanded: if the same model both replied AND
+ * wrote the state, it would reverse-engineer the state to justify its own reply
+ * (harsh reply → invents "readinessToPush: high" to excuse itself). Fact-finding is
+ * kept separate from decision-making.
  *
- * Trust gate: model output is clamped/whitelisted. Pattern timestamps are server-owned;
- * the model may describe evidence/confidence/confirmation but cannot forge chronology.
+ * Trust gate: whatever the model returns is passed through coerceUnderstanding(),
+ * which clamps ranges and whitelists enums — the model can never poison the state
+ * with an out-of-range frustration level or an invented mood.
  *
- * Offline/fail-safe: any error returns the prior state unchanged.
+ * Offline/fail-safe: any error returns the prior state unchanged (understanding never
+ * regresses on a hiccup, and a reply can still be produced from what we already knew).
  */
 
 import type OpenAI from "openai";
@@ -29,9 +35,7 @@ Rules:
 - topic: what this message is about (recovery/nutrition/workout/life/gratitude/progress).
 - observations.confidenceTrend / frustrationLevel(1-10) / readinessToPush(low/medium/high) / trustLevel(1-10): nudge SLOWLY over time; one message rarely swings these hard. If they're angry at the coach, trust drops and frustration rises.
 - profile.keyFacts: append a durable fact ONLY if they revealed something lasting. Two kinds count: (a) life facts — an injury, their job, family, a firm goal, a food they can't eat; and (b) EVIDENCE of how they respond — observed behaviour that ages well, e.g. "responds well to encouragement", "goes quiet when pushed hard", "mentioned wanting to quit", "logs food daily", "opens up in voice notes". Store the EVIDENCE (what they said or did), never your interpretation ("trustLevel 7", "mood frustrated") — those you infer fresh each message. Never store a passing mood as a fact.
-- observations.learnedPatterns: use this ONLY for repeated, evidence-backed behavioural patterns that can improve future coaching. A single event is NOT a pattern. Never infer a hidden cause from missing data. Never write "overeats on weekends" because Saturdays are missing; that is uncertainty, not evidence. Pattern `text` must describe what was observed, `evidence` must name the concrete repeated evidence, `confidence` is low/medium/high, and `confirmed` is true only when the client explicitly confirms the pattern or the evidence has repeated independently. Keep at most 8 patterns. When a known pattern is contradicted, update its evidence/confidence instead of silently preserving it.
-- Pattern chronology is NOT model-owned. Do not invent `firstObserved` or `lastObserved` timestamps; the server will retain and update them from persisted state and the current turn.
-- profile.lifeStory: a <=50-word narrative in TWO parts. First, WHO THEY ARE (permanent — e.g. "a cleaner, two daughters, wants to be strong for her grandchildren") — keep this stable. Then THEIR CURRENT CHAPTER (what's happening now — update only this part as things change). Do not turn a single incident into a permanent identity statement.
+- profile.lifeStory: a <=50-word narrative in TWO parts. First, WHO THEY ARE (permanent — e.g. "a cleaner, two daughters, wants to be strong for her grandchildren") — keep this stable. Then THEIR CURRENT CHAPTER (what's happening now — e.g. "recovering from flu, confidence dipping, looking forward to next week") — update only this part as things change. Splitting it this way keeps the permanent truth from being overwritten by a passing week.
 - Leave stats untouched (those come from the database, not from you).
 
 Return ONLY valid JSON matching the shape you were given. No prose, no explanation.`;
@@ -39,16 +43,20 @@ Return ONLY valid JSON matching the shape you were given. No prose, no explanati
 export interface PerceptionInput {
   message: string;
   prior: UnderstandingState;
+  /** trustworthy DB-derived stats to fold in (streak, weight direction, averages) */
   stats?: Partial<UnderstandingState["stats"]>;
   userId?: string | null;
 }
 
 export async function runPerception(openai: OpenAI, input: PerceptionInput): Promise<UnderstandingState> {
   const { message, prior, stats, userId } = input;
+  // Stats are DB truth — fold them in regardless of the model, and never let the model touch them.
   const withStats: UnderstandingState = { ...prior, stats: { ...prior.stats, ...(stats || {}) } };
 
   try {
     assertAiOnline("perception");
+    // We send the model the durable subset + current, and ask for an update. Stats are
+    // omitted from what the model sees it can change.
     const seed = {
       profile: withStats.profile,
       current: withStats.current,
@@ -57,7 +65,7 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const resp = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0,
-      max_tokens: 360,
+      max_tokens: 320,
       response_format: { type: "json_object" },
       messages: [
         { role: "system", content: PERCEPTION_SYSTEM },
@@ -75,46 +83,9 @@ export async function runPerception(openai: OpenAI, input: PerceptionInput): Pro
     const content = resp.choices[0]?.message?.content;
     if (!content) return withStats;
     const parsed = JSON.parse(content);
-    const now = new Date().toISOString();
-    const priorPatterns = withStats.observations.learnedPatterns || [];
-    const candidatePatterns = Array.isArray(parsed?.observations?.learnedPatterns) ? parsed.observations.learnedPatterns : [];
-    const byText = new Map<string, any>();
-    for (const p of candidatePatterns) {
-      const text = typeof p?.text === "string" ? p.text.trim() : "";
-      if (text) byText.set(text.toLowerCase(), p);
-    }
-    const mergedPatterns = priorPatterns.map(existing => {
-      const candidate = byText.get(existing.text.trim().toLowerCase());
-      if (!candidate) return existing;
-      return {
-        ...existing,
-        ...candidate,
-        text: existing.text,
-        evidence: typeof candidate.evidence === "string" && candidate.evidence.trim() ? candidate.evidence : existing.evidence,
-        firstObserved: existing.firstObserved,
-        lastObserved: now,
-        confirmed: existing.confirmed || candidate.confirmed === true,
-      };
-    });
-    const existingKeys = new Set(priorPatterns.map(p => p.text.trim().toLowerCase()));
-    for (const candidate of candidatePatterns) {
-      const text = typeof candidate?.text === "string" ? candidate.text.trim() : "";
-      if (!text || existingKeys.has(text.toLowerCase())) continue;
-      mergedPatterns.push({
-        ...candidate,
-        text,
-        firstObserved: now,
-        lastObserved: now,
-        confirmed: candidate.confirmed === true,
-      });
-    }
-    const parsedWithPatterns = {
-      ...parsed,
-      observations: { ...withStats.observations, ...(parsed?.observations || {}), learnedPatterns: mergedPatterns },
-    };
-    const coerced = coerceUnderstanding(parsedWithPatterns, withStats.profile.name, withStats);
+    const coerced = coerceUnderstanding(parsed, withStats.profile.name);
     coerced.stats = withStats.stats;
-    coerced.updatedAt = now;
+    coerced.updatedAt = new Date().toISOString();
     return coerced;
   } catch (e) {
     if (!isAiOfflineError(e)) console.warn("[PERCEPTION] update failed (keeping prior state):", (e as any)?.message || e);

--- a/server/understanding/state.ts
+++ b/server/understanding/state.ts
@@ -24,25 +24,12 @@ export type Topic = "recovery" | "nutrition" | "workout" | "life" | "gratitude" 
 export type Trend = "rising" | "stable" | "falling";
 export type Readiness = "low" | "medium" | "high";
 export type WeightDirection = "up" | "down" | "stable";
-export type PatternConfidence = "low" | "medium" | "high";
 
 export interface ReentryState {
   /** Number of full days since the coach last had a persisted understanding for this client. */
   daysSinceLastContact: number | null;
   /** True when the gap is long enough that continuity should be re-established, not assumed. */
   isReturning: boolean;
-}
-
-export interface LearnedPattern {
-  /** What has actually been observed, stated without diagnosis or interpretation. */
-  text: string;
-  /** The concrete evidence behind the observation. */
-  evidence: string;
-  confidence: PatternConfidence;
-  firstObserved: string;
-  lastObserved: string;
-  /** True only when the client explicitly confirmed the pattern or it has repeated evidence. */
-  confirmed: boolean;
 }
 
 export interface UnderstandingState {
@@ -66,8 +53,6 @@ export interface UnderstandingState {
     frustrationLevel: number; // 1-10
     readinessToPush: Readiness;
     trustLevel: number;       // 1-10
-    /** Repeated, evidence-backed patterns; never treated as facts without evidence. */
-    learnedPatterns: LearnedPattern[];
   };
   /** objective baseline — DERIVED from the DB snapshot each turn, never persisted here */
   stats: {
@@ -84,16 +69,12 @@ export function defaultUnderstanding(name = "there"): UnderstandingState {
   return {
     profile: { name, lifeStory: "", keyFacts: [], preferences: { numberFree: true } },
     current: { mood: "neutral", healthStatus: "healthy", topic: "life", reentry: { daysSinceLastContact: null, isReturning: false } },
-    observations: { confidenceTrend: "stable", frustrationLevel: 3, readinessToPush: "medium", trustLevel: 5, learnedPatterns: [] },
+    observations: { confidenceTrend: "stable", frustrationLevel: 3, readinessToPush: "medium", trustLevel: 5 },
     stats: { streak: 0, weightDirection: "stable", recentProteinAvg: 0, recentStepAvg: 0 },
     updatedAt: new Date().toISOString(),
   };
 }
 
-/**
- * Convert elapsed time since a stored understanding into a deterministic re-entry signal.
- * A missing stored state means there is no reliable prior contact to call a gap.
- */
 export function reentryFromAgeHours(ageHours: number, hasStoredContact = true): ReentryState {
   if (!hasStoredContact || !Number.isFinite(ageHours) || ageHours < 0) {
     return { daysSinceLastContact: null, isReturning: false };
@@ -102,46 +83,18 @@ export function reentryFromAgeHours(ageHours: number, hasStoredContact = true): 
   return { daysSinceLastContact: days, isReturning: days >= 2 };
 }
 
-/**
- * INFERENCE DECAY (Law 5 — facts are sacred, inferences expire). `observations` are the
- * coach's READ on the person (frustration, confidence trend, readiness) — educated guesses,
- * not facts. After a gap they go stale: nothing worse than a coach still treating someone as
- * "anxious" or "frustrated" weeks later. So on reload we pull the volatile reads back toward
- * neutral. TRUST is different — it's EARNED, durable, and only fades after a long absence.
- */
 export function decayObservations(
   o: UnderstandingState["observations"],
   ageHours: number,
 ): UnderstandingState["observations"] {
-  if (!(ageHours >= 48)) return o; // fresh (<2 days) — the read still holds
+  if (!(ageHours >= 48)) return o;
   const d = defaultUnderstanding().observations;
   return {
-    confidenceTrend: "stable",   // no trend assumption survives a gap
-    readinessToPush: "medium",   // re-earn the read on how hard to push
-    frustrationLevel: Math.round(o.frustrationLevel * 0.5 + d.frustrationLevel * 0.5), // halfway back to baseline
-    trustLevel: ageHours >= 24 * 30 ? Math.round(o.trustLevel * 0.7 + d.trustLevel * 0.3) : o.trustLevel, // trust only fades after ~a month away
-    learnedPatterns: o.learnedPatterns,
+    confidenceTrend: "stable",
+    readinessToPush: "medium",
+    frustrationLevel: Math.round(o.frustrationLevel * 0.5 + d.frustrationLevel * 0.5),
+    trustLevel: ageHours >= 24 * 30 ? Math.round(o.trustLevel * 0.7 + d.trustLevel * 0.3) : o.trustLevel,
   };
-}
-
-/**
- * Learned patterns are not facts. They age out when the evidence is stale.
- * - low/medium confidence: 90 days
- * - confirmed high confidence: 180 days
- */
-export function pruneLearnedPatterns(patterns: LearnedPattern[], nowMs = Date.now()): LearnedPattern[] {
-  const DAY = 86_400_000;
-  return patterns
-    .filter(p => p && typeof p.text === "string" && p.text.trim() && typeof p.evidence === "string" && p.evidence.trim())
-    .filter(p => {
-      const last = new Date(p.lastObserved).getTime();
-      if (!Number.isFinite(last)) return false;
-      const ageDays = Math.max(0, (nowMs - last) / DAY);
-      const maxDays = p.confirmed && p.confidence === "high" ? 180 : 90;
-      return ageDays <= maxDays;
-    })
-    .sort((a, b) => new Date(b.lastObserved).getTime() - new Date(a.lastObserved).getTime())
-    .slice(0, 8);
 }
 
 const MOODS = new Set<Mood>(["frustrated", "anxious", "motivated", "neutral", "hopeful"]);
@@ -150,7 +103,6 @@ const TOPICS = new Set<Topic>(["recovery", "nutrition", "workout", "life", "grat
 const TRENDS = new Set<Trend>(["rising", "stable", "falling"]);
 const READY = new Set<Readiness>(["low", "medium", "high"]);
 const WDIR = new Set<WeightDirection>(["up", "down", "stable"]);
-const PATTERN_CONFIDENCE = new Set<PatternConfidence>(["low", "medium", "high"]);
 
 const clampInt = (n: unknown, lo: number, hi: number, dflt: number): number => {
   const v = typeof n === "number" ? n : Number(n);
@@ -158,37 +110,15 @@ const clampInt = (n: unknown, lo: number, hi: number, dflt: number): number => {
   return Math.max(lo, Math.min(hi, Math.round(v)));
 };
 const oneOf = <T,>(set: Set<T>, v: unknown, dflt: T): T => (set.has(v as T) ? (v as T) : dflt);
-const validIso = (value: unknown, fallback: string): string => {
-  if (typeof value !== "string") return fallback;
-  const t = new Date(value).getTime();
-  return Number.isFinite(t) ? new Date(t).toISOString() : fallback;
-};
 
-/**
- * Coerce arbitrary parsed JSON (from storage OR from a model) into a valid, safe
- * UnderstandingState. This is the trust gate: a model can never write an out-of-range
- * frustration level or an invented mood into the system — it is clamped/whitelisted here.
- *
- * `fallbackState` lets a perception update preserve durable fields the model omitted.
- */
-export function coerceUnderstanding(raw: any, fallbackName = "there", fallbackState?: UnderstandingState): UnderstandingState {
-  const d = fallbackState ? coerceUnderstandingBase(fallbackState) : defaultUnderstanding(fallbackName);
+export function coerceUnderstanding(raw: any, fallbackName = "there"): UnderstandingState {
+  const d = defaultUnderstanding(fallbackName);
   if (!raw || typeof raw !== "object") return d;
   const p = raw.profile ?? {};
   const c = raw.current ?? {};
   const o = raw.observations ?? {};
   const s = raw.stats ?? {};
   const re = c.reentry ?? {};
-  const now = new Date().toISOString();
-  const rawPatterns = Array.isArray(o.learnedPatterns) ? o.learnedPatterns : d.observations.learnedPatterns;
-  const patterns = pruneLearnedPatterns(rawPatterns.map((p: any) => ({
-    text: typeof p?.text === "string" ? p.text.trim().slice(0, 180) : "",
-    evidence: typeof p?.evidence === "string" ? p.evidence.trim().slice(0, 240) : "",
-    confidence: oneOf(PATTERN_CONFIDENCE, p?.confidence, "low"),
-    firstObserved: validIso(p?.firstObserved, now),
-    lastObserved: validIso(p?.lastObserved, now),
-    confirmed: typeof p?.confirmed === "boolean" ? p.confirmed : false,
-  })), Date.now());
   return {
     profile: {
       name: typeof p.name === "string" && p.name.trim() ? p.name.trim().slice(0, 60) : d.profile.name,
@@ -210,7 +140,6 @@ export function coerceUnderstanding(raw: any, fallbackName = "there", fallbackSt
       frustrationLevel: clampInt(o.frustrationLevel, 1, 10, d.observations.frustrationLevel),
       readinessToPush: oneOf(READY, o.readinessToPush, d.observations.readinessToPush),
       trustLevel: clampInt(o.trustLevel, 1, 10, d.observations.trustLevel),
-      learnedPatterns: patterns,
     },
     stats: {
       streak: clampInt(s.streak, 0, 100000, d.stats.streak),
@@ -218,28 +147,15 @@ export function coerceUnderstanding(raw: any, fallbackName = "there", fallbackSt
       recentProteinAvg: clampInt(s.recentProteinAvg, 0, 100000, d.stats.recentProteinAvg),
       recentStepAvg: clampInt(s.recentStepAvg, 0, 10000000, d.stats.recentStepAvg),
     },
-    updatedAt: validIso(raw.updatedAt, d.updatedAt),
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : d.updatedAt,
   };
 }
 
-function coerceUnderstandingBase(state: UnderstandingState): UnderstandingState {
-  return {
-    profile: { ...state.profile, keyFacts: [...state.profile.keyFacts], preferences: { ...state.profile.preferences } },
-    current: { ...state.current, reentry: { ...state.current.reentry } },
-    observations: { ...state.observations, learnedPatterns: [...state.observations.learnedPatterns] },
-    stats: { ...state.stats },
-    updatedAt: state.updatedAt,
-  };
-}
-
-/** The durable subset — what is safe to PERSIST (profile + observations only). */
 export function persistableUnderstanding(s: UnderstandingState): Pick<UnderstandingState, "profile" | "observations"> {
   return { profile: s.profile, observations: s.observations };
 }
 
-export function serializeUnderstanding(s: UnderstandingState): string {
-  return JSON.stringify(s);
-}
+export function serializeUnderstanding(s: UnderstandingState): string { return JSON.stringify(s); }
 
 export function parseUnderstanding(json: string | null | undefined, fallbackName = "there"): UnderstandingState {
   if (!json) return defaultUnderstanding(fallbackName);
@@ -247,7 +163,6 @@ export function parseUnderstanding(json: string | null | undefined, fallbackName
   catch { return defaultUnderstanding(fallbackName); }
 }
 
-// ---- Canonical coaching decision contract (P0) ----
 export type DecisionState = "CONTINUE" | "CHANGE" | "INVESTIGATE" | "REFER";
 export type DecisionEvidence = "sufficient" | "insufficient";
 export type DecisionFocus = "safety" | "hunger" | "intake" | "none";
@@ -260,15 +175,11 @@ export function selectDecisionState(input: DecisionInputs): DecisionState {
 }
 export function isCoachingDecisionState(value: unknown): value is DecisionState { return value === "CONTINUE" || value === "CHANGE" || value === "INVESTIGATE" || value === "REFER"; }
 
-/** Deterministic adapter from the live evidence objects into the canonical decision contract. */
 export interface RuntimeDecisionInputs { hungerEvidence?: any; deficitEvidence?: any; requiresReferral?: boolean; }
 export interface RuntimeDecisionResult { state: DecisionState; evidence: DecisionEvidence; meaningfulProblem: boolean; hasMinimumUsefulQuestion: boolean; focus: DecisionFocus; }
 const decisionStorage = new AsyncLocalStorage<RuntimeDecisionResult>();
 export function currentRuntimeDecision(): RuntimeDecisionResult | undefined { return decisionStorage.getStore(); }
-const rememberRuntimeDecision = (decision: RuntimeDecisionResult): RuntimeDecisionResult => {
-  decisionStorage.enterWith(decision);
-  return decision;
-};
+const rememberRuntimeDecision = (decision: RuntimeDecisionResult): RuntimeDecisionResult => { decisionStorage.enterWith(decision); return decision; };
 export function deriveRuntimeDecision(input: RuntimeDecisionInputs): RuntimeDecisionResult {
   if (input.requiresReferral) return rememberRuntimeDecision({ state: "REFER", evidence: "sufficient", meaningfulProblem: true, hasMinimumUsefulQuestion: false, focus: "safety" });
   const hunger = input.hungerEvidence;

--- a/server/understanding/store.ts
+++ b/server/understanding/store.ts
@@ -1,8 +1,16 @@
 /**
- * The UnderstandingState store: durable read/write per client.
+ * The UnderstandingState store (blueprint Days 11-20): durable read/write per client.
  *
- * loadUnderstanding merges the PERSISTED durable subset onto a freshly-seeded state.
- * saveUnderstanding writes only the durable subset through the trust gate.
+ * loadUnderstanding merges the PERSISTED durable subset (profile + observations) onto a
+ * freshly-seeded state (which carries this-turn volatile fields + DB-derived stats). So
+ * every turn starts from: what we durably know about the person + where they are right now.
+ *
+ * saveUnderstanding writes back ONLY the durable subset, through the trust gate — the
+ * volatile mood/topic and the DB stats are never persisted (they'd be stale or a model
+ * guess). This is the discipline the reviews demanded: persist only what you can trust.
+ *
+ * Fail-open everywhere: a store miss/error must never break a reply — we fall back to the
+ * seed. The table (client_understanding) is created by `npm run db:push`.
  */
 
 import { eq } from "drizzle-orm";
@@ -13,7 +21,6 @@ import {
   coerceUnderstanding,
   persistableUnderstanding,
   decayObservations,
-  pruneLearnedPatterns,
   reentryFromAgeHours,
 } from "./state";
 
@@ -25,11 +32,9 @@ export async function loadUnderstanding(userId: string, seed: UnderstandingState
     const stored = coerceUnderstanding(
       { profile: row.profile, observations: row.observations },
       seed.profile.name,
-      seed,
     );
     const ageHours = row.updatedAt ? (Date.now() - new Date(row.updatedAt).getTime()) / 3_600_000 : 0;
     stored.observations = decayObservations(stored.observations, ageHours);
-    stored.observations.learnedPatterns = pruneLearnedPatterns(stored.observations.learnedPatterns);
     const reentry = reentryFromAgeHours(ageHours, !!row.updatedAt);
     return {
       profile: {


### PR DESCRIPTION
Rollback of the learned-pattern memory slice after Railway reported a failed production deployment on merge commit `57b5de4`.

This restores the exact `main` state from `b2baa1e`, which was the last known-green line before the memory slice. The memory work remains preserved on `cto/coaching-memory-patterns` for re-application as a smaller, independently verified slice once the Railway failure is understood.

No product doctrine or decision-focus behaviour is being reverted.