### PR TITLE
Bring validated food event correction model onto main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 - `MEDIA_BASE_URL` — CDN root for exercise GIFs and portion images
 - `PAYFAST_MERCHANT_ID`, `APP_URL`
 - `PROACTIVE_PAUSED=true` — global killswitch for all proactive messages
+- `FOOD_EVENTS=off` — killswitch for the Event Model (see below); reverts to one row per message
 
 ## GIF setup (pending human task)
 Set `MEDIA_BASE_URL` in Railway, then upload files to `MEDIA_BASE_URL/ex/<slug>.gif`.
@@ -42,6 +43,14 @@ canonical must exist in the original (hallucination brake); on timeout/error the
 original message proceeds unchanged. Killswitch: `NORMALIZER=off` in Railway.
 QUESTION classification also guards the step logger from eating questions.
 Voice transcripts get normalized too — media recursion re-enters handleMessage as text.
+
+### Event Model (one message, N events)
+A food message is not an event — each labelled meal in it is. Two meals in one message are two
+`meal_logs` rows, each with its own label, items and numbers; the day is the sum of its events;
+the turn still gets ONE reply. A correction is netted BEFORE the write when it is in the same
+message, and lands on the event that holds the food when it is in the next one. The rules are
+pure and live in `server/food-identity-correction.ts`; the boundary is `docs/EVENT-MODEL.md`
+and §9 of `script/acceptance-hold.ts` (real DB). Killswitch: `FOOD_EVENTS=off` in Railway.
 
 ## Never touch without full understanding
 - `server/coach-prompt.ts` — any change to food philosophy or coaching voice must preserve goal-aware logic (fat_loss gets portion context, muscle_gain gets encouragement)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,6 +5,35 @@ folded into an unrelated work order. Nothing here is authorized for change.
 
 ---
 
+## EVT-1 — Multi-day catch-up rows are events with no items
+
+**Recorded:** 2026-08-16, while building the Event Model (`docs/EVENT-MODEL.md`).
+**Status:** OPEN — recorded, not adjudicated. No fix authorized.
+**Not an Event Model defect.** This path already wrote one row per day and was not
+touched; the gap only became visible once "what is an event" was written down.
+
+`handleFoodContext`'s multi-day branch ("chicken Wednesday, oats Thursday") commits
+each day through `commitFoodLog` with `items: []`, `carbsInt: 0`, `fatInt: 0`. So:
+
+- a correction naming a food (*"the rice on Wednesday was wrong"*) can TARGET the row —
+  `pickCorrectionTargets` matches the raw message — but `applyCorrection` then has an
+  empty item list to edit, so nothing changes and the client is told nothing changed;
+- the carbs and fat on those rows are `estimateCarbsFat`'s ratio guess rather than the
+  table's measured numbers, which the scanner path has for the same foods;
+- the day-ledger falls back to the raw message for the diary line, which reads
+  `"wednesday: chicken and rice"` rather than the foods.
+
+The fix looks like three lines — pass the adjusted foods through the same item shape and
+`carbsFatFromFoods` the scanner path uses. It is NOT done here because it changes stored
+numbers on a path no acceptance case exercises, and this work order was frozen.
+
+**Adjudicate deliberately.** If it is picked up, it wants a row-level case in
+`acceptance-hold.ts` first — a multi-day dump, then a correction naming a food from the
+middle day — because "the correction silently did nothing" is exactly the failure this
+product cannot see from the reply.
+
+---
+
 ## PRIV-1 — Client message content is written to the application log stream
 
 **Recorded:** 2026-08-11, during WO7 acceptance (the privacy grep).

--- a/docs/EVENT-MODEL.md
+++ b/docs/EVENT-MODEL.md
@@ -1,0 +1,110 @@
+# THE EVENT MODEL — one message, N events
+
+**Shipped 2026-08-16.** Killswitch: `FOOD_EVENTS=off` in Railway.
+
+The frozen work order, in one line:
+
+```
+message → N events → grouped corrections → trusted retrieval → correct aggregates → one final response
+```
+
+---
+
+## What was actually wrong
+
+A message was an event. `"2 eggs and pap for breakfast, chicken and rice for lunch"` produced
+**one** `meal_logs` row: every food merged, labelled with whichever slot was named first,
+stamped with one time.
+
+The segmentation was not missing — it has existed for months. It only ever shaped the **reply**.
+So the product SAID "breakfast … lunch …" and STORED a single blob called breakfast, and every
+consequence flows from that gap between what it says and what it keeps:
+
+- `remove my lunch` cannot find a lunch inside a row called breakfast;
+- a correction lands on whatever was written last, which after a split is a coin toss;
+- the diary reads one line for two meals;
+- anything per-slot is unanswerable from the data.
+
+Two more failures were found while building it, and they are in the boundary below:
+a correction **inside** the logging message, and non-food content **inside** a food dump.
+
+## What it is now
+
+| Stage | Where it lives | Rule |
+|---|---|---|
+| message → N events | `planEventWrites` (`food-identity-correction.ts`), called from the scanner path | a labelled segment carrying food is an event; below two, nothing changes |
+| grouped corrections (in-message) | `netMessageFoods` / `netEventFoods` | a food the client withdraws in the same breath is netted **before** the write |
+| grouped corrections (next turn) | `pickCorrectionTargets` + `recordEventGroup` | the fix lands on the event that HOLDS the food; a bare move takes the whole group |
+| trusted retrieval | `food-log-mgmt.ts` | candidates are read from the rows, and matched against the items those rows actually hold |
+| correct aggregates | the day ledger, unchanged | the day is the sum of its events — asserted against the rows, not the cache |
+| one final response | `food-context.ts`, unchanged | N events still produce ONE reply. Law 15 forbids a receipt, so it is not a per-slot breakdown either |
+
+**No new table.** `meal_logs` has been one row per event since it was written; nothing ever wrote
+the second row. **No meal-slot taxonomy**: the label is whatever word the client used, passed
+through unchanged. **No new test framework, no prompt rewrite, no dashboard work.**
+
+## The acceptance boundary
+
+Nine cases, all at the ROW level, in `script/acceptance-hold.ts` (§9) — the reply was never the
+thing that was wrong. Run with a real database:
+
+```
+DATABASE_URL=postgresql://… npx tsx script/acceptance-hold.ts
+```
+
+| # | Case | State |
+|---|---|---|
+| 9.1 | two meals in one message are two rows, each with the slot the client named | ✅ verified |
+| 9.2 | the day total is the sum of the events, nothing double-counted | ✅ verified |
+| 9.3 | one final response, accounting for both events | ✅ verified |
+| 9.4 | **intra-message correction** — the withdrawn food is never written | ✅ verified |
+| 9.5 | **non-food content in a food dump** — no phantom item, no request to price their back | ✅ verified |
+| 9.6 | a correction lands on the event holding the food; the other event is untouched | ✅ verified |
+| 9.7 | a bare move takes the whole group — both events, or two days are wrong at once | ✅ verified |
+| 9.8 | an ordinary single meal is unchanged: one row, the client's sentence, its confirmation | ✅ verified |
+| — | the seven pre-existing acceptance cases (§P0.1, §5, the hold, WO2, fix 3, §6, 6, 7, 8) | ✅ still green |
+
+**Verified how.** 2026-08-16, against a real PostgreSQL instance through the real
+`handleMessage` pipeline: **82/82**. The same harness on the pre-change code scores **72/82** —
+the ten failures are the defects above, so these tests can fail, which is the only reason to
+trust that they passed. Plus `npm test` (1,019 unit + 316 routing + the guards) and
+`npm run gauntlet` (fully green, all five slices).
+
+Not verified by any of this: the coaching **voice** on a split log. That needs a real model and
+belongs to `script/reality-test.ts`, which is a different test and is reported separately.
+
+## The two the investigation found last
+
+**Intra-message correction.** *"I had rice and chicken for lunch, actually not rice, it was pap"*
+is one turn. The scanner reads left to right and finds rice, chicken AND pap; the correction
+machinery only ever looked at a message that FOLLOWED a log. All three were written, and the day
+was ~260 kcal wrong before it began — the silent kind of wrong, which nobody can see to complain
+about. It is netted before the write, so nothing is inserted and then repaired.
+
+The first draft of that netting ate the chicken: the food table resolves "rice and chicken" to a
+single combo dish, so a name filter removed both foods — the identical defect `applyCorrection`
+was written to fix one turn earlier. It now delegates to `applyCorrection` rather than keeping a
+second copy of the composition rule. **That failure was found by running the harness against a
+real database, not by reading the code.**
+
+**Non-food content inside a food dump.** *"…and my back is sore and I didn't sleep"* is not an
+unpriced ingredient. "back" and "sore" are not in the notice's NOISE list, so the leftover
+vocabulary was audited as menu items and the client was asked whether it was fried or grilled —
+answering the half of their message that mattered most with a request to itemise it.
+`plateClausesOnly` is now the one owner of "which half of this message is about the plate", read
+by both the unpriced-food notice and the supplement model. A clause is dropped only when it is
+positively recognised as body-or-life talk, and a caller-supplied veto keeps any clause that
+really does carry food ("so tired I ate a whole pizza").
+
+## Deliberately NOT done
+
+- **The multi-day catch-up path stores no items** (`items: []`). Recorded in `docs/BACKLOG.md`
+  as EVT-1, not fixed: those rows are already one per day, the fix changes their carb/fat numbers
+  from estimated to measured, and no case in the boundary demonstrates it. Adjudicate it on its
+  own merits rather than folding it into this work order.
+- **Reply ownership for a food dump that carries feeling but no question.** Today the turn ends
+  at the food confirmation unless the message also asks something (`routes.ts`, WO2). Changing
+  that is a routing decision with a double-log risk, and it is a prompt/routing question, not an
+  Event Model one.
+- **Meal-slot taxonomy, a new event table, a dashboard read of per-event data.** Out of scope by
+  instruction, and none of them is needed for the boundary above.

