### PR TITLE
Harness integrity + P0-5 · weight: a suite that can fail, and one reader for the scale

### DIFF
--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -89,6 +89,31 @@ const BUDGET = {
    */
   localDecisionSenders: 6,
   /**
+   * GUARD #15 — see directLedgerReads above. Client-facing reads of weight_logs that do not go
+   * through getWeightTruth, and therefore cannot honour do_not_mention.
+   *
+   * MEASURED 26 on main@266a8c2b, 15 after this cut. The eleven that went are every surface that
+   * SPOKE A FIGURE without asking: the model context (client-snapshot, gpt.ts x2), the plateau
+   * nudge, monthly photo day, the "not seeing results" stats line, the three client-asked commands
+   * in misc-commands (which now say WHY they may answer, rather than answering by never checking),
+   * and one dead duplicate in macro-card-attach that nothing called.
+   *
+   * The fifteen that remain are deliberately still here, and they are not the same kind of thing:
+   *
+   *   6  read only `loggedAt` — "is a trend assertable", "when did they last weigh" — and quote
+   *      nothing. response-gate, one-action-command, understanding/live, chat-log, monday x2.
+   *      They come home when trend-usability gets an owner, which is P0-7.
+   *   6  monday and weekly already apply the rule themselves (mentionsForbidden, in-file). Moving
+   *      them is consolidation, not a behaviour fix, and mixing the two in one PR is how a
+   *      behavioural claim gets buried in a refactor.
+   *   2  scheduler/shared.ts — loadProactiveState, which feeds chooseAction, and chooseAction has
+   *      carried its own scaleIsOffLimits gate since Cut 7.
+   *   1  business.ts runAutoCalAdjust — a target computation, not a sentence.
+   *
+   * LOWER THIS as each of those lands. Never raise it.
+   */
+  directWeightReads: 15,
+  /**
    * GUARD #9 — AUTHORSHIP POINTS (2026-08-04). Every `return "…"` in server/ is a place
    * something other than the engine can put words in front of a client.
    *
@@ -616,6 +641,46 @@ function unclassifiedSenders(): { missing: string[]; legacy: number } {
   return { missing, legacy };
 }
 
+/**
+ * GUARD #15 — THE LEDGER HAS OWNERS, AND THE CLIENT PATH USES THEM (2026-08-25, P0-5).
+ *
+ * THE DEFECT THIS EXISTS TO STOP, measured on main@266a8c2b: `users.do_not_mention` is the client
+ * saying "stop bringing up my weight". Exactly ONE reader on the client path honoured it —
+ * getProgressTruth. Four others read weight_logs directly and spoke the figure with no check:
+ * the model's context (twice, one of them under "Quote these figures EXACTLY as written"), the
+ * plateau nudge, and monthly photo day. The reactive mouth's strip is a last resort that only
+ * covers reactive TEXT — not a proactive send, and not a rendered card.
+ *
+ * That is the same shape as every other defect in this repo's last six months: a correct owner
+ * exists, and the surfaces that speak simply do not go through it. So the number of direct reads
+ * is not a tidiness metric — it is the count of places where a client-facing claim is made without
+ * the rule that governs it. It may only FALL, and it falls one DOMAIN at a time.
+ *
+ * SCOPE, stated so it cannot drift: files that compose something a client sees. Excluded by
+ * declaration and not by accident — the owner itself, the domain WRITERS (a handler that inserts
+ * a weigh-in must address the table), admin and dashboard routes, and storage/audit tooling, none
+ * of which are the coach speaking. server/handlers/safety.ts is excluded DELIBERATELY and
+ * permanently: a rapid-loss check that stands down because the client asked us not to discuss the
+ * scale is the one place where honouring that request would be dangerous.
+ */
+const LEDGER_OWNER_FILES = ["server/day-ledger.ts", "server/day-ledger-core.ts"];
+const DOMAIN_WRITERS: Record<string, string[]> = {
+  weight: ["server/handlers/weight.ts", "server/handlers/safety.ts"],
+};
+function directLedgerReads(table: string, writers: string[]): string[] {
+  const clientPath = files.filter(f =>
+    (f.startsWith("server/handlers/") || f.startsWith("server/brain/") || f.startsWith("server/scheduler/")
+      || f.startsWith("server/understanding/") || f.startsWith("server/verifiers/")
+      || f === "server/gpt.ts" || f === "server/macro-card-attach.ts")
+    && !LEDGER_OWNER_FILES.includes(f) && !writers.includes(f));
+  const hits: string[] = [];
+  for (const f of clientPath) {
+    const n = (readFileSync(f, "utf-8").match(new RegExp(`from\\(${table}\\)`, "g")) || []).length;
+    for (let i = 0; i < n; i++) hits.push(f);
+  }
+  return hits;
+}
+
 const files = [...walk("server"), ...walk("shared")];
 const read = (f: string) => readFileSync(f, "utf-8");
 const all = files.map(read);
@@ -641,6 +706,8 @@ const actual = {
   unreachableCapabilities: unreachableExports(files, walk("script")).length,
   /** Proactive senders still running their own action ladder. See GUARD #14. */
   localDecisionSenders: unclassifiedSenders().legacy,
+  /** Client-facing reads of weight_logs that bypass getWeightTruth. See GUARD #15. */
+  directWeightReads: directLedgerReads("weightLogs", DOMAIN_WRITERS.weight).length,
   // EVERY PLACE THAT TALKS TO TWILIO DIRECTLY (2026-08-05).
   //
   // Twilio is a reseller of Meta's WhatsApp API, not the destination — OUTSTANDING.md has

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3745,7 +3745,18 @@ test("cut11: don't-mention is enforced by the object, not by each renderer", () 
   // The object refuses to carry the number, so every presentation is safe with nothing to print.
   assert.ok(/const withheld = !askedThemselves && mentionsForbidden\("weight scale weigh", user\?\.doNotMention\)/.test(dl),
     "the truth object applies the prohibition");
-  assert.ok(/withheld\s*\?\s*\{ known: false, currentKg: null, changeKg: null, withheld: true \}/.test(dl),
+  // THE OBJECT REFUSES TO CARRY THE NUMBER. This matched one exact literal, so when the weight
+  // block moved into getWeightTruth (2026-08-25, P0-5) — same rule, same nulls, now reachable by
+  // the surfaces that were bypassing it entirely — the assertion broke while the property it
+  // names got STRONGER. That is what a source-string test does: it grades where the code is.
+  //
+  // Kept here as a structural smoke check, deliberately tolerant of layout. The behavioural
+  // grading lives in production-parity — "P0-5 . getWeightTruth withholds, and stands down rather
+  // than filtering", which calls it against a seeded ledger and asserts the returned object
+  // carries no weigh-ins at all. Assert behaviour there, not shape here.
+  const withheldBranch = dl.slice(dl.indexOf("if (withheld) {"), dl.indexOf("if (withheld) {") + 260);
+  assert.ok(/known: false/.test(withheldBranch) && /currentKg: null/.test(withheldBranch)
+    && /changeKg: null/.test(withheldBranch) && /points: \[\]/.test(withheldBranch),
     "a withheld weight is absent, not merely unrendered");
   // Cut 8's rule still holds: a prohibition is about US raising it, never about refusing to answer.
   assert.ok(/const askedThemselves = mentionsForbidden\(String\(opts\?\.clientMessage \|\| ""\), user\?\.doNotMention\)/.test(dl),

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -64,13 +64,41 @@ let passed = 0;
 let failed = 0;
 const failures: string[] = [];
 
-function test(name: string, fn: () => void) {
-  try {
-    fn();
-    passed++;
-  } catch (err: any) {
+/**
+ * A SUITE THAT CANNOT FAIL IS A GREEN LIGHT WIRED TO NOTHING (fixed 2026-08-25).
+ *
+ * This ran `fn()`, ignored what came back, and incremented `passed`. 86 of the 332 cases in this
+ * file are async, so for every one of them `fn()` returned immediately, the try/catch could not
+ * see the rejection, and the pass was recorded whether or not the assertions held. The file then
+ * ends with a synchronous `process.exit(0)`, which kills the process before the rejection can even
+ * surface as an unhandled one — so there was no symptom at all. Not a theory: a control asserting
+ * `1 === 2` was counted as PASSED and the suite exited 0.
+ *
+ * THE PART THAT MATTERS MOST. This exact defect was found and fixed in food-scanner-tests.ts, then
+ * found and fixed again in unit-tests.ts — whose comment reads "the same defect was found and
+ * fixed in script/food-scanner-tests.ts; it was never fixed here." It was never fixed here either.
+ * The repair existed, was written down twice, and two suites were left behind: the same
+ * owner-exists-but-callers-do-not shape as every production defect in this repo's last six months,
+ * turned on the instrument that is supposed to catch them.
+ *
+ * `pending` is awaited before the tally below. See the PROBE control at the end of the file.
+ */
+const pending: Array<Promise<void>> = [];
+
+function test(name: string, fn: () => void | Promise<void>) {
+  const fail = (err: any) => {
     failed++;
-    failures.push(`  ✗ ${name}\n    ${err.message}`);
+    failures.push(`  ✗ ${name}\n    ${err?.message || err}`);
+  };
+  try {
+    const result = fn();
+    if (result && typeof (result as Promise<void>).then === "function") {
+      pending.push((result as Promise<void>).then(() => { passed++; }, fail));
+    } else {
+      passed++;
+    }
+  } catch (err: any) {
+    fail(err);
   }
 }
 
@@ -2930,9 +2958,14 @@ test("verdict: the downgrade asks for what is missing, never for what they just 
   assert.notEqual(loggedToday.action.kind, "log", "they already logged today");
 
   // Not logged today and thin: asking for the log is exactly right.
+  // HOUR 18, NOT 12 (fixture repaired 2026-08-25, unmasked by the runner fix). The rung this
+  // exercises is "nothing logged and the day is NEARLY OVER", gated on LATE = 17. At noon the day
+  // is not nearly over and the decision correctly returns `hold` — so this case had been asserting
+  // `log` against a state that cannot produce it, and passing anyway because the runner discarded
+  // the rejection. The product is right; the fixture named an hour the rung does not cover.
   const notLogged = decideProactive(decisionState({
     food: { loggedDays7d: 2, daysSinceAnyLog: 1 },
-    today: { kcal: 0, protein: 0, steps: 8200, logged: false, hour: 12 },
+    today: { kcal: 0, protein: 0, steps: 8200, logged: false, hour: 18 },
     weight: { daysSinceWeighIn: 1, trendUsable: false },
     evidence: { foodSufficient: false, weightSufficient: false },
   }), decisionProfile);
@@ -3053,7 +3086,15 @@ test("event boundaries: segmentation needs TWO, so one mention is not a split", 
   const n = (msg: string) => [...msg.matchAll(new RegExp(MEAL_BOUNDARY_RE.source, "gi"))].length;
   assert.equal(n("I had chicken and pap at lunch"), 1, "one meal is one meal");
   assert.equal(n("2 spoons of pap"), 0, "no meal word, no boundary");
-  assert.equal(n("I had a pre-workout snack"), 1, "snack counts, and one is not a split");
+  // A BOUNDARY NEEDS THE PREPOSITION (assertion repaired 2026-08-25, unmasked by the runner fix).
+  // MEAL_BOUNDARY_RE is `(for|in|at|during|as) + (a|my|the)? + <meal word>`. "I had a pre-workout
+  // snack" is a BARE mention with no preposition, so it is deliberately 0 — which is exactly what
+  // the next test in this file documents for "then two amagwinya around four". This case asserted
+  // 1 against a pattern that cannot return 1 for it, and contradicted its own neighbour, and both
+  // stayed green because the runner never saw the rejection. `as a snack` is the real one-boundary
+  // form, so the case keeps its subject: a snack counts, and one boundary is not a split.
+  assert.equal(n("I had biltong as a snack"), 1, "snack counts, and one is not a split");
+  assert.equal(n("I had a pre-workout snack"), 0, "a bare mention with no preposition is not a boundary");
 });
 
 test("event boundaries: PRE-positioned phrasing is still unhandled — documented, not hidden", async () => {
@@ -3418,7 +3459,15 @@ test("cut6: the ladder is reachable for a client who has actually vanished", asy
   // AND THE ASK MUST SHRINK. A month gone is not a bigger version of three days gone — it is
   // someone who has decided they failed, and the only ask small enough is to say hi.
   assert.match(gone(30).todo, /say hi/i, "month-plus is the smallest ask on the ladder");
-  assert.ok(gone(30).todo.length < gone(3).todo.length, "the ask gets smaller, not louder");
+  // SMALLER IN EFFORT, NOT IN CHARACTERS (assertion repaired 2026-08-25, unmasked by the runner
+  // fix). This compared `todo.length` — a PROXY for the size of the ask, and the wrong one:
+  // "Just say hi. That's the whole ask today." (39 chars) is a smaller ask than "Log one meal
+  // today. Any meal." (29 chars) while being the longer string. The property is what the client is
+  // asked to DO, so that is what is asserted: at three days we still ask for a log; at a month we
+  // ask for nothing but a hello. The product had this right the whole time.
+  assert.match(gone(3).todo, /log|tell me/i, "three days gone still asks for one real log");
+  assert.ok(!/log|meal|train|weigh|walk/i.test(gone(30).todo),
+    `a month gone must ask for no work at all, got: ${gone(30).todo}`);
   assert.match(gone(30).why + gone(3).why, /haven't blown anything|nothing is lost/i,
     "absolution is explicit — silence is usually shame, not busyness");
 });
@@ -3955,6 +4004,26 @@ test("startup: /health answers without a database", () => {
   assert.ok(earlyReturn > 0 && dbCall > 0 && earlyReturn < dbCall,
     "it reports startup state BEFORE requiring a live query — the two states we most need to tell apart both used to come back as one opaque error");
 });
+
+// ── THE INSTRUMENT CHECKS ITSELF (2026-08-25) ────────────────────────────────────────────────
+//
+// The control the harness fix exists for. `PROBE_MUST_FAIL=1` makes this one async case throw;
+// with the runner repaired the suite must then exit RED and name it, and without the variable it
+// must pass. That red/green pair is the only evidence that an async failure in this file is
+// actually observed — before the fix, an async case asserting 1 === 2 was counted as PASSED.
+//
+// It is async ON PURPOSE. A synchronous control would have passed through the broken runner too
+// and proved nothing about the 86 cases that were silently non-blocking.
+test("PROBE: an async failure in this suite is actually observed", async () => {
+  await Promise.resolve();
+  if (process.env.PROBE_MUST_FAIL === "1") {
+    assert.fail("deliberate async failure — the suite MUST report this and exit non-zero");
+  }
+});
+
+// EVERY ASYNC CASE MUST LAND BEFORE THE TALLY. Without this the counts below are printed while
+// most of the file is still running, which is what made the whole suite advisory.
+await Promise.all(pending);
 
 console.log(`\ngap-tests: ${passed}/${passed + failed} passed`);
 if (failures.length > 0) {

--- a/script/integration-tests.ts
+++ b/script/integration-tests.ts
@@ -17,13 +17,33 @@ let passed = 0;
 let failed = 0;
 const failures: string[] = [];
 
-function test(name: string, fn: () => void) {
-  try {
-    fn();
-    passed++;
-  } catch (err: any) {
+/**
+ * THE SAME REPAIR AS THE OTHER THREE SUITES (2026-08-25).
+ *
+ * Every case in this file is synchronous today, so this runner has never actually lost a failure —
+ * this is not a bug fix, it is closing the trap before someone falls into it. The identical defect
+ * was found and fixed in food-scanner-tests.ts, then again in unit-tests.ts, then again in
+ * gap-tests.ts where it was hiding 86 non-blocking cases and three real failures. Three times is
+ * not a coincidence: the shape invites it, because an `async` case looks exactly like a working
+ * one right up until it needs to fail. Left as-is, the first async test added here would be
+ * unfailable on the day it was written, and nobody would find out.
+ */
+const pending: Array<Promise<void>> = [];
+
+function test(name: string, fn: () => void | Promise<void>) {
+  const fail = (err: any) => {
     failed++;
-    failures.push(`  ✗ ${name}\n    ${err.message}`);
+    failures.push(`  ✗ ${name}\n    ${err?.message || err}`);
+  };
+  try {
+    const result = fn();
+    if (result && typeof (result as Promise<void>).then === "function") {
+      pending.push((result as Promise<void>).then(() => { passed++; }, fail));
+    } else {
+      passed++;
+    }
+  } catch (err: any) {
+    fail(err);
   }
 }
 
@@ -329,6 +349,9 @@ test("proactive pause: PROACTIVE_PAUSED=1 (wrong value) → not paused", () => {
 }
 
 // ── Results ──────────────────────────────────────────────────────────────────
+
+// Every async case must land before the tally, or the counts are printed mid-run.
+await Promise.all(pending);
 
 console.log(`\nintegration-tests: ${passed}/${passed + failed} passed`);
 if (failures.length > 0) {

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2182,10 +2182,22 @@ async function main() {
     // …and asking to SEE it still renders it — including when the ASK is phrased as permission.
     // "Can I get tomorrow's session?" is a possessive naming the object; "Can I do my workout
     // tomorrow?" proposes a time. Grammar decides, not a verb list.
+    // THE RENDERER ANSWERED — a session, or its own rest-day answer for a day that has none.
+    //
+    // This asserted `Week \d` alone, which encodes an assumption the fixture cannot keep: with
+    // trainingDaysPerWeek 3 the schedule is Mon/Wed/Fri, so "tomorrow" is a rest day on four days
+    // out of seven and the renderer correctly returns "*Tuesday — Rest Day.*". It failed on
+    // main@266a8c2b for that reason and passed the day before. The property under test is the
+    // GRAMMAR — a possessive naming the object reaches the workout owner, rather than being
+    // answered as a schedule question — and the rest-day render is that owner answering.
+    const RENDERED = /Week \d|\*\s*\w+day\s+—\s+Rest Day/i;
     for (const view of ["Show me tomorrow's workout.", "Tomorrow's workout?",
                         "Can I see tomorrow's workout?", "Can I get tomorrow's session?"]) {
       const reply = await serialise(() => say(view));
-      assert.match(reply, /Week \d/i, `a view request stopped rendering: ${view} → ${reply.slice(0, 70)}`);
+      assert.match(reply, RENDERED, `a view request stopped rendering: ${view} → ${reply.slice(0, 70)}`);
+      // …and it is NOT the schedule answer, which is the failure this whole block exists to catch.
+      assert.ok(!/do this session tomorrow|do it later today/i.test(reply),
+        `a view request was answered as a schedule question: ${view} → ${reply.slice(0, 70)}`);
     }
 
     // The opposite still holds end to end: a reported session is still written to today.
@@ -2194,7 +2206,7 @@ async function main() {
     // And the ordinary workout doors are untouched.
     for (const view of ["workout", "What is tomorrow's session?"]) {
       const reply = await serialise(() => say(view));
-      assert.match(reply, /Week \d/i, `a legitimate workout view was broken: ${view} → ${reply.slice(0, 70)}`);
+      assert.match(reply, RENDERED, `a legitimate workout view was broken: ${view} → ${reply.slice(0, 70)}`);
     }
   });
 
@@ -2203,12 +2215,23 @@ async function main() {
   // attributeMultiDayReport shipped in PR #52 with EIGHT test references and ZERO production
   // callers. These grade the wiring, not the library.
   check("P0-2 . a multi-day report writes each day, in one reply", async () => {
-    const r = await writesFor("Monday pap and chicken. Tuesday eggs and toast. Wednesday I trained and walked 8000 steps");
+    // THE FIXTURE IS DATED RELATIVE TO TODAY (determinism fix, 2026-08-25). It named Monday,
+    // Tuesday and Wednesday literally, so on a Tuesday one of the three resolved to TODAY and the
+    // three-day report collapsed into two — the suite graded a different scenario depending on the
+    // weekday CI happened to run. It failed on main@266a8c2b for exactly that reason, and passed
+    // in the same repo the day before. A guard whose verdict is a function of the calendar cannot
+    // hold a ratchet. These are the three days ending yesterday, so they are always distinct and
+    // always in the past, which is what this test was always about. Days 4-2 back, not 3-1:
+    // the reply renders the most recent day as "yesterday" rather than by name, which is correct
+    // and friendly — and would make a name assertion fail for the wrong reason.
+    const [d1, d2, d3] = [4, 3, 2].map(n =>
+      new Date(NOW - n * 86_400_000).toLocaleDateString("en-ZA", { weekday: "long", timeZone: "Africa/Johannesburg" }));
+    const r = await writesFor(`${d1} pap and chicken. ${d2} eggs and toast. ${d3} I trained and walked 8000 steps`);
     assert.ok(r.mealDays.length >= 2, `expected meals on two named days, got ${JSON.stringify(r.mealDays)}`);
     // ONE reply, covering every domain — food from its own owner, training and steps from the
     // backfill that dated them. An unacknowledged write is how "did you even log it?" happens.
-    assert.match(r.out, /Monday/i, `the reply lost a day: ${r.out.slice(0, 120)}`);
-    assert.match(r.out, /Wednesday/i, `the backfilled day was written but never acknowledged: ${r.out.slice(0, 120)}`);
+    assert.match(r.out, new RegExp(d1, "i"), `the reply lost a day: ${r.out.slice(0, 120)}`);
+    assert.match(r.out, new RegExp(d3, "i"), `the backfilled day was written but never acknowledged: ${r.out.slice(0, 120)}`);
     assert.match(r.out, /session/i, "the reply does not mention the session it wrote");
     assert.match(r.out, /8,000 steps/i, "the reply does not mention the steps it wrote");
     assert.match(r.out, /kcal/i, "food lost its quantity-aware owner");
@@ -2220,7 +2243,7 @@ async function main() {
     assert.equal(r.allStepWrites, 1, `${r.allStepWrites} step rows written for one report`);
     // Distinct days, and none of them today — the whole point is that they land where named.
     const days = new Set([...r.backfillWorkoutDays, ...r.backfillStepDays]);
-    assert.equal(days.size, 1, "the Wednesday session and steps landed on different days");
+    assert.equal(days.size, 1, `the ${d3} session and steps landed on different days`);
     assert.ok(!days.has(sastDayKeyOf(new Date())), "a named past day was written as today");
     // ONE reply, and it says what was written.
 
@@ -2535,6 +2558,83 @@ async function main() {
       "I'm done eating junk",
       "I can't stop eating today",
     ]) assert.ok(!foodDayIsClosed(open), `a food CHOICE was recorded as a closed day: ${open}`);
+  });
+
+  // ── P0-5 · THE SCALE HAS ONE READER, AND IT KNOWS WHO ASKED US TO DROP IT (2026-08-25) ────
+  //
+  // `users.do_not_mention` is the client saying "stop bringing up my weight". One reader honoured
+  // it. These grade the surfaces that did not — and each prohibition is paired with the identical
+  // fixture minus the request, so none can pass because a figure was missing anyway.
+  //
+  // Deliberately NOT "does client-snapshot import getWeightTruth". The property is what the
+  // client-facing text CONTAINS.
+  const KG = /\b\d{2,3}(?:\.\d)?\s*kg\b/i;
+
+  async function snapshotFor(doNotMention: string | null): Promise<string> {
+    const { buildClientSnapshot } = await import("../server/brain/client-snapshot");
+    const { weightLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+    return serialise(async () => {
+      const today = new Date();
+      g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[weightLogs, [
+        { weight: "83.4", at: new Date(NOW - 20 * 86_400_000), loggedAt: new Date(NOW - 20 * 86_400_000) },
+        { weight: "82.0", at: today, loggedAt: today },
+      ]]]);
+      // The user is PASSED, never written to the global. Reassigning __KAMLIFE_STUB_USER here made
+      // two unrelated checks red: they run concurrently and read that global, so for the length of
+      // this case they were coaching a client who had asked us to drop the scale, and the mouth
+      // stripped their replies. A fixture that changes what other tests are testing is not a
+      // fixture, and the failures it caused looked like product regressions.
+      try { return String(await buildClientSnapshot({ ...USER, doNotMention }) ?? ""); }
+      finally { delete g.__KAMLIFE_STUB_ROWS; }
+    });
+  }
+
+  check("P0-5 . the model's context carries no weight figure for a client who asked us to drop it", async () => {
+    const held = await snapshotFor("weight");
+    const weightLines = held.split("\n").filter(l => /^Weight:/.test(l) || KG.test(l));
+    assert.ok(!weightLines.some(l => KG.test(l)),
+      `a kg figure reached the model for a do-not-mention client: ${weightLines.join(" | ").slice(0, 200)}`);
+    // AND IT MUST NOT ADVERTISE THE WITHHOLDING. "Weight withheld" in the context is an invitation
+    // to ask about it, which is the thing the client asked us to stop doing.
+    assert.ok(!/withheld|not allowed|do not mention/i.test(held),
+      "the context told the model a weight figure was being kept from it");
+  });
+
+  check("P0-5 control . the same client without the request DOES get the figure", async () => {
+    const open = await snapshotFor(null);
+    assert.ok(/^Weight: started/m.test(open) && KG.test(open),
+      `the snapshot carried no weight figure at all — the prohibition above proves nothing: ${open.slice(0, 200)}`);
+  });
+
+  check("P0-5 . getWeightTruth withholds, and stands down rather than filtering", async () => {
+    const { getWeightTruth } = await import("../server/day-ledger");
+    const { weightLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+    const out = await serialise(async () => {
+      g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[weightLogs, [
+        { weight: "83.4", at: new Date(NOW - 20 * 86_400_000), loggedAt: new Date(NOW - 20 * 86_400_000) },
+        { weight: "82.0", at: new Date(), loggedAt: new Date() },
+      ]]]);
+      const r = {
+        held: await getWeightTruth({ ...USER, doNotMention: "weight" }),
+        asked: await getWeightTruth({ ...USER, doNotMention: "weight" }, { clientMessage: "what is my weight?" }),
+        open: await getWeightTruth({ ...USER, doNotMention: null }),
+      };
+      delete g.__KAMLIFE_STUB_ROWS;
+      return r;
+    });
+    assert.ok(out.held.withheld && out.held.points.length === 0 && out.held.currentKg === null,
+      `a withheld read still carried weigh-ins: ${JSON.stringify(out.held).slice(0, 160)}`);
+    // THEY MAY RAISE IT THEMSELVES. A coach who won't answer a direct question is not honouring
+    // anything, it is sulking — the same rule chat-log has applied at the mouth since Cut 8.
+    assert.ok(!out.asked.withheld && out.asked.currentKg !== null,
+      `a client who asked about their own weight was refused: ${JSON.stringify(out.asked).slice(0, 160)}`);
+    assert.ok(out.open.known && out.open.startKg === 83.4 && out.open.currentKg === 82,
+      `the ordinary read is wrong: ${JSON.stringify(out.open).slice(0, 160)}`);
+    // NEGATIVE means lost — one convention, and the surfaces that print a direction depend on it.
+    assert.ok(out.open.changeKg !== null && out.open.changeKg < 0,
+      `sign convention broke: ${out.open.changeKg}`);
   });
 
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────

--- a/server/brain/client-snapshot.ts
+++ b/server/brain/client-snapshot.ts
@@ -12,7 +12,8 @@
  */
 
 import { db } from "../db";
-import { weightLogs, workoutLogs, mealLogs, stepLogs, chatHistory } from "../../shared/schema";
+import { workoutLogs, mealLogs, stepLogs, chatHistory } from "../../shared/schema";
+import { getWeightTruth } from "../day-ledger";
 import { eq, gte, desc, asc, and, sql } from "drizzle-orm";
 import { weeklyTrendSlopeKg } from "../handlers/weight";
 import { getPhaseNames } from "../programme";
@@ -137,20 +138,26 @@ export async function buildClientSnapshot(user: any): Promise<string> {
     const inLast = (days: number) => wLogs.filter(w => w.loggedAt && new Date(w.loggedAt).getTime() >= now - days * DAY).length;
     lines.push(`Sessions: ${total} total (lifetime), ${inLast(7)} in the last 7 days, ${inLast(28)} in the last 4 weeks. Current streak: ${user.workoutStreak || 0}.`);
 
-    const wl = await db.select({ weight: weightLogs.weight, loggedAt: weightLogs.loggedAt })
-      .from(weightLogs).where(eq(weightLogs.userId, user.id))
-      .orderBy(desc(weightLogs.loggedAt)).limit(40).catch(() => [] as { weight: string; loggedAt: Date | null }[]);
-    if (wl.length === 0) {
+    // THE SCALE COMES FROM THE OWNER THAT KNOWS WHO ASKED US TO DROP IT (2026-08-25, P0-5).
+    //
+    // This was a direct weight_logs read, and the block below hands the model a figure with
+    // "Quote these figures EXACTLY as written". A client who said "stop bringing up my weight" got
+    // theirs handed over anyway, with an instruction to repeat it. The reactive mouth's strip is
+    // the last resort — and a last resort that has to fire is a decision nobody made.
+    //
+    // `withheld` and "none logged" are deliberately the SAME branch here. The model must not be
+    // told a figure is being kept from it: a context line saying "weight withheld" is an invitation
+    // to ask about it, which is the thing the client asked us to stop doing.
+    const wt = await getWeightTruth(user).catch(() => null);
+    if (!wt || !wt.known || wt.points.length === 0) {
       lines.push(`Weight: none logged yet — do not quote a weight figure.`);
     } else {
-      const cur = parseFloat(String(wl[0].weight));
-      const oldest = wl[wl.length - 1];
-      const start = parseFloat(String(oldest.weight));
-      const spanDays = Math.max(1, Math.round((now - new Date(oldest.loggedAt || now).getTime()) / DAY));
-      const weeks = Math.max(1, Math.round(spanDays / 7));
+      const cur = wt.currentKg!;
+      const start = wt.startKg!;
+      const weeks = Math.max(1, Math.round(Math.max(1, wt.spanDays) / 7));
       const totalChange = +(cur - start).toFixed(1);
-      const recent = wl.filter(r => r.loggedAt && new Date(r.loggedAt).getTime() >= now - 21 * DAY);
-      const points = recent.map(r => ({ dayOffset: Math.round(new Date(r.loggedAt!).getTime() / DAY), kg: parseFloat(String(r.weight)) }));
+      const recent = wt.points.filter(p => p.at.getTime() >= now - 21 * DAY);
+      const points = recent.map(p => ({ dayOffset: Math.round(p.at.getTime() / DAY), kg: p.kg }));
       const slope = weeklyTrendSlopeKg(points, 2, 5);
       const recentTrend = slope === null ? "not enough recent weigh-ins to call a trend yet"
         : Math.abs(slope) < 0.1 ? "flat over the last ~3 weeks (a plateau)"
@@ -217,7 +224,9 @@ export async function buildClientSnapshot(user: any): Promise<string> {
     }
     for (const r of stepRows) { const e = slot(r.resolvedDay!); e.steps = Math.max(e.steps, Number(r.steps) || 0); }
     for (const w of wLogs) if (w.loggedAt && new Date(w.loggedAt).getTime() >= now - 7 * DAY) slot(sastDayKey(w.loggedAt ?? now)).trained = true;
-    for (const r of wl) if (r.loggedAt && new Date(r.loggedAt).getTime() >= now - 7 * DAY) slot(sastDayKey(r.loggedAt ?? now)).kg = parseFloat(String(r.weight));
+    // The seven-day story carries a per-day kg too, and it was reading the same raw rows. Withheld
+    // means `points` is empty, so the days simply carry no scale figure — the story still runs.
+    for (const p of wt?.points ?? []) if (p.at.getTime() >= now - 7 * DAY) slot(sastDayKey(p.at)).kg = p.kg;
     for (const r of said as any[]) {
       const t = String(r.messageIn || "").replace(/\s+/g, " ").trim();
       const e = slot(sastDayKey(r.createdAt ?? now));

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -400,6 +400,93 @@ export interface ProgressWeight {
   changeKg: number | null;
   /** True only in the don't-mention case, so a caller can tell "we don't know" from "not ours to say". */
   withheld: boolean;
+  /** The first weigh-in in the window — what "since you started" is measured from. */
+  startKg: number | null;
+  /** Days between the first and last weigh-in. 0 when there are fewer than two. */
+  spanDays: number;
+  /** Every weigh-in in the window, oldest first. Empty when withheld. For a chart or a trend. */
+  points: Array<{ kg: number; at: Date }>;
+}
+
+/**
+ * THE SCALE HAS ONE READER, AND IT KNOWS WHO ASKED US TO DROP IT (2026-08-25, P0-5 · weight).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE DEFECT THIS EXISTS TO STOP
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * `users.do_not_mention` is the client saying "stop bringing up my weight". Measured on
+ * main@266a8c2b, exactly ONE reader on the client path honoured it — getProgressTruth. Four
+ * others read weight_logs directly and spoke the number with no check at all:
+ *
+ *   brain/client-snapshot.ts   builds the model's context: "Weight: started 83.4kg, now 82.0kg
+ *                              … Quote these figures EXACTLY as written."
+ *   gpt.ts                     two more weigh-in reads into the same context
+ *   macro-card-attach.ts       renders the change into a card IMAGE — the reactive mouth strips
+ *                              forbidden TEXT, and cannot touch a picture
+ *   handlers/lifecycle.ts      "Weight: ↓ 1.4kg lost (83.4kg → 82.0kg)"
+ *
+ * The reply boundary's strip is a last resort, not the rule: the architecture note on
+ * DayState.doNotMention says it plainly — the decision must stand down, because stripping the
+ * sentence afterwards leaves the coach with nothing to say. And it only guards the reactive path,
+ * so a proactive weight line and a rendered card were never guarded at all.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT THIS IS NOT
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Not a new service and not a second progress owner. It is the weight block that was already
+ * inside getProgressTruth, lifted so the surfaces that need ONLY weight can reach it without
+ * pulling a full progress read — and getProgressTruth calls it, so there is still exactly one
+ * definition of "what the scale says". Same move, and the same reason, as sessionsSince.
+ *
+ * THEY MAY RAISE IT THEMSELVES. `clientMessage` carries the turn's text: "don't mention my
+ * weight" is not "refuse to tell me my weight when I ask", and a coach who won't answer a direct
+ * question is not honouring anything. Three commands in misc-commands.ts — weight history, my
+ * weight, body check — are exactly that case, and they now say so by passing the message rather
+ * than by not having asked.
+ */
+export async function getWeightTruth(
+  user: any,
+  opts?: { clientMessage?: string | null; windowDays?: number },
+): Promise<ProgressWeight> {
+  const since = opts?.windowDays && opts.windowDays > 0
+    ? new Date(Date.now() - opts.windowDays * 86_400_000)
+    : null;
+
+  const askedThemselves = mentionsForbidden(String(opts?.clientMessage || ""), user?.doNotMention);
+  const withheld = !askedThemselves && mentionsForbidden("weight scale weigh", user?.doNotMention);
+  // THE READ DOES NOT HAPPEN WHEN IT IS NOT OURS TO SAY. Returning nulls after querying would
+  // still leave the rows one careless destructure away from a caller; not asking is the honest
+  // shape of standing down, and it is cheaper.
+  if (withheld) {
+    return { known: false, currentKg: null, changeKg: null, withheld: true, startKg: null, spanDays: 0, points: [] };
+  }
+
+  const rows = await db.select({ weight: weightLogs.weight, at: weightLogs.loggedAt })
+    .from(weightLogs)
+    .where(since ? and(eq(weightLogs.userId, user.id), gte(weightLogs.loggedAt, since)) : eq(weightLogs.userId, user.id))
+    .orderBy(weightLogs.loggedAt);
+
+  const points = (rows as Array<{ weight: unknown; at: Date | null }>)
+    .map(r => ({ kg: Number(r.weight), at: new Date(r.at as Date) }))
+    .filter(p => Number.isFinite(p.kg));
+
+  const change = weightChangeKg(rows as Array<{ weight: unknown }>);
+  const latest = points.length ? points[points.length - 1].kg : NaN;
+  const spanDays = points.length >= 2
+    ? Math.max(1, Math.round((points[points.length - 1].at.getTime() - points[0].at.getTime()) / 86_400_000))
+    : 0;
+
+  return {
+    known: change !== null,
+    currentKg: Number.isFinite(latest) ? latest : null,
+    changeKg: change,
+    withheld: false,
+    startKg: points.length ? points[0].kg : null,
+    spanDays,
+    points,
+  };
 }
 
 export interface ProgressTruth {
@@ -456,7 +543,7 @@ export async function getProgressTruth(
     ? new Date(Date.now() - opts.weightWindowDays * 86_400_000)
     : null;
 
-  const [today, windowRows, sessions, stepRows, weighIns] = await Promise.all([
+  const [today, windowRows, sessions, stepRows, weight] = await Promise.all([
     getDayLedger(user.id, { user }),
     db.select({
       label: mealLogs.mealLabel, kcal: mealLogs.kcalInt, protein: mealLogs.proteinInt,
@@ -469,11 +556,10 @@ export async function getProgressTruth(
       total: sql<number>`COALESCE(SUM(${stepLogs.steps}),0)::int`,
     }).from(stepLogs)
       .where(and(eq(stepLogs.userId, user.id), gte(stepLogs.loggedAt, since))),
-    db.select({ weight: weightLogs.weight }).from(weightLogs)
-      .where(weightSince
-        ? and(eq(weightLogs.userId, user.id), gte(weightLogs.loggedAt, weightSince))
-        : eq(weightLogs.userId, user.id))
-      .orderBy(weightLogs.loggedAt),
+    // ONE DEFINITION OF WHAT THE SCALE SAYS (2026-08-25). This was the weight query, the
+    // don't-mention check and the change arithmetic, inline — the only copy that honoured the
+    // client's request, which is why four other surfaces could speak a figure it had withheld.
+    getWeightTruth(user, { clientMessage: opts?.clientMessage, windowDays: opts?.weightWindowDays }),
   ]);
 
   const window = foldWindowRows(windowRows as LedgerRow[], days, d => sastDayKey(d));
@@ -481,11 +567,6 @@ export async function getProgressTruth(
   const provenance = summariseProvenance(
     (windowRows as any[]).map(r => ({ kcal: Number(r.kcal) || 0, items: r.items, source: r.source })),
   );
-
-  const askedThemselves = mentionsForbidden(String(opts?.clientMessage || ""), user?.doNotMention);
-  const withheld = !askedThemselves && mentionsForbidden("weight scale weigh", user?.doNotMention);
-  const change = weightChangeKg(weighIns as Array<{ weight: unknown }>);
-  const latest = weighIns.length ? Number((weighIns[weighIns.length - 1] as any).weight) : NaN;
 
   // THE TRAINING COUNT WE ACTUALLY HOLD, left on the turn (2026-08-22). Exactly what the step
   // read above does, for exactly the same reason: the mouth has to be able to tell a recital from
@@ -503,13 +584,6 @@ export async function getProgressTruth(
     totalSteps: Number((stepRows[0] as any)?.total || 0),
     daysOnProgramme: daysOnProgramme(user),
     provenance,
-    weight: withheld
-      ? { known: false, currentKg: null, changeKg: null, withheld: true }
-      : {
-        known: change !== null,
-        currentKg: Number.isFinite(latest) ? latest : null,
-        changeKg: change,
-        withheld: false,
-      },
+    weight,
   };
 }

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -331,12 +331,9 @@ export async function buildPatternSummary(user: any): Promise<string> {
         .where(and(eq(chatHistory.userId, user.id), gte(chatHistory.createdAt, sevenDaysAgo)))
         .orderBy(desc(chatHistory.createdAt))
         .limit(100),
-      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5 · weight). These were two direct
-      // weight_logs reads feeding a line straight into the model's context, and neither asked
-      // whether the client had told us to stop bringing up their weight. `withheld` returns no
-      // points at all, so weightInContextLine gets nothing to say and the block below falls to
-      // "No weight data this week" — the model is never told a figure is being kept from it,
-      // because that is an invitation to ask about it.
+      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5). Two direct weight_logs reads used to
+      // feed this straight into the model's context, neither asking do_not_mention. Why in
+      // getWeightTruth; withheld yields no points, so the block below says "No weight data".
       getWeightTruth(user, { windowDays: 7 }).catch(() => null),
       getWeightTruth(user, { windowDays: 28 }).catch(() => null),
       db.select().from(stepLogs)

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -11,6 +11,7 @@ import { patternCache, PATTERN_CACHE_TTL_MS } from "./cache";
 import { getClientNarrative } from "./intelligence/profile";
 import { verifyBrainReply } from "./brain/reply-verifier";
 import { weightInContextLine } from "./weight-context";
+import { getWeightTruth } from "./day-ledger";
 import { captureQualitySignal } from "./quality-signals";
 import { verifyMealEstimate } from "./verifiers/meal-verifier";
 import { assertAiOnline, isAiOfflineError } from "./ai-offline";
@@ -330,17 +331,14 @@ export async function buildPatternSummary(user: any): Promise<string> {
         .where(and(eq(chatHistory.userId, user.id), gte(chatHistory.createdAt, sevenDaysAgo)))
         .orderBy(desc(chatHistory.createdAt))
         .limit(100),
-      db.select().from(weightLogs)
-        .where(and(eq(weightLogs.userId, user.id), gte(weightLogs.loggedAt, sevenDaysAgo)))
-        .orderBy(desc(weightLogs.loggedAt))
-        .limit(5),
-      db.select().from(weightLogs)
-        .where(and(
-          eq(weightLogs.userId, user.id),
-          gte(weightLogs.loggedAt, twentyEightDaysAgo)
-        ))
-        .orderBy(desc(weightLogs.loggedAt))
-        .limit(12),
+      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5 · weight). These were two direct
+      // weight_logs reads feeding a line straight into the model's context, and neither asked
+      // whether the client had told us to stop bringing up their weight. `withheld` returns no
+      // points at all, so weightInContextLine gets nothing to say and the block below falls to
+      // "No weight data this week" — the model is never told a figure is being kept from it,
+      // because that is an invitation to ask about it.
+      getWeightTruth(user, { windowDays: 7 }).catch(() => null),
+      getWeightTruth(user, { windowDays: 28 }).catch(() => null),
       db.select().from(stepLogs)
         .where(and(eq(stepLogs.userId, user.id), gte(stepLogs.loggedAt, sevenDaysAgo)))
         .orderBy(desc(stepLogs.loggedAt))
@@ -411,14 +409,17 @@ export async function buildPatternSummary(user: any): Promise<string> {
     // WEIGHT IN CONTEXT (2026-07-22): bare "up 1.3kg this week" was the intelligence gap —
     // no attribution to WHEN the weight moved or the client's STATE. Engine in weight-context.ts.
     const restingNow = readHealthState(user).isSick;
+    // `points` is oldest-first from the owner; weightInContextLine took newest-first rows.
+    const monthPoints = [...(monthWeights?.points ?? [])].reverse();
     let weightTrend = weightInContextLine({
       goalType: user.goalType,
-      weighIns: (monthWeights as any[]).map((w) => ({ weight: parseFloat(String(w.weight)), at: w.loggedAt })),
+      weighIns: monthPoints.map(p => ({ weight: p.kg, at: p.at })),
       resting: restingNow,
     });
     if (!weightTrend) {
-      weightTrend = recentWeights.length > 0
-        ? `Weight logged: ${recentWeights[0].weight}kg — no trend yet.`
+      const latest7 = recentWeights?.currentKg;
+      weightTrend = latest7 != null
+        ? `Weight logged: ${latest7}kg — no trend yet.`
         : "No weight data this week.";
     }
 

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -35,6 +35,7 @@ import { isAskingNotReporting, sastToday, sastDayStart, proteinOptions , commaNa
 import { getMenuText } from "../onboarding";
 import { SA_FOODS_SEED } from "../foods";
 import { scanForSAFoods, weeklyNetLine } from "./food-scanner";
+import { getWeightTruth } from "../day-ledger";
 
 export async function handleLifecycle(ctx: {
   phone: string;
@@ -494,12 +495,16 @@ export async function handleLifecycle(ctx: {
       const daysActive = user.createdAt
         ? Math.max(1, Math.round((Date.now() - new Date(user.createdAt).getTime()) / 86_400_000))
         : 0;
-      const firstWeightRow = await db.select({ weight: weightLogs.weight })
-        .from(weightLogs).where(eq(weightLogs.userId, user.id))
-        .orderBy(asc(weightLogs.loggedAt)).limit(1);
-      const startWeight = firstWeightRow[0] ? parseFloat(String(firstWeightRow[0].weight)) : null;
-      const currentWeight = user.currentWeight ? parseFloat(String(user.currentWeight)) : null;
-      const weightDelta = startWeight && currentWeight ? currentWeight - startWeight : null;
+      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5 · weight). This read weight_logs for the
+      // start figure and took `current` from users.currentWeight — a second, unchecked definition
+      // of the same fact — then printed "Weight: ↓ 1.4kg lost (83.4kg → 82.0kg)" to a client who
+      // may have asked us to stop bringing up their weight. They did not raise it here: the branch
+      // fires on "not seeing results", which is about the PROGRAMME. So no clientMessage is passed
+      // and a withheld client simply gets sessions and days, which is the honest set.
+      const wt = await getWeightTruth(user).catch(() => null);
+      const startWeight = wt?.startKg ?? null;
+      const currentWeight = wt?.currentKg ?? null;
+      const weightDelta = wt?.known ? wt.changeKg : null;
 
       let statsLine = "";
       if (sessions > 0 || daysActive > 7) {

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -37,7 +37,7 @@ import { sastToday, sastDayStart, looksLikeDirectionRequest, classifyPainReport 
 import { isDespairNotAQuestion } from "../despair";
 import { SA_FOODS_SEED } from "../foods";
 import { turnEvidence } from "./chat-log";
-import { getProgressTruth, sessionsThisCalendarWeek } from "../day-ledger";
+import { getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
 
@@ -559,21 +559,22 @@ export async function handleMiscCommands(ctx: {
   // ---- WEIGHT HISTORY — "weight history", "weight trend", "how much have I lost" ----
   if (/\b(weight history|weight trend|my weights|all my weights|weight progress|how much (weight )?(have i|did i) (lost?|gained?)|total (weight )?(lost?|gained?)|weight (since|over time))\b/i.test(m)) {
     try {
-      const logs = await db.select({ weight: weightLogs.weight, loggedAt: weightLogs.loggedAt })
-        .from(weightLogs)
-        .where(eq(weightLogs.userId, user.id))
-        .orderBy(asc(weightLogs.loggedAt));
+      // THEY ASKED, SO THEY GET AN ANSWER (2026-08-25, P0-5 · weight). The owner applies the
+      // do-not-mention rule, and `clientMessage` is what tells it this client raised the scale
+      // themselves — "don't mention my weight" is not "refuse to tell me my weight when I ask".
+      // That exemption used to be accidental: this command simply never checked. Now it is stated.
+      const wt = await getWeightTruth(user, { clientMessage: m });
+      const logs = wt.points;
       if (logs.length === 0) return `No weight history yet. Log your first weight — just send "84kg".`;
-      const first = parseFloat(String(logs[0].weight));
-      const latest = parseFloat(String(logs[logs.length - 1].weight));
+      const first = logs[0].kg;
+      const latest = logs[logs.length - 1].kg;
       const totalChange = latest - first;
       const goal = user.goalType || "fat_loss";
       const changeDir = totalChange < 0 ? `Down ${Math.abs(totalChange).toFixed(1)}kg` : totalChange > 0 ? `Up ${totalChange.toFixed(1)}kg` : "No change";
       const verdict = goal === "fat_loss" && totalChange < -1 ? "Moving in the right direction." : goal === "muscle_gain" && totalChange > 0.5 ? "Scale is going up — keep fuelling." : goal === "fat_loss" && totalChange >= 0 ? "Scale hasn't moved yet — check food logging consistency." : "";
-      const recent = logs.slice(-5).map(l => {
-        const d = new Date(l.loggedAt as Date);
-        return `• ${parseFloat(String(l.weight)).toFixed(1)}kg — ${d.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`;
-      }).join("\n");
+      const recent = logs.slice(-5).map(l =>
+        `• ${l.kg.toFixed(1)}kg — ${l.at.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`,
+      ).join("\n");
       const name2 = user.name?.split(" ")[0] || "";
       return `*${name2 ? name2 + "'s " : ""}Weight History*\n\n${recent}\n\n${changeDir} since you started. ${verdict}`.trim();
     } catch { /* fall through */ }
@@ -1005,8 +1006,8 @@ export async function handleMiscCommands(ctx: {
   if (m === "my body" || m === "body check" || m === "recomp" || m === "body recomp" || m === "body composition" || /\b(body\s*check|body\s*comp|recomp|my\s*body|body\s*progress)\b/i.test(m)) {
     try {
       const [weights, measurements, workouts, clothingData] = await Promise.all([
-        db.select({ weight: weightLogs.weight, date: weightLogs.loggedAt }).from(weightLogs)
-          .where(eq(weightLogs.userId, user.id)).orderBy(asc(weightLogs.loggedAt)),
+        // Same owner, same reason: "body check" is the client asking about their own body.
+        getWeightTruth(user, { clientMessage: m }).then(w => w.points.map(p => ({ weight: p.kg, date: p.at }))),
         db.select({ type: bodyMeasurements.measurementType, value: bodyMeasurements.value, date: bodyMeasurements.loggedAt })
           .from(bodyMeasurements).where(eq(bodyMeasurements.userId, user.id)).orderBy(desc(bodyMeasurements.loggedAt)).limit(20),
         db.select({ id: workoutLogs.id }).from(workoutLogs).where(eq(workoutLogs.userId, user.id)),
@@ -1411,8 +1412,9 @@ export async function handleMiscCommands(ctx: {
   const asksWeightProjection = /\b(should|target|goal|aim)\b.{0,40}\bweight\b|\bweight\b.{0,40}\b(in|by)\s+(\d+\s*(?:weeks?|months?)|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*|next year)\b/i.test(m);
   if (!asksWeightProjection && !ctx.isQuestion && (m === "weight chart" || m === "weight graph" || m === "weight trend" || m === "my weight" || /\b(weight\s*(?:chart|graph|trend|history|journey)|scale\s*trend)\b/i.test(m))) {
     try {
-      const weights = await db.select({ weight: weightLogs.weight, date: weightLogs.loggedAt })
-        .from(weightLogs).where(eq(weightLogs.userId, user.id)).orderBy(asc(weightLogs.loggedAt));
+      // "my weight" / "weight chart" — they raised it, so the owner answers rather than withholds.
+      const weights = (await getWeightTruth(user, { clientMessage: m })).points
+        .map(p => ({ weight: p.kg, date: p.at }));
 
       if (weights.length < 2) {
         return `Not enough weight logs for a trend. Log your weight regularly — "84.5kg" — and I will show you the full picture over time.`;

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -295,30 +295,15 @@ const HINT_SUBJECTS: Array<[string, RegExp]> = [
 
 
 
-/**
- * kg changed since their first weigh-in — NEGATIVE when they have lost weight, matching
- * AchievementFacts.weightChangeKg. Undefined when there are fewer than two weigh-ins, because
- * one reading is a starting point and not yet progress. Fail-open: a DB miss returns undefined
- * and the card falls back to the next true thing, never to an invented one.
- */
-async function weightChangeSinceStart(userId?: string): Promise<number | undefined> {
-  if (!userId) return undefined;
-  try {
-    // Imported HERE, not at module scope. This module is statically imported by unit-tests.ts
-    // for its pure helpers, and a top-level `import { db }` makes db.ts evaluate at load —
-    // which demands a real DATABASE_URL and takes the whole pure suite down. (It survived
-    // before only because `db` was imported and never used, so esbuild elided it: a live
-    // import that nothing depended on. The first real use is what exposed it.)
-    const { db } = await import("./db");
-    const rows = await db.select({ weight: weightLogs.weight }).from(weightLogs)
-      .where(eq(weightLogs.userId, userId)).orderBy(asc(weightLogs.loggedAt));
-    if (rows.length < 2) return undefined;
-    const first = parseFloat(String(rows[0].weight));
-    const last = parseFloat(String(rows[rows.length - 1].weight));
-    if (!Number.isFinite(first) || !Number.isFinite(last)) return undefined;
-    return last - first;
-  } catch { return undefined; }
-}
+// A SECOND WEIGH-IN READER WITH NOTHING CALLING IT — DELETED (2026-08-25, P0-5 · weight).
+//
+// `weightChangeSinceStart` computed kg-since-start from weight_logs directly, with no
+// do-not-mention check, for a card that no code path builds: zero callers, and it did not carry
+// the `export` that GUARD #13 examines, so reachability never saw it either. It was not leaking a
+// figure in production — nothing ran it — but it was a loaded second definition of "what the scale
+// says", sitting in the module that renders IMAGES, where the reply boundary's text strip cannot
+// reach. The next person to want a weight line on a card would have found it and used it.
+// getWeightTruth in day-ledger.ts is the reader. There is no reason for a second one here.
 
 /** Render an achievement card and return its media marker, or "" if it can't be served. */
 export function achievementCardMarker(ach: AchievementCardData): string {

--- a/server/scheduler/jobs/onboarding.ts
+++ b/server/scheduler/jobs/onboarding.ts
@@ -5,6 +5,7 @@ import {
   getActiveClients, isPaused, programmeDaysSince, sastDayStart,
 } from "../shared";
 import { getGoalProfile } from "../../goal-profiles";
+import { getWeightTruth } from "../../day-ledger";
 
 // One-time catch-up: send step sync guide to any active client who has never
 // received it (existing beta testers signed up before Day 3 auto-message was added).
@@ -108,17 +109,20 @@ export async function runMonthlyMeasurements(): Promise<void> {
     if (!(await claimDailySlot(client.id, "monthly_measurements"))) continue;
     try {
       const name = (client.name || "there").split(" ")[0];
-      const [latestWeight] = await db.select({ weight: weightLogs.weight, loggedAt: weightLogs.loggedAt }).from(weightLogs).where(eq(weightLogs.userId, client.id)).orderBy(desc(weightLogs.loggedAt)).limit(1);
-      const [oldestWeight] = await db.select({ weight: weightLogs.weight }).from(weightLogs).where(and(eq(weightLogs.userId, client.id), gte(weightLogs.loggedAt, threeMonthsAgo))).orderBy(asc(weightLogs.loggedAt)).limit(1);
-      let contextLine = "";
-      if (latestWeight && oldestWeight && latestWeight.weight !== oldestWeight.weight) {
-        const diff = parseFloat(String(latestWeight.weight)) - parseFloat(String(oldestWeight.weight));
-        const direction = diff < 0 ? `down ${Math.abs(diff).toFixed(1)}kg` : `up ${diff.toFixed(1)}kg`;
-        const goal = client.goalType || "fat_loss";
-        const onTrack = (goal === "fat_loss" && diff < 0) || (goal === "muscle_gain" && diff > 0);
-        contextLine = `\n\nScale says you're ${direction} since we started. ${onTrack ? "That's the right direction." : "Let's look at what needs to change."}`;
-      }
-      const msg = latestWeight
+      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5 · weight). Two direct weight_logs reads
+      // fed "Scale says you're down 1.4kg since we started" into a proactive send — and proactive
+      // text never passes the reactive mouth, so the do-not-mention strip could not reach it
+      // either. Nothing in this file had ever asked. A withheld client keeps photo day and the
+      // energy-and-clothes question, which is the part of this message that was never about a
+      // number anyway.
+      const wt = await getWeightTruth(client, { windowDays: 92 }).catch(() => null);
+      const contextLine = wt?.known && wt.changeKg !== null && Math.abs(wt.changeKg) > 0
+        ? `\n\nScale says you're ${wt.changeKg < 0 ? `down ${Math.abs(wt.changeKg).toFixed(1)}kg` : `up ${wt.changeKg.toFixed(1)}kg`} since we started. ${
+            ((client.goalType || "fat_loss") === "fat_loss" && wt.changeKg < 0)
+            || ((client.goalType || "fat_loss") === "muscle_gain" && wt.changeKg > 0)
+              ? "That's the right direction." : "Let's look at what needs to change."}`
+        : "";
+      const msg = wt?.currentKg != null
         ? `${name}, it's the 1st — *photo day* 📸\n\nWeigh in this morning (before food, after bathroom) and send me the number.\n\nThen send a *progress photo* — front on, good light, same spot as last month, relaxed. And tell me how your *energy and clothes* are feeling.${contextLine}`
         : `${name}, it's the 1st — *photo day* 📸\n\nStep on the scale this morning, before food, after bathroom. Send me the number.\n\nThen send a *progress photo* — front on, good light, relaxed — and tell me how your *energy* is and how your *clothes* are fitting.\n\nYour shape and your energy show the change long before the scale does. No tape measure — we go on how you look and feel.`;
       await sendWhatsApp(client.phoneNumber, msg);

--- a/server/scheduler/jobs/programme.ts
+++ b/server/scheduler/jobs/programme.ts
@@ -6,6 +6,7 @@ import {
   todaySAST, thisWeekUTC, claimProactive, claimDailySlot,
 } from "../shared";
 import { getGoalProfile } from "../../goal-profiles";
+import { getWeightTruth } from "../../day-ledger";
 
 export async function runPhaseAdvancement(): Promise<void> {
   console.log("[SCHEDULER] JOB: Phase advancement check");
@@ -192,10 +193,16 @@ export async function runPlateauDetection(): Promise<void> {
       }
 
       // ── STAGE 1 — detect a fresh 3-week plateau and issue the first change ───
-      const recentWeights = await db.select({ weight: weightLogs.weight, loggedAt: weightLogs.loggedAt }).from(weightLogs).where(and(eq(weightLogs.userId, client.id), gte(weightLogs.loggedAt, twentyOneDaysAgo))).orderBy(asc(weightLogs.loggedAt));
+      // THE SCALE COMES FROM ITS OWNER (2026-08-25, P0-5 · weight). A direct weight_logs read
+      // whose whole output is a message ABOUT the scale — "your weight has been stable for 3
+      // weeks" — sent to a client who may have asked us to stop raising it, on the proactive path
+      // where the reactive strip never runs. Withheld now returns no points, so the plateau nudge
+      // stands down for that client rather than being stripped into nonsense afterwards.
+      const wt = await getWeightTruth(client, { windowDays: 21 }).catch(() => null);
+      const recentWeights = wt?.points ?? [];
       if (recentWeights.length < 2) continue;
-      const oldest = parseFloat(String(recentWeights[0].weight));
-      const newest = parseFloat(String(recentWeights[recentWeights.length - 1].weight));
+      const oldest = recentWeights[0].kg;
+      const newest = recentWeights[recentWeights.length - 1].kg;
       if (Math.abs(newest - oldest) > 0.5) continue;
       // DB claim (weekly window) replaces the old state-file flag, which a container
       // recycle would wipe — causing a repeat plateau message on restart.


### PR DESCRIPTION
From `main@266a8c2b`. Three commits, in the order the CTO ruled: weight slice → harness integrity proven red/green → merge.

---

# 1. Harness integrity (`1b654e2`) — the blocking question, answered

**The answer is: not disproven. Confirmed, and worse than reported.**

## Measured

| suite | cases | async | runner |
|---|---|---|---|
| `gap-tests.ts` | 332 | **86** | discarded the promise |
| `integration-tests.ts` | 33 | 0 | same runner, no damage yet |
| `unit-tests.ts` | — | — | already repaired |
| `food-scanner-tests.ts` | — | — | already repaired |

The runner called `fn()`, ignored what came back, and incremented `passed`. For an async case `fn()` returns immediately, so the `try/catch` cannot see the rejection and the pass is recorded whether or not the assertions hold. The file then ends with a **synchronous `process.exit(0)`**, which kills the process before the rejection can even surface as an unhandled one. There was no symptom at all.

## Proven before fixing

A control asserting `1 === 2`, inserted into the unmodified suite:

```
gap-tests: 335/335 passed
✓ all gap checks passed
EXIT 0
```

Not a theory about what might happen. **26% of that suite was a green light wired to nothing.**

## The part that matters most

This exact defect was found and fixed in `food-scanner-tests.ts`, then found and fixed again in `unit-tests.ts` — whose comment reads *"the same defect was found and fixed in script/food-scanner-tests.ts; it was never fixed here."*

**It was never fixed here either.** The repair existed, was written down twice, and two suites were left behind. That is the same shape as every production defect in this repo's last six months — owner exists, callers do not — turned on the instrument that is supposed to catch them.

## The control, permanent

A `PROBE` case, **async on purpose** — a synchronous control would have passed through the broken runner too and proved nothing about the 86.

```
PROBE_MUST_FAIL=1  →  334/335, PROBE named in Failures, EXIT 1
unset              →  335/335,                          EXIT 0
```

## What the repair unmasked — three real failures, all pre-existing

Confirmed **identical on `main@266a8c2b`** with only the runner changed, so none come from P0-4b or P0-5. All three are broken **tests**, not broken product — and each fails the way we keep warning about: a stale fixture, or a proxy.

1. **verdict/downgrade** — asserted `log` with `hour: 12` against a rung gated on `LATE = 17` (*"nothing logged and the day is NEARLY OVER"*). At noon the decision correctly returns `hold`. The fixture named an hour the rung does not cover.
2. **event boundaries** — asserted `MEAL_BOUNDARY_RE` matches `"I had a pre-workout snack"`. The pattern requires a preposition, so a bare mention is deliberately `0` — which is **exactly what the next test in the file documents**. The case contradicted its own neighbour, and both stayed green.
3. **cut6 silence ladder** — asserted `gone(30).todo.length < gone(3).todo.length`. String length as a proxy for the size of an ask: *"Just say hi. That's the whole ask today."* (39 chars) **is** smaller than *"Log one meal today. Any meal."* (29 chars). Now asserts the property itself.

No product code in that commit.

---

# 2. P0-5 · weight (`b7f7fc4`)

`users.do_not_mention` is the client saying *"stop bringing up my weight"*. Exactly **one** reader on the client path honoured it — `getProgressTruth`. Four others read `weight_logs` directly and spoke the figure with no check:

| surface | what it says |
|---|---|
| `brain/client-snapshot.ts` | the model's context — `Weight: started 83.4kg, now 82.0kg … Quote these figures EXACTLY as written.` |
| `gpt.ts` | two more weigh-in reads into the same context |
| `scheduler/jobs/programme.ts` | the plateau nudge — a message entirely *about* the scale |
| `scheduler/jobs/onboarding.ts` | photo day — `Scale says you're down 1.4kg since we started` |

The reply boundary's strip is a last resort, and the architecture note on `DayState.doNotMention` says why it is not the rule: **the decision must stand down**, because stripping the sentence afterwards leaves the coach with nothing to say. It also only covers reactive *text* — the two scheduler surfaces never pass it, on either count.

**The owner.** `getWeightTruth(user, { clientMessage, windowDays })`. When withheld it does not read the rows at all. `getProgressTruth` calls it, so there is still one definition — same move as `sessionsSince`. `clientMessage` re-opens it for a direct question, so the three client-asked commands now say *why* they may answer instead of answering because nothing checked.

`handlers/safety.ts` keeps its own read, deliberately and permanently: a rapid-loss check that stands down on a do-not-mention request is the one place honouring it would be dangerous.

**One dead duplicate deleted.** `macro-card-attach`'s `weightChangeSinceStart` — zero callers, not exported, so GUARD #13 could not see it. Not a live leak; a loaded second definition in the module that renders **images**, where a text strip cannot reach.

**GUARD #15 — the ratchet.** Client-facing `weight_logs` reads **26 → 15**, budgeted at the measured figure, may only fall. The fifteen remaining are itemised with what each waits on: 6 read only `loggedAt` for trend-usability (P0-7), 6 already apply the rule in-file, 2 feed `chooseAction`'s own gate, 1 is a target computation.

**Acceptance** — behavioural, each prohibition paired with the identical fixture minus the request:

| case | expected |
|---|---|
| `doNotMention: "weight"` | no kg figure in the model's context — **and not told one is withheld**, since that invites the question |
| same client, no request | **does** get the figure |
| withheld client who asks | is answered |
| sign convention | negative still means lost |

One of these caught its own fixture: reassigning `__KAMLIFE_STUB_USER` turned two unrelated checks red, because they run concurrently and read that global. The user is passed, never written.

---

# 3. Test determinism (`0a25a2f`)

Two parity cases were **red on `main@266a8c2b` today and green in the CI that merged #54 yesterday**, with no product change between. Both graded weekday-relative fixtures against calendar-fixed expectations. No product code.

---

## Suite

`26/28`, the pre-existing baseline (`check-file-sizes`, `check-architecture` — same lines as #53/#54). `authorshipPoints` **426 → 425**. No budget raised, nothing suppressed.

## The principle this slice earned

> A canonical owner isn't enough. Its callers must use it — and the test proving that must be capable of failing.

Both halves of that were false in this repo this week. Both are now enforced: GUARD #15 counts the callers, and the PROBE proves the instrument can fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa