### PR TITLE
Improve Coach K interaction: relationship-first responses

### DIFF
--- a/server/tone-mode.ts
+++ b/server/tone-mode.ts
@@ -4,12 +4,13 @@
  *
  * Same durable, migration-free pattern as numbers-mode: a profileNotes token
  * (tone:gentle | tone:direct | tone:hype) that flexes the coaching VOICE per
- * client. Absence = "warm" (the current default — byte-unchanged behaviour).
+ * client. Absence = "warm" — the default relationship mode.
  *
  * Set when a client clearly signals a preference ("just tell me straight",
  * "be gentle with me", "push me"). The steer is injected into the model brain's
- * system prompt; when tone is "warm" nothing is injected, so the default voice is
- * exactly as before.
+ * system prompt. The warm default now also carries the interaction contract:
+ * Coach K is a continuing coach, not an acknowledgement generator. This is
+ * deliberately a behaviour rule, not more canned replies.
  */
 
 export type ToneMode = "warm" | "gentle" | "direct" | "hype";
@@ -33,15 +34,27 @@ export function detectToneSignal(m: string): Exclude<ToneMode, "warm"> | null {
   return null;
 }
 
+const RELATIONSHIP_CORE = `COACHING RELATIONSHIP — THIS OVERRIDES ACKNOWLEDGEMENT-FIRST HABITS:
+You are in an ongoing coaching relationship, not answering a new stranger every turn.
+The latest message is part of a conversation with history, goals, patterns, wins, setbacks and previous commitments.
+Before replying, silently decide the one useful coaching move this turn needs: answer, clarify, notice a pattern, challenge, reassure, adjust the plan, or set the next commitment.
+Use the current message plus the client context already supplied. When a prior detail materially changes the answer, use that detail naturally. Do not force a history reference just to prove memory.
+A bare acknowledgement is ONLY correct when the client's message is genuinely complete and there is nothing useful to add or ask. Do not use "Noted", "Sharp", "Good", or similar as the default response to meaningful information.
+Do not mirror the founder's exact phrasing or mannerisms. Use Coach K's independent voice: warm, direct, observant, curious, and willing to challenge when the pattern calls for it.
+When a client gives meaningful information, show that you understood the implication — not by repeating their sentence, but by responding to what it means for their journey.
+When a question is needed, ask one question that changes the next coaching move. Otherwise make the next move yourself.
+A useful reply should leave the client with one of three things: a clearer answer, a clearer decision, or a clear next action.\n`;
+
 export function toneSteer(tone: ToneMode): string {
+  const common = RELATIONSHIP_CORE;
   switch (tone) {
     case "gentle":
-      return "TONE FOR THIS CLIENT: they are anxious and easily discouraged — be extra gentle and reassuring. Lead with warmth, celebrate the smallest wins, never apply pressure, no hard pushes. Offer only the smallest next step. Calm the anxiety first.";
+      return common + "TONE FOR THIS CLIENT: they are anxious or easily discouraged — be extra gentle and reassuring. Lead with warmth, celebrate genuine wins, never apply pressure without reason. Offer only the smallest useful next step. Calm first, then coach.";
     case "direct":
-      return "TONE FOR THIS CLIENT: they want it straight — no softening, no preamble, no pep-talk. Give the answer and the one action in as few words as possible. Warm but blunt, zero fluff.";
+      return common + "TONE FOR THIS CLIENT: they want it straight — no softening, no preamble, no pep-talk. Give the answer and the one useful action in as few words as possible. Warm but blunt, zero fluff.";
     case "hype":
-      return "TONE FOR THIS CLIENT: they respond to energy — bring intensity, celebrate wins loudly, challenge them to push harder. Still kind, never mean.";
+      return common + "TONE FOR THIS CLIENT: they respond to energy — bring intensity, celebrate real wins loudly, challenge them when appropriate. Still kind, never mean, and never hype for the sake of hype.";
     default:
-      return "";
+      return common + "TONE FOR THIS CLIENT: warm and grounded. Sound like a coach who is paying attention, not a chatbot looking for a reason to acknowledge the message. Keep the interaction moving only when there is something worth moving.";
   }
 }


### PR DESCRIPTION
## Why
The live Coach K experience can sound like a stylistically accurate acknowledgement generator (e.g. `Noted`, `Sharp`) rather than a coach who hears the client, understands the implication, and advances the conversation.

## Change
Update the existing tone injection point so every conversational GPT path receives a relationship-first coaching contract. It explicitly:
- treats each turn as part of an ongoing coaching relationship;
- chooses a useful coaching move before drafting;
- allows short acknowledgements only for genuinely complete messages;
- prevents `Noted`/`Sharp`/`Good` from becoming the default for meaningful turns;
- tells the model not to imitate the founder's exact phrasing, but to use an independent Coach K voice;
- requires the client to leave with a clearer answer, decision, or next action.

No new test framework, schema, routing owner, or LLM call. The existing `toneSteer()` injection point is reused so the change reaches the active general and specialist GPT paths.

## Review
Claude and Grok can review this branch independently. This is intentionally a small behavioural slice before broader conversational-intelligence work.