--- a/script/acceptance-hold.ts
+++ b/script/acceptance-hold.ts
@@ -373,6 +373,125 @@ console.log("\n── 8. forceLog governs the LOG_MEAL write ──");
     (await dayRows(uC.id)).length === 0, `rows=${(await dayRows(uC.id)).length}`);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. THE EVENT MODEL — one message, N events. (2026-08-16.)
+//
+//   message → N events → grouped corrections → trusted retrieval → correct aggregates
+//   → one final response
+//
+// Every assertion here is at the ROW level, because the reply was never the thing that was
+// wrong: the product has been SAYING "breakfast … lunch …" and STORING one blob called
+// breakfast since the segmentation was written. The seven cases above are the acceptance
+// boundary this joins; 9.4 and 9.5 are the two the investigation found last — a correction
+// inside the logging message itself, and non-food content inside a food dump.
+// ─────────────────────────────────────────────────────────────────────────────
+{
+  console.log("\n── 9. the event model: one message, N events ──");
+  const phone = "whatsapp:+27000000111";
+  const DUMP = "2 eggs and pap for breakfast, chicken and rice for lunch";
+
+  // 9.1 — N EVENTS. Two meals in one message are two rows, each labelled with the slot the
+  // client named. This is the whole change; everything below depends on it.
+  const u = await freshUser(phone);
+  const reply = await handleMessage(phone, DUMP);
+  const rows = await db.select({ id: mealLogs.id, kcal: mealLogs.kcalInt, prot: mealLogs.proteinInt,
+    label: mealLogs.mealLabel, raw: mealLogs.rawMessage, items: mealLogs.items })
+    .from(mealLogs).where(and(eq(mealLogs.userId, u.id), gte(mealLogs.loggedAt, sastDayStart())));
+  const labels = rows.map(r => String(r.label || "").toLowerCase()).sort();
+  check("9.1 two meals in one message are TWO rows", rows.length === 2, `rows=${rows.length} labels=${labels.join(",")}`);
+  check("9.1 each row carries the slot the CLIENT named", labels.join(",") === "breakfast,lunch", labels.join(","));
+  const named = (label: string) => (rows.find(r => String(r.label || "").toLowerCase() === label)?.items as any[] || [])
+    .map(i => String(i?.name || "").toLowerCase()).join(" ");
+  check("9.1 the breakfast row holds the breakfast food", /egg|pap/.test(named("breakfast")), named("breakfast"));
+  check("9.1 the lunch row holds the lunch food", /chicken|rice/.test(named("lunch")), named("lunch"));
+  check("9.1 no food landed on the wrong plate", !/chicken/.test(named("breakfast")) && !/\begg/.test(named("lunch")),
+    `${named("breakfast")} | ${named("lunch")}`);
+  check("9.1 every row carries its own calories", rows.every(r => (r.kcal || 0) > 0), JSON.stringify(rows.map(r => r.kcal)));
+
+  // 9.2 — CORRECT AGGREGATES. The day is the sum of its events, and the number the client was
+  // told matches the rows. A split that changes the total is a worse bug than the one it fixes.
+  const { recomputeTodayFoodTotals, invalidateFoodTotalsCache } = await import("../server/handlers/food-scanner");
+  invalidateFoodTotalsCache(u.id);   // read the ROWS, never the write-path's cached answer
+  const ledger = await recomputeTodayFoodTotals(u.id);
+  check("9.2 the day total is the sum of the events", ledger.calories === sum(rows as any),
+    `ledger=${ledger.calories} rows=${sum(rows as any)}`);
+  check("9.2 nothing was double-counted", ledger.calories < 2000, `${ledger.calories} kcal for two ordinary meals`);
+
+  // 9.3 — ONE FINAL RESPONSE. Two events, one reply — not two receipts stapled together, and
+  // NOT a per-slot breakdown either: Law 15 forbids a receipt, so what must hold is that one
+  // sentence accounts for food from both events rather than confirming only the first.
+  check("9.3 ONE reply for the turn", (reply.match(/Logged \d+ days/g) || []).length === 0 && reply.length < 900,
+    `${reply.length} chars`);
+  check("9.3 and it accounts for BOTH events", /egg|pap/i.test(reply) && /chicken|rice/i.test(reply), reply.slice(0, 200));
+
+  // 9.4 — INTRA-MESSAGE CORRECTION (newly discovered). The client withdraws a food in the same
+  // breath they logged it. Netted before the write: the rice must never reach a row at all.
+  const p2 = "whatsapp:+27000000112";
+  const u2 = await freshUser(p2);
+  await handleMessage(p2, "I had rice and chicken for lunch, actually not rice, it was pap");
+  const r2 = await db.select({ items: mealLogs.items, kcal: mealLogs.kcalInt }).from(mealLogs)
+    .where(and(eq(mealLogs.userId, u2.id), gte(mealLogs.loggedAt, sastDayStart())));
+  // ITEMS ONLY. The raw message is the client's sentence and still contains the word "rice" —
+  // reading it here would pass this test while the rice sat in the total. What is COUNTED is
+  // the items and the kcal, so that is what is asserted.
+  const plate2 = r2.flatMap(r => (r.items as any[] || []).map(i => String(i?.name || "").toLowerCase())).join(" | ");
+  check("9.4 the withdrawn rice was never written", !/rice/.test(plate2), plate2);
+  check("9.4 the replacement they named IS written", /pap/.test(plate2), plate2);
+  check("9.4 the food they never corrected survives", /chicken/.test(plate2), plate2);
+  check("9.4 the day is priced without the rice", sum(r2 as any) > 0 && sum(r2 as any) < 900, `${sum(r2 as any)} kcal`);
+
+  // 9.5 — NON-FOOD CONTENT INSIDE A FOOD DUMP (newly discovered). A sore back is not an
+  // unpriced ingredient, and must not be logged, priced, or read back as one.
+  const p3 = "whatsapp:+27000000113";
+  const u3 = await freshUser(p3);
+  const r3 = await handleMessage(p3, `${DUMP}, my back is sore and I didn't sleep`);
+  const rows3 = await dayRows(u3.id);
+  const plate3 = rows3.flatMap(r => ((r as any).items as any[] || []).map(i => String(i?.name || "").toLowerCase())).join(" ");
+  check("9.5 the food still logs normally", rows3.length === 2 && sum(rows3 as any) > 0, `rows=${rows3.length}`);
+  check("9.5 no phantom item from the body clause", !/back|sore|sleep/.test(plate3), plate3);
+  check("9.5 the client is not asked to price their back",
+    !/could not price|couldn'?t price/i.test(r3) || !/back|sore|sleep/i.test(r3), r3.slice(-220));
+
+  // 9.6 — GROUPED CORRECTION, TRUSTED RETRIEVAL. The fix lands on the event that HOLDS the
+  // food, read from the rows — not on whichever row happened to be written last.
+  const p4 = "whatsapp:+27000000114";
+  const u4 = await freshUser(p4);
+  await handleMessage(p4, "2 eggs and bread for breakfast, chicken and rice for lunch");
+  const before4 = await dayRows(u4.id);
+  await handleMessage(p4, "it wasn't bread, it was pap");
+  const after4 = await db.select({ label: mealLogs.mealLabel, items: mealLogs.items })
+    .from(mealLogs).where(and(eq(mealLogs.userId, u4.id), gte(mealLogs.loggedAt, sastDayStart())));
+  const plateOf = (label: string) => (after4.find(r => String(r.label || "").toLowerCase() === label)?.items as any[] || [])
+    .map(i => String(i?.name || "").toLowerCase()).join(" ");
+  check("9.6 the breakfast row was corrected", !/bread/.test(plateOf("breakfast")) && /pap/.test(plateOf("breakfast")),
+    plateOf("breakfast"));
+  check("9.6 the lunch row was NOT touched", /chicken/.test(plateOf("lunch")) && /rice/.test(plateOf("lunch")),
+    plateOf("lunch"));
+  check("9.6 no row was created by the correction", after4.length === before4.length, `${before4.length} → ${after4.length}`);
+
+  // 9.7 — A BARE MOVE TAKES THE WHOLE GROUP. "That was yesterday" about a two-meal message must
+  // move both, or the totals are wrong on two days at once — silently, and on both.
+  const p5 = "whatsapp:+27000000115";
+  const u5 = await freshUser(p5);
+  await handleMessage(p5, DUMP);
+  await handleMessage(p5, "actually that was yesterday");
+  const left = await dayRows(u5.id);
+  const all5 = await db.select({ id: mealLogs.id }).from(mealLogs).where(eq(mealLogs.userId, u5.id));
+  check("9.7 both events moved — today is empty", left.length === 0, `still on today: ${left.length}`);
+  check("9.7 and both still exist — a move is not a delete", all5.length === 2, `rows=${all5.length}`);
+
+  // 9.8 — AN ORDINARY LOG IS UNCHANGED. The whole point of the segment gate: one meal, one row,
+  // one confirmation, exactly as before. If this fails, the change is not worth having.
+  const p6 = "whatsapp:+27000000116";
+  const u6 = await freshUser(p6);
+  const r6 = await handleMessage(p6, "chicken and rice for lunch");
+  const rows6 = await dayRows(u6.id);
+  check("9.8 a single meal is still a single row", rows6.length === 1, `rows=${rows6.length}`);
+  check("9.8 it still carries the client's own sentence",
+    /chicken and rice for lunch/i.test(String((rows6[0] as any)?.raw || "")), String((rows6[0] as any)?.raw));
+  check("9.8 and still gets its confirmation", /got it|logged|kcal/i.test(r6), r6.slice(0, 120));
+}
+
 console.log(`\nacceptance-hold: ${pass}/${pass + fail} passed against a REAL database`);
 if (fail) { console.log(`FAILED:\n${failures.map(f => `  - ${f}`).join("\n")}`); process.exit(1); }
 process.exit(0);

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -1605,6 +1605,198 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
     }
   });
 
+  // ============================================================
+  // THE EVENT MODEL — one message, N events (2026-08-16)
+  //
+  // message → N events → grouped corrections → trusted retrieval → correct aggregates →
+  // one final response. Every assertion below is on the DECISION, not on prose: which rows a
+  // message owes, what survives a self-correction, and which row a later correction is about.
+  // ============================================================
+
+  test("event model: two labelled meals in one message owe TWO rows, not one", async () => {
+    const { planEventWrites } = await import("../server/food-identity-correction");
+    const buckets = [
+      { label: "Breakfast", text: "2 eggs and pap", foods: [{ name: "Eggs" }, { name: "Pap" }] },
+      { label: "Lunch", text: "chicken and rice", foods: [{ name: "Chicken" }, { name: "Rice" }] },
+    ];
+    const whole = { label: "breakfast", message: "2 eggs and pap for breakfast, chicken and rice for lunch", foods: buckets.flatMap(b => b.foods) };
+    const events = planEventWrites(buckets, whole);
+    assert.equal(events.length, 2, "one message, two events");
+    assert.deepEqual(events.map(e => e.label), ["breakfast", "lunch"], "each event keeps the slot the CLIENT named");
+    // The stored line is the segment, never the paragraph: the diary must read "chicken and
+    // rice" against lunch, and two rows quoting one sentence would also collide with the
+    // four-minute duplicate guard at the write door.
+    assert.ok(events[1].rawMessage.includes("chicken and rice"), events[1].rawMessage);
+    assert.ok(!events[1].rawMessage.includes("2 eggs"), "an event must not carry another event's food");
+    assert.deepEqual(events[1].foods.map((f: any) => f.name), ["Chicken", "Rice"]);
+  });
+
+  test("event model: an ordinary single meal is byte-identical — one row, the whole message", async () => {
+    const { planEventWrites } = await import("../server/food-identity-correction");
+    const foods = [{ name: "Chicken" }, { name: "Rice" }];
+    // No labelled segments at all (the common case), and one labelled segment (also common).
+    for (const buckets of [[], [{ label: "Lunch", text: "chicken and rice", foods }]]) {
+      const events = planEventWrites(buckets, { label: "lunch", message: "chicken and rice for lunch", foods });
+      assert.equal(events.length, 1, "a single meal is a single event");
+      assert.equal(events[0].rawMessage, "chicken and rice for lunch", "the client's own sentence is what is stored");
+      assert.equal(events[0].foods.length, 2);
+    }
+    // A labelled segment with no food is not an event — "dinner is still coming" owes no row.
+    const empty = planEventWrites(
+      [{ label: "Breakfast", text: "2 eggs", foods: [{ name: "Eggs" }] }, { label: "Dinner", text: "still to come", foods: [] }],
+      { label: "breakfast", message: "2 eggs for breakfast, dinner still to come", foods: [{ name: "Eggs" }] });
+    assert.equal(empty.length, 1, "an empty segment owes no row");
+  });
+
+  test("event model: FOOD_EVENTS=off restores the merged single write", async () => {
+    const { planEventWrites } = await import("../server/food-identity-correction");
+    const buckets = [
+      { label: "Breakfast", text: "eggs", foods: [{ name: "Eggs" }] },
+      { label: "Lunch", text: "chicken", foods: [{ name: "Chicken" }] },
+    ];
+    const whole = { label: "breakfast", message: "eggs for breakfast, chicken for lunch", foods: [{ name: "Eggs" }, { name: "Chicken" }] };
+    const before = process.env.FOOD_EVENTS;
+    try {
+      process.env.FOOD_EVENTS = "off";
+      const off = planEventWrites(buckets, whole);
+      assert.equal(off.length, 1, "the killswitch must collapse the split, not merely warn");
+      assert.equal(off[0].foods.length, 2, "and the merged write still carries every food");
+    } finally {
+      if (before === undefined) delete process.env.FOOD_EVENTS; else process.env.FOOD_EVENTS = before;
+    }
+  });
+
+  test("intra-message correction: a food taken back in the same breath is never written", async () => {
+    const { planCorrection, netEventFoods } = await import("../server/food-identity-correction");
+    // NEWLY DISCOVERED CASE 1. The scanner reads left to right and finds rice, chicken AND pap;
+    // the correction machinery only ever looked at the message AFTER a log, so the rice the
+    // client withdrew mid-sentence was logged anyway — ~260 kcal of silent error.
+    const msg = "I had rice and chicken for lunch, actually not rice, it was pap";
+    const parsed = [{ name: "Rice" }, { name: "Chicken" }, { name: "Pap" }];
+    const net = netEventFoods(parsed, planCorrection(msg, false));
+    const names = net.foods.map(f => f.name.toLowerCase());
+    assert.ok(!names.includes("rice"), `the withdrawn rice must not be written — got ${JSON.stringify(names)}`);
+    assert.ok(names.includes("chicken"), "the food nobody corrected is retained");
+    assert.ok(names.includes("pap"), "the replacement they named is kept");
+    assert.deepEqual(net.removed, ["rice"], "and the drop is reported, never silent");
+
+    // THE COMBO — the way this failed in its first draft, against a real database. The food
+    // table resolves "rice and chicken" to ONE dish, so a name filter removed both foods and
+    // the chicken vanished. Same rule as applyCorrection: split the dish, keep the half they
+    // did not correct, re-priced through the resolver.
+    const combo = netEventFoods(
+      [{ name: "Chicken and rice" }, { name: "Pap" }],
+      planCorrection(msg, false),
+      (f: string) => (/chicken/i.test(f) ? { name: "Chicken" } : /pap/i.test(f) ? { name: "Pap" } : null));
+    const comboNames = combo.foods.map(f => f.name.toLowerCase()).join(" ");
+    assert.ok(/chicken/.test(comboNames), `THE CHICKEN MUST SURVIVE THE COMBO — got ${comboNames}`);
+    assert.ok(!/rice/.test(comboNames), `and the rice must be gone — got ${comboNames}`);
+  });
+
+  test("intra-message correction: it can only drop, never invent, and never empties the plate", async () => {
+    const { planCorrection, netEventFoods } = await import("../server/food-identity-correction");
+    // An ordinary log is untouched — this is the case that must never regress.
+    for (const msg of ["chicken and rice for lunch", "two eggs and toast", "pap and beef stew for supper"]) {
+      const parsed = [{ name: "Chicken" }, { name: "Rice" }];
+      const net = netEventFoods(parsed, planCorrection(msg, false));
+      assert.equal(net.removed.length, 0, `"${msg}" must net nothing`);
+      assert.equal(net.foods.length, 2, `"${msg}" must keep every parsed food`);
+    }
+    // A negation naming a food nobody logged is a no-op, not an error.
+    const noOp = netEventFoods([{ name: "Pap" }, { name: "Chicken" }], planCorrection("pap and chicken, no sugar", false));
+    assert.equal(noOp.foods.length, 2, "a negated food that was never parsed changes nothing");
+    // AND THE ONE-FOOD FLOOR: "no rice" against a single parsed food is a removal request about
+    // an EXISTING entry — food-log-mgmt owns that, and it asks. Netting here would log an empty
+    // meal and swallow the request in the same move.
+    const floor = netEventFoods([{ name: "Rice" }], planCorrection("no rice", false));
+    assert.equal(floor.foods.length, 1, "the plate is never netted to nothing");
+    assert.equal(floor.removed.length, 0, "and nothing is reported as dropped");
+  });
+
+  test("grouped corrections: the fix lands on the event that holds the food, not the newest row", async () => {
+    const { planCorrection, pickCorrectionTargets } = await import("../server/food-identity-correction");
+    // Two events from one message. Rows come back newest-first, so the LUNCH is row 0 — which is
+    // exactly why "it wasn't rice, it was pap" used to edit the wrong meal once a message could
+    // write more than one row.
+    const rows = [
+      { id: "lunch-row", mealLabel: "lunch", rawMessage: "Lunch: chicken and rice", items: [{ name: "Chicken" }, { name: "Rice" }] },
+      { id: "breakfast-row", mealLabel: "breakfast", rawMessage: "Breakfast: 2 eggs and bread", items: [{ name: "Eggs" }, { name: "Bread" }] },
+    ];
+    const bread = pickCorrectionTargets(rows, planCorrection("it wasn't bread, it was pap", false), ["lunch-row", "breakfast-row"]);
+    assert.deepEqual(bread.map(r => r.id), ["breakfast-row"], "the row holding the bread is the target");
+    const rice = pickCorrectionTargets(rows, planCorrection("it wasn't rice, it was pap", false), ["lunch-row", "breakfast-row"]);
+    assert.deepEqual(rice.map(r => r.id), ["lunch-row"], "the row holding the rice is the target");
+  });
+
+  test("grouped corrections: a bare move takes the whole group; nothing else does", async () => {
+    const { planCorrection, pickCorrectionTargets, recordEventGroup, readEventGroup, _resetEventGroups } =
+      await import("../server/food-identity-correction");
+    const rows = [
+      { id: "b", mealLabel: "lunch", rawMessage: "Lunch: chicken", items: [{ name: "Chicken" }] },
+      { id: "a", mealLabel: "breakfast", rawMessage: "Breakfast: eggs", items: [{ name: "Eggs" }] },
+    ];
+    const move = planCorrection("actually that was yesterday", true);
+    // With the group: both rows move, or the totals are wrong on two days at once.
+    assert.deepEqual(pickCorrectionTargets(rows, move, ["a", "b"]).map(r => r.id).sort(), ["a", "b"]);
+    // Without a fresh group (a restart, or an older meal): the most recent row only — exactly
+    // what this code did before the Event Model existed. That is the fail-open direction.
+    assert.deepEqual(pickCorrectionTargets(rows, move, []).map(r => r.id), ["b"]);
+    // A correction that NAMES a food is never a group operation, group or no group.
+    const named = pickCorrectionTargets(rows, planCorrection("it wasn't eggs, it was pap", true), ["a", "b"]);
+    assert.deepEqual(named.map(r => r.id), ["a"], "a named food beats the group");
+
+    // The group memory itself: written, read back, and expired rather than trusted forever.
+    _resetEventGroups();
+    assert.deepEqual(readEventGroup("u1"), [], "no group is the honest default");
+    recordEventGroup("u1", ["a", "b"]);
+    assert.deepEqual(readEventGroup("u1"), ["a", "b"]);
+    assert.deepEqual(readEventGroup("u1", Date.now() + 31 * 60_000), [], "a stale group must not capture a later correction");
+  });
+
+  test("non-food content in a food dump is not priced as food", async () => {
+    const { plateClausesOnly, aboutTheirBodyNotThePlate, unloggedFoodNotice } =
+      await import("../server/unlogged-notice");
+    // NEWLY DISCOVERED CASE 2, verbatim shape. "back" and "sore" are not in NOISE, so the
+    // unpriced-food notice audited them as menu items and asked whether they were fried.
+    const dump = "2 eggs and pap for breakfast, chicken and rice for lunch, my back is sore and I didn't sleep";
+    assert.ok(aboutTheirBodyNotThePlate("my back is sore"), "a sore back is not an ingredient");
+    assert.ok(!aboutTheirBodyNotThePlate("2 eggs and pap for breakfast"), "and a plate is not a symptom");
+    const plate = plateClausesOnly(dump, () => false);
+    assert.ok(!/sore|sleep/.test(plate), `the body clauses must be gone: "${plate}"`);
+    assert.ok(/eggs/.test(plate) && /chicken/.test(plate), `and every food must survive: "${plate}"`);
+    const notice = unloggedFoodNotice(dump, ["Eggs", "Pap", "Chicken", "Rice"]);
+    assert.equal(notice, "", `nothing was dropped, so nothing may be claimed: "${notice}"`);
+    // THE VETO. A clause that really does carry food is kept, however it is framed.
+    const tired = plateClausesOnly("I was so tired I ate a whole pizza", c => /pizza/.test(c));
+    assert.ok(/pizza/.test(tired), `the veto must save a real food: "${tired}"`);
+    // And a genuinely unpriced food still gets said out loud — the notice is not disarmed.
+    const missed = unloggedFoodNotice("I had bunny chow and atchar for lunch", ["Rice"]);
+    assert.ok(/bunny|atchar/i.test(missed), `an unpriced food must still be named: "${missed}"`);
+  });
+
+  test("event model: the write door is wired to all of it", async () => {
+    // Source-level, because the wiring is the part a pure test cannot see: the loop exists, the
+    // group is recorded, later events cannot amend earlier ones, and the reply is still ONE.
+    const src = readFileSync("server/handlers/food-context.ts", "utf-8");
+    assert.ok(/planEventWrites\(segmentBuckets/.test(src), "the split is not wired to the scanner path");
+    assert.ok(/skipAmend: i > 0/.test(src), "sibling events must not amend each other");
+    assert.ok(/recordEventGroup\(user\.id, eventIds\)/.test(src), "the group is not recorded for the correction that follows");
+    assert.ok(/netMessageFoods\(message, segmentBuckets/.test(src),
+      "the self-correction must be netted from the CLIENT's message, before the write");
+    assert.ok(src.indexOf("netMessageFoods(message") < src.indexOf("const events = planEventWrites"),
+      "the netting must happen BEFORE the write is planned, not after");
+    const commit = src.slice(src.indexOf("const events = planEventWrites"), src.indexOf("if (!committed.ok)"));
+    assert.equal((commit.match(/await commitFoodLog\(/g) || []).length, 1,
+      "one write door, called in a loop — never a second copy per shape");
+    assert.ok(!/return `Logged \$\{events/.test(src), "N events must still produce ONE reply");
+    // The correction path reads the ROWS and picks its target from them.
+    const mgmt = readFileSync("server/handlers/food-log-mgmt.ts", "utf-8");
+    assert.ok(/pickCorrectionTargets\(rows, plan, readEventGroup\(user\.id\)\)/.test(mgmt),
+      "the correction target must be chosen from the stored rows plus the turn's group");
+    assert.ok(!/\.orderBy\(desc\(mealLogs\.loggedAt\)\)\.limit\(1\);\s*\n\s*if \(row\)/.test(mgmt),
+      "the blind most-recent-row read is back");
+  });
+
   test("a legitimate zero is not refilled from the chat log", async () => {
     // recomputeTodayFoodTotals text-scraped chatHistory whenever TODAY read zero, so a meal moved
     // to yesterday stayed counted on today, and a wiped day put its calories straight back.

--- a/server/food-identity-correction.ts
+++ b/server/food-identity-correction.ts
@@ -285,6 +285,203 @@ export function applyCorrection<T extends { name?: string }>(
 }
 
 /**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE EVENT MODEL — one message, N events (2026-08-16).
+ *
+ * The frozen work order:
+ *   message → N events → grouped corrections → trusted retrieval → correct aggregates
+ *   → one final response
+ *
+ * What was wrong: a message was an EVENT. "Two eggs and pap for breakfast, chicken and rice
+ * for lunch" produced ONE meal_logs row — every food merged, labelled with whichever slot was
+ * named first, stamped with one time. The segmentation existed, but only to shape the REPLY;
+ * the database never heard about it. So the client was told breakfast and lunch, and the
+ * record held a single blob called "breakfast". Everything downstream inherits that:
+ * "remove my lunch" cannot find a lunch, a correction lands on whatever was written last, the
+ * diary reads one line for two meals, and per-slot anything is unanswerable.
+ *
+ * NO NEW TABLE, by instruction and by preference: meal_logs IS the event store, and it has
+ * been one row per event since it was written — nothing ever wrote the second row. The three
+ * pieces below are what a message needs before it may become several rows:
+ *
+ *   netEventFoods       a message that corrects ITSELF is netted BEFORE anything is written.
+ *   recordEventGroup    the rows one message wrote, remembered for the correction that follows.
+ *   pickCorrectionTargets   which of those rows a correction is actually about.
+ *
+ * All three are pure or memory-only, so the composition rules are testable without a database
+ * — the same contract planCorrection and applyCorrection above already keep.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+/**
+ * INTRA-MESSAGE CORRECTION — the client corrects themselves inside one message.
+ *
+ * "I had rice and chicken for lunch, actually not rice, it was pap" is ONE turn. The scanner
+ * reads it left to right and finds three foods: rice, chicken, pap. All three were logged,
+ * because a correction was only ever looked for in a message that FOLLOWED a log. The rice the
+ * client took back in the same breath was counted anyway, and the day was ~200 kcal wrong
+ * before it began — the silent kind of wrong, which no one can see to complain about.
+ *
+ * Netting happens before the write, never after: nothing is inserted and then repaired, so
+ * there is no window in which the record says something the client never said.
+ *
+ * DELIBERATELY NARROW. It can only DROP a food this very message parsed — it never reads a
+ * stored row, never adds anything, and a negation that names a food nobody logged is a no-op.
+ * The replacement food needs no special handling: it is in the same sentence, so the scanner
+ * has already found it, which is exactly why the naive read logged all three.
+ *
+ * THE COMBO, AGAIN. The first version filtered by name and it ate the chicken: the table
+ * resolves "rice and chicken" to a single combo dish, so "not rice" matched the whole item and
+ * removed both foods — the identical defect applyCorrection was written to fix one turn later.
+ * So this does not own a second copy of the composition rule; it delegates to applyCorrection
+ * with an empty add list, and the caller supplies the same kind of resolver it does.
+ */
+export function netEventFoods<T extends { name?: string }>(
+  foods: T[],
+  plan: CorrectionPlan,
+  resolve: (food: string) => T | null = () => null,
+): { foods: T[]; removed: string[] } {
+  if (!plan?.remove?.length || foods.length === 0) return { foods, removed: [] };
+  // ADD IS NOT THIS FUNCTION'S BUSINESS: the replacement is in the same sentence and the
+  // scanner already priced it. Adding here would log it twice.
+  const { items, removed } = applyCorrection(foods, { ...plan, add: [] }, resolve);
+  // NEVER NET THE PLATE TO NOTHING. "no rice" against a one-food log is a removal request about
+  // an EXISTING entry, not a self-correction — that belongs to food-log-mgmt, which asks and
+  // holds rather than guessing. Dropping the only food here would log an empty meal AND
+  // swallow the request in the same move.
+  if (items.length === 0) return { foods, removed: [] };
+  return { foods: items, removed };
+}
+
+/**
+ * The same netting across a whole message: every event bucket, one plan, one list of what was
+ * dropped. Returns [] — and touches nothing — when the message carries no negation, or when
+ * there is only one food in the whole message (see the floor in netEventFoods).
+ *
+ * It EDITS the buckets it is given, because they are the caller's working list for this turn
+ * and copying them would leave two answers to "what is on the plate" in one function.
+ */
+export function netMessageFoods<T extends { name?: string }>(
+  message: string,
+  buckets: Array<{ foods: T[] }>,
+  resolve: (food: string) => T | null,
+): string[] {
+  const plan = planCorrection(message, false);
+  const total = buckets.reduce((s, b) => s + b.foods.length, 0);
+  if (plan.remove.length === 0 || total < 2) return [];
+  const dropped: string[] = [];
+  for (const b of buckets) {
+    const net = netEventFoods(b.foods, plan, resolve);
+    b.foods = net.foods;
+    dropped.push(...net.removed);
+  }
+  return dropped;
+}
+
+/**
+ * HOW MANY ROWS DOES THIS MESSAGE OWE? — the split itself.
+ *
+ * A labelled segment carrying food IS an event: "2 eggs and pap for breakfast, chicken and rice
+ * for lunch" owes two rows, not one row called breakfast. Below two labelled segments nothing
+ * changes — a single meal is a single event and its write is byte-identical to what it always
+ * was, which is why an ordinary log cannot be affected by any of this.
+ *
+ * The raw message stored on a split event is the SEGMENT, not the whole sentence: the diary
+ * line for lunch must read "chicken and rice", and two rows quoting the same paragraph would
+ * also collide with the four-minute duplicate guard at the write door.
+ *
+ * NOT a meal-slot taxonomy: the label is whatever word the client used, passed through
+ * unchanged. This function does not know what a "meal" is and must never learn.
+ *
+ * FOOD_EVENTS=off in Railway restores the merged single-row write, instantly and per-deploy.
+ */
+export interface EventWrite<F> { label: string; rawMessage: string; foods: F[] }
+
+export function planEventWrites<F>(
+  buckets: Array<{ label: string; text: string; foods: F[] }>,
+  whole: { label: string; message: string; foods: F[] },
+): Array<EventWrite<F>> {
+  const events = buckets.filter(b => b.label && b.foods.length > 0);
+  if (process.env.FOOD_EVENTS === "off" || events.length < 2) {
+    return [{ label: whole.label, rawMessage: whole.message, foods: whole.foods }];
+  }
+  return events.map(b => ({ label: b.label.toLowerCase(), rawMessage: `${b.label}: ${b.text}`, foods: b.foods }));
+}
+
+/**
+ * THE EVENT GROUP — the rows one message wrote, held long enough to be corrected as a unit.
+ *
+ * Once a message can write three rows, "actually that was yesterday" has three possible
+ * meanings and the old code could only express one of them: move the most recent row. That
+ * leaves two meals on today and one on yesterday, and the day totals on BOTH days are then
+ * wrong — the failure mode this whole work order exists to end.
+ *
+ * Memory, not schema: keyed by client, thirty minutes, dropped on restart. The same shape as
+ * the executor's pending-confirmation park, and for the same reason — a correction is a live
+ * back-and-forth, not durable state. When the memory is empty the correction path behaves
+ * exactly as it did before this existed, which is the fail-open direction.
+ */
+const _eventGroups = new Map<string, { ids: string[]; at: number }>();
+const GROUP_TTL_MS = 30 * 60_000;
+
+export function recordEventGroup(userId: string, ids: string[]): void {
+  const clean = ids.map(String).filter(Boolean);
+  if (!userId || clean.length === 0) return;
+  _eventGroups.set(userId, { ids: clean, at: Date.now() });
+  if (_eventGroups.size > 5000) _eventGroups.clear();
+}
+
+/** The ids this client's last logging turn wrote, or [] when there is no fresh group. */
+export function readEventGroup(userId: string, now = Date.now()): string[] {
+  const g = _eventGroups.get(userId);
+  if (!g) return [];
+  if (now - g.at > GROUP_TTL_MS) { _eventGroups.delete(userId); return []; }
+  return g.ids;
+}
+
+/** Test/ops hook — clear the group memory. */
+export function _resetEventGroups(): void { _eventGroups.clear(); }
+
+/**
+ * WHICH EVENT IS THIS CORRECTION ABOUT? — trusted retrieval, from the rows.
+ *
+ * Answered from what is STORED, never from what the model remembers: the candidate rows come
+ * from the database, and the food the client named is matched against the items those rows
+ * actually hold. Three answers, in order of how much the client told us:
+ *
+ *   1. THEY NAMED A FOOD  → the row that holds it. Scored, so a correction naming two foods
+ *      lands on the entry holding both rather than on whichever was written last. A tie is
+ *      broken by recency, because the newer entry is the one they are still talking about.
+ *   2. A BARE MOVE, WITH A GROUP  → every row that message wrote. "That was yesterday" about a
+ *      three-meal dump moves all three, or the aggregates are wrong on two days at once.
+ *   3. ANYTHING ELSE  → the most recent row. Exactly what this code did before, so a
+ *      single-event day is byte-identical.
+ *
+ * PURE. The caller does the reading and the writing; this only decides the target.
+ */
+export function pickCorrectionTargets<T extends { id: string; items?: unknown; rawMessage?: string | null; mealLabel?: string | null }>(
+  rowsNewestFirst: T[],
+  plan: CorrectionPlan,
+  groupIds: string[] = [],
+): T[] {
+  const rows = rowsNewestFirst.filter(Boolean);
+  if (rows.length === 0) return [];
+  const named = [...(plan?.remove || []), ...(plan?.add || [])].map(s => s.toLowerCase()).filter(Boolean);
+  const haystack = (row: T) => `${row.rawMessage || ""} ${row.mealLabel || ""} ${(Array.isArray(row.items) ? row.items : [])
+    .map((i: any) => String(i?.name || i?.foodName || "")).join(" ")}`.toLowerCase();
+  if (named.length > 0) {
+    const scored = rows.map((r, i) => ({ r, i, n: named.filter(f => haystack(r).includes(f)).length }));
+    const best = scored.reduce((a, b) => (b.n > a.n || (b.n === a.n && b.i < a.i) ? b : a));
+    if (best.n > 0) return [best.r];
+  }
+  if (plan?.moves && groupIds.length > 1) {
+    const group = rows.filter(r => groupIds.includes(String(r.id)));
+    if (group.length > 0) return group;
+  }
+  return [rows[0]];
+}
+
+/**
  * NEVER DELETE ON A PROMISE (2026-08-07).
  *
  * Two correction branches could not compute the new numbers — a photo meal stores no per-item

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -18,13 +18,13 @@ import {
 import { macroCardMarker, cardOrTotals, achievementCardShown, cardBaseUrl } from "../macro-card-attach";
 import { cardWillAttach } from "../card-policy";
 import { claimOncePerDay } from "../once-daily";
-import { estimateCarbsFat } from "../macro-estimate";
+import { estimateCarbsFat, carbsFatFromFoods } from "../macro-estimate";
 import { captureFriction } from "../friction";
 import { nutritionGuardrailNudge } from "../nutrition-guardrails";
 import { checkFoodPatterns, checkPerfectDay } from "./checks";
 import { gptFoodFallback, gptFoodSupplement, type GptFoodItem, askCoachK } from "../gpt";
 import { logChat, withTimeout, turnMutation } from "./chat-log";
-import { unloggedFoodNotice, carriesFeelingClause } from "../unlogged-notice";
+import { unloggedFoodNotice, carriesFeelingClause, plateClausesOnly } from "../unlogged-notice";
 import { enforceReplyContract, clientAskedForDetail } from "../reply-contract";
 import { sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, slotFromSastHour, slotFromCaptionTime, isNightWorker, looksLikeDeepEmotionalShare, effectiveMealLoggedAt, spaceName, isAskingNotReporting } from "../utils";
 import { explicitMealSlot } from "../understanding/actions";
@@ -32,7 +32,7 @@ import { getPortionMemory, personalPortionFor, getSlotContext, resolveInferredSl
 import { invalidatePatternCache } from "../cache";
 import { educationNote, remainingInMeals } from "../education";
 import { firstActionCelebration } from "../activation";
-import { amendRecentMeal, replaceHeldMeal } from "../food-identity-correction";
+import { amendRecentMeal, replaceHeldMeal, netMessageFoods, planEventWrites, recordEventGroup } from "../food-identity-correction";
 
 // One owner — this literal was declared twice in this file.
 const TREAT_WORDS = /\b(dessert|treat|pudding|cake|chocolate|ice cream|biscuit|cookie)\b/i;
@@ -106,6 +106,8 @@ interface CommitFoodLogParams {
   items: Array<{ name: string; grams: number; kcal: number; protein: number; category: string }>;
   mealLabel: string | null | undefined;
   loggedAt: Date;
+  /** Later events of ONE message. They are siblings, never amendments of each other. */
+  skipAmend?: boolean;
 }
 
 interface CommitFoodLogResult {
@@ -114,6 +116,8 @@ interface CommitFoodLogResult {
   prevCals: number;
   runningCals: number;
   runningProtein: number;
+  /** The row this write landed on — inserted, amended or held. The event's identity. */
+  id?: string;
 }
 
 // THE single chokepoint for every food-log write (Box 2). GUARANTEE: complete macros — kcal +
@@ -149,14 +153,15 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
   const itemNames = (Array.isArray(params.items) ? params.items : []).map((i: any) => String(i?.name || i?.foodName || "")).filter(Boolean);
   // A held row's REPLACEMENT and an AMENDMENT both rewrite an existing row and suppress the
   // insert below. Neither ever creates a second row.
-  const heldId = await replaceHeldMeal(params.userId, `${rawSlice} ${itemNames.join(" ")}`, patch);
-  const amendedId = heldId || await amendRecentMeal(params.userId, itemNames, patch);
+  const heldId = params.skipAmend ? null : await replaceHeldMeal(params.userId, `${rawSlice} ${itemNames.join(" ")}`, patch);
+  const amendedId = heldId || (params.skipAmend ? null : await amendRecentMeal(params.userId, itemNames, patch));
   if (amendedId) { invalidatePatternCache(params.userId); invalidateFoodTotalsCache(params.userId); }
   let insertOk = true;
+  let rowId = amendedId || recentDup[0]?.id || undefined;
   const wasDup = recentDup.length > 0 || !!amendedId;
   if (!wasDup) {
     try {
-      await db.insert(mealLogs).values({
+      const [inserted] = await db.insert(mealLogs).values({
         userId: params.userId,
         rawMessage: rawSlice,
         source: params.source,
@@ -167,7 +172,8 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
         items: params.items,
         mealLabel: params.mealLabel,
         loggedAt: effLoggedAt,
-      });
+      }).returning({ id: mealLogs.id });
+      rowId = inserted?.id || rowId;
       invalidatePatternCache(params.userId);
       invalidateFoodTotalsCache(params.userId);
       turnMutation(`INSERT meal kcal=${params.kcalInt} prot=${params.proteinInt} label=${params.mealLabel || "none"} at=${String(effLoggedAt).slice(0, 10)}`, `[MEAL_LOG] user=...${String(params.userId || "").slice(-6)}`);
@@ -190,7 +196,7 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
     }).where(eq(users.phoneNumber, params.phone));
   } catch (e) { console.error("[MEAL_LOG] calorie update failed — user:", String(params.userId || "").slice(-6), e); }
 
-  return { ok: insertOk, wasDup, prevCals, runningCals, runningProtein };
+  return { ok: insertOk, wasDup, prevCals, runningCals, runningProtein, id: rowId };
 }
 
 type HandleMessageFn = (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[]) => Promise<string>;
@@ -1007,9 +1013,15 @@ export async function handleFoodContext(ctx: {
 
     // ---- PARTIAL MATCH SUPPLEMENT — catch items the SA scanner missed; attributed back to
     // the segment whose text mentions them.
-    if (allAdjustedFoods.length > 0 && hasUnmatchedFoodContent(m, allAdjustedFoods)) {
+    // NON-FOOD CONTENT INSIDE A FOOD DUMP (2026-08-16): "…and my back is sore and I didn't
+    // sleep" is not an unpriced ingredient. It reached both the supplement model and the
+    // unlogged-food notice as leftover vocabulary — the client was asked whether their back was
+    // fried or grilled. Only the clauses about the plate are priced; the veto keeps any clause
+    // the scanner finds food in ("so tired I ate a whole pizza").
+    const plateText = plateClausesOnly(message, c => scanForSAFoods(c).length > 0);
+    if (allAdjustedFoods.length > 0 && hasUnmatchedFoodContent(plateText, allAdjustedFoods)) {
       try {
-        const suppItems = await gptFoodSupplement(message, user, allAdjustedFoods.map(f => f.name));
+        const suppItems = await gptFoodSupplement(plateText, user, allAdjustedFoods.map(f => f.name));
         if (suppItems && suppItems.length > 0) {
           // Dedup: skip GPT items whose name overlaps with an already-matched SA food
           const filtered = suppItems.filter((si: GptFoodItem) => {
@@ -1051,6 +1063,20 @@ export async function handleFoodContext(ctx: {
       } catch (e) {
         console.warn("[PARTIAL-MATCH SUPP] error:", e);
       }
+    }
+
+    // INTRA-MESSAGE CORRECTION — the client takes a food back in the same breath they logged it
+    // ("rice and chicken for lunch, actually not rice, it was pap"). Netted per event BEFORE the
+    // write, so the record never holds a food they already withdrew. The resolver re-prices the
+    // half of a combo dish they kept — "rice and chicken" is ONE table item, and dropping it
+    // whole is how the chicken went missing the first time this was written.
+    const mem = await getPortionMemory(user.id);
+    const dropped = netMessageFoods(message, segmentBuckets,
+      f => (adjustFoodsForSegment(scanForSAFoods(f, { exactOnly: true }).slice(0, 1), f, mem)[0] as AdjFood) ?? null);
+    if (dropped.length > 0) {
+      allAdjustedFoods.length = 0;
+      allAdjustedFoods.push(...segmentBuckets.flatMap(b => b.foods));
+      console.log(`[FOOD_EVENT] self-correction netted before the write — dropped: ${dropped.join(", ")}`);
     }
 
     // Build the multi-meal breakdown AFTER supplement attribution (so GPT items are included).
@@ -1166,47 +1192,35 @@ export async function handleFoodContext(ctx: {
 
       const scannerLoggedAt = parseMealDate(message);
       const scannerIsRetro = isRetroactiveMeal(message);
-      // Carbs/fat per food: LOWER of the dry estimate (per-100g x grams — overcounts
-      // cooked staples) and the ratio estimate (energy share — overcounts alcohol).
-      // The error modes never hit the same food, so min() is right for both.
-      const macroEnergy = (f: any) => 4 * (f.proteinPer100g || 0) + 4 * (f.carbsPer100g || 0) + 9 * (f.fatPer100g || 0);
-      const totalCarbs = Math.round(allAdjustedFoods.reduce((s, f: any) => {
-        const grams = (f.typicalPortionGrams || 100) * (f.quantity || 1);
-        const dry = grams * (f.carbsPer100g || 0) / 100;
-        const e = macroEnergy(f);
-        const ratio = e > 0 ? (f.adjustedCalories || 0) * (4 * (f.carbsPer100g || 0) / e) / 4 : dry;
-        return s + Math.min(dry, ratio);
-      }, 0));
-      const totalFat = Math.round(allAdjustedFoods.reduce((s, f: any) => {
-        const grams = (f.typicalPortionGrams || 100) * (f.quantity || 1);
-        const dry = grams * (f.fatPer100g || 0) / 100;
-        const e = macroEnergy(f);
-        const ratio = e > 0 ? (f.adjustedCalories || 0) * (9 * (f.fatPer100g || 0) / e) / 9 : dry;
-        return s + Math.min(dry, ratio);
-      }, 0));
       const firstSegLabel = mealSegments.find(s => s.label)?.label
         || extractMealLabel(message, undefined, { kcal: totalCals, protein: Math.round(totalProtein) }, user, await getSlotContext(user.id));
-      const scannerItems = allAdjustedFoods.map(f => ({
-        name: f.name,
-        grams: Math.round((f.typicalPortionGrams || 100) * (f.quantity || 1)),
-        kcal: f.adjustedCalories,
-        protein: f.adjustedProtein,
-        category: f.category,
-        origin: f.origin || "db",
+      const itemsOf = (fs: any[]) => fs.map(f => ({
+        name: f.name, grams: Math.round((f.typicalPortionGrams || 100) * (f.quantity || 1)),
+        kcal: f.adjustedCalories, protein: f.adjustedProtein, category: f.category, origin: f.origin || "db",
       }));
-      const committed = await commitFoodLog({
-        userId: user.id,
-        phone,
-        rawMessage: message.slice(0, 1000),
-        source: "sa_scanner",  // retro is TIMING (loggedAt), never the origin
-        kcalInt: totalCals,
-        proteinInt: Math.round(totalProtein),
-        carbsInt: totalCarbs,
-        fatInt: totalFat,
-        items: scannerItems,
-        mealLabel: firstSegLabel,
-        loggedAt: scannerLoggedAt,
-      });
+      // THE EVENT MODEL — one message, N events (planEventWrites, food-identity-correction.ts).
+      // skipAmend: events of ONE message are siblings, never amendments of each other — without
+      // it "eggs for breakfast, eggs and pap for lunch" folds the lunch into the breakfast row
+      // it just wrote, because containment is exactly what an amendment looks like.
+      const events = planEventWrites(segmentBuckets, { label: firstSegLabel || "", message, foods: allAdjustedFoods });
+      let committed = { ok: true, wasDup: false, prevCals: 0, runningCals: 0, runningProtein: 0 } as CommitFoodLogResult;
+      const eventIds: string[] = [];
+      for (const [i, ev] of events.entries()) {
+        const cf = carbsFatFromFoods(ev.foods);
+        const c = await commitFoodLog({
+          userId: user.id, phone, rawMessage: ev.rawMessage.slice(0, 1000),
+          source: "sa_scanner",  // retro is TIMING (loggedAt), never the origin
+          kcalInt: ev.foods.reduce((s, f) => s + (f.adjustedCalories || 0), 0),
+          proteinInt: Math.round(ev.foods.reduce((s, f) => s + (f.adjustedProtein || 0), 0)),
+          carbsInt: cf.carbs, fatInt: cf.fat,
+          items: itemsOf(ev.foods), mealLabel: ev.label || firstSegLabel,
+          loggedAt: scannerLoggedAt, skipAmend: i > 0,
+        });
+        if (c.id) eventIds.push(c.id);
+        committed = i === 0 ? c : { ...c, prevCals: committed.prevCals };
+      }
+      // The rows this turn wrote, so the correction that follows can be about all of them.
+      recordEventGroup(user.id, eventIds);
       if (!committed.ok) {
         const failReply = `Eish — I worked out that meal (~${totalCals} kcal | ${Math.round(totalProtein)}g protein) but couldn't save it just now. Send it again in a moment and I'll log it.`;
         await logChat(user.id, message, failReply, "FOOD_LOG_FAILED");

--- a/server/handlers/food-log-mgmt.ts
+++ b/server/handlers/food-log-mgmt.ts
@@ -10,7 +10,7 @@ import { sastDayStart, sastToday, looksLikeQuestion, parseQuantityCorrection, is
 import { foodMatchesText, singularFood, perServingEstimate } from "../serving-units";
 import { goalStatusLine } from "../education";
 import { recomputeTodayFoodTotals, invalidateFoodTotalsCache, weeklyNetLine, scanForSAFoods, dropMeals } from "./food-scanner";
-import { parseIdentityCorrection, correctionCandidates, holdForReplacement, isMealDateMove, planCorrection, applyCorrection, type IdentityCorrection } from "../food-identity-correction";
+import { parseIdentityCorrection, correctionCandidates, holdForReplacement, isMealDateMove, planCorrection, applyCorrection, pickCorrectionTargets, readEventGroup, type IdentityCorrection } from "../food-identity-correction";
 
 import { UNAVAILABLE_RE } from "../food-swaps";
 import { turnMutation, turnState } from "./chat-log";
@@ -121,11 +121,19 @@ export async function handleFoodLogMgmt(user: any, m: string): Promise<string | 
   const movesDay = isMealDateMove(m, isRetroactiveMeal(m));
   const plan = looksLikeQuestion(m) ? null : planCorrection(m, movesDay);
   if (plan?.isCorrection && (plan.moves || plan.remove.length + plan.add.length >= 2)) {
-    const [row] = await db.select({
+    // GROUPED, AND READ FROM THE ROWS (2026-08-16, the Event Model). This used to take the single
+    // most recent entry, which was the only entry a message could produce. Now that "eggs for
+    // breakfast, chicken for lunch" writes two, the most recent row is a coin toss: "the rice was
+    // wrong" would edit the breakfast because it happened to be written last. pickCorrectionTargets
+    // answers it from what is STORED — the row that actually holds the food they named — and a bare
+    // move ("that was yesterday") takes the whole group, because leaving one of two meals behind
+    // makes the totals wrong on two days at once.
+    const rows = await db.select({
       id: mealLogs.id, raw: mealLogs.rawMessage, label: mealLogs.mealLabel, at: mealLogs.loggedAt,
       items: mealLogs.items, kcalInt: mealLogs.kcalInt, proteinInt: mealLogs.proteinInt,
-    }).from(mealLogs).where(eq(mealLogs.userId, user.id)).orderBy(desc(mealLogs.loggedAt)).limit(1);
-    if (row) {
+    }).from(mealLogs).where(eq(mealLogs.userId, user.id)).orderBy(desc(mealLogs.loggedAt)).limit(10);
+    const targets = pickCorrectionTargets(rows, plan, readEventGroup(user.id));
+    if (targets.length > 0) {
       const resolveFood = (food: string) => {
         const hit = scanForSAFoods(food, { exactOnly: true })[0] || scanForSAFoods(food)[0];
         return hit ? {
@@ -133,28 +141,37 @@ export async function handleFoodLogMgmt(user: any, m: string): Promise<string | 
           protein: hit.typicalPortionProtein || 0, category: hit.category,
         } : null;
       };
-      const stored = (Array.isArray(row.items) ? row.items : []) as Array<{ name?: string; kcal?: number; protein?: number }>;
-      const { items: newItems, removed, added } = applyCorrection(stored, plan, resolveFood as any);
-      const target = plan.moves ? parseMealDate(m) : (row.at as Date);
-      // Totals come from the items when every item carries its own numbers; otherwise the row's
-      // stored totals stand, because inventing a total from a partial plate is how a correction
-      // turns into a wrong number the client cannot see.
-      const priced = newItems.length > 0 && newItems.every(i => typeof i.kcal === "number");
-      const newKcal = priced ? newItems.reduce((s, i) => s + (i.kcal || 0), 0) : row.kcalInt;
-      const newProt = priced ? newItems.reduce((s, i) => s + (i.protein || 0), 0) : row.proteinInt;
-      if (removed.length || added.length || plan.moves) {
+      let touched = 0;
+      const plates: string[] = [];
+      let target = new Date();
+      for (const row of targets) {
+        const stored = (Array.isArray(row.items) ? row.items : []) as Array<{ name?: string; kcal?: number; protein?: number }>;
+        const { items: newItems, removed, added } = applyCorrection(stored, plan, resolveFood as any);
+        target = plan.moves ? parseMealDate(m) : (row.at as Date);
+        // Totals come from the items when every item carries its own numbers; otherwise the row's
+        // stored totals stand, because inventing a total from a partial plate is how a correction
+        // turns into a wrong number the client cannot see.
+        const priced = newItems.length > 0 && newItems.every(i => typeof i.kcal === "number");
+        const newKcal = priced ? newItems.reduce((s, i) => s + (i.kcal || 0), 0) : row.kcalInt;
+        const newProt = priced ? newItems.reduce((s, i) => s + (i.protein || 0), 0) : row.proteinInt;
+        if (!(removed.length || added.length || plan.moves)) continue;
         await db.update(mealLogs).set({
           items: newItems as any, kcalInt: newKcal, proteinInt: newProt,
           loggedAt: target, corrected: true,
         }).where(eq(mealLogs.id, row.id));
-        invalidateFoodTotalsCache(user.id);
-        const recC = await recomputeTodayFoodTotals(user.id);
-        await db.update(users).set({ todayCalories: recC.calories, todayProteinG: recC.protein, todayCaloriesDate: sastToday() }).where(eq(users.id, user.id));
+        touched++;
+        plates.push(newItems.map(i => String(i.name || "")).filter(Boolean).join(", "));
         turnMutation(`CORRECT removed=[${removed}] added=[${added}] day=${String(row.at).slice(0, 10)}→${mealDateLabel(target)} kcal=${row.kcalInt}→${newKcal}`);
         turnState({ storedItems: stored.map(i => i.name), newItems: newItems.map(i => i.name) }, mealDateLabel(target));
         console.log(`[MEAL_CORRECT] ${String(row.id).slice(0, 8)} removed=[${removed}] added=[${added}] `
-          + `day=${String(row.at).slice(0, 10)}→${mealDateLabel(target)} kcal=${row.kcalInt}→${newKcal} user=...${String(user.id).slice(-6)}`);
-        const plate = newItems.map(i => String(i.name || "")).filter(Boolean).join(", ") || "that meal";
+          + `day=${String(row.at).slice(0, 10)}→${mealDateLabel(target)} kcal=${row.kcalInt}→${newKcal} `
+          + `of ${targets.length} target(s) user=...${String(user.id).slice(-6)}`);
+      }
+      if (touched > 0) {
+        invalidateFoodTotalsCache(user.id);
+        const recC = await recomputeTodayFoodTotals(user.id);
+        await db.update(users).set({ todayCalories: recC.calories, todayProteinG: recC.protein, todayCaloriesDate: sastToday() }).where(eq(users.id, user.id));
+        const plate = plates.filter(Boolean).join("; ") || "that meal";
         const when = plan.moves ? ` on ${mealDateLabel(target)}` : "";
         return `Fixed — ${plate}${when}.\n\nToday: ~${recC.calories} kcal | ~${recC.protein}g protein.`;
       }

--- a/server/macro-estimate.ts
+++ b/server/macro-estimate.ts
@@ -11,6 +11,30 @@
  * captured no carb data — the SA scanner measures carbs from the food table directly and
  * must never be overwritten by this. Pure — unit-tested in script/unit-tests.ts.
  */
+/**
+ * THE MEASURED HALF — carbs and fat for foods the table actually knows.
+ *
+ * Moved here 2026-08-16 from the scanner path, where it was inlined twice, once per macro. It
+ * had to have one owner the moment a message could write several rows: every event prices its
+ * own plate, and two copies of this arithmetic drifting apart would put a different definition
+ * of "carbs" on the breakfast row and the lunch row of the same sentence.
+ *
+ * Per food, take the LOWER of the dry estimate (per-100g × grams — overcounts cooked staples,
+ * which absorb water) and the energy-share estimate (overcounts alcohol, which carries energy
+ * in neither macro). The two error modes never hit the same food, so min() is right for both.
+ */
+export function carbsFatFromFoods(foods: any[]): { carbs: number; fat: number } {
+  const energy = (f: any) => 4 * (f.proteinPer100g || 0) + 4 * (f.carbsPer100g || 0) + 9 * (f.fatPer100g || 0);
+  // The 4 and the 9 cancel out of the energy-share form (kcal × 4·c/e ÷ 4), so they are not
+  // written here — carrying them would look like arithmetic the reader must check.
+  const macro = (per100: "carbsPer100g" | "fatPer100g") => Math.round((foods || []).reduce((s, f: any) => {
+    const dry = (f.typicalPortionGrams || 100) * (f.quantity || 1) * (f[per100] || 0) / 100;
+    const e = energy(f);
+    return s + Math.min(dry, e > 0 ? (f.adjustedCalories || 0) * ((f[per100] || 0) / e) : dry);
+  }, 0));
+  return { carbs: macro("carbsPer100g"), fat: macro("fatPer100g") };
+}
+
 export function estimateCarbsFat(kcal: number, proteinG: number): { carbs: number; fat: number } {
   const k = Number(kcal) || 0;
   const p = Math.max(0, Number(proteinG) || 0);

--- a/server/unlogged-notice.ts
+++ b/server/unlogged-notice.ts
@@ -114,6 +114,44 @@ export function asksAboutWeightProgress(text: string): boolean {
     || /\b(am i|are we) (actually )?(losing|in a deficit)\b/.test(t);
 }
 
+/**
+ * IS THIS CLAUSE ABOUT THEIR BODY OR THEIR DAY, RATHER THAN THEIR PLATE? (2026-08-16.)
+ *
+ * The sibling carriesFeelingClause could not answer for the sentence that actually shipped:
+ * "2 eggs and pap for breakfast, chicken and rice for lunch, my back is sore and I didn't
+ * sleep." Nothing in that names a feeling in the words the feeling test knows, so the food
+ * dump's leftover vocabulary — back, sore, sleep — was audited as unpriced FOOD and the client
+ * was asked whether it was fried or grilled. It is also, separately, the half of the message
+ * that matters most to them.
+ *
+ * Same doctrine as its sibling, and the same deliberate narrowness: it gates the two places
+ * that would otherwise try to PRICE the client's body, and it decides nothing about routing,
+ * logging, or who answers. A clause is only dropped when it is positively recognised as body
+ * or life talk — everything unrecognised is kept, so the failure direction is today's
+ * behaviour rather than a lost meal.
+ */
+export function aboutTheirBodyNotThePlate(text: string): boolean {
+  const t = (text || "").toLowerCase();
+  if (carriesFeelingClause(t)) return true;
+  return /\b(sore|stiff|aching|aches?|pains?|painful|cramp\w*|headache|nausea|nauseous|dizzy|exhausted|shattered|tired|flu|fever|period|slept|sleeping|insomnia|stressed|anxious|overtime|deadline|shift|missed (?:the )?(?:gym|session|workout|training)|skipped (?:the )?(?:gym|session|workout|training)|didn'?t sleep|couldn'?t sleep|no sleep)\b/.test(t);
+}
+
+/**
+ * THE HALF OF THE MESSAGE THAT IS ABOUT FOOD. One owner, because two callers price text and
+ * both were pricing the client's back.
+ *
+ * `keep` is the caller's veto — it is handed each flagged clause and returns true when the
+ * clause really does carry food ("I was so tired I ate a whole pizza"). Without a veto nothing
+ * that names food can be lost, because the caller who knows how to recognise food is the one
+ * who supplies it: the notice checks what it logged, the scanner path asks the scanner.
+ */
+export function plateClausesOnly(message: string, keep: (clause: string) => boolean = () => false): string {
+  const clauses = String(message || "").split(/(?<=[.!?;\n])|,\s+|\s+\band then\b\s+|\s+\bbut\b\s+/i);
+  const kept = clauses.filter(c => !aboutTheirBodyNotThePlate(c) || keep(c.toLowerCase()));
+  const text = kept.join(" ").replace(/\s+/g, " ").trim();
+  return text || String(message || "");
+}
+
 export function unloggedFoodWords(message: string, loggedNames: string[]): string[] {
   const logged = loggedNames.join(" ").toLowerCase();
   const words = (message || "").toLowerCase()
@@ -168,7 +206,11 @@ export function unloggedFoodNotice(message: string, loggedNames: string[], ask =
   if (place && !loggedJoined.includes(place.stem)) {
     return ask ? clarifyPlaceAsk(place.name) : unloggedPlaceNotice(message, loggedNames);
   }
-  const words = unloggedFoodWords(message, loggedNames);
+  // The same trade as the feeling gate above, applied clause by clause: the body-and-day half
+  // of a food dump is not audited for missing calories. A clause that carries something we DID
+  // log is kept, so "so tired I ate a whole pizza" is still read for its pizza.
+  const plate = plateClausesOnly(lo, c => loggedNames.some(n => n && c.includes(n.toLowerCase())));
+  const words = unloggedFoodWords(plate, loggedNames);
   if (words.length < 2) return "";               // one stray word is usually not a food
   return ask
     ? clarifyFoodAsk(words)


### PR DESCRIPTION
Bring Claude's previously validated event-model implementation forward. This specifically addresses intra-message corrections and food/non-food clause handling discovered from the real product trace. The source commit reports 82/82 acceptance-hold cases against real PostgreSQL and keeps the existing event model owner intact. Target is main so the current product line can be reconciled in one place.