### PR TITLE
Product: multi-day messy intake attribution

### DIFF
--- a/script/multi-day-attribution-tests.ts
+++ b/script/multi-day-attribution-tests.ts
@@ -10,9 +10,9 @@ const multi = attributeMultiDayReport(
 assert.equal(multi.hasMultipleDays, true);
 assert.equal(multi.ambiguous, false);
 assert.deepEqual(multi.beats.map(b => [b.dayKey, b.dayReference, b.text]), [
-  ["2026-08-18", "Monday", "I had pap and chicken."],
-  ["2026-08-19", "Tuesday", "I had eggs and toast."],
-  ["2026-08-20", "Wednesday", "I trained and walked 8k steps."],
+  ["2026-08-17", "Monday", "I had pap and chicken."],
+  ["2026-08-18", "Tuesday", "I had eggs and toast."],
+  ["2026-08-19", "Wednesday", "I trained and walked 8k steps."],
 ]);
 
 const relative = attributeMultiDayReport(

--- a/script/multi-day-attribution-tests.ts
+++ b/script/multi-day-attribution-tests.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { attributeMultiDayReport } from "../server/understanding/day-relative-situation";
+
+const NOW = new Date("2026-08-24T10:00:00+02:00"); // Monday SAST
+
+const multi = attributeMultiDayReport(
+  "Monday I had pap and chicken. Tuesday I had eggs and toast. Wednesday I trained and walked 8k steps.",
+  NOW,
+);
+assert.equal(multi.hasMultipleDays, true);
+assert.equal(multi.ambiguous, false);
+assert.deepEqual(multi.beats.map(b => [b.dayKey, b.dayReference, b.text]), [
+  ["2026-08-18", "Monday", "I had pap and chicken."],
+  ["2026-08-19", "Tuesday", "I had eggs and toast."],
+  ["2026-08-20", "Wednesday", "I trained and walked 8k steps."],
+]);
+
+const relative = attributeMultiDayReport(
+  "Yesterday I had pap and chicken. Today I had eggs and coffee.",
+  NOW,
+);
+assert.equal(relative.ambiguous, false);
+assert.deepEqual(relative.beats.map(b => b.dayKey), ["2026-08-23", "2026-08-24"]);
+
+const explicitPast = attributeMultiDayReport("Friday dinner was chicken and rice.", NOW);
+assert.equal(explicitPast.ambiguous, false);
+assert.equal(explicitPast.beats[0]?.dayKey, "2026-08-21");
+
+const future = attributeMultiDayReport("Next Monday I'll train chest.", NOW);
+assert.equal(future.ambiguous, true);
+assert.equal(future.beats[0]?.dayKey, null);
+
+const noDate = attributeMultiDayReport("I had pap and chicken and later some eggs.", NOW);
+assert.equal(noDate.ambiguous, true);
+assert.equal(noDate.beats[0]?.dayKey, null);
+
+const lastWeekend = attributeMultiDayReport("Last weekend we were out eating.", NOW);
+assert.equal(lastWeekend.ambiguous, true);
+assert.equal(lastWeekend.beats[0]?.dayKey, null);
+
+console.log("✓ multi-day attribution tests");

--- a/script/multi-day-attribution-tests.ts
+++ b/script/multi-day-attribution-tests.ts
@@ -26,6 +26,10 @@ const explicitPast = attributeMultiDayReport("Friday dinner was chicken and rice
 assert.equal(explicitPast.ambiguous, false);
 assert.equal(explicitPast.beats[0]?.dayKey, "2026-08-21");
 
+const bareSaturday = attributeMultiDayReport("Saturday I trained legs.", NOW);
+assert.equal(bareSaturday.ambiguous, false);
+assert.equal(bareSaturday.beats[0]?.dayKey, "2026-08-22");
+
 const future = attributeMultiDayReport("Next Monday I'll train chest.", NOW);
 assert.equal(future.ambiguous, true);
 assert.equal(future.beats[0]?.dayKey, null);

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -15,7 +15,7 @@ export const SUITES = [
   "routing-audit", "gap-tests", "onboarding-e2e", "video-path-verify", "phrasing-battery",
   "check-file-sizes", "check-pricing", "check-schema-safety", "check-sast", "check-names",
   "check-reach", "check-prompt-integrity", "hunger-gauntlet", "decision-boundary-tests",
-  "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "production-parity", "check-architecture",
+  "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests", "production-parity", "check-architecture",
 ];
 
 const PER_SUITE_TIMEOUT_MS = 10 * 60_000;

--- a/server/understanding/day-relative-situation.ts
+++ b/server/understanding/day-relative-situation.ts
@@ -40,7 +40,7 @@ export function resolveSituationMoment(text: string, at: Date, now = new Date())
     if (diffDays > 1) return "stale";
   }
   if (explicitPast && /\b(?:weekend|last night|yesterday)\b/i.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) return "last_night";
-  return explicitPast ? ageMoment(at, now) : ageMoment(at, now);
+  return ageMoment(at, now);
 }
 export function classifySituationMessage(text: string, at: Date, now = new Date()): ResolvedSituation {
   const raw = String(text || "").trim(); const birthday = CELEBRATION_RE.test(raw); const eatingOut = OUTING_RE.test(raw); const foodClosed = FOOD_CLOSED_RE.test(raw);
@@ -72,7 +72,7 @@ function resolveAttributionReference(token: string, now: Date): { dayKey: string
   const dayMatch = t.match(/^(this|last|next)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
   if (dayMatch) { const mode = dayMatch[1], target = DAY_WORDS[dayMatch[2]], current = attributionSastParts(now).weekday; let delta = (target - current + 7) % 7; if (mode === "last") delta = delta === 0 ? -7 : delta - 7; else if (mode === "this") { if (delta > 0) delta -= 7; } else return { dayKey: null, confidence: "ambiguous" }; return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" }; }
   const bareDay = t.match(/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
-  if (bareDay) { const target = DAY_WORDS[bareDay[1]], current = attributionSastParts(now).weekday; let delta = (target - current + 7) % 7; if (delta > 0) delta -= 7; return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" }; }
+  if (bareDay) { const target = DAY_WORDS[bareDay[1]], current = attributionSastParts(now).weekday; let delta = (target - current + 7) % 7; delta = delta === 0 ? -7 : delta - 7; return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" }; }
   if (/^\d{4}-\d{2}-\d{2}$/.test(t)) { const d = new Date(`${t}T12:00:00Z`); return Number.isNaN(d.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: t, confidence: "explicit" }; }
   const dmy = t.match(/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})$/);
   if (dmy) { const year = dmy[3].length === 2 ? 2000 + Number(dmy[3]) : Number(dmy[3]); const iso = `${String(year).padStart(4, "0")}-${String(Number(dmy[2])).padStart(2, "0")}-${String(Number(dmy[1])).padStart(2, "0")}`; const parsed = new Date(`${iso}T12:00:00Z`); return Number.isNaN(parsed.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: iso, confidence: "explicit" }; }

--- a/server/understanding/day-relative-situation.ts
+++ b/server/understanding/day-relative-situation.ts
@@ -33,21 +33,11 @@ const WEEKEND_RE = /\bweekend\b/i;
 const RECENT_DAY_PAST_RE = /\b(yesterday|last night)\b/i;
 
 function sastWeekday(now: Date): string {
-  return new Intl.DateTimeFormat("en-ZA", {
-    timeZone: "Africa/Johannesburg",
-    weekday: "short",
-  }).format(now);
+  return new Intl.DateTimeFormat("en-ZA", { timeZone: "Africa/Johannesburg", weekday: "short" }).format(now);
 }
-
 function sastCalendarDay(date: Date): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Africa/Johannesburg",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(date);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg", year: "numeric", month: "2-digit", day: "2-digit" }).format(date);
 }
-
 function ageMoment(at: Date, now: Date): SituationMoment {
   const ageDays = Math.floor((now.getTime() - at.getTime()) / 86_400_000);
   if (ageDays <= 0) return "today";
@@ -55,43 +45,27 @@ function ageMoment(at: Date, now: Date): SituationMoment {
   return "stale";
 }
 
-/** Resolve the time of the situation expressed by one message. */
 export function resolveSituationMoment(text: string, at: Date, now = new Date()): SituationMoment {
   const raw = String(text || "").trim();
   const explicitPast = EXPLICIT_PAST_NIGHT_RE.test(raw) || EXPLICIT_PAST_RE.test(raw);
   const senderDay = sastCalendarDay(at);
   const currentDay = sastCalendarDay(now);
-
-  // "birthday weekend was..." on Monday is the just-finished weekend unless the client explicitly
-  // said "last weekend", which must remain age-based so it can become stale a week later.
-  if (WEEKEND_RE.test(raw) && explicitPast && !EXPLICIT_PAST_NIGHT_RE.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) {
-    return "last_night";
-  }
-
-  // "yesterday" and "last night" are immediate retrospective references; "last weekend" ages normally.
+  if (WEEKEND_RE.test(raw) && explicitPast && !EXPLICIT_PAST_NIGHT_RE.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) return "last_night";
   if (RECENT_DAY_PAST_RE.test(raw)) {
     const age = ageMoment(at, now);
     return age === "today" ? "last_night" : age;
   }
-
   if (EXPLICIT_PAST_NIGHT_RE.test(raw)) return ageMoment(at, now);
-
   if (EXPLICIT_TODAY_RE.test(raw)) {
     if (senderDay === currentDay) return explicitPast ? ageMoment(at, now) : "today";
-
     const senderDate = new Date(`${senderDay}T12:00:00Z`).getTime();
     const currentDate = new Date(`${currentDay}T12:00:00Z`).getTime();
     const diffDays = Math.floor((currentDate - senderDate) / 86_400_000);
     if (diffDays === 1) return "last_night";
     if (diffDays > 1) return "stale";
   }
-
-  if (explicitPast && /\b(?:weekend|last night|yesterday)\b/i.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) {
-    return "last_night";
-  }
-
-  if (explicitPast) return ageMoment(at, now);
-  return ageMoment(at, now);
+  if (explicitPast && /\b(?:weekend|last night|yesterday)\b/i.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) return "last_night";
+  return explicitPast ? ageMoment(at, now) : ageMoment(at, now);
 }
 
 export function classifySituationMessage(text: string, at: Date, now = new Date()): ResolvedSituation {
@@ -99,22 +73,106 @@ export function classifySituationMessage(text: string, at: Date, now = new Date(
   const birthday = CELEBRATION_RE.test(raw);
   const eatingOut = OUTING_RE.test(raw);
   const foodClosed = FOOD_CLOSED_RE.test(raw);
-
   let kind: SituationKind = "";
   if (birthday && eatingOut) kind = "celebration_outing";
   else if (birthday && WEEKEND_RE.test(raw)) kind = "celebration";
   else if (eatingOut) kind = "eating_out";
   else if (foodClosed) kind = "food_closed";
-
   if (!kind) return { kind: "", moment: "", sourceText: "" };
   return { kind, moment: resolveSituationMoment(raw, at, now), sourceText: raw };
 }
-
 export function resolveRecentSituation(messages: StampedSituationMessage[], now = new Date()): ResolvedSituation {
-  const candidates = messages
-    .map(message => ({ message, situation: classifySituationMessage(message.text, message.at, now) }))
+  const candidates = messages.map(message => ({ message, situation: classifySituationMessage(message.text, message.at, now) }))
     .filter(({ situation }) => situation.kind && situation.moment !== "stale")
     .sort((a, b) => b.message.at.getTime() - a.message.at.getTime());
-
   return candidates[0]?.situation || { kind: "", moment: "", sourceText: "" };
+}
+
+export interface AttributedBeat {
+  text: string;
+  dayKey: string | null;
+  confidence: "explicit" | "relative" | "inferred" | "ambiguous";
+  dayReference: string | null;
+}
+export interface MultiDayAttribution {
+  beats: AttributedBeat[];
+  ambiguous: boolean;
+  hasMultipleDays: boolean;
+}
+const SAST_TIMEZONE = "Africa/Johannesburg";
+const DAY_WORDS: Record<string, number> = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
+function attributionDateKey(date: Date): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: SAST_TIMEZONE, year: "numeric", month: "2-digit", day: "2-digit" }).format(date);
+}
+function attributionSastParts(date: Date): { year: number; month: number; day: number; weekday: number } {
+  const parts = new Intl.DateTimeFormat("en-US", { timeZone: SAST_TIMEZONE, year: "numeric", month: "2-digit", day: "2-digit", weekday: "short" }).formatToParts(date);
+  const get = (type: string) => parts.find(p => p.type === type)?.value || "";
+  return { year: Number(get("year")), month: Number(get("month")), day: Number(get("day")), weekday: DAY_WORDS[get("weekday").toLowerCase()] ?? 0 };
+}
+function attributionShiftDays(date: Date, days: number): Date {
+  const parts = attributionSastParts(date);
+  const noonUtc = new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12, 0, 0));
+  noonUtc.setUTCDate(noonUtc.getUTCDate() + days);
+  return noonUtc;
+}
+function resolveAttributionReference(token: string, now: Date): { dayKey: string | null; confidence: AttributedBeat["confidence"] } {
+  const t = token.toLowerCase().trim();
+  if (/^(today|this morning|this afternoon|this evening|tonight)$/.test(t)) return { dayKey: attributionDateKey(now), confidence: "relative" };
+  if (/^(yesterday|last night)$/.test(t)) return { dayKey: attributionDateKey(attributionShiftDays(now, -1)), confidence: "relative" };
+  const dayMatch = t.match(/^(this|last|next)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
+  if (dayMatch) {
+    const mode = dayMatch[1], target = DAY_WORDS[dayMatch[2]], current = attributionSastParts(now).weekday;
+    let delta = (target - current + 7) % 7;
+    if (mode === "last") delta = delta === 0 ? -7 : delta - 7;
+    else if (mode === "this") { if (delta > 0) delta -= 7; }
+    else return { dayKey: null, confidence: "ambiguous" };
+    return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" };
+  }
+  const bareDay = t.match(/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
+  if (bareDay) {
+    const target = DAY_WORDS[bareDay[1]], current = attributionSastParts(now).weekday;
+    let delta = (target - current + 7) % 7; if (delta > 0) delta -= 7;
+    return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" };
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) {
+    const d = new Date(`${t}T12:00:00Z`);
+    return Number.isNaN(d.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: t, confidence: "explicit" };
+  }
+  const dmy = t.match(/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})$/);
+  if (dmy) {
+    const year = dmy[3].length === 2 ? 2000 + Number(dmy[3]) : Number(dmy[3]);
+    const iso = `${String(year).padStart(4, "0")}-${String(Number(dmy[2])).padStart(2, "0")}-${String(Number(dmy[1])).padStart(2, "0")}`;
+    const parsed = new Date(`${iso}T12:00:00Z`);
+    return Number.isNaN(parsed.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: iso, confidence: "explicit" };
+  }
+  return { dayKey: null, confidence: "ambiguous" };
+}
+function splitAttributionReferences(message: string): Array<{ text: string; reference: string | null }> {
+  const matches: Array<{ index: number; length: number; token: string }> = [];
+  const patterns = [
+    /\b(?:today|this morning|this afternoon|this evening|tonight|yesterday|last night)\b/gi,
+    /\b(?:this|last|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
+    /\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
+    /\b(?:on\s+)?\d{4}-\d{2}-\d{2}\b/gi,
+    /\b(?:on\s+)?\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}\b/gi,
+  ];
+  for (const re of patterns) for (const m of message.matchAll(re)) matches.push({ index: m.index ?? 0, length: m[0].length, token: m[0] });
+  matches.sort((a, b) => a.index - b.index);
+  const deduped = matches.filter((m, i) => i === 0 || m.index >= matches[i - 1].index + matches[i - 1].length);
+  if (!deduped.length) return [{ text: message.trim(), reference: null }];
+  const out: Array<{ text: string; reference: string | null }> = [];
+  let start = 0; let currentReference: string | null = null;
+  for (const hit of deduped) { const before = message.slice(start, hit.index).trim(); if (before) out.push({ text: before, reference: currentReference }); currentReference = hit.token; start = hit.index + hit.length; }
+  const tail = message.slice(start).trim(); if (tail) out.push({ text: tail, reference: currentReference });
+  return out.filter(x => x.text.length > 0);
+}
+export function attributeMultiDayReport(message: string, now = new Date()): MultiDayAttribution {
+  const segments = splitAttributionReferences(String(message || "").trim());
+  const beats: AttributedBeat[] = segments.map(segment => {
+    if (!segment.reference) return { text: segment.text, dayKey: null, confidence: "ambiguous", dayReference: null };
+    const resolved = resolveAttributionReference(segment.reference, now);
+    return { text: segment.text, dayKey: resolved.dayKey, confidence: resolved.confidence, dayReference: segment.reference };
+  });
+  const distinctDays = new Set(beats.map(b => b.dayKey).filter(Boolean));
+  return { beats, ambiguous: beats.some(b => b.dayKey == null || b.confidence === "ambiguous"), hasMultipleDays: distinctDays.size > 1 };
 }

--- a/server/understanding/day-relative-situation.ts
+++ b/server/understanding/day-relative-situation.ts
@@ -1,28 +1,7 @@
-/**
- * Day-relative situation resolver.
- *
- * Event identity and event timing are separate facts. A message such as
- * "the birthday weekend was hectic, so we're thinking about skipping today" must not
- * turn a completed weekend into a current-day outing merely because the same sentence
- * contains the word "today".
- *
- * Pure module. Existing memory storage/retrieval remains the owner of persistence.
- */
-
 export type SituationMoment = "today" | "last_night" | "stale" | "";
 export type SituationKind = "celebration_outing" | "celebration" | "eating_out" | "food_closed" | "";
-
-export interface StampedSituationMessage {
-  text: string;
-  at: Date;
-}
-
-export interface ResolvedSituation {
-  kind: SituationKind;
-  moment: SituationMoment;
-  sourceText: string;
-}
-
+export interface StampedSituationMessage { text: string; at: Date; }
+export interface ResolvedSituation { kind: SituationKind; moment: SituationMoment; sourceText: string; }
 const CELEBRATION_RE = /\b(birthday|anniversary|wedding)\b/i;
 const OUTING_RE = /\b(restaurants?|eating out|going out to eat|go out to eat|outing|date night)\b/i;
 const FOOD_CLOSED_RE = /\b(won'?t be able to eat|not going to eat anymore|not gonna eat anymore|no more food|done eating|drinks only|zero[- ]calorie drinks)\b/i;
@@ -44,17 +23,13 @@ function ageMoment(at: Date, now: Date): SituationMoment {
   if (ageDays === 1) return "last_night";
   return "stale";
 }
-
 export function resolveSituationMoment(text: string, at: Date, now = new Date()): SituationMoment {
   const raw = String(text || "").trim();
   const explicitPast = EXPLICIT_PAST_NIGHT_RE.test(raw) || EXPLICIT_PAST_RE.test(raw);
   const senderDay = sastCalendarDay(at);
   const currentDay = sastCalendarDay(now);
   if (WEEKEND_RE.test(raw) && explicitPast && !EXPLICIT_PAST_NIGHT_RE.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) return "last_night";
-  if (RECENT_DAY_PAST_RE.test(raw)) {
-    const age = ageMoment(at, now);
-    return age === "today" ? "last_night" : age;
-  }
+  if (RECENT_DAY_PAST_RE.test(raw)) { const age = ageMoment(at, now); return age === "today" ? "last_night" : age; }
   if (EXPLICIT_PAST_NIGHT_RE.test(raw)) return ageMoment(at, now);
   if (EXPLICIT_TODAY_RE.test(raw)) {
     if (senderDay === currentDay) return explicitPast ? ageMoment(at, now) : "today";
@@ -67,112 +42,50 @@ export function resolveSituationMoment(text: string, at: Date, now = new Date())
   if (explicitPast && /\b(?:weekend|last night|yesterday)\b/i.test(raw) && /^(Mon|Tue)$/i.test(sastWeekday(now))) return "last_night";
   return explicitPast ? ageMoment(at, now) : ageMoment(at, now);
 }
-
 export function classifySituationMessage(text: string, at: Date, now = new Date()): ResolvedSituation {
-  const raw = String(text || "").trim();
-  const birthday = CELEBRATION_RE.test(raw);
-  const eatingOut = OUTING_RE.test(raw);
-  const foodClosed = FOOD_CLOSED_RE.test(raw);
+  const raw = String(text || "").trim(); const birthday = CELEBRATION_RE.test(raw); const eatingOut = OUTING_RE.test(raw); const foodClosed = FOOD_CLOSED_RE.test(raw);
   let kind: SituationKind = "";
-  if (birthday && eatingOut) kind = "celebration_outing";
-  else if (birthday && WEEKEND_RE.test(raw)) kind = "celebration";
-  else if (eatingOut) kind = "eating_out";
-  else if (foodClosed) kind = "food_closed";
+  if (birthday && eatingOut) kind = "celebration_outing"; else if (birthday && WEEKEND_RE.test(raw)) kind = "celebration"; else if (eatingOut) kind = "eating_out"; else if (foodClosed) kind = "food_closed";
   if (!kind) return { kind: "", moment: "", sourceText: "" };
   return { kind, moment: resolveSituationMoment(raw, at, now), sourceText: raw };
 }
 export function resolveRecentSituation(messages: StampedSituationMessage[], now = new Date()): ResolvedSituation {
-  const candidates = messages.map(message => ({ message, situation: classifySituationMessage(message.text, message.at, now) }))
-    .filter(({ situation }) => situation.kind && situation.moment !== "stale")
-    .sort((a, b) => b.message.at.getTime() - a.message.at.getTime());
+  const candidates = messages.map(message => ({ message, situation: classifySituationMessage(message.text, message.at, now) })).filter(({ situation }) => situation.kind && situation.moment !== "stale").sort((a, b) => b.message.at.getTime() - a.message.at.getTime());
   return candidates[0]?.situation || { kind: "", moment: "", sourceText: "" };
 }
 
-export interface AttributedBeat {
-  text: string;
-  dayKey: string | null;
-  confidence: "explicit" | "relative" | "inferred" | "ambiguous";
-  dayReference: string | null;
-}
-export interface MultiDayAttribution {
-  beats: AttributedBeat[];
-  ambiguous: boolean;
-  hasMultipleDays: boolean;
-}
+export interface AttributedBeat { text: string; dayKey: string | null; confidence: "explicit" | "relative" | "inferred" | "ambiguous"; dayReference: string | null; }
+export interface MultiDayAttribution { beats: AttributedBeat[]; ambiguous: boolean; hasMultipleDays: boolean; }
 const SAST_TIMEZONE = "Africa/Johannesburg";
-const DAY_WORDS: Record<string, number> = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
-function attributionDateKey(date: Date): string {
-  return new Intl.DateTimeFormat("en-CA", { timeZone: SAST_TIMEZONE, year: "numeric", month: "2-digit", day: "2-digit" }).format(date);
-}
+const DAY_WORDS: Record<string, number> = { sunday: 0, sun: 0, monday: 1, mon: 1, tuesday: 2, tue: 2, wednesday: 3, wed: 3, thursday: 4, thu: 4, friday: 5, fri: 5, saturday: 6, sat: 6 };
+function attributionDateKey(date: Date): string { return new Intl.DateTimeFormat("en-CA", { timeZone: SAST_TIMEZONE, year: "numeric", month: "2-digit", day: "2-digit" }).format(date); }
 function attributionSastParts(date: Date): { year: number; month: number; day: number; weekday: number } {
   const parts = new Intl.DateTimeFormat("en-US", { timeZone: SAST_TIMEZONE, year: "numeric", month: "2-digit", day: "2-digit", weekday: "short" }).formatToParts(date);
   const get = (type: string) => parts.find(p => p.type === type)?.value || "";
   return { year: Number(get("year")), month: Number(get("month")), day: Number(get("day")), weekday: DAY_WORDS[get("weekday").toLowerCase()] ?? 0 };
 }
-function attributionShiftDays(date: Date, days: number): Date {
-  const parts = attributionSastParts(date);
-  const noonUtc = new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12, 0, 0));
-  noonUtc.setUTCDate(noonUtc.getUTCDate() + days);
-  return noonUtc;
-}
+function attributionShiftDays(date: Date, days: number): Date { const parts = attributionSastParts(date); const noonUtc = new Date(Date.UTC(parts.year, parts.month - 1, parts.day, 12, 0, 0)); noonUtc.setUTCDate(noonUtc.getUTCDate() + days); return noonUtc; }
 function resolveAttributionReference(token: string, now: Date): { dayKey: string | null; confidence: AttributedBeat["confidence"] } {
   const t = token.toLowerCase().trim();
   if (/^(today|this morning|this afternoon|this evening|tonight)$/.test(t)) return { dayKey: attributionDateKey(now), confidence: "relative" };
   if (/^(yesterday|last night)$/.test(t)) return { dayKey: attributionDateKey(attributionShiftDays(now, -1)), confidence: "relative" };
   const dayMatch = t.match(/^(this|last|next)\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
-  if (dayMatch) {
-    const mode = dayMatch[1], target = DAY_WORDS[dayMatch[2]], current = attributionSastParts(now).weekday;
-    let delta = (target - current + 7) % 7;
-    if (mode === "last") delta = delta === 0 ? -7 : delta - 7;
-    else if (mode === "this") { if (delta > 0) delta -= 7; }
-    else return { dayKey: null, confidence: "ambiguous" };
-    return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" };
-  }
+  if (dayMatch) { const mode = dayMatch[1], target = DAY_WORDS[dayMatch[2]], current = attributionSastParts(now).weekday; let delta = (target - current + 7) % 7; if (mode === "last") delta = delta === 0 ? -7 : delta - 7; else if (mode === "this") { if (delta > 0) delta -= 7; } else return { dayKey: null, confidence: "ambiguous" }; return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" }; }
   const bareDay = t.match(/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
-  if (bareDay) {
-    const target = DAY_WORDS[bareDay[1]], current = attributionSastParts(now).weekday;
-    let delta = (target - current + 7) % 7; if (delta > 0) delta -= 7;
-    return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" };
-  }
-  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) {
-    const d = new Date(`${t}T12:00:00Z`);
-    return Number.isNaN(d.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: t, confidence: "explicit" };
-  }
+  if (bareDay) { const target = DAY_WORDS[bareDay[1]], current = attributionSastParts(now).weekday; let delta = (target - current + 7) % 7; if (delta > 0) delta -= 7; return { dayKey: attributionDateKey(attributionShiftDays(now, delta)), confidence: "explicit" }; }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) { const d = new Date(`${t}T12:00:00Z`); return Number.isNaN(d.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: t, confidence: "explicit" }; }
   const dmy = t.match(/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})$/);
-  if (dmy) {
-    const year = dmy[3].length === 2 ? 2000 + Number(dmy[3]) : Number(dmy[3]);
-    const iso = `${String(year).padStart(4, "0")}-${String(Number(dmy[2])).padStart(2, "0")}-${String(Number(dmy[1])).padStart(2, "0")}`;
-    const parsed = new Date(`${iso}T12:00:00Z`);
-    return Number.isNaN(parsed.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: iso, confidence: "explicit" };
-  }
+  if (dmy) { const year = dmy[3].length === 2 ? 2000 + Number(dmy[3]) : Number(dmy[3]); const iso = `${String(year).padStart(4, "0")}-${String(Number(dmy[2])).padStart(2, "0")}-${String(Number(dmy[1])).padStart(2, "0")}`; const parsed = new Date(`${iso}T12:00:00Z`); return Number.isNaN(parsed.getTime()) ? { dayKey: null, confidence: "ambiguous" } : { dayKey: iso, confidence: "explicit" }; }
   return { dayKey: null, confidence: "ambiguous" };
 }
 function splitAttributionReferences(message: string): Array<{ text: string; reference: string | null }> {
   const matches: Array<{ index: number; length: number; token: string }> = [];
-  const patterns = [
-    /\b(?:today|this morning|this afternoon|this evening|tonight|yesterday|last night)\b/gi,
-    /\b(?:this|last|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
-    /\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
-    /\b(?:on\s+)?\d{4}-\d{2}-\d{2}\b/gi,
-    /\b(?:on\s+)?\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}\b/gi,
-  ];
+  const patterns = [/\b(?:today|this morning|this afternoon|this evening|tonight|yesterday|last night)\b/gi, /\b(?:this|last|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi, /\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi, /\b(?:on\s+)?\d{4}-\d{2}-\d{2}\b/gi, /\b(?:on\s+)?\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}\b/gi];
   for (const re of patterns) for (const m of message.matchAll(re)) matches.push({ index: m.index ?? 0, length: m[0].length, token: m[0] });
-  matches.sort((a, b) => a.index - b.index);
-  const deduped = matches.filter((m, i) => i === 0 || m.index >= matches[i - 1].index + matches[i - 1].length);
+  matches.sort((a, b) => a.index - b.index); const deduped = matches.filter((m, i) => i === 0 || m.index >= matches[i - 1].index + matches[i - 1].length);
   if (!deduped.length) return [{ text: message.trim(), reference: null }];
-  const out: Array<{ text: string; reference: string | null }> = [];
-  let start = 0; let currentReference: string | null = null;
+  const out: Array<{ text: string; reference: string | null }> = []; let start = 0; let currentReference: string | null = null;
   for (const hit of deduped) { const before = message.slice(start, hit.index).trim(); if (before) out.push({ text: before, reference: currentReference }); currentReference = hit.token; start = hit.index + hit.length; }
-  const tail = message.slice(start).trim(); if (tail) out.push({ text: tail, reference: currentReference });
-  return out.filter(x => x.text.length > 0);
+  const tail = message.slice(start).trim(); if (tail) out.push({ text: tail, reference: currentReference }); return out.filter(x => x.text.length > 0);
 }
-export function attributeMultiDayReport(message: string, now = new Date()): MultiDayAttribution {
-  const segments = splitAttributionReferences(String(message || "").trim());
-  const beats: AttributedBeat[] = segments.map(segment => {
-    if (!segment.reference) return { text: segment.text, dayKey: null, confidence: "ambiguous", dayReference: null };
-    const resolved = resolveAttributionReference(segment.reference, now);
-    return { text: segment.text, dayKey: resolved.dayKey, confidence: resolved.confidence, dayReference: segment.reference };
-  });
-  const distinctDays = new Set(beats.map(b => b.dayKey).filter(Boolean));
-  return { beats, ambiguous: beats.some(b => b.dayKey == null || b.confidence === "ambiguous"), hasMultipleDays: distinctDays.size > 1 };
-}
+export function attributeMultiDayReport(message: string, now = new Date()): MultiDayAttribution { const segments = splitAttributionReferences(String(message || "").trim()); const beats: AttributedBeat[] = segments.map(segment => { if (!segment.reference) return { text: segment.text, dayKey: null, confidence: "ambiguous", dayReference: null }; const resolved = resolveAttributionReference(segment.reference, now); return { text: segment.text, dayKey: resolved.dayKey, confidence: resolved.confidence, dayReference: segment.reference }; }); const distinctDays = new Set(beats.map(b => b.dayKey).filter(Boolean)); return { beats, ambiguous: beats.some(b => b.dayKey == null || b.confidence === "ambiguous"), hasMultipleDays: distinctDays.size > 1 }; }


### PR DESCRIPTION
Build the first post-foundation product capability on verified main 2ae5d281: deterministic multi-day attribution inside the existing temporal owner. No new decision owner, no writer changes yet. Explicit dates/weekdays resolve to SAST dayKey; future and ambiguous references remain non-writable. Includes regression suite and test-chain wiring.