### PR TITLE
P1: enforce medication safety at the reply boundary

### DIFF
--- a/script/decision-boundary-tests.ts
+++ b/script/decision-boundary-tests.ts
@@ -93,4 +93,17 @@ assert.deepEqual(detectMedicationContext("I had eggs and pap today."), {
   present: false, medicationClass: null, unsafeRequest: false, reason: null,
 });
 
+assert.match(
+  verifyBrainReply("Take 1mg Ozempic and keep your calorie deficit.", { goalType: "fat_loss", clientMessage: "What dose of Ozempic should I take?" }).violation || "",
+  /Unsafe medication request/i,
+);
+assert.equal(
+  verifyBrainReply("Please speak to your doctor about the dose.", { goalType: "fat_loss", clientMessage: "What dose of Ozempic should I take?" }).ok,
+  true,
+);
+assert.match(
+  verifyBrainReply("Buy it from the seller and keep training.", { goalType: "fat_loss", clientMessage: "Where can I buy semaglutide?" }).violation || "",
+  /Unsafe medication request|sourcing/i,
+);
+
 console.log("decision-boundary-tests: all passed");

--- a/server/brain/reply-verifier.ts
+++ b/server/brain/reply-verifier.ts
@@ -7,6 +7,7 @@
  */
 
 import { currentRuntimeDecision, type RuntimeDecisionResult } from "../understanding/state";
+import { detectMedicationContext } from "../medication-context";
 
 export interface VerifierFacts {
   goalType?: string | null;
@@ -72,6 +73,22 @@ function decisionBoundaryViolation(reply: string, decision: RuntimeDecisionResul
     "doctor", "dietitian", "clinician", "healthcare professional", "medical help", "seek medical care", "emergency",
   ])) return DECISION_VIOLATIONS.referMissing;
 
+  return null;
+}
+
+function medicationBoundaryViolation(reply: string, clientMessage: string): string | null {
+  const medication = detectMedicationContext(clientMessage);
+  if (!medication.unsafeRequest) return null;
+  const text = (reply || "").toLowerCase();
+  if (!containsAny(text, ["doctor", "pharmacist", "clinician", "healthcare professional", "medical care", "seek medical help", "emergency"])) {
+    return `Unsafe medication request (${medication.reason}) must be redirected to a doctor, pharmacist, or other appropriate medical professional; do not answer it as ordinary coaching.`;
+  }
+  if (/\b(calorie|calories|kcal|protein|steps|step|workout|training|session|deficit|meal plan|diet)\b/i.test(text)) {
+    return `Unsafe medication request (${medication.reason}) must remain a referral/safety response. Do not continue ordinary diet, training, or weight-loss coaching in the same reply.`;
+  }
+  if (medication.reason === "sourcing" && /\b(buy|seller|supplier|source|sourcing|black market|hairdresser)\b/i.test(text)) {
+    return "The reply must not facilitate medication sourcing or black-market access.";
+  }
   return null;
 }
 
@@ -147,6 +164,9 @@ export function verifyBrainReply(reply: string, facts: VerifierFacts, decisionOv
     const violation = decisionBoundaryViolation(r, decision);
     if (violation) return { ok: false, violation };
   }
+
+  const medicationViolation = medicationBoundaryViolation(r, facts.clientMessage || "");
+  if (medicationViolation) return { ok: false, violation: medicationViolation };
 
   if (/\b(?:cure|reverse|heal|get rid of|eliminate|fix)\s+(?:your\s+|the\s+|his\s+|her\s+)?(?:diabetes|diabetic|hypertension|high blood pressure|blood pressure|cholesterol|pcos|thyroid|arthritis|ibs|cancer|condition|illness|disease|diagnosis)\b/i.test(r)) {
     return { ok: false, violation: "Your reply claims to cure/reverse/heal a medical CONDITION. KamLife is a wellness coach, NOT a doctor or medical device — this is a compliance and liability breach and must NEVER be said. Rewrite: coach the healthy HABITS (movement, food, sleep, consistency) that support how they feel, and for anything about the condition itself defer to their doctor ('I'm your coach, not your doctor — your doctor guides the condition, I'll help you build the habits around it'). Never promise to cure, reverse or fix a disease." };


### PR DESCRIPTION
Make the new deterministic medication context boundary authoritative at the Coach K mouth.

Unsafe medication requests now require a medical referral posture and cannot be answered with ordinary diet/training coaching or sourcing help.

Adds regression coverage for dosing and sourcing failures plus a valid referral response.

No schema, dependency, routing, WhatsApp, Meta, or infrastructure changes.