### PR TITLE
P0-4: one Coach at both doors — the outbound truth floor, and the proactive decision migration

### DIFF
--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -77,6 +77,18 @@ const BUDGET = {
    */
   unreachableCapabilities: 59,
   /**
+   * GUARD #14 — see unclassifiedSenders above. Six proactive senders still choose their own
+   * behavioural instruction: monday's weigh-in reminder and diet-break restore, programme's weekly
+   * check-in and plateau ladder, business's supplement nudge, onboarding's step-sync catch-up.
+   *
+   * Set to the measured figure, and it may only FALL. Two of the six are waiting on P0-7 (one pace
+   * owner) rather than on wiring — naming that here is what stops it being rediscovered in a
+   * transcript. The senders classified RECOGNITION, RESOURCE and OPERATIONAL are not in this
+   * number because they carry no next-move instruction at all; that is a decision recorded per
+   * job in the register, not an exemption anyone can take silently.
+   */
+  localDecisionSenders: 6,
+  /**
    * GUARD #9 — AUTHORSHIP POINTS (2026-08-04). Every `return "…"` in server/ is a place
    * something other than the engine can put words in front of a client.
    *
@@ -566,6 +578,44 @@ function unreachableExports(prod: string[], probes: string[]): Array<{ file: str
   return out;
 }
 
+/**
+ * GUARD #14 — EVERY PROACTIVE SENDER IS CLASSIFIED (2026-08-25, P0-4b).
+ *
+ * THE DEFECT THIS EXISTS TO STOP, measured on main@d005081: eleven of fourteen sending files ran
+ * their own action ladder — 32 sends deciding what the client should do next, from the ledger
+ * alone, with no knowledge of the decision owner or of anything the client had said that day.
+ * Nobody decided that; each one was a locally-reasonable addition and there was nothing that had
+ * to be updated when a twelfth appeared.
+ *
+ * This is the thing that has to be updated. A new cron that talks to a client is a product
+ * decision about what the coach is allowed to say, and it does not compile past this guard until
+ * somebody makes it: CANONICAL (the instruction comes from chooseAction), RECOGNITION (it asks
+ * for nothing), RESOURCE (it delivers an artefact), OPERATIONAL (it is not coaching), or
+ * LEGACY_LOCAL (it still decides locally, and is counted as debt below).
+ *
+ * READ STATICALLY ON PURPOSE. Importing the register would pull in the scheduler, the database
+ * and the Twilio client to answer a question about a declaration. The subject of this guard IS
+ * the declaration, so reading the source is reading the subject — unlike a behavioural claim,
+ * where a source match proves nothing.
+ */
+function unclassifiedSenders(): { missing: string[]; legacy: number } {
+  const register = readFileSync("server/scheduler/proactive-decision.ts", "utf-8");
+  const declared = new Set([...register.matchAll(/\bjob:\s*"(\w+)"/g)].map(m => m[1]));
+  const legacy = [...register.matchAll(/cls:\s*"LEGACY_LOCAL"/g)].length;
+  const missing: string[] = [];
+  for (const f of readdirSync("server/scheduler/jobs").filter(n => n.endsWith(".ts"))) {
+    const src = readFileSync(`server/scheduler/jobs/${f}`, "utf-8");
+    // Split at each exported job entry point; a segment that sends is a sender.
+    const marks = [...src.matchAll(/^export (?:async )?function (\w+)/gm)];
+    for (let i = 0; i < marks.length; i++) {
+      const body = src.slice(marks[i].index!, marks[i + 1]?.index ?? src.length);
+      if (!/\bsendWhatsApp(?:Buttons)?\s*\(/.test(body)) continue;
+      if (!declared.has(marks[i][1])) missing.push(`${marks[i][1]}  server/scheduler/jobs/${f}`);
+    }
+  }
+  return { missing, legacy };
+}
+
 const files = [...walk("server"), ...walk("shared")];
 const read = (f: string) => readFileSync(f, "utf-8");
 const all = files.map(read);
@@ -589,6 +639,8 @@ const actual = {
   authorshipPoints: countClientFacingMouths(files),
   /** Exported capabilities no client message can reach. See GUARD #13. */
   unreachableCapabilities: unreachableExports(files, walk("script")).length,
+  /** Proactive senders still running their own action ladder. See GUARD #14. */
+  localDecisionSenders: unclassifiedSenders().legacy,
   // EVERY PLACE THAT TALKS TO TWILIO DIRECTLY (2026-08-05).
   //
   // Twilio is a reseller of Meta's WhatsApp API, not the destination — OUTSTANDING.md has
@@ -801,6 +853,15 @@ const ownership = problems.filter(p => p.includes("[OWNERSHIP]"));
 console.log(ownership.length === 0
   ? "ownership: OK — one owner per declared question, one reader per declared fact"
   : `ownership: ${ownership.length} VIOLATION(S) — a second authority exists`);
+
+// GUARD #14. An unclassified sender is not a budget overrun — it is a product decision nobody
+// made, so it names the job and refuses rather than incrementing a number.
+const senders = unclassifiedSenders();
+if (senders.missing.length > 0) {
+  problems.push(`  ✗ ${senders.missing.length} proactive sender(s) talk to a client with no classification in server/scheduler/proactive-decision.ts:`);
+  for (const m of senders.missing) problems.push(`      ${m}`);
+  problems.push(`      Decide what it is allowed to say: CANONICAL | RECOGNITION | RESOURCE | OPERATIONAL | LEGACY_LOCAL.`);
+}
 
 const unreachable = unreachableExports(files, walk("script"));
 if (actual.unreachableCapabilities > BUDGET.unreachableCapabilities) {

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2314,6 +2314,229 @@ async function main() {
       "a rejected proactive message still reached the send path");
   });
 
+  /**
+   * FIRE A REAL SCHEDULER JOB AND READ WHAT THE CLIENT WOULD HAVE READ.
+   *
+   * Not a call to the composer, and not a call to the decision — the exported cron entry point,
+   * through server/scheduler/shared.sendWhatsApp: the outbound floor, the provenance gate,
+   * humanizeReply, and the bubble split. Capture is via SHADOW mode, which is the product's own
+   * "record instead of send" door, so nothing here is a seam that exists only for the test.
+   *
+   * `saidToday` is chat_history as the held-constraint reader sees it — the client's own words.
+   */
+  async function runEveningThroughTheDoor(
+    saidToday: Array<{ message_in: string; created_at: Date }>,
+    ledger: { proteinTarget?: number; who: string },
+  ): Promise<string[]> {
+    const { runEveningAccountability } = await import("../server/scheduler/jobs/evening");
+    const { shadowReplies, sentProactive, mealLogs, workoutLogs, weightLogs, stepLogs, chatHistory } =
+      await import("../shared/schema");
+    const g = globalThis as any;
+    const today = new Date();
+
+    return serialise(async () => {
+      const priorShadow = process.env.SHADOW;
+      const priorPause = process.env.PROACTIVE_PAUSED;
+      process.env.SHADOW = "on";
+      // The harness pins PROACTIVE_PAUSED=true so no cron fires while the reactive cases run. This
+      // case IS the cron, so the killswitch is lifted for its duration and restored after. Inside
+      // serialise(), so nothing else is running while it is off.
+      process.env.PROACTIVE_PAUSED = "false";
+      g.__KAMLIFE_STUB_PGROWS = (sql: string) => (/chat_history/i.test(String(sql)) ? saidToday : []);
+      g.__KAMLIFE_STUB_USER = {
+        ...USER,
+        // A DISTINCT CLIENT PER CASE. The proactive budget is per user and in memory, so two cases
+        // sharing an id means the second one is silenced by the first — and "it said nothing"
+        // would read as "it obeyed the constraint".
+        id: `parity-${ledger.who}`,
+        phoneNumber: `whatsapp:+2782000${ledger.who.length}${ledger.who.charCodeAt(0)}`,
+        trainingDaysPerWeek: 4,      // this week = 0/4 — by the ledger they are behind
+        totalWorkoutsCompleted: 0,
+        proteinTarget: ledger.proteinTarget ?? 140,
+        calorieTarget: 2000,
+        stepsTarget: 8500,
+        lastActiveAt: today,
+        profileNotes: "",
+      };
+      // A LEDGER THAT SUPPORTS A PRESCRIPTION. Without evidence, decideProactive downgrades every
+      // prescription to a question — which would make "it did not say train" true for the wrong
+      // reason. Two weigh-ins twenty days apart make the weight trend usable, which is the
+      // evidence gate's own sufficiency condition.
+      //
+      // Rows carry BOTH the column name and the alias each query selects it under, because the
+      // stub returns seeded rows verbatim rather than applying drizzle's projection.
+      const meal = { id: 1, at: today, loggedAt: today, kcalInt: 900, proteinInt: 0,
+                     todayCal: 900, todayProt: 0 };
+      g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([
+        [sentProactive, [{ id: 1 }]],                       // claimDailySlot must be winnable
+        [chatHistory, [{ id: 1, createdAt: today, intent: "FOOD_LOG", messageIn: "chicken and rice" }]],
+        [mealLogs, [meal]],
+        [workoutLogs, []],                                  // zero sessions this week
+        [weightLogs, [
+          { id: 2, weight: "82.0", w: "82.0", at: new Date(NOW - 86_400_000), loggedAt: new Date(NOW - 86_400_000) },
+          { id: 1, weight: "83.4", w: "83.4", at: new Date(NOW - 20 * 86_400_000), loggedAt: new Date(NOW - 20 * 86_400_000) },
+        ]],
+        [stepLogs, [{ avg: 9000, steps: 9000, at: today, loggedAt: today }]],
+      ]);
+      const writes: Array<{ table: any; values: any }> = [];
+      g.__KAMLIFE_STUB_WRITES = writes;
+      try {
+        await runEveningAccountability().catch(() => undefined);
+      } finally {
+        delete g.__KAMLIFE_STUB_WRITES;
+        delete g.__KAMLIFE_STUB_ROWS;
+        delete g.__KAMLIFE_STUB_PGROWS;
+        g.__KAMLIFE_STUB_USER = { ...USER };
+        if (priorShadow === undefined) delete process.env.SHADOW; else process.env.SHADOW = priorShadow;
+        if (priorPause === undefined) delete process.env.PROACTIVE_PAUSED; else process.env.PROACTIVE_PAUSED = priorPause;
+      }
+      return writes
+        .filter(w => w.table === shadowReplies && typeof w.values?.body === "string")
+        .map(w => String(w.values.body));
+    });
+  }
+
+  // ── P0-4b · HELD STATE CANNOT BE CONTRADICTED BY A PROACTIVE MESSAGE (2026-08-25) ─────────
+  //
+  // The CTO's acceptance shape, and deliberately NOT "does weekly.ts call chooseAction" — that is
+  // a source-string trap that stays green when the call is made and its answer discarded.
+  //
+  // Held state: rest day (training declined in the client's own words) / food day closed / last
+  // night's birthday outing / this week = 0 of 4. A proactive sender fires. It must not tell the
+  // client to train, must not tell them to eat more, and the instruction it does carry must be the
+  // canonical one.
+  const BIRTHDAY = { message_in: "was my cousin's birthday last night, we ate out", created_at: new Date(NOW - 12 * 3_600_000) };
+  const SAYS_TRAINING = /\b(?:get|do|finish|start|complete)\b[^.!?\n]{0,40}\b(?:today'?s |the |your |a )?(?:session|workout)\b|training day and the session is still not done/i;
+  const SAYS_EAT = /\bget to \d+\s*g\b|\badd one more (?:proper )?meal\b|\bmake your next meal\b|\bget protein into your next meal\b/i;
+
+  // Four cases, one job, one door. Each PROHIBITION is paired with the identical fixture minus the
+  // constraint, which must produce the very instruction the other one forbids — so neither
+  // assertion can pass because the job went quiet or because the ladder never reached that rung.
+  check("P0-4b . training declined today — a real scheduler job must not tell them to train", async () => {
+    // proteinTarget 0 takes the food rungs out of the ladder, so `train` is what the decision
+    // would otherwise reach on 0 of 4 sessions. That is the rung under test.
+    const all = (await runEveningThroughTheDoor(
+      [{ message_in: "I'm not training today", created_at: new Date() }, BIRTHDAY],
+      { who: "trainheld", proteinTarget: 0 },
+    )).join("\n---\n");
+    assert.ok(!SAYS_TRAINING.test(all),
+      `told a client who said they are not training today to train: ${all.slice(0, 300)}`);
+  });
+
+  check("P0-4b control . same state, nothing said — it DOES tell them to train", async () => {
+    const sent = await runEveningThroughTheDoor([BIRTHDAY], { who: "traincontrol", proteinTarget: 0 });
+    assert.ok(sent.length > 0, "the evening job sent nothing at all — the prohibition above proves nothing");
+    const all = sent.join("\n---\n");
+    assert.ok(SAYS_TRAINING.test(all),
+      `0 of 4 sessions and no constraint, and the job never asked for a session: ${all.slice(0, 300)}`);
+    // …and it is the canonical renderer saying it, not a string this job wrote.
+    assert.ok(/One thing today:/i.test(all), `the instruction did not come from formatOneAction: ${all.slice(0, 300)}`);
+  });
+
+  check("P0-4b . food day closed — a real scheduler job must not tell them to eat", async () => {
+    const all = (await runEveningThroughTheDoor(
+      [{ message_in: "I'm not eating anything else today", created_at: new Date() }, BIRTHDAY],
+      { who: "foodheld", proteinTarget: 140 },
+    )).join("\n---\n");
+    assert.ok(!SAYS_EAT.test(all),
+      `told a client who closed their food day to eat: ${all.slice(0, 300)}`);
+  });
+
+  check("P0-4b control . same state, nothing said — it DOES ask for protein", async () => {
+    const sent = await runEveningThroughTheDoor([BIRTHDAY], { who: "foodcontrol", proteinTarget: 140 });
+    assert.ok(sent.length > 0, "the evening job sent nothing at all — the prohibition above proves nothing");
+    const all = sent.join("\n---\n");
+    // At or after 20:00 the same rung faces tomorrow — one rung, two renderings, both a real ask.
+    assert.ok(SAYS_EAT.test(all) || /start tomorrow with protein/i.test(all),
+      `protein at zero against a 140g target and the job asked for nothing: ${all.slice(0, 300)}`);
+  });
+
+  // The decision half, isolated: `trainingDeclined` is a DayState INPUT, not a filter applied to
+  // the sentence afterwards. Same state twice, one field apart.
+  check("P0-4b . trainingDeclined stands `train` down, and nothing else", async () => {
+    const { chooseAction } = await import("../server/one-action");
+    const behind = {
+      goal: "fat_loss" as any, weeksOnProgramme: 3,
+      daysSinceAnyLog: 0, daysSinceWeighIn: 1, loggedToday: true,
+      proteinPct: 1, caloriePct: 1,
+      sessionsThisWeek: 0, sessionsTarget: 4,
+      stepsToday: 9000, stepsTarget: 8500, hour: 19,
+    };
+    assert.equal(chooseAction(behind).kind, "train", "0 of 4 sessions and the ladder did not reach train");
+    assert.notEqual(chooseAction({ ...behind, trainingDeclined: true }).kind, "train",
+      "a client who ruled today out was still told to train");
+    // It suppresses ONE rung, it does not silence the coach: the same client short on protein
+    // still gets the protein ask, because that is not what they declined.
+    assert.equal(chooseAction({ ...behind, trainingDeclined: true, proteinPct: 0.2 }).kind, "protein",
+      "declining training silenced an unrelated rung");
+  });
+
+  // The door half, isolated: the floor blocks a contradiction written by hand, so a sender nobody
+  // has migrated still cannot say it. Without this the migration protects only what it touched.
+  check("P0-4b . the outbound floor blocks a contradiction from an unmigrated sender", async () => {
+    const { enforceOutboundTruth } = await import("../server/outbound-authority");
+    const g = globalThis as any;
+    const out = await serialise(async () => {
+      g.__KAMLIFE_STUB_PGROWS = (sql: string) => (/chat_history/i.test(String(sql))
+        ? [{ message_in: "I'm not training today", created_at: new Date() },
+           { message_in: "I'm done eating for today", created_at: new Date() }]
+        : []);
+      const r = {
+        train: await enforceOutboundTruth(USER.id, "whatsapp:+27000000301", "Kam, get today's session done before bed."),
+        eat: await enforceOutboundTruth(USER.id, "whatsapp:+27000000302", "Kam, get to 140g protein tonight."),
+        recognition: await enforceOutboundTruth(USER.id, "whatsapp:+27000000303", "Kam, 9,000 steps today. Strong."),
+      };
+      delete g.__KAMLIFE_STUB_PGROWS;
+      return r;
+    });
+    assert.ok(!out.train.ok && out.train.reason === "contradicts_held_constraint",
+      `a training instruction reached a client who declined training: ${JSON.stringify(out.train)}`);
+    assert.ok(!out.eat.ok && out.eat.reason === "contradicts_held_constraint",
+      `a food instruction reached a client who closed their food day: ${JSON.stringify(out.eat)}`);
+    // THE CONTROL. A floor that blocks recognition is a floor that will be routed around.
+    assert.ok(out.recognition.ok, `recognition was blocked by the constraint rule: ${out.recognition.detail}`);
+  });
+
+  // THE FALSE-POSITIVE CONTROL, and it caught a real one. The first matcher took any eating verb
+  // near any food noun, which would have suppressed Sunday's meal plan and the shopping list for a
+  // client who closed their food day that afternoon — a week's artefact lost to a constraint about
+  // tonight. A rule that swallows the deliverable is a rule people route around.
+  check("P0-4b . the constraint rule does not swallow artefacts, logging asks or recognition", async () => {
+    const { asksForFoodToday, asksForTrainingToday } = await import("../server/held-constraints");
+    const mustPass = [
+      "*Kam — your 3-day plan for the week ahead:*\n\nDay 1 breakfast: eggs + toast. Prep protein on Sunday.",
+      "Your R100 week plan — eggs 12 pack R45, pilchards 3 tins R36. Shop at Shoprite this weekend.",
+      "One quick thing before bed: tell me what you ate.",
+      "Kam, 9,000 steps and a session done today. Strong.",
+      "Reply *1* to see tomorrow's workout.",
+      "Week 5 wrap-up: 3 workouts done, 5 days food logged.",
+    ];
+    for (const m of mustPass) {
+      assert.ok(!asksForFoodToday(m), `a non-instruction was read as an ask for food: ${m.slice(0, 70)}`);
+      assert.ok(!asksForTrainingToday(m), `a non-instruction was read as an ask to train: ${m.slice(0, 70)}`);
+    }
+    // …and it still sees the two things it exists to see.
+    assert.ok(asksForFoodToday("Make your next meal a protein one — tin fish, eggs or amasi."));
+    assert.ok(asksForTrainingToday("Get today's session done."));
+  });
+
+  // The reader half: "anything else" is a quantity, "anything fried" is an object. Found while
+  // building the fixture above, and the distinction is the whole reason this owner is narrow.
+  check("P0-4b . a closed food day is read from the client's own words, not the topic", async () => {
+    const { foodDayIsClosed } = await import("../server/one-action");
+    for (const closed of [
+      "I'm not eating anything else today",
+      "not eating anything more today",
+      "I'm done eating for today",
+    ]) assert.ok(foodDayIsClosed(closed), `a plain closure was not read as one: ${closed}`);
+    for (const open of [
+      "I'm not eating anything fried today",
+      "I'm done eating badly",
+      "I'm done eating junk",
+      "I can't stop eating today",
+    ]) assert.ok(!foodDayIsClosed(open), `a food CHOICE was recorded as a closed day: ${open}`);
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2254,6 +2254,66 @@ async function main() {
     assert.equal(after.totalWorkoutsCompleted, 8, "the lifetime session count was not updated");
   });
 
+  // ── P0-4 · ONE COACH AT BOTH DOORS (2026-08-25) ───────────────────────────────────────────
+  //
+  // The behavioural-authority work lives in reconcileTurnReply, inside `inTurn` — so it governed
+  // REACTIVE replies only. 69 proactive sends across 14 files, 3 of which consult the decision
+  // owner. This grades the shared floor: a claim about durable state, checked against durable
+  // state, on the proactive path too.
+  check("P0-4 . a proactive send may not assert a training count the record denies", async () => {
+    const { enforceOutboundTruth } = await import("../server/outbound-authority");
+    const { mealLogs, workoutLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+
+    const verdicts = await serialise(async () => {
+      // The record holds ONE session in the window.
+      g.__KAMLIFE_STUB_ROWS = new Map([[workoutLogs, [{ n: 1 }]]]);
+      const out = {
+        contradicts: await enforceOutboundTruth(USER.id, "whatsapp:+27000000101", "Strong week — that's 4 sessions in the bag."),
+        matches: await enforceOutboundTruth(USER.id, "whatsapp:+27000000102", "That's 1 session this week — let's build on it."),
+        noClaim: await enforceOutboundTruth(USER.id, "whatsapp:+27000000103", "Morning Kam. 8,500 steps today and protein first."),
+        firstSend: await enforceOutboundTruth(USER.id, "whatsapp:+27000000104", "Same message body for the duplicate check."),
+        repeat: await enforceOutboundTruth(USER.id, "whatsapp:+27000000104", "Same message body for the duplicate check."),
+      };
+      delete g.__KAMLIFE_STUB_ROWS;
+      return out;
+    });
+
+    assert.ok(!verdicts.contradicts.ok, "a proactive message claimed 4 sessions against a record of 1");
+    assert.equal(verdicts.contradicts.reason, "session_count_contradicts_record");
+    assert.ok(verdicts.matches.ok, `a truthful count was blocked: ${verdicts.matches.detail}`);
+    // THE CONTROL THAT KEEPS THIS HONEST: the morning brief's step TARGET carries no evidence and
+    // must still go out. Porting verifyBrainReply wholesale would have silenced it.
+    assert.ok(verdicts.noClaim.ok, `an ordinary proactive message was blocked: ${verdicts.noClaim.detail}`);
+    assert.ok(verdicts.firstSend.ok, "the first send of a message was blocked");
+    assert.ok(!verdicts.repeat.ok && verdicts.repeat.reason === "duplicate",
+      "the same proactive message went out twice");
+  });
+
+  check("P0-4b . the proactive DOOR consults the floor, not just the floor existing", async () => {
+    // The first version of this asserted the source contained the call — and stayed green when
+    // the door was changed to ignore the verdict. This drives sendWhatsApp itself.
+    const { sendWhatsApp } = await import("../server/scheduler/shared");
+    const { workoutLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+    const seen = await serialise(async () => {
+      g.__KAMLIFE_STUB_ROWS = new Map([[workoutLogs, [{ n: 1 }]]]);
+      const from = CONSOLE_LINES.length;
+      const realErr = console.error;
+      const errs: string[] = [];
+      console.error = (...a: any[]) => { errs.push(a.map(String).join(" ")); };
+      try {
+        await sendWhatsApp("whatsapp:+27000000201", "Strong week — that's 4 sessions in the bag.").catch(() => undefined);
+      } finally { console.error = realErr; }
+      delete g.__KAMLIFE_STUB_ROWS;
+      return { errs, after: CONSOLE_LINES.slice(from) };
+    });
+    assert.ok(seen.errs.some(l => /OUTBOUND_AUTHORITY\] BLOCKED/.test(l)),
+      `the door sent a message the floor rejected: ${JSON.stringify(seen.errs).slice(0, 160)}`);
+    assert.ok(!seen.after.some(l => /SCHEDULER\] Sent|delivery/i.test(l)),
+      "a rejected proactive message still reached the send path");
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/db.ts
+++ b/server/db.ts
@@ -19,7 +19,7 @@ function makeStubDb(): any {
     const fn: any = () => {};
     return new Proxy(fn, {
       get(_t, prop: string | symbol) {
-        if (prop === "then") {
+        if (prop === "then" || prop === "catch" || prop === "finally") {
           const stubUser = (globalThis as any).__KAMLIFE_STUB_USER;
           // SEEDED LEDGER ROWS (2026-08-22). Same opt-in shape as __KAMLIFE_STUB_USER, one table
           // deeper: a suite that needs the stub to hold a real workout/step/meal history sets
@@ -30,16 +30,30 @@ function makeStubDb(): any {
           const seeded = (globalThis as any).__KAMLIFE_STUB_ROWS as Map<any, any[]> | undefined;
           const rows = seeded?.get(state.table)
             ?? (state.table === (schema as any).users && stubUser ? [{ ...stubUser }] : []);
+          // `.catch()` USED TO DISCARD THE SEED (fixed 2026-08-25). It returned
+          // `Promise.resolve([]).catch(h)` — a resolved promise of the EMPTY array, whatever the
+          // suite had seeded. Every query in loadProactiveState ends in `.catch(() => [])`, so a
+          // seeded ledger reached none of them: the state came back all-null and any test built on
+          // it graded the come_back rung instead of the one it meant to. Same class of defect as
+          // the `.catch()` on the drizzle chain that silently disabled the outbound floor.
+          if (prop === "catch") return (h: any) => Promise.resolve(rows).catch(h);
+          if (prop === "finally") return (h: any) => Promise.resolve(rows).finally(h);
           return (res: any, rej: any) => Promise.resolve(rows).then(res, rej);
         }
-        if (prop === "catch") return (h: any) => Promise.resolve([]).catch(h);
-        if (prop === "finally") return (h: any) => Promise.resolve([]).finally(h);
         return (...args: any[]) => {
           if (prop === "from" || prop === "into") return chain({ table: args[0] });
           if ((prop === "set" || prop === "values") && state.table === (schema as any).users
               && args[0] && typeof args[0] === "object" && !Array.isArray(args[0])) {
             const stubUser = (globalThis as any).__KAMLIFE_STUB_USER;
             if (stubUser) Object.assign(stubUser, args[0]);
+          }
+          // WRITES ARE OBSERVABLE (2026-08-25). A suite that needs to grade what a code path wrote
+          // — as opposed to what it returned — sets globalThis.__KAMLIFE_STUB_WRITES to an array
+          // and reads it back. The proactive door captures its final outbound body through
+          // shadowDoor's insert, so this is how "what would the client have read" is graded end to
+          // end without patching Twilio or adding a seam to production code. Unset: no-op.
+          if (prop === "values" && Array.isArray((globalThis as any).__KAMLIFE_STUB_WRITES)) {
+            (globalThis as any).__KAMLIFE_STUB_WRITES.push({ table: state.table, values: args[0] });
           }
           return chain(state);
         };
@@ -98,7 +112,18 @@ function makeRealDb(p: ReturnType<typeof makeRealPool>) {
 }
 
 const stubPool = {
-  query: async () => ({ rows: [] }),
+  // SEEDED RAW ROWS (2026-08-25). The drizzle stub grew __KAMLIFE_STUB_ROWS for the same reason
+  // this needs one: the held-constraint reader goes through pool.query, not drizzle, so "the
+  // client said at 08:00 that they are not training today" could not be expressed offline — and
+  // an invariant about held state cannot be graded against a history that is always empty.
+  // Opt-in: a function of (sql, params) returning rows, or a flat array. Unset — which is every
+  // existing caller — behaves exactly as before.
+  query: async (text?: any, params?: any) => {
+    const seed = (globalThis as any).__KAMLIFE_STUB_PGROWS;
+    if (typeof seed === "function") return { rows: seed(text, params) ?? [] };
+    if (Array.isArray(seed)) return { rows: seed };
+    return { rows: [] };
+  },
   connect: async () => ({ query: async () => ({ rows: [] }), release() {} }),
   end: async () => {},
   on() {},

--- a/server/held-constraints.ts
+++ b/server/held-constraints.ts
@@ -1,0 +1,104 @@
+/**
+ * HELD CONSTRAINTS — what the client already ruled out today (2026-08-25, P0-4b).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHY THIS IS ITS OWN OWNER
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * `foodDayIsClosed` and `trainingDayIsDeclined` are the twin readers of an explicit constraint —
+ * "I'm not eating anything else today", "I'm not training today". Both existed. Neither was HELD:
+ *
+ *   • foodDayIsClosed was re-derived inline in the morning job, from its own copy of the query.
+ *   • trainingDayIsDeclined was computed at the reactive door into `_isWorkoutRefusal` — an
+ *     underscore-prefixed local that nothing read — and DayState had no field to carry it.
+ *
+ * So the constraint lived for exactly one expression and then evaporated. A client who said at
+ * 08:00 "I'm not training today" got told at 19:00 that the session was still not done, and a
+ * client who closed food at 19:55 could still be sent a dinner suggestion at 20:00, because every
+ * later surface re-decided from the ledger and the ledger does not record what someone SAID.
+ *
+ * One reader, two consumers: the proactive decision (so the ladder never chooses the ask) and the
+ * outbound floor (so no sender can contradict it by hand). Those are deliberately different jobs
+ * — the first stops us choosing it, the second stops anyone else saying it anyway.
+ *
+ * TODAY ONLY. A constraint is a statement about a day, not a standing preference; "I'm not
+ * training today" said on Tuesday must not silence Wednesday. That is what `doNotMention` is for.
+ */
+
+import { foodDayIsClosed, trainingDayIsDeclined } from "./one-action";
+import { recentClientMessagesStamped } from "./memory";
+import { readHealthState } from "./health-state";
+import { sastDaysBetween } from "./sast";
+
+export interface HeldConstraints {
+  /** They said they are done eating for today. */
+  foodDayClosed: boolean;
+  /** They said they are not training today. */
+  trainingDeclined: boolean;
+  /** Durable illness state — not a keyword scan. Rest outranks everything but silence. */
+  sick: boolean;
+}
+
+export const NO_CONSTRAINTS: HeldConstraints = { foodDayClosed: false, trainingDeclined: false, sick: false };
+
+/**
+ * Read what today's own words already settled.
+ *
+ * Fails OPEN — an unreadable chat history must not invent a constraint that silences the coach.
+ * The failure mode of a false `true` here is a client who never hears from us again on a day they
+ * said nothing about; the failure mode of a false `false` is the message we were already sending.
+ */
+export async function readHeldConstraints(
+  phone: string,
+  client?: { profileNotes?: string | null } | null,
+): Promise<HeldConstraints> {
+  const sick = client ? !!readHealthState(client).isSick : false;
+  try {
+    const stamped = await recentClientMessagesStamped(phone);
+    const todays = stamped.filter(s => sastDaysBetween(s.at) === 0);
+    return {
+      foodDayClosed: todays.some(s => foodDayIsClosed(s.text)),
+      trainingDeclined: todays.some(s => trainingDayIsDeclined(s.text)),
+      sick,
+    };
+  } catch (e: any) {
+    console.warn(`[HELD_CONSTRAINTS] unreadable for ${String(phone).slice(-8)}: ${e?.message || e}`);
+    return { ...NO_CONSTRAINTS, sick };
+  }
+}
+
+// ── WHAT AN OUTBOUND MESSAGE IS ASKING FOR ───────────────────────────────────────────────────
+//
+// Deliberately narrow, and deliberately about the ASK rather than the topic. "You ate well today"
+// mentions food and asks for nothing; "get to 120g tonight" asks for a meal. Only the second can
+// contradict a closed food day. A topic matcher here would block half the product's recognition.
+
+/**
+ * An instruction to eat something MORE, in what is left of today.
+ *
+ * The scope is the whole point, and the first draft of this got it wrong: it matched any eating
+ * verb near any food noun, which would have blocked Sunday's meal plan ("Breakfast: eggs + toast")
+ * and the shopping list from a client who happened to close their food day that afternoon — an
+ * artefact for the week ahead, suppressed by a constraint about tonight.
+ *
+ * Two things are deliberately NOT here. A request to LOG is not a request to eat: a closed food
+ * day says nothing about telling us what was already eaten, and blocking that would cost the day's
+ * record. And a plan for another day is not an ask about this one.
+ */
+export function asksForFoodToday(text: string): boolean {
+  const t = String(text || "");
+  return /\b(?:make|have|get|add|grab|cook|order|eat)\b[^.!?\n]{0,40}\b(?:next meal|one more (?:proper )?meal|another meal|something (?:to eat|else))\b/i.test(t)
+    || /\b(?:eat|have|get|add|grab)\b[^.!?\n]{0,40}\b(?:tonight|before bed|this evening|right now)\b/i.test(t)
+    || /\bprotein\b[^.!?\n]{0,40}\b(?:tonight|before bed|at your next meal)\b/i.test(t)
+    || /\bget to \d+\s*g\b/i.test(t);
+}
+
+/** An instruction to train today. Not "you trained", not "tomorrow's session". */
+export function asksForTrainingToday(text: string): boolean {
+  const t = String(text || "");
+  if (/\b(?:tomorrow|next week|yesterday)\b/i.test(t) && !/\btoday|tonight\b/i.test(t)) return false;
+  return /\b(?:do|get|finish|start|complete|hit)\b[^.!?\n]{0,40}\b(?:today'?s session|the session|your session|your workout|today'?s workout|a session)\b/i.test(t)
+    || /\bone session\b[^.!?\n]{0,40}\b(?:today|tonight|before)\b/i.test(t)
+    || /\btraining day and the session is still not done\b/i.test(t)
+    || /\b(?:train|get to the gym)\b[^.!?\n]{0,30}\b(?:today|tonight)\b/i.test(t);
+}

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -92,6 +92,20 @@ export interface DayState {
    * prescribed a meal is the 19:55 screenshot.
    */
   foodDayClosed?: boolean;
+  /**
+   * They ruled out training today, in their own words — the twin of foodDayClosed.
+   *
+   * `trainingDayIsDeclined` has existed since 2026-08-24 and DayState had no field to put its
+   * answer in, so the constraint was computed at the reactive door and then discarded: the
+   * decision itself never heard it. A client who said "I'm not training today" and is behind for
+   * the week still reached rung 8 and was told to get today's session done — by BOTH doors, since
+   * the proactive path runs the same ladder. `train` stands down here for the same reason
+   * `eat_more` stands down for a closed food day: they told us, and being told is the point.
+   *
+   * It does not excuse the week. Steps still rank above it, and the week's count is unchanged —
+   * this suppresses one instruction for one day, it does not rewrite the record.
+   */
+  trainingDeclined?: boolean;
 }
 
 export type ActionKind =
@@ -287,7 +301,12 @@ export function foodDayIsClosed(text: string): boolean {
   // followed by the end of the clause or by a marker that scopes it in TIME; an adverb or a food
   // noun after it means they described how they eat, not that they have stopped.
   if (!/\b(?:can'?t|cannot|couldn'?t|struggle(?:s|d)? to|unable to)\s+(?:stop|quit)\s+eating\b/i.test(t)
-      && /\b(?:not|no longer|done|finished|stop|stopping|quit|quitting)\s+(?:going\s+to\s+|gonna\s+)?eat(?:ing)?(?=\s*(?:$|[.!?,;])|\s+(?:anymore|any\s+more|again|today|tonight|for\s+(?:the\s+)?(?:rest\s+of\s+the\s+)?(?:day|today|night|evening)|for\s+now|until\s+tomorrow)\b)/i.test(t)) return true;
+      // "ANYTHING ELSE" IS A QUANTITY, NOT AN OBJECT (2026-08-25, found while building the P0-4b
+      // acceptance fixture). "I'm not eating anything else today" is the plainest possible closure
+      // and it fell through, because the marker after the verb was a noun phrase rather than a
+      // time word. It is admitted only in the `else`/`more` forms — those mean NOTHING FURTHER.
+      // A bare `anything` stays out, so "not eating anything fried today" is still a food choice.
+      && /\b(?:not|no longer|done|finished|stop|stopping|quit|quitting)\s+(?:going\s+to\s+|gonna\s+)?eat(?:ing)?(?=\s*(?:$|[.!?,;])|\s+(?:anymore|any\s+more|again|today|tonight|(?:any|no)\s*thing\s+(?:else|more)|for\s+(?:the\s+)?(?:rest\s+of\s+the\s+)?(?:day|today|night|evening)|for\s+now|until\s+tomorrow)\b)/i.test(t)) return true;
   if (/\b(?:just|only)\s+(?:going to |gonna )?(?:have )?(?:alcohol|drinks|zero[- ]calorie)/i.test(t)) return true;
   if (/\b(?:alcohol|zero[- ]calorie drinks).{0,60}(?:today|tonight|the rest of the day)\b/i.test(t)) return true;
   return false;
@@ -405,8 +424,8 @@ export function chooseAction(s: DayState): OneAction {
     };
   }
 
-  // 8. TRAINING, behind for the week.
-  if (s.sessionsTarget > 0 && s.sessionsThisWeek < s.sessionsTarget) {
+  // 8. TRAINING, behind for the week — unless they already ruled today out.
+  if (s.sessionsTarget > 0 && s.sessionsThisWeek < s.sessionsTarget && !s.trainingDeclined) {
     const left = s.sessionsTarget - s.sessionsThisWeek;
     return {
       kind: "train",
@@ -474,7 +493,8 @@ export interface ProactiveProfile {
  * already in buildDayState; it is stated here so both callers cannot disagree about it.
  */
 export function dayStateFrom(
-  s: ProactiveStateForDecision, p: ProactiveProfile, opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean },
+  s: ProactiveStateForDecision, p: ProactiveProfile,
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean },
 ): DayState {
   return {
     firstName: s.name,
@@ -499,6 +519,7 @@ export function dayStateFrom(
     hour: opts?.hour ?? s.today.hour,
     atKeyboard: opts?.atKeyboard,
     foodDayClosed: opts?.foodDayClosed,
+    trainingDeclined: opts?.trainingDeclined,
   };
 }
 
@@ -599,7 +620,8 @@ function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEv
 }
 
 export function decideProactive(
-  s: ProactiveStateForDecision, p: ProactiveProfile, opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean },
+  s: ProactiveStateForDecision, p: ProactiveProfile,
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean },
 ): ProactiveDecision {
   let action = chooseAction(dayStateFrom(s, p, opts));
   let evidence = evidenceFor(s, action.kind);

--- a/server/outbound-authority.ts
+++ b/server/outbound-authority.ts
@@ -39,12 +39,13 @@
 
 import { sessionCountsIn } from "./utils";
 import { isDuplicateOutbound } from "./reply-hygiene";
+import { readHeldConstraints, asksForFoodToday, asksForTrainingToday } from "./held-constraints";
 
 export interface OutboundVerdict {
   /** May this leave the building? */
   ok: boolean;
   /** Machine-readable cause, for the counters. */
-  reason?: "session_count_contradicts_record" | "duplicate";
+  reason?: "session_count_contradicts_record" | "duplicate" | "contradicts_held_constraint";
   detail?: string;
 }
 
@@ -59,6 +60,8 @@ export async function enforceOutboundTruth(
   userId: string | null,
   recipientKey: string,
   text: string,
+  /** The recipient's row, when the door already holds it — carries the durable illness state. */
+  recipientUser?: { profileNotes?: string | null } | null,
 ): Promise<OutboundVerdict> {
   const body = String(text || "");
   if (!body.trim()) return { ok: true };
@@ -85,7 +88,36 @@ export async function enforceOutboundTruth(
     }
   }
 
-  // 2. THE SAME MESSAGE TWICE IS NEVER RIGHT. The reactive door has said so since 2026-08-21; two
+  // 2. A MESSAGE MAY NOT CONTRADICT WHAT THE CLIENT ALREADY SETTLED TODAY (2026-08-25, P0-4b).
+  //
+  //    This is the rule that makes the migration hold. Eleven of fourteen proactive senders ran
+  //    their own action ladder — "if sessions < target then say train", "if protein short then say
+  //    get to 120g" — computed from the LEDGER, which records what a client did and knows nothing
+  //    about what they SAID. So "I'm not training today" at 08:00 and "training day and the
+  //    session is still not done" at 19:00 were both correct by their own inputs.
+  //
+  //    Migrating a sender to chooseAction fixes that sender. This fixes the door, which is the
+  //    only place the property can be true for senders nobody has migrated yet and for the next
+  //    one somebody writes. The migration below it exists so that senders pass this rule by
+  //    construction rather than by being blocked.
+  //
+  //    Opt-in, like rule 1: the constraint read only happens when the text is actually ASKING for
+  //    food or training today. Recognition ("you trained 3 times this week") costs nothing.
+  const asksFood = asksForFoodToday(body);
+  const asksTraining = asksForTrainingToday(body);
+  if (asksFood || asksTraining) {
+    // The lookup key is the phone, which is what recipientKey is on this door.
+    const held = await readHeldConstraints(recipientKey, recipientUser ?? null);
+    if (asksFood && held.foodDayClosed) {
+      return { ok: false, reason: "contradicts_held_constraint", detail: `food day closed; text asks for food: ${body.slice(0, 60)}` };
+    }
+    if (asksTraining && (held.trainingDeclined || held.sick)) {
+      const which = held.sick ? "sick" : "training declined";
+      return { ok: false, reason: "contradicts_held_constraint", detail: `${which}; text asks for training: ${body.slice(0, 60)}` };
+    }
+  }
+
+  // 3. THE SAME MESSAGE TWICE IS NEVER RIGHT. The reactive door has said so since 2026-08-21; two
   //    crons covering the same ground on the same morning had nothing stopping them.
   if (isDuplicateOutbound(`proactive:${recipientKey}`, body)) {
     return { ok: false, reason: "duplicate", detail: body.slice(0, 60) };

--- a/server/outbound-authority.ts
+++ b/server/outbound-authority.ts
@@ -1,0 +1,95 @@
+/**
+ * OUTBOUND AUTHORITY — the floor both doors stand on (2026-08-25, P0-4).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHY THIS EXISTS
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * The behavioural-authority work of the last weeks lives in reconcileTurnReply, which runs
+ * inside `inTurn` — so it governs REACTIVE replies and nothing else. Measured on main@0950344d:
+ * 69 proactive sends across 14 files, of which 3 consult the decision owner. The proactive door
+ * (scheduler/shared.sendWhatsApp) applies provenance, hygiene and a template-leak gate, and none
+ * of the truth checks.
+ *
+ * So the product can still be one Coach in conversation and a different one at 06:00, on Monday,
+ * and in the weekly review. This is the shared floor that ends that — deliberately a FLOOR, not
+ * a copy of the reactive boundary.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT IS AND IS NOT PORTABLE
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * verifyBrainReply is NOT called here, and that is a deliberate refusal rather than an oversight.
+ * Its step-attribution rule blocks a step figure that has no evidence on the turn — correct for a
+ * reply, wrong for a cron: the morning brief's "👟 8,500 steps" is a TARGET carrying no target
+ * marker, so applying that rule wholesale would silence the single most important message in the
+ * product. A boundary that has to be exempted everywhere teaches people to route around it.
+ *
+ * What ports cleanly is what needs no turn: a claim about durable state, checked against durable
+ * state, and a repeat of something just sent.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHY A BLOCK, NOT A REWRITE
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * A reactive turn has someone waiting, so silence is the worst outcome and the reply is repaired.
+ * Nobody is waiting for a nudge. A false claim about a client's own training is worse than a
+ * missed message, so a proactive send that fails this floor is dropped and recorded.
+ */
+
+import { sessionCountsIn } from "./utils";
+import { isDuplicateOutbound } from "./reply-hygiene";
+
+export interface OutboundVerdict {
+  /** May this leave the building? */
+  ok: boolean;
+  /** Machine-readable cause, for the counters. */
+  reason?: "session_count_contradicts_record" | "duplicate";
+  detail?: string;
+}
+
+/** The window every weekly surface already uses; getProgressTruth's default. */
+const SESSION_WINDOW_DAYS = 7;
+
+/**
+ * The floor. `userId` may be null when the recipient cannot be resolved — the state checks then
+ * cannot run and only the turn-free ones apply, which is the honest degradation.
+ */
+export async function enforceOutboundTruth(
+  userId: string | null,
+  recipientKey: string,
+  text: string,
+): Promise<OutboundVerdict> {
+  const body = String(text || "");
+  if (!body.trim()) return { ok: true };
+
+  // 1. A TRAINING COUNT MUST MATCH THE RECORD. The reactive path has refused to confirm a session
+  //    history the log denies since 2026-08-22; a weekly or programme message asserting the same
+  //    number was never checked at all. Opt-in: this only reads the ledger when the text actually
+  //    asserts a count, so the common send pays nothing.
+  const claimed = sessionCountsIn(body);
+  if (claimed.length > 0 && userId) {
+    try {
+      const { sessionsSince } = await import("./day-ledger");
+      const held = await sessionsSince(userId, SESSION_WINDOW_DAYS);
+      if (!claimed.every(n => n === held)) {
+        return {
+          ok: false,
+          reason: "session_count_contradicts_record",
+          detail: `said ${claimed[0]}, record holds ${held} in ${SESSION_WINDOW_DAYS} days`,
+        };
+      }
+    } catch (e: any) {
+      // The read failed. Do not assert an unverified count at a client who did not ask.
+      return { ok: false, reason: "session_count_contradicts_record", detail: `count unverifiable: ${e?.message || e}` };
+    }
+  }
+
+  // 2. THE SAME MESSAGE TWICE IS NEVER RIGHT. The reactive door has said so since 2026-08-21; two
+  //    crons covering the same ground on the same morning had nothing stopping them.
+  if (isDuplicateOutbound(`proactive:${recipientKey}`, body)) {
+    return { ok: false, reason: "duplicate", detail: body.slice(0, 60) };
+  }
+
+  return { ok: true };
+}

--- a/server/scheduler/jobs/evening.ts
+++ b/server/scheduler/jobs/evening.ts
@@ -7,8 +7,46 @@ import {
 } from "../shared";
 import { readHealthState } from "../../health-state";
 import { sendWhatsAppButtons } from "../../twilio-interactive";
-import { usesMacroTargets } from "../../goal-profiles";
-import { proteinOptions } from "../../utils";
+import { canonicalNextMove } from "../proactive-decision";
+import { sastHour } from "../../sast";
+
+/**
+ * WHAT HAPPENED TODAY, WITH NOTHING ASKED FOR (2026-08-25, P0-4b).
+ *
+ * Pure and instruction-free on purpose. Everything this used to say AFTER the facts — "get to
+ * 120g tonight", "push to 8,500 tomorrow", "log tonight's food", "one more thing before bed" —
+ * was a second action ladder deciding from the ledger, which cannot know what the client SAID.
+ * It is why a client who closed food at 19:55 got a protein target at 20:00.
+ *
+ * The facts still belong here. The instruction comes from canonicalNextMove.
+ */
+export function eveningRecognition(f: {
+  name: string;
+  workedOut: boolean;
+  proteinLogged: number;
+  proteinTarget: number;
+  foodLogged: boolean;
+  steps: number;
+  stepsTarget: number;
+  sick: boolean;
+}): string {
+  if (f.sick) return `Rest up, ${f.name}. No targets today. Your data is saved — we pick up when you're better.`;
+
+  const done: string[] = [];
+  if (f.workedOut) done.push("session done");
+  if (f.proteinLogged > 0) done.push(`${f.proteinLogged}g protein`);
+  else if (f.foodLogged) done.push("food logged");
+  if (f.steps > 0) done.push(`${f.steps.toLocaleString()} steps`);
+
+  if (done.length === 0) return `${f.name}, nothing logged yet today.`;
+
+  const clean = f.workedOut
+    && f.steps >= f.stepsTarget
+    && f.proteinTarget > 0 && f.proteinLogged >= Math.round(f.proteinTarget * 0.9);
+  return clean
+    ? `${f.name}, clean day — ${done.join(", ")}.`
+    : `${f.name}, today: ${done.join(", ")}.`;
+}
 
 export async function runEveningAccountability(): Promise<void> {
   console.log("[SCHEDULER] JOB: Evening accountability");
@@ -27,16 +65,16 @@ export async function runEveningAccountability(): Promise<void> {
       const phone = client.phoneNumber;
       const todayLogs = await getTodayLogs(client.id);
 
+      // THE EMPTY DAY IS A DECISION LIKE ANY OTHER (2026-08-25, P0-4b). These two branches were a
+      // ladder of their own: a day-one client got "Reply *1* … get it done tonight" — a training
+      // instruction chosen from account age — and everyone else got "tell me what you ate". The
+      // first duplicated the onboarding sequence's Day 1 message, which is that job's to own; the
+      // second is `log`, which chooseAction has ranked since Cut 6. Both now come from there, so
+      // a client who told us at 08:00 that they are not training tonight is not told to train.
       if (todayLogs.length === 0) {
-        if (await claimDailySlot(client.id, "evening")) {
-          const isNewClient = !client.totalWorkoutsCompleted && client.createdAt &&
-            (Date.now() - new Date(client.createdAt).getTime()) > 6 * 3_600_000 &&
-            (Date.now() - new Date(client.createdAt).getTime()) < 48 * 3_600_000;
-          if (isNewClient) {
-            await sendWhatsApp(phone, `${name}, your programme is loaded and ready. Reply *1* to see today's workout — it takes 20 minutes. The first session is always the hardest. Get it done tonight.`);
-          } else {
-            await sendWhatsApp(phone, `${name}, haven't heard from you today — no stress. One quick thing before bed: tell me what you ate. Even just your last meal. That's all I need to keep you moving.`);
-          }
+        const empty = await canonicalNextMove(client, { hour: sastHour() });
+        if (empty.line && await claimDailySlot(client.id, "evening")) {
+          await sendWhatsApp(phone, `${name}, haven't heard from you today — no stress.\n\n${empty.line}`);
         }
         continue;
       }
@@ -73,96 +111,53 @@ export async function runEveningAccountability(): Promise<void> {
         .orderBy(desc(stepLogs.loggedAt)).limit(1);
 
       const workedOut = !!todayWorkout;
-      const stepsDone = todayStep ? todayStep.steps >= stepsTarget : false;
-      const protHit = todayProt >= Math.round(protTarget * 0.9);
       const stepCount = todayStep?.steps ?? 0;
-      const goal = client.goalType || "fat_loss";
-      const calTarget = client.calorieTarget || 0;
-      // Mirrors the calorieCeilingHit logic in food-scanner — don't push more food/protein
-      // when the user is already meaningfully over their daily calorie budget.
-      const calorieCeilingHit = calTarget > 0 && (todayCal - calTarget) >= 100;
 
-      // Proactive dinner suggestion: user has been active today but no dinner logged yet.
-      // Identify "dinner" as a meal logged in the last 4 hours — if absent and it's evening, suggest.
-      const fourHoursAgo = new Date(Date.now() - 4 * 3_600_000);
-      const [recentMeal] = await db.select({ id: mealLogs.id })
-        .from(mealLogs)
-        .where(and(eq(mealLogs.userId, client.id), gte(mealLogs.loggedAt, fourHoursAgo)))
-        .limit(1)
-        .catch(() => [] as { id: number }[]);
-      const noDinnerYet = !recentMeal;
-      const hasBeenActive = todayCal > 0 || workedOut || stepCount > 1000;
+      // ── ONE COACH AT 20:00 (2026-08-25, P0-4b) ──────────────────────────────────────────────
+      //
+      // What was here: a seven-branch cascade over a score of (food + workout + steps), plus a
+      // separate dinner-suggestion ladder above it with its own goal switch and protein-gap
+      // arithmetic. Between them they could say "get to 120g tonight", "push to 8,500 tomorrow",
+      // "training day and the session is still not done", "carry protein into tomorrow's first
+      // meal" and "one more thing before bed" — five different next moves, none of which had ever
+      // heard of chooseAction, all decided from the ledger alone.
+      //
+      // The ledger records what a client DID. It cannot record what they SAID. That is the whole
+      // defect: "I'm not training today" at 08:00 and "the session is still not done" at 19:00
+      // were each correct by their own inputs, and the client heard a coach who was not listening.
+      //
+      // Now: the facts are recognition, and the single instruction is the canonical one — which
+      // reads the same held constraints the morning brief reads.
+      const move = await canonicalNextMove(client, { hour: sastHour() });
+      const recap = eveningRecognition({
+        name,
+        workedOut,
+        proteinLogged: todayProt,
+        proteinTarget: protTarget,
+        foodLogged: todayCal > 0,
+        steps: stepCount,
+        stepsTarget,
+        sick,
+      });
 
-      if (noDinnerYet && hasBeenActive && !sick && !calorieCeilingHit && await claimDailySlot(client.id, "evening")) {
-        const protGap = protTarget - todayProt;
-        let dinnerSuggestion: string;
-        if (!usesMacroTargets(goal)) {
-          // Wellness / has-a-condition client — no protein-gram maths, just a warm plate nudge.
-          dinnerSuggestion = `${name}, dinner time. Keep it simple and balanced — some protein, some veg, and you're sorted. What do you have at home tonight?`;
-        } else if (goal === "muscle_gain") {
-          const mealOption = protGap > 40 ? "rice + chicken, or pap + mince + veg" : `eggs + toast, or ${proteinOptions(client).split(",")[0]} on bread`;
-          dinnerSuggestion = `${name}, dinner time. Still need ${protGap > 0 ? `${protGap}g protein` : "a solid meal"}. Options: ${mealOption}. What are you working with tonight?`;
-        } else {
-          const opts = proteinOptions(client);
-          const protNote = protGap > 30
-            ? `${protGap}g protein still to go — `
-            : protGap > 0
-              ? `Almost on protein — `
-              : `On protein today — `;
-          const lightOpts = protGap > 30
-            ? `scrambled eggs + veg (highest protein-to-calorie), or ${opts.split(",")[0].trim()} and salad`
-            : `keep it light: something lean and small`;
-          dinnerSuggestion = `${name}, dinner time. ${protNote}${lightOpts}. What do you have at home?`;
+      // THE BUTTONS SURVIVE; THE DECISION TO PRESS DOES NOT. A one-tap "Doing it tonight / Swap to
+      // tomorrow / Rest day today" is a real capability and the only place the client can hand us
+      // a schedule decision. It used to fire on `isTrainingDay` — the fixed weekday schedule —
+      // which is a calendar, not a coach. It now fires when, and only when, the decision owner has
+      // actually chosen `train`, so a declined or sick day never renders it.
+      if (move.action.kind === "train" && isTrainingDay) {
+        if (await claimDailySlot(client.id, "evening")) {
+          await sendWhatsAppButtons(phone, `${recap}\n\n${move.line}`, [
+            "Doing it tonight",
+            "Swap to tomorrow",
+            "Rest day today",
+          ]);
         }
-        await sendWhatsApp(phone, dinnerSuggestion);
         continue;
       }
 
-      let msg: string;
-
-      if (sick) {
-        msg = `Rest up, ${name}. No targets today. Your data is saved — we pick up when you're better.`;
-      } else {
-        const score = (todayCal > 0 ? 1 : 0) + (workedOut ? 1 : 0) + (stepsDone ? 1 : 0);
-        if (score === 3) {
-          const highlight = protHit ? `${todayProt}g protein, session done, steps hit` : `session done, steps hit, food logged`;
-          msg = `${name}, clean day — ${highlight}. Do it again tomorrow.`;
-        } else if (workedOut && protHit) {
-          msg = `${name}, session done and ${todayProt}g protein logged. ${stepCount > 0 ? `${stepCount.toLocaleString()} steps — push to ${stepsTarget.toLocaleString()} tomorrow.` : `Log your steps — walking is half the programme.`}`;
-        } else if (workedOut && stepsDone) {
-          msg = `${name}, session done and ${stepCount.toLocaleString()} steps. Log tonight's food so I can track your protein.`;
-        } else if (workedOut) {
-          msg = `${name}, session done. ${todayCal > 0 ? (calorieCeilingHit ? `${todayProt}g protein logged — calories done for today.` : `${todayProt}g protein logged — get to ${protTarget}g tonight.`) : `No food logged. Log tonight's meal.`}`;
-        } else if (isTrainingDay) {
-          const foodLine = todayCal > 0 ? ` Food's in.` : ``;
-          const sessionMsg = `${name}, training day and the session is still not done.${foodLine} You've got tonight — what's the plan?`;
-          if (await claimDailySlot(client.id, "evening")) {
-            await sendWhatsAppButtons(phone, sessionMsg, [
-              "Doing it tonight",
-              "Swap to tomorrow",
-              "Rest day today",
-            ]);
-          }
-          continue;
-        } else if (stepsDone) {
-          const restStepNote = goal === "muscle_gain"
-            ? `Good active recovery.`
-            : `Steps are your calorie burn today — no gym, so these matter.`;
-          msg = `${name}, ${stepCount.toLocaleString()} steps on a rest day. ${restStepNote} ${todayCal > 0 ? `${todayProt}g protein — ${protHit ? "target hit." : calorieCeilingHit ? "calories done for today." : `${protTarget - todayProt}g short of target.`}` : `Log tonight's food.`}`;
-        } else if (todayCal > 0 || stepCount > 0) {
-          const done = stepCount > 0 ? `${stepCount.toLocaleString()} steps` : `food logged`;
-          const gap = stepCount < stepsTarget
-            ? `${(stepsTarget - stepCount).toLocaleString()} steps short`
-            : calorieCeilingHit
-              ? `calories done for today — carry protein into tomorrow's first meal`
-              : `protein at ${todayProt}g — get to ${protTarget}g`;
-          msg = `${name}, ${done} today. ${gap}. One more thing before bed.`;
-        } else {
-          msg = `${name}, no logs yet today — no stress. Just send me your last meal before bed and we keep the momentum going.`;
-        }
-      }
-
-      if (await claimDailySlot(client.id, "evening")) { await sendWhatsApp(phone, msg); }
+      const msg = [recap, move.line].filter(Boolean).join("\n\n");
+      if (msg && await claimDailySlot(client.id, "evening")) { await sendWhatsApp(phone, msg); }
     } catch (err) {
       console.error(`[SCHEDULER] Evening accountability error — ${client.phoneNumber}:`, err);
     }

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -15,9 +15,9 @@ import { readHealthState } from "../../health-state";
 // message, so the experiment measured nothing. Deleting the send deletes an empty measurement.
 import { morningClosingLine, composeMorning, yesterdayObservation, breakfastReplayLine } from "../../morning-message";
 import { adaptTargets, adaptiveInputFrom } from "../../adaptive-targets";
-import { chooseAction, decideProactive, formatOneAction, underPolicy, foodDayIsClosed } from "../../one-action";
-import { loadSituationFrame, recentClientMessagesStamped } from "../../memory";
-import { sastDaysBetween } from "../../sast";
+import { chooseAction, decideProactive, formatOneAction, underPolicy } from "../../one-action";
+import { loadSituationFrame } from "../../memory";
+import { readHeldConstraints } from "../../held-constraints";
 
 /**
  * WHAT WE SAY TO SOMEONE WHO HAS GONE — decided by the ladder, not written here.
@@ -477,6 +477,11 @@ export async function runMorningCheckin(): Promise<void> {
         const breakfastAsk = `🍳 What's for breakfast?${repeatSuggestion || ""}`;
         let decisionLine = "";
         try {
+          // ONE READER FOR BOTH CONSTRAINTS (2026-08-25, P0-4b). This was an inline copy of the
+          // query that read only the food half — trainingDayIsDeclined existed and had nowhere to
+          // go, so a client who said "I'm not training today" could still be told to. Now the
+          // outbound floor and the decision read the same held state about the same day.
+          const held = await readHeldConstraints(phone, client);
           const decision = decideProactive(state, {
             dreamGoal: client.dreamGoal,
             biggestStruggle: client.biggestStruggle,
@@ -489,8 +494,8 @@ export async function runMorningCheckin(): Promise<void> {
             stepsTarget: Number(client.stepsTarget) || 0,
           }, {
             hour: 7,
-            foodDayClosed: (await recentClientMessagesStamped(phone).catch(() => []))
-              .some(s => sastDaysBetween(s.at) === 0 && foodDayIsClosed(s.text)),
+            foodDayClosed: held.foodDayClosed,
+            trainingDeclined: held.trainingDeclined,
           });
           decisionLine = decision.line;
           console.log(`[MORNING] ${client.id.slice(-6)} decision=${decision.state} evidence=${decision.evidence} action=${decision.action.kind}`);

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -13,6 +13,7 @@ import { getTrajectoryForUser } from "../../trajectory-report";
 import { runWeeklyRecaps } from "../../weekly-recap";
 import { generateMealPlan } from "../../meal-plan";
 import { mentionsForbidden } from "../../brain/reply-verifier";
+import { canonicalNextMove } from "../proactive-decision";
 
 export async function runFridayWeekendStrategy(): Promise<void> {
   console.log("[SCHEDULER] JOB: Friday weekend strategy");
@@ -60,6 +61,13 @@ export async function runFridayWeekendStrategy(): Promise<void> {
         : weightChange > 0.2 ? `⬆️ Up ${weightChange.toFixed(1)}kg`
         : `➡️ Weight holding`;
 
+      // THE WRAP-UP REPORTS; IT DOES NOT PRESCRIBE (2026-08-25, P0-4b). The four closings this
+      // replaces were a local ladder over (sessions, foodDays, account age) that always landed on
+      // the same two rules — "protein at every meal and one session before Sunday night" — and one
+      // of them said "Reply *1* right now" to a client who might have told us that morning they
+      // were not training. The numbers above are a real report and stay; the instruction is the
+      // canonical one, which has read what they said.
+      const move = await canonicalNextMove(client);
       const lines = [
         `*${name} — Week ${week} wrap-up:*`,
         ``,
@@ -67,15 +75,8 @@ export async function runFridayWeekendStrategy(): Promise<void> {
         `📋 ${foodDays} day${foodDays !== 1 ? "s" : ""} food logged`,
         avgSteps > 0 ? `👟 ${avgSteps.toLocaleString()} avg steps` : "",
         weightLine,
-        ``,
-        sessions >= (client.trainingDaysPerWeek || 3) && foodDays >= 5
-          ? `Sharp week, ${name}. Two rules this weekend — protein at every meal and one session before Sunday night. That is it.`
-          : sessions === 0 && new Date(client.createdAt || 0).getTime() > Date.now() - 7 * 86_400_000
-          ? `${name}, first week is about building the habit. Get one session in before Sunday and you'll be on track from day one.`
-          : sessions === 0
-          ? `Zero sessions this week — still time to change that. One session before Sunday is all it takes. Reply *1* right now.`
-          : `Weekend is where most people lose the week. Two rules only — protein at every meal and one session before Sunday night.`,
       ].filter(Boolean);
+      if (move.line) lines.push(``, move.line);
 
       await sendWhatsApp(client.phoneNumber, lines.join("\n"));
       sent++;
@@ -106,14 +107,22 @@ export async function runSundayWeeklyReport(): Promise<void> {
       const clientAgeDays = client.createdAt
         ? Math.floor((Date.now() - new Date(client.createdAt).getTime()) / 86_400_000)
         : 999;
+      // THE THIN-WEEK EXITS GO THROUGH THE LADDER TOO (2026-08-25, P0-4b). "Send me what you're
+      // eating right now" and "Target this week: 5 days" were the fifth and sixth hand-written
+      // versions of chooseAction's `come_back` and `log` rungs, and they were the versions that
+      // reached the client who had gone quietest — the one the ladder's escalation was written
+      // for. A week of silence and six weeks of silence got the same sentence here.
       if (chats.length === 0) {
         if (clientAgeDays < 2) continue; // just onboarded today — skip
-        await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week. The restart is simple — send me what you're eating right now. One meal. That's the whole task.`);
+        const quiet = await canonicalNextMove(client);
+        if (quiet.line) await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week.\n\n${quiet.line}`);
         continue;
       }
       const daysWithLogs = new Set(chats.map(c => new Date(c.createdAt!).toDateString())).size;
       if (daysWithLogs < 3) {
-        await sendWhatsApp(client.phoneNumber, `${name}, ${daysWithLogs} day${daysWithLogs !== 1 ? "s" : ""} logged. You're in it — keep going. Target this week: 5 days, just one meal a day is enough.`);
+        const thin = await canonicalNextMove(client);
+        const opener = `${name}, ${daysWithLogs} day${daysWithLogs !== 1 ? "s" : ""} logged this week. You're in it.`;
+        await sendWhatsApp(client.phoneNumber, thin.line ? `${opener}\n\n${thin.line}` : opener);
         continue;
       }
 
@@ -174,40 +183,24 @@ export async function runSundayWeeklyReport(): Promise<void> {
       const clientGoalWeekly = client.goalType || "fat_loss";
       const isMuscleGainWeekly = clientGoalWeekly === "muscle_gain";
       const budgetTierWeekly = client.weeklyFoodBudget || "100_300";
-      const isBudgetTight = budgetTierWeekly === "under_50" || budgetTierWeekly === "50_100" || budgetTierWeekly === "under_100" || budgetTierWeekly === "100_300";
-      let warning = "";
-      if (completedSessions === 0) {
-        warning = `⚠️ Zero sessions this week — one session this week is all I need from you.`;
-      } else if (junkCount >= 3) {
-        warning = isMuscleGainWeekly
-          ? `Processed & fried food showed up ${junkCount}x this week. For muscle gain this hurts — your calories need to come from protein-dense sources, not fried food. Keep the calories, fix the source. Chicken, rice, eggs over KFC and chips.`
-          : `Takeaways & cooldrinks showed up ${junkCount}x this week — no stress, enjoy them now and then. Just keep the other days protein-first.`;
-      } else if (noProteinDays >= 3) {
-        const proteinSources = isBudgetTight
-          ? `pilchards (R12/tin, 25g protein) and eggs (R3–4 each, 6g protein) — protein on any budget`
-          : `chicken, eggs, pilchards, Greek yoghurt, or biltong`;
-        warning = isMuscleGainWeekly
-          ? `⚠️ ${noProteinDays} days this week with no protein logged. Muscle cannot grow without it — this is the single biggest limiter right now. Tonight: ${proteinSources}. This is non-negotiable.`
-          : `Protein: ${noProteinDays} days this week without protein logged. Even one egg or a tin of pilchards (R12, 25g protein) counts — start with one meal tonight.`;
-      }
 
-      let focus = "";
-      if (completedSessions > 0 && completedSessions < plannedSessions) {
-        const sessionsShort = plannedSessions - completedSessions;
-        focus = isMuscleGainWeekly
-          ? `Train ${sessionsShort} more time${sessionsShort !== 1 ? "s" : ""} than last week — muscle growth requires the stimulus. No sessions = no signal to grow.`
-          : `Train ${sessionsShort} more time${sessionsShort !== 1 ? "s" : ""} than last week.`;
-      } else if (proteinHitRate < 60) {
-        focus = isBudgetTight
-          ? `Protein at every meal — pilchards, eggs, beans. Pilchards are R12 for 25g protein — the best protein per rand in SA.`
-          : isMuscleGainWeekly
-          ? `Protein at every meal, no exceptions. This is what drives your goal — eggs, pilchards, chicken, Greek yoghurt.`
-          : `Protein at every meal — eggs, pilchards, beans, chicken.`;
-      } else if (stepEntries.length === 0) {
-        focus = `Log your steps at least 3 days this week.`;
-      } else {
-        focus = `Maintain the consistency — same output or better.`;
-      }
+      // ── TWO LADDERS BECOME ONE OBSERVATION AND ONE DECISION (2026-08-25, P0-4b) ────────────
+      //
+      // `warning` and `focus` were both if-else ladders over the same week, disagreeing by
+      // construction: a client with zero sessions and thin protein got "one session this week is
+      // all I need from you" in one slot and "Protein at every meal" in the other — two next moves
+      // in one message, from two ladders, neither of them the decision owner. Add the third one in
+      // the morning brief and the product had three opinions about Sunday.
+      //
+      // What survives is what was genuinely an OBSERVATION rather than an instruction: the junk
+      // count is a real pattern in their own logs, and naming it without prescribing is exactly
+      // what recognition is for. The instruction is the canonical move, once.
+      const observation = junkCount >= 3
+        ? `Takeaways & cooldrinks showed up ${junkCount}x this week.`
+        : noProteinDays >= 3
+        ? `${noProteinDays} day${noProteinDays !== 1 ? "s" : ""} this week without protein logged.`
+        : "";
+      const move = await canonicalNextMove(client);
 
       const logScore = Math.round((daysWithLogs / 7) * 25);
       const trainScore = Math.round((Math.min(completedSessions, plannedSessions) / plannedSessions) * 35);
@@ -247,14 +240,14 @@ export async function runSundayWeeklyReport(): Promise<void> {
       ].filter(l => l !== null);
 
       if (milestoneLine) lines.push(milestoneLine, ``);
-      if (warning) lines.push(warning, ``);
-      // Adaptive step goal takes the "This week" slot when warranted — it's the most
-      // useful, most personal instruction we can give (meet them where they are).
+      if (observation) lines.push(observation, ``);
+      // The adaptive step goal is a TARGET CHANGE this job is offering, not a next move — it is
+      // the client's call, one tap, and it stays. It does not compete with the decision below.
       if (stepAdj) lines.push(`👟 *Your steps:* ${stepAdj.reason}`);
-      else lines.push(`*This week:* ${focus}`);
-      if (totalScore >= 85) lines.push(``, `${name}, this is what results look like. Same energy next week.`);
-      else if (totalScore >= 60) lines.push(``, `Solid week, ${name}. One more push and you are in the top tier. Go.`);
-      else lines.push(``, `${name}, below your best but you are still here. That matters. Reset Sunday night and go again Monday.`);
+      if (totalScore >= 85) lines.push(``, `${name}, this is what results look like.`);
+      else if (totalScore >= 60) lines.push(``, `Solid week, ${name}.`);
+      else lines.push(``, `${name}, below your best but you are still here. That matters.`);
+      if (move.line) lines.push(``, move.line);
       // One-tap acceptance — routes to the deterministic step-target updater. Client's call.
       if (stepAdj) lines.push(``, `[BUTTONS:Set steps to ${stepAdj.newTarget}]`);
 
@@ -385,14 +378,21 @@ export async function runWeekendFoodAudit(): Promise<void> {
       const weekendProteinRate = weekendLogs.length > 0 ? weekendProtein / weekendLogs.length : 0;
       const name = client.name || "there";
 
+      // THE PATTERN IS OURS TO SEE; THE MOVE IS NOT OURS TO INVENT (2026-08-25, P0-4b). The
+      // weekday-versus-weekend comparison is a genuine observation nothing else in the product
+      // makes, and it stays. Both branches then ended in the same locally-chosen prescription —
+      // "protein first at every meal" — which is chooseAction's rung 5, written a seventh time and
+      // sent without ever asking whether the client had closed food or was ill.
+      const pattern = weekendJunkRate > weekdayJunkRate + 0.3
+        ? `${name} — pattern spotted. Your weekday eating is solid. But ${weekendJunk > 0 ? `${weekendJunk} weekend meal${weekendJunk !== 1 ? "s" : ""}` : "your weekends"} this week looked different from your weekdays.`
+        : weekendProteinRate < weekdayProteinRate - 0.3
+        ? `${name} — you are hitting protein well during the week. But weekends your protein drops.`
+        : "";
+      if (!pattern) continue;
       // Claim only when there is actually a pattern to flag — DB-backed weekly dedup.
-      if (weekendJunkRate > weekdayJunkRate + 0.3) {
-        if (!(await claimProactive(client.id, "weekend_food_audit", thisWeekUTC()))) continue;
-        await sendWhatsApp(client.phoneNumber, `${name} — pattern spotted. Your weekday eating is solid. But ${weekendJunk > 0 ? `${weekendJunk} weekend meal${weekendJunk !== 1 ? "s" : ""}` : "your weekends"} this week had foods that are undoing the weekday work. One rule for weekends: protein first at every meal, then eat what you want after. That single rule changes everything.`);
-      } else if (weekendProteinRate < weekdayProteinRate - 0.3) {
-        if (!(await claimProactive(client.id, "weekend_food_audit", thisWeekUTC()))) continue;
-        await sendWhatsApp(client.phoneNumber, `${name} — you are hitting protein well during the week. But weekends your protein drops. When you are out, at a braai, or grabbing food on the go — always anchor the meal with protein first.`);
-      }
+      if (!(await claimProactive(client.id, "weekend_food_audit", thisWeekUTC()))) continue;
+      const audit = await canonicalNextMove(client);
+      await sendWhatsApp(client.phoneNumber, audit.line ? `${pattern}\n\n${audit.line}` : pattern);
     } catch (err) { console.error(`[SCHEDULER] Weekend food audit error — ${client.phoneNumber}:`, err); }
   }
 }

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -1,0 +1,276 @@
+/**
+ * THE CANONICAL NEXT MOVE, FOR PROACTIVE SENDERS (2026-08-25, P0-4b).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT THIS REPLACES
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Measured on main@d005081: eleven of fourteen sending files ran their own action ladder. Not a
+ * wording variant — a second decision engine, several of them, each with its own thresholds:
+ *
+ *   evening.ts   score = food + workout + steps, then a seven-branch cascade ending in
+ *                "get to 120g tonight" / "training day and the session is still not done"
+ *   weekly.ts    `warning` (zero sessions → train; junk ≥ 3 → fix the source; no-protein days
+ *                ≥ 3 → "Tonight: pilchards") and `focus` (train N more / protein every meal /
+ *                log your steps / maintain), chosen by its own if-else
+ *   programme.ts plateau ladder: cut carbs a third → add 2,000 steps → hold the carbs
+ *
+ * Every one of them decided from the LEDGER alone, so none could know what the client had said
+ * that day, and all of them could disagree with the morning brief that went out eleven hours
+ * earlier from `chooseAction`.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT THIS IS NOT
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Not a new decision engine, not a router, not a second opinion. It is the assembly the morning
+ * job already performs — canonical state → held constraints → decideProactive → formatOneAction —
+ * lifted out of that one job so the other senders can reach the SAME decision instead of writing
+ * their own. If this file ever contains an `if` about protein, steps or sessions, it has become
+ * the twelfth ladder and should be deleted.
+ *
+ * Recognition, reports and questions do not come through here. A sender that only tells the
+ * client what happened, or asks them something, has no behavioural instruction to source — see
+ * proactive-registry.ts, where that is stated per job rather than left to be inferred.
+ */
+
+import { chooseAction, decideProactive, formatOneAction, underPolicy, type OneAction } from "../one-action";
+import { readHeldConstraints, NO_CONSTRAINTS, type HeldConstraints } from "../held-constraints";
+import { loadProactiveState } from "./shared";
+
+export interface CanonicalMove {
+  /** Ready to place in a message. "" when the decision is `hold` — nothing to add is an answer. */
+  line: string;
+  action: OneAction;
+  /** CONTINUE / CHANGE / INVESTIGATE / REFER, the shared verdict vocabulary. */
+  state: "CONTINUE" | "CHANGE" | "INVESTIGATE" | "REFER";
+  held: HeldConstraints;
+  /** True when the ledger read failed and the degraded contract was applied instead. */
+  degraded: boolean;
+}
+
+function profileOf(client: any) {
+  return {
+    dreamGoal: client.dreamGoal,
+    biggestStruggle: client.biggestStruggle,
+    lifeContext: client.lifeContext,
+    doNotMention: client.doNotMention,
+    weeksOnProgramme: Math.max(0, (client.programmeWeek || 1) - 1),
+    sessionsTarget: Number(client.trainingDaysPerWeek) || 3,
+    calorieTarget: Number(client.calorieTarget) || 0,
+    proteinTarget: Number(client.proteinTarget) || 0,
+    stepsTarget: Number(client.stepsTarget) || 0,
+  };
+}
+
+/**
+ * The one behavioural instruction this client should hear right now.
+ *
+ * Fails soft, and the fallback is still the ladder — the same degradation morning has applied
+ * since Cut 6. A ledger timeout must not produce silence, and it must not produce a hand-written
+ * sentence either; it produces the same decision from the facts we still hold, under the same
+ * policy boundary (no evidence, no prescription).
+ */
+export async function canonicalNextMove(
+  client: any,
+  opts?: { hour?: number },
+): Promise<CanonicalMove> {
+  const firstName = String(client.name || "").split(" ")[0] || undefined;
+  const profile = profileOf(client);
+  const held = await readHeldConstraints(client.phoneNumber, client).catch(() => NO_CONSTRAINTS);
+
+  try {
+    const state = await loadProactiveState(client);
+    const decision = decideProactive(state, profile, {
+      hour: opts?.hour,
+      foodDayClosed: held.foodDayClosed,
+      trainingDeclined: held.trainingDeclined,
+    });
+    console.log(`[PROACTIVE_DECISION] ${String(client.id || "").slice(-6)} decision=${decision.state} action=${decision.action.kind} foodClosed=${held.foodDayClosed} trainingDeclined=${held.trainingDeclined}`);
+    return {
+      line: decision.action.kind === "hold" ? "" : formatOneAction(decision.action, firstName),
+      action: decision.action,
+      state: decision.state,
+      held,
+      degraded: false,
+    };
+  } catch (e: any) {
+    console.warn(`[PROACTIVE_DECISION] state unavailable for ${String(client.id || "").slice(-6)}: ${e?.message || e}`);
+    // We cannot build a ProactiveState — that is what just failed — so the evidence gate cannot
+    // run. Apply its contract directly: an unevidenced prescription is downgraded, never sent.
+    const action = underPolicy(chooseAction({
+      firstName,
+      goal: (client.goalType as any) || "general",
+      dreamGoal: client.dreamGoal,
+      biggestStruggle: client.biggestStruggle,
+      lifeContext: client.lifeContext,
+      doNotMention: client.doNotMention,
+      weeksOnProgramme: profile.weeksOnProgramme,
+      daysSinceAnyLog: 0, daysSinceWeighIn: 0, loggedToday: false,
+      proteinPct: 1, caloriePct: 1,
+      sessionsThisWeek: 0, sessionsTarget: 0,
+      stepsToday: 0, stepsTarget: 0,
+      sick: held.sick,
+      hour: opts?.hour ?? 12,
+      foodDayClosed: held.foodDayClosed,
+      trainingDeclined: held.trainingDeclined,
+    }), { evidenced: false, dreamGoal: client.dreamGoal });
+    return {
+      line: action.kind === "hold" ? "" : formatOneAction(action, firstName),
+      action,
+      state: action.kind === "hold" ? "CONTINUE" : "INVESTIGATE",
+      held,
+      degraded: true,
+    };
+  }
+}
+
+/**
+ * ── THE REGISTER ──────────────────────────────────────────────────────────────────────────
+ *
+ * WHAT EVERY PROACTIVE SENDER IS ALLOWED TO SAY (2026-08-25, P0-4b).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE ACCEPTANCE CONDITION THIS FILE ANSWERS
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ *   "Every proactive behavioural instruction either comes from chooseAction, or the sender is
+ *    explicitly classified as recognition-only."
+ *
+ * EXPLICITLY is the operative word. Before this file, the answer for any given cron was "read the
+ * four hundred lines and find out" — which is why eleven senders grew their own action ladder
+ * without anyone deciding they should. The classification is a product decision, so it is written
+ * down as one, per job, with the reason.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE CLASSES
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ *   CANONICAL      Carries a next-move behavioural instruction, and sources it from
+ *                  canonicalNextMove() → decideProactive → chooseAction. One coach.
+ *
+ *   RECOGNITION    Recognition, a report of what happened, or a question. No behavioural
+ *                  instruction at all. This is a real and honourable class — a coach who ends
+ *                  every message with a task teaches you that you can never be doing well.
+ *
+ *   RESOURCE       Delivers a scheduled artefact whose content IS the message: a shopping list,
+ *                  a meal plan, a measurement prompt, a programme session. The artefact has its
+ *                  own owner; this is not a daily next-move decision and routing it through
+ *                  chooseAction would replace a meal plan with "eat more protein".
+ *
+ *   OPERATIONAL    Account, billing, trial, system. "Reply PAY to renew" is a transaction, not
+ *                  coaching, and the decision owner has nothing to say about it.
+ *
+ *   LEGACY_LOCAL   Carries a behavioural instruction that is STILL decided locally. Named, not
+ *                  hidden. Every one of these is a defect with a date on it; the count is a
+ *                  budget in script/check-architecture.ts that may only go down.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHY LEGACY_LOCAL EXISTS RATHER THAN A CLAIM THAT THE MIGRATION IS FINISHED
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Thirty-two sends across eleven files were making their own decisions. Migrating all of them in
+ * one commit is the "rewrite proactive" that was explicitly ruled out, and a registry that called
+ * them all CANONICAL because a migration is planned would be the same false claim this whole cut
+ * exists to stop. So the two daily coaching ladders are migrated now, the rest are named, and the
+ * NON-CONTRADICTION rule at the outbound door (outbound-authority.ts rule 2) already binds every
+ * sender in this table — migrated or not — from today.
+ *
+ * A LEGACY_LOCAL sender is not free to say anything. It is free to be wrong about WHICH useful
+ * thing to say. It is not free to contradict what the client already told us.
+ */
+export type ProactiveClass = "CANONICAL" | "RECOGNITION" | "RESOURCE" | "OPERATIONAL" | "LEGACY_LOCAL";
+
+export interface ProactiveSender {
+  /** Exported job function name. */
+  job: string;
+  /** File under server/scheduler/jobs/, without the extension. */
+  file: string;
+  cls: ProactiveClass;
+  /** Why this class, in one line. Not decoration — the next person changes it against this. */
+  because: string;
+}
+
+export const PROACTIVE_SENDERS: readonly ProactiveSender[] = [
+  // ── morning.ts ────────────────────────────────────────────────────────────────────────────
+  { job: "runMorningCheckin", file: "morning", cls: "CANONICAL",
+    because: "The brief's only instruction is decisionLine, from decideProactive; composeMorning strips directives out of the recognition prose." },
+
+  // ── evening.ts ────────────────────────────────────────────────────────────────────────────
+  { job: "runEveningAccountability", file: "evening", cls: "CANONICAL",
+    because: "Migrated 2026-08-25. The score cascade and dinner ladder are gone; recognition of the day stays, the instruction comes from canonicalNextMove." },
+
+  // ── weekly.ts ─────────────────────────────────────────────────────────────────────────────
+  { job: "runFridayWeekendStrategy", file: "weekly", cls: "CANONICAL",
+    because: "Migrated 2026-08-25. The week's numbers are a report; the weekend instruction is the canonical move." },
+  { job: "runSundayWeeklyReport", file: "weekly", cls: "CANONICAL",
+    because: "Migrated 2026-08-25. Report card and score are recognition; `warning` and `focus` were two local ladders and are now one canonical move." },
+  { job: "runWeekendFoodAudit", file: "weekly", cls: "CANONICAL",
+    because: "Migrated 2026-08-25. The weekday/weekend pattern is a genuine observation; the rule that followed it was a local prescription." },
+  { job: "runSundayEveningCheckin", file: "weekly", cls: "RECOGNITION",
+    because: "Every branch ends in a question about their week. It asks; it never instructs." },
+  { job: "runNsvCheckin", file: "weekly", cls: "RECOGNITION",
+    because: "Four non-scale-victory prompts, all questions. The point is that it asks for nothing." },
+  { job: "runSundayMealPlan", file: "weekly", cls: "RESOURCE",
+    because: "Delivers generateMealPlan's artefact. The plan is the message." },
+
+  // ── monday.ts ─────────────────────────────────────────────────────────────────────────────
+  { job: "runMondayProgress", file: "monday", cls: "RECOGNITION",
+    because: "A progress report against the record." },
+  { job: "runMondayGroceries", file: "monday", cls: "RESOURCE",
+    because: "Delivers the shopping list artefact." },
+  { job: "runWeightReminder", file: "monday", cls: "LEGACY_LOCAL",
+    because: "Asks for a weigh-in on its own schedule; chooseAction owns the `weigh` rung and its staleness rule. Not yet migrated." },
+  { job: "runDietBreakCheck", file: "monday", cls: "LEGACY_LOCAL",
+    because: "Restores targets (operational) and then instructs — 'Log your food today'. The instruction half is not yet canonical." },
+
+  // ── programme.ts ──────────────────────────────────────────────────────────────────────────
+  { job: "runPhaseAdvancement", file: "programme", cls: "RESOURCE",
+    because: "Announces a programme phase change and offers the session. The programme is the artefact." },
+  { job: "runGoalCheck", file: "programme", cls: "RECOGNITION",
+    because: "Checkpoint questions about the goal, plus a Week 9 choice. It asks." },
+  { job: "runInjuryFollowup", file: "programme", cls: "RECOGNITION",
+    because: "Asks how the injury is; adjusts only on the answer." },
+  { job: "runWeeklyMondayCheckin", file: "programme", cls: "LEGACY_LOCAL",
+    because: "A per-week script that instructs — 'Complete N sessions', 'hit your step target', 'add weight or reps'. Twelve local branches. Not yet migrated." },
+  { job: "runPlateauDetection", file: "programme", cls: "LEGACY_LOCAL",
+    because: "Its own three-rung intervention ladder (cut carbs → add 2,000 steps → hold). A real pace owner is P0-7; until then it is named, not blessed." },
+
+  // ── business.ts ───────────────────────────────────────────────────────────────────────────
+  { job: "runSubscriptionExpiryCheck", file: "business", cls: "OPERATIONAL", because: "Billing." },
+  { job: "runPaymentFailureRecovery", file: "business", cls: "OPERATIONAL", because: "Billing." },
+  { job: "runSignupNudge", file: "business", cls: "OPERATIONAL", because: "Pre-subscription funnel; there is no client state to decide from." },
+  { job: "runWeeklyKpiReport", file: "business", cls: "OPERATIONAL", because: "Goes to the founder, not to a client." },
+  { job: "runMonthlyNps", file: "business", cls: "OPERATIONAL", because: "One survey question." },
+  { job: "runStepLeaderboard", file: "business", cls: "RECOGNITION", because: "Standings and a rank. No instruction." },
+  { job: "runAutoCalAdjust", file: "business", cls: "OPERATIONAL",
+    because: "Announces a target change the adaptive-targets owner made. The change is the message." },
+  { job: "runStepTargetAdaptation", file: "business", cls: "OPERATIONAL",
+    because: "Announces a step-target change made by targets.ts. Same reason." },
+  { job: "runMonthEndBudget", file: "business", cls: "RESOURCE",
+    because: "A costed shopping plan for the month-end squeeze. The list is the message." },
+  { job: "runPaydayShoppingNudge", file: "business", cls: "RESOURCE",
+    because: "A costed buy-list keyed to the pay cycle, pointing at the shopping-list owner." },
+  { job: "runSupplementReminder", file: "business", cls: "LEGACY_LOCAL",
+    because: "Instructs on a supplement the client logged before. Harmless today, but it is an instruction chosen locally." },
+
+  // ── onboarding.ts ─────────────────────────────────────────────────────────────────────────
+  { job: "runEarlyOnboarding", file: "onboarding", cls: "RESOURCE",
+    because: "The seven-day welcome sequence. It teaches the product's surface — what to reply, what it can do — on a fixed calendar; it is not a decision about their day." },
+  { job: "runMonthlyMeasurements", file: "onboarding", cls: "RESOURCE", because: "The measurement prompt artefact." },
+  { job: "runReferralNudge", file: "onboarding", cls: "OPERATIONAL", because: "Growth ask." },
+  { job: "runGoalReassessment", file: "onboarding", cls: "RECOGNITION",
+    because: "Asks whether the stated goal still matches what they are chasing." },
+  { job: "runStepSyncCatchup", file: "onboarding", cls: "LEGACY_LOCAL",
+    because: "Asks for a step figure on its own trigger; `walk` and `log` are chooseAction's rungs. Not yet migrated." },
+
+  // ── trial.ts / reminders.ts / narrative.ts / media-recovery.ts / spend-watchdog.ts ─────────
+  { job: "runTrialCountdown", file: "trial", cls: "OPERATIONAL", because: "Trial expiry and conversion." },
+  { job: "runSpendWatchdog", file: "spend-watchdog", cls: "OPERATIONAL", because: "Cost alert to the founder." },
+  { job: "runMediaJobRecovery", file: "media-recovery", cls: "OPERATIONAL",
+    because: "Apologises for a failed media job and asks for a resend. A system apology, not coaching." },
+  { job: "runMonthlyNarrative", file: "narrative", cls: "RECOGNITION",
+    because: "The month told back to them as a story." },
+  { job: "runDueReminders", file: "reminders", cls: "RESOURCE",
+    because: "Replays a reminder the CLIENT set, in their own words. Ours to deliver, not to re-decide." },
+] as const;

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -526,13 +526,18 @@ export async function sendWhatsApp(to: string, body: string, mediaUrl?: string):
   // try/catch, not `.catch()` on the query chain: a rejected chain and an empty result are
   // different things, and conflating them silently disabled this floor the first time.
   let recipientId: string | null = null;
+  // profile_notes carries the durable illness state the held-constraint rule reads. Selected here
+  // rather than re-queried inside the floor: this lookup already runs, and one read is one read.
+  let recipientRow: { id: string; profileNotes: string | null } | null = null;
   try {
-    const rows = await db.select({ id: users.id }).from(users).where(eq(users.phoneNumber, to)).limit(1);
-    recipientId = rows[0]?.id ?? null;
+    const rows = await db.select({ id: users.id, profileNotes: users.profileNotes })
+      .from(users).where(eq(users.phoneNumber, to)).limit(1);
+    recipientRow = (rows[0] as any) ?? null;
+    recipientId = recipientRow?.id ?? null;
   } catch (e: any) {
     console.warn(`[OUTBOUND_AUTHORITY] recipient lookup failed for ${to.slice(-8)}: ${e?.message || e}`);
   }
-  const verdict = await enforceOutboundTruth(recipientId, to, body);
+  const verdict = await enforceOutboundTruth(recipientId, to, body, recipientRow);
   if (!verdict.ok) {
     console.error(`[OUTBOUND_AUTHORITY] BLOCKED proactive send to ${to.slice(-8)} — ${verdict.reason}: ${verdict.detail}`);
     return;

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -16,6 +16,7 @@ import { checkOutboundMessage } from "../verifiers/proactive-gate";
 import { readHealthState } from "../health-state";
 import { provenanceGate, shadowDoor } from "../verifiers/response-gate";
 import { humanizeReply } from "../reply-hygiene";
+import { enforceOutboundTruth } from "../outbound-authority";
 import { templateSid, WINDOW_RECOVERY_TEMPLATE } from "../whatsapp-templates";
 
 export { db, pool };
@@ -517,6 +518,26 @@ export async function sendWhatsApp(to: string, body: string, mediaUrl?: string):
   // false claim this product ever made was sent by a cron job.
   //
   // Runs before the bubble split so a claim spanning a "---" boundary is still one sentence.
+  // ── THE OUTBOUND FLOOR (2026-08-25, P0-4) ─────────────────────────────────────────────────
+  // Provenance and hygiene have run on this path since July; the TRUTH checks never did. 69
+  // proactive sends across 14 files, of which 3 consult the decision owner — so the Coach could
+  // be one thing in conversation and another at 06:00. This is the shared boundary. It reads the
+  // ledger only when the message actually asserts a training count, so the ordinary send is free.
+  // try/catch, not `.catch()` on the query chain: a rejected chain and an empty result are
+  // different things, and conflating them silently disabled this floor the first time.
+  let recipientId: string | null = null;
+  try {
+    const rows = await db.select({ id: users.id }).from(users).where(eq(users.phoneNumber, to)).limit(1);
+    recipientId = rows[0]?.id ?? null;
+  } catch (e: any) {
+    console.warn(`[OUTBOUND_AUTHORITY] recipient lookup failed for ${to.slice(-8)}: ${e?.message || e}`);
+  }
+  const verdict = await enforceOutboundTruth(recipientId, to, body);
+  if (!verdict.ok) {
+    console.error(`[OUTBOUND_AUTHORITY] BLOCKED proactive send to ${to.slice(-8)} — ${verdict.reason}: ${verdict.detail}`);
+    return;
+  }
+
   const checked = await provenanceGate(to, body);
   // VOICE, ENFORCED (2026-07-30). humanizeReply — the numbered-list reshape, the platitude strip,
   // the wall-of-text break — existed since 22 July and was wired into exactly ONE caller

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -74,7 +74,8 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
     //
     // It now asks the decision owner, on canonical state, under the same policy contract every
     // other caller uses. theNextMove is deleted.
-    const { chooseAction, underPolicy, foodDayIsClosed } = await import("../one-action");
+    const { chooseAction, underPolicy, foodDayIsClosed, trainingDayIsDeclined } = await import("../one-action");
+    const { readHeldConstraints } = await import("../held-constraints");
     const { getProgressTruth, sessionsThisCalendarWeek } = await import("../day-ledger");
     const { sastHour } = await import("../sast");
     const { getTodayWorkoutState } = await import("../workout-state");
@@ -82,6 +83,7 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
     const { getDisplayName } = await import("../utils");
 
     const truth = await getProgressTruth(user, { days: 7 });
+    const held = await readHeldConstraints(user.phoneNumber, user).catch(() => ({ foodDayClosed: false, trainingDeclined: false, sick: false }));
     const weekSessions = await sessionsThisCalendarWeek(user.id).catch(() => 0);
     const wState = await getTodayWorkoutState(user).catch(() => ({ type: "REST" as const }));
     const calTarget = Number(user.calorieTarget) || 0;
@@ -105,7 +107,14 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
       hour: sastHour(),
       // They are typing to us right now — this rides out on a reply, not as a nudge.
       atKeyboard: true,
-      foodDayClosed: foodDayIsClosed(message || ""),
+      // A CONSTRAINT OUTLIVES THE SENTENCE THAT STATED IT (2026-08-25, P0-4b). This read only the
+      // CURRENT message, so a client who closed food at 12:00 and asked an unrelated question at
+      // 19:00 was decided for as though they had never said it — the constraint expired at the end
+      // of the turn that carried it. `held` is today's statements; the live message is folded in
+      // because it has not reached chat_history yet. trainingDeclined is the twin, and until now
+      // it had no field at all: routes.ts computed it into `_isWorkoutRefusal` and dropped it.
+      foodDayClosed: held.foodDayClosed || foodDayIsClosed(message || ""),
+      trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
     } as any), { evidenced: truth.window.daysLogged >= 3, dreamGoal: user.dreamGoal });
 
     // RECORD THE PROVENANCE. The verifier needs to know what this turn's canonical decision was,


### PR DESCRIPTION
Base retargeted to `main` and rebased onto `d005081` after #53 was squash-merged.

Two commits, one subject: **the proactive path stops being a second coach.**

## P0-4a — the shared outbound floor (`4a3d7d7`)

`reconcileTurnReply` runs inside `inTurn`, so every truth check the last weeks built governed **reactive replies only**. The proactive door applied provenance, hygiene and a template-leak gate and none of the truth checks.

`server/outbound-authority.ts` is the floor both doors stand on:
1. a training count asserted in the text must match `workoutLogs`;
2. the same message twice is never right.

Deliberately *not* a copy of the reactive boundary — `verifyBrainReply`'s step rule would silence the morning brief's `👟 8,500 steps`, a target with no target marker. A boundary that has to be exempted everywhere teaches people to route around it.

## P0-4b — the migration (`b5de611`)

Eleven of fourteen sending files ran their own action ladder — 32 sends deciding what the client should do next, from the ledger alone.

**The ledger records what a client DID. It cannot record what they SAID.** That is the whole defect: `I'm not training today` at 08:00 and `training day and the session is still not done` at 19:00 were each correct by their own inputs.

### Held constraints get an owner
`server/held-constraints.ts`. `foodDayIsClosed` was re-derived inline in the morning job; `trainingDayIsDeclined` was computed at the reactive door into `_isWorkoutRefusal` — an underscore-prefixed local that nothing read — and `DayState` had no field to carry it. One reader now, today only, shared by the decision and the door.

### The decision hears it
`DayState.trainingDeclined` stands rung 8 down, the twin of `foodDayClosed` on rungs 4 and 5. It suppresses **one rung for one day**: the same client short on protein still gets the protein ask. Threaded into the reactive path too, where `foodDayClosed` read only the *current* message — so a constraint expired at the end of the turn that stated it.

### The door enforces it
`outbound-authority` rule 2: a proactive message may not ask for food or training the client already ruled out today. This binds all 32 sends — including the ones nobody has migrated, and the next one somebody writes. Narrow on purpose: a request to **log** is not a request to eat, and a plan for the week ahead is not an ask about tonight.

### The migration itself — finite, not a rewrite
`canonicalNextMove()` lifts the assembly the morning job already performed (`state → held constraints → decideProactive → formatOneAction`).

| file | what was deleted |
|---|---|
| `evening.ts` | the seven-branch score cascade and the dinner ladder. The day's facts stay as recognition; the one-tap session buttons survive but render only when the decision chose `train` |
| `weekly.ts` | Friday's four closings, Sunday's `warning` **and** `focus` (two ladders disagreeing inside one message), the two thin-week exits, the weekend audit's prescription |

### Every sender is classified, including the ones that are not done
A register in `proactive-decision.ts` names all 36 senders `CANONICAL` / `RECOGNITION` / `RESOURCE` / `OPERATIONAL` / `LEGACY_LOCAL`, each with its reason. Six are `LEGACY_LOCAL` — still deciding locally, **named rather than hidden**, and counted as a budget that may only fall. Calling them all CANONICAL because a migration is planned would be the same false claim this cut exists to stop.

**GUARD #14** refuses an unclassified sender by name. Verified it bites: removing one entry produces `runEveningAccountability  server/scheduler/jobs/evening.ts — Decide what it is allowed to say`.

## Acceptance, through the real door

A real cron entry point fires against a seeded ledger and the client's own words, captured via **SHADOW** — the product's own record-instead-of-send door, not a seam added for the test. Not `does weekly.ts call chooseAction`; that is a source-string trap that stays green when the call is made and its answer discarded.

Four cases, each prohibition paired with the identical fixture minus the constraint:

| held state | decision | outcome |
|---|---|---|
| training declined, 0/4 sessions | `hold` | does not ask for a session |
| *nothing said*, 0/4 sessions | `train` | **does** ask for a session, rendered by `formatOneAction` |
| food day closed, protein 0/140 | `train` | does not ask for food — they closed food, not training |
| *nothing said*, protein 0/140 | `protein` | **does** ask for protein |

Neither prohibition can pass because the job went quiet.

## Two defects found while building it

- The stub's `.catch()` resolved to `[]` regardless of seeded rows. Every query in `loadProactiveState` ends in `.catch(() => [])`, so a seeded ledger reached none of them and any test built on that state graded the `come_back` rung instead of the one it meant to. Same class as the `.catch()` that silently disabled the outbound floor.
- `foodDayIsClosed` missed `I'm not eating anything else today` — the plainest possible closure. `anything else` / `anything more` mean *nothing further* and are now admitted; a bare `anything` is not, so `not eating anything fried today` is still a food choice.

## Suite

`26/28 green`. RED: `check-file-sizes`, `check-architecture` — **identical lines to the CI verified on #53**, no new failures.

```
✗ server/gpt.ts 1473 (1450) · food-context 1484 (1450) · media 1559 (1550) · routes 1424 (1200) · utils 1345 (1200)
✗ messageDeciders: 32/31 · looksLikePredicates: 21/20 · authorshipPoints: 426/420
```

No budget raised, nothing suppressed. `modules` held at its budget of 239 by merging the register into the decision module rather than shipping a fourth file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa