### PR TITLE
P0-5 · food: one SAST day boundary, in SQL too

### DIFF
--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -114,6 +114,26 @@ const BUDGET = {
    */
   directWeightReads: 15,
   /**
+   * GUARD #16 — see handRolledDayBuckets above. SQL that decides which SAST day a ledger row
+   * belongs to, written somewhere other than the owner.
+   *
+   * MEASURED 7 on main@86f1c1e1, 5 after this cut. FOUR different spellings of one rule:
+   *
+   *   early-commands.ts   ×2   DATE(logged_at + INTERVAL '2 hours')                   correct
+   *   food-scanner.ts     ×2   to_char(logged_at + interval '2 hours', 'YYYY-MM-DD')  correct
+   *   one-action-cmd.ts   ×1   DATE(logged_at AT TIME ZONE 'UTC' + INTERVAL …)        correct
+   *   gpt.ts              ×2   DATE(logged_at)                                        WRONG — UTC
+   *
+   * The two wrong ones are gone; they take the bucket from sastDayBucketSql now. The five that
+   * remain are CORRECT TODAY and are still counted, deliberately. Four correct copies of a rule is
+   * exactly the state this repo was in when the fifth was written as DATE(logged_at) and nobody
+   * noticed for months — and it is the state client-snapshot.ts was fixed out of in August without
+   * the rule itself ever getting a home.
+   *
+   * LOWER THIS by moving them onto the owner. Never raise it.
+   */
+  handRolledDayBuckets: 5,
+  /**
    * GUARD #9 — AUTHORSHIP POINTS (2026-08-04). Every `return "…"` in server/ is a place
    * something other than the engine can put words in front of a client.
    *
@@ -681,6 +701,48 @@ function directLedgerReads(table: string, writers: string[]): string[] {
   return hits;
 }
 
+/**
+ * GUARD #16 — ONE DAY BOUNDARY, INCLUDING IN SQL (2026-08-25, P0-5 · food).
+ *
+ * `sastDayKey` has owned "which SAST day is this" in TypeScript since the SAST cut. A query that
+ * GROUPs BY day asks the same question in SQL, and TypeScript ownership does not reach it — so
+ * three different answers grew, measured on main@86f1c1e1:
+ *
+ *   early-commands   DATE(logged_at + INTERVAL '2 hours')          SAST
+ *   food-scanner     to_char(logged_at + interval '2 hours', …)    SAST
+ *   gpt.ts (×2)      DATE(logged_at)                               UTC   ← wrong
+ *
+ * South Africa is UTC+2, no DST, so the UTC form pulls a supper logged after 22:00 UTC — midnight
+ * SAST — back into the previous day. Two SAST days merge into one, changing the daily totals and
+ * the divisor they are averaged over. The Coach was handed "avg 120g, target hit" for a client the
+ * owner scores at "avg 60g, target missed".
+ *
+ * This is the SECOND time the same bug has been fixed: client-snapshot.ts carries a comment dated
+ * 2026-08-13 describing it exactly. Fixing the site and not the rule is what let it survive in
+ * gpt.ts, so the rule now has one home — sastDayBucketSql in day-ledger.ts — and this refuses a
+ * second spelling of it.
+ *
+ * SCOPE: SQL day-bucketing over a LEDGER table, in files that speak to a client. The owner is
+ * exempt because it is the definition. A bare `DATE(...)` on any other expression is not matched —
+ * this guard is about the ledger's day boundary, not about SQL style.
+ */
+const DAY_BUCKET_SQL = /(?:DATE|to_char|date_trunc)\s*\(\s*\$\{(?:mealLogs|stepLogs|workoutLogs|weightLogs)\./gi;
+function handRolledDayBuckets(): string[] {
+  const out: string[] = [];
+  for (const f of files) {
+    if (f === "server/day-ledger.ts" || f === "server/day-ledger-core.ts") continue;
+    const clientFacing = f.startsWith("server/handlers/") || f.startsWith("server/brain/")
+      || f.startsWith("server/scheduler/") || f.startsWith("server/understanding/")
+      || f.startsWith("server/verifiers/") || f === "server/gpt.ts";
+    if (!clientFacing) continue;
+    const src = readFileSync(f, "utf-8").split("\n");
+    src.forEach((ln, i) => {
+      if (new RegExp(DAY_BUCKET_SQL.source, "i").test(ln)) out.push(`${f}:${i + 1}  ${ln.trim().slice(0, 88)}`);
+    });
+  }
+  return out;
+}
+
 const files = [...walk("server"), ...walk("shared")];
 const read = (f: string) => readFileSync(f, "utf-8");
 const all = files.map(read);
@@ -708,6 +770,8 @@ const actual = {
   localDecisionSenders: unclassifiedSenders().legacy,
   /** Client-facing reads of weight_logs that bypass getWeightTruth. See GUARD #15. */
   directWeightReads: directLedgerReads("weightLogs", DOMAIN_WRITERS.weight).length,
+  /** Hand-rolled SQL day buckets over a ledger table. See GUARD #16. */
+  handRolledDayBuckets: handRolledDayBuckets().length,
   // EVERY PLACE THAT TALKS TO TWILIO DIRECTLY (2026-08-05).
   //
   // Twilio is a reseller of Meta's WhatsApp API, not the destination — OUTSTANDING.md has

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2637,6 +2637,67 @@ async function main() {
       `sign convention broke: ${out.open.changeKg}`);
   });
 
+  // ── P0-5 · FOOD · ONE SAST DAY BOUNDARY, IN SQL TOO (2026-08-25) ──────────────────────────
+  //
+  // The exact case that exposed the defect. `sastDayKey` has owned "which day is this" in
+  // TypeScript for months; a GROUP BY answers the same question in SQL, and gpt.ts answered it
+  // with DATE(logged_at) — the UTC day — while every other food surface used SAST.
+  //
+  // South Africa is UTC+2 with no DST, so a supper logged after 22:00 UTC is 00:00+ SAST: the UTC
+  // bucket pulls it BACK into the previous day. Two SAST days become one, which changes the daily
+  // totals AND the divisor they are averaged over.
+  check("P0-5 food . the SAST day bucket is one rule, and it is not the UTC day", async () => {
+    const { sastDayKey } = await import("../server/sast");
+
+    // Dinner 21:00 SAST and a late snack 00:30 SAST — two SAST days, ONE UTC day.
+    const dinner = new Date("2026-08-20T19:00:00Z");   // 21:00 SAST on the 20th
+    const lateSnack = new Date("2026-08-20T22:30:00Z");  // 00:30 SAST on the 21st
+
+    const utcDay = (d: Date) => d.toISOString().slice(0, 10);
+    assert.equal(utcDay(dinner), utcDay(lateSnack),
+      "fixture broken: these must share a UTC day, or the case proves nothing");
+    assert.notEqual(sastDayKey(dinner), sastDayKey(lateSnack),
+      "fixture broken: these must be different SAST days");
+    assert.equal(sastDayKey(lateSnack), "2026-08-21", "the small-hours meal belongs to the NEXT SAST day");
+
+    // The consequence, stated as the numbers the model is handed. 70g + 50g against a 140g target.
+    const sastBuckets = [dinner, lateSnack].reduce((m, d, i) => {
+      const k = sastDayKey(d); m.set(k, (m.get(k) || 0) + [70, 50][i]); return m;
+    }, new Map<string, number>());
+    const utcBuckets = [dinner, lateSnack].reduce((m, d, i) => {
+      const k = utcDay(d); m.set(k, (m.get(k) || 0) + [70, 50][i]); return m;
+    }, new Map<string, number>());
+    const avg = (m: Map<string, number>) => Math.round([...m.values()].reduce((a, b) => a + b, 0) / m.size);
+    const compliant = (m: Map<string, number>) => [...m.values()].filter(p => p >= 140 * 0.8).length;
+
+    assert.equal(sastBuckets.size, 2); assert.equal(avg(sastBuckets), 60); assert.equal(compliant(sastBuckets), 0);
+    assert.equal(utcBuckets.size, 1); assert.equal(avg(utcBuckets), 120); assert.equal(compliant(utcBuckets), 1);
+  });
+
+  // …and the SQL the owner hands out actually shifts. A rule stated only in TypeScript is how the
+  // two boundaries diverged in the first place.
+  check("P0-5 food . the owner's SQL day bucket shifts to SAST, and gpt.ts uses it", async () => {
+    const { sastDayBucketSql } = await import("../server/day-ledger");
+    const { mealLogs } = await import("../shared/schema");
+    // Read the literal chunks of the fragment. JSON.stringify cannot be used — a drizzle SQL
+    // object holds a column reference and is circular.
+    const frag = sastDayBucketSql(mealLogs.loggedAt as any) as any;
+    const rendered = (frag.queryChunks ?? [])
+      .flatMap((c: any) => (Array.isArray(c?.value) ? c.value : []))
+      .join(" ");
+    assert.match(rendered, /interval '2 hours'/i,
+      `the owner's day bucket does not shift to SAST: ${rendered.slice(0, 160)}`);
+    assert.match(rendered, /to_char/i, "the bucket must render a YYYY-MM-DD key, comparable to sastDayKey");
+
+    // THE REACHABILITY HALF. An owner nothing calls is the defect this repo keeps repeating, so
+    // this asserts the two client-facing food claims no longer carry their own UTC rule.
+    const gpt = readFileSync("server/gpt.ts", "utf-8");
+    assert.ok(!/DATE\(\$\{mealLogs\.loggedAt\}\)/.test(gpt),
+      "gpt.ts still buckets meals by the UTC calendar day");
+    assert.equal((gpt.match(/sastDayBucketSql\(mealLogs\.loggedAt\)/g) || []).length, 4,
+      "both food claims must take the bucket from the owner, in select AND group by");
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -14,6 +14,7 @@
 import { db } from "./db";
 import { mealLogs, stepLogs, users, workoutLogs, weightLogs } from "../shared/schema";
 import { and, eq, gte, lt, desc, sql } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { sastDayStart, sastToday } from "./utils";
 import { sastDayKey } from "./sast";
 import { foldLedgerRows, freshTodayWater, foldWindowRows, weightChangeKg, summariseProvenance,
@@ -504,6 +505,46 @@ export interface ProgressTruth {
   /** How much of this window we actually KNOW — db / label / ai / photo / unknown, and the
    *  confidence that falls out of it. Known / likely / unknown, measured rather than asserted. */
   provenance: FoodProvenance;
+}
+
+/**
+ * WHICH SAST DAY A ROW BELONGS TO, IN SQL (2026-08-25, P0-5 · food).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE DEFECT THIS EXISTS TO STOP
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * `sastDayKey` has owned "which day is this" in TypeScript since the SAST cut. A query that
+ * GROUPs BY day answers the same question in SQL, and there were three different answers to it
+ * in this repo, measured on main@86f1c1e1:
+ *
+ *   early-commands.ts   DATE(logged_at + INTERVAL '2 hours')            SAST ✓
+ *   food-scanner.ts     to_char(logged_at + interval '2 hours', …)      SAST ✓
+ *   gpt.ts  (×2)        DATE(logged_at)                                 UTC  ✗
+ *
+ * South Africa is UTC+2 and observes no DST, so `DATE(logged_at)` on a UTC timestamp is the UTC
+ * calendar day. A meal eaten between 22:00 and 23:59 UTC — that is 00:00 to 01:59 SAST, an
+ * ordinary late supper here — is pulled BACK into the previous day's bucket. Two SAST days become
+ * one, which changes both the daily totals and the number of days they are averaged over:
+ *
+ *   dinner 21:00 SAST (70g) + late snack 00:30 SAST (50g), target 140g
+ *     SAST (owner)  →  2 logged days, avg  60g, 0 days at ≥80% of target
+ *     UTC  (gpt.ts) →  1 logged day,  avg 120g, 1 day  at ≥80% of target
+ *
+ * Those two numbers reach the model as "Average protein logged is …" and as protCompliance28,
+ * which drives the trajectory label. The Coach reads the client's week differently depending on
+ * which of the three rules the query happened to use.
+ *
+ * THIS IS THE SECOND TIME. client-snapshot.ts carries a comment dated 2026-08-13 describing the
+ * identical bug — "this file grouped the protein average by UTC and the 7-day story by SAST" —
+ * and fixing it there is what this repo does instead of fixing the rule. So the rule now has one
+ * home, and GUARD #16 refuses a second spelling of it.
+ *
+ * Returns text (YYYY-MM-DD) so it matches sastDayKey's output exactly, and so a caller can join
+ * or compare against a TypeScript day key without a cast.
+ */
+export function sastDayBucketSql(col: AnyPgColumn) {
+  return sql<string>`to_char(${col} + interval '2 hours', 'YYYY-MM-DD')`;
 }
 
 /**

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -365,7 +365,6 @@ export async function buildPatternSummary(user: any): Promise<string> {
     const foodLogs = recentChats.filter(c => c.intent === "FOOD_LOG");
     let avgProtein: number | null = null;
     try {
-      // Same owner bucket: the boundary decides the divisor as well as the totals (P0-5).
       const dailyProtein = await db.select({
         day: sastDayBucketSql(mealLogs.loggedAt),
         protein: sql<number>`COALESCE(SUM(${mealLogs.proteinInt}), 0)::int`,

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -11,7 +11,7 @@ import { patternCache, PATTERN_CACHE_TTL_MS } from "./cache";
 import { getClientNarrative } from "./intelligence/profile";
 import { verifyBrainReply } from "./brain/reply-verifier";
 import { weightInContextLine } from "./weight-context";
-import { getWeightTruth } from "./day-ledger";
+import { getWeightTruth, sastDayBucketSql } from "./day-ledger";
 import { captureQualitySignal } from "./quality-signals";
 import { verifyMealEstimate } from "./verifiers/meal-verifier";
 import { assertAiOnline, isAiOfflineError } from "./ai-offline";
@@ -345,13 +345,13 @@ export async function buildPatternSummary(user: any): Promise<string> {
         .from(workoutLogs)
         .where(and(eq(workoutLogs.userId, user.id), gte(workoutLogs.loggedAt, twentyEightDaysAgo)))
         .catch(() => [{ count: 0 }]),
-      // 28-day protein compliance — days at ≥80% of target
+      // 28-day protein compliance. Day bucket from the owner — was DATE(), the UTC day (P0-5).
       db.select({
-        day: sql<string>`DATE(${mealLogs.loggedAt})`,
+        day: sastDayBucketSql(mealLogs.loggedAt),
         total: sql<number>`COALESCE(SUM(${mealLogs.proteinInt}), 0)::int`,
       }).from(mealLogs)
         .where(and(eq(mealLogs.userId, user.id), gte(mealLogs.loggedAt, twentyEightDaysAgo)))
-        .groupBy(sql`DATE(${mealLogs.loggedAt})`)
+        .groupBy(sastDayBucketSql(mealLogs.loggedAt))
         .catch(() => [] as { day: string; total: number }[]),
     ]);
 
@@ -365,13 +365,14 @@ export async function buildPatternSummary(user: any): Promise<string> {
     const foodLogs = recentChats.filter(c => c.intent === "FOOD_LOG");
     let avgProtein: number | null = null;
     try {
+      // Same owner bucket: the boundary decides the divisor as well as the totals (P0-5).
       const dailyProtein = await db.select({
-        day: sql<string>`DATE(${mealLogs.loggedAt})`,
+        day: sastDayBucketSql(mealLogs.loggedAt),
         protein: sql<number>`COALESCE(SUM(${mealLogs.proteinInt}), 0)::int`,
       })
         .from(mealLogs)
         .where(and(eq(mealLogs.userId, user.id), gte(mealLogs.loggedAt, sevenDaysAgo)))
-        .groupBy(sql`DATE(${mealLogs.loggedAt})`);
+        .groupBy(sastDayBucketSql(mealLogs.loggedAt));
       const dailyTotals = dailyProtein.map(d => d.protein).filter(p => p > 0);
       if (dailyTotals.length >= 2) {
         avgProtein = Math.round(dailyTotals.reduce((a, b) => a + b, 0) / dailyTotals.length);


### PR DESCRIPTION
From `main@86f1c1e1`. Two lines of behaviour change, one owner, one guard.

## The rule, and the four spellings of it

`sastDayKey` has owned *"which SAST day is this"* in TypeScript since the SAST cut. A `GROUP BY` asks the same question in SQL, where TypeScript ownership does not reach. Four different spellings had grown — one of them wrong:

| file | spelling | day |
|---|---|---|
| `early-commands.ts` ×2 | `DATE(logged_at + INTERVAL '2 hours')` | SAST ✓ |
| `food-scanner.ts` ×2 | `to_char(logged_at + interval '2 hours', …)` | SAST ✓ |
| `one-action-command.ts` ×1 | `DATE(logged_at AT TIME ZONE 'UTC' + …)` | SAST ✓ |
| **`gpt.ts` ×2** | **`DATE(logged_at)`** | **UTC ✗** |

*(Correction to my earlier report: four spellings, not three. I missed the `one-action-command.ts` form on the first pass.)*

## Why it matters

South Africa is UTC+2 with no DST, so `DATE(logged_at)` is the **UTC** calendar day. A supper logged after 22:00 UTC — midnight SAST, an ordinary late meal here — is pulled **back** into the previous day's bucket. Two SAST days merge into one, changing the daily totals *and* the divisor they are averaged over:

```
dinner 21:00 SAST (70g) + late snack 00:30 SAST (50g), target 140g

  SAST (owner)   2 logged days,  avg  60g,  0 days at ≥80% of target
  UTC  (gpt.ts)  1 logged day,   avg 120g,  1 day  at ≥80% of target
```

Both numbers are **reachable and client-affecting**. `buildPatternSummary` runs on the live reply path and hands the model `Average protein logged is at or above target (avg 120g vs 140g)`; the 28-day figure drives `protCompliance28`, which drives the trajectory label. The Coach read the client's week differently depending on which spelling the query happened to use.

## The second time

`client-snapshot.ts` carries a comment dated **2026-08-13** describing this exact bug — *"this file grouped the protein average by UTC and the 7-day story by SAST, so a meal logged at 00:30 SAST landed on yesterday in the numbers and today in the story."*

It was fixed **there**, and the rule was never given a home — which is why `gpt.ts` kept it. Same shape as the test-harness defect last week: the repair existed, was written down, and the next site was left behind.

## The fix

`sastDayBucketSql` in `day-ledger.ts` — one definition, returning `YYYY-MM-DD` so it matches `sastDayKey` exactly and can be compared against a TypeScript day key without a cast. `gpt.ts`'s two reads take it.

## GUARD #16

Hand-rolled SQL day buckets over a ledger table, in client-facing files: **7 → 5**, may only fall.

The five that remain are **correct today and still counted, deliberately.** Four correct copies of a rule is precisely the state this repo was in when the fifth was written as `DATE(logged_at)` and nobody noticed for months.

## Acceptance

- **The boundary case itself** — two meals sharing a UTC day but *not* a SAST day, with the resulting buckets, averages and compliance counts asserted on both sides. The fixture asserts its own preconditions, so it cannot silently stop testing the boundary.
- **The reachability half** — `gpt.ts` carries no `DATE(mealLogs.loggedAt)`, and takes the bucket from the owner in both `select` and `group by`.
- **Negative controls, both run:** reverting the fix turns the case RED (`gpt.ts still buckets meals by the UTC calendar day`); adding a sixth spelling moves GUARD #16 to `6 — budget 5`.

## Not in this PR, by instruction

`food-commands.ts:329` divides protein by 7 calendar days where the owner's rule is per **logged** day. It gates a *"protein gap detected"* warning rather than printing a figure, so it can produce a false warning but not a wrong number. Filed for the food follow-up rather than mixed in here.

## Suite

`26/28` — the known baseline. `check-file-sizes` and `check-architecture` only, same lines as #53/#54/#55. `gpt.ts` held at **1471**, its post-#55 baseline. No budget raised, nothing suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_