### PR TITLE
Outbound floor: judge only the numbers it can adjudicate

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2698,6 +2698,80 @@ async function main() {
       "both food claims must take the bucket from the owner, in select AND group by");
   });
 
+  // ── THE FLOOR MAY ONLY JUDGE WHAT IT CAN ACTUALLY ADJUDICATE (2026-08-25) ─────────────────
+  //
+  // PR #54 gave this rule authority over outbound communication without giving it enough
+  // information to know what each number MEANS. It extracted every session-shaped number and
+  // required all of them to equal the 7-day ledger count, so "Training: 2/4 sessions" read as a
+  // claim of 2 AND 4 — and the weekly Report Card was blocked for every client whose sessions did
+  // not exactly equal their target. These are the real message bodies, through the real floor.
+  check("floor . a real Report Card is not blocked by its own target", async () => {
+    const { enforceOutboundTruth } = await import("../server/outbound-authority");
+    const { workoutLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+
+    const REPORT_CARD = [
+      "*Kam — Week 5 Report Card*", "",
+      "📅 Showed up: 5/7 days",
+      "💪 Training: 2/4 sessions",
+      "👟 Steps: 7,400 avg (87% of 8,500 target)",
+      "", "*Weekly Score: 68/100 — Building*",
+    ].join("\n");
+
+    const out = await serialise(async () => {
+      // The record genuinely holds 2 sessions in the window.
+      g.__KAMLIFE_STUB_ROWS = new Map([[workoutLogs, [{ n: 2 }]]]);
+      const r = {
+        card: await enforceOutboundTruth(USER.id, "whatsapp:+27000000401", REPORT_CARD),
+        milestone: await enforceOutboundTruth(USER.id, "whatsapp:+27000000402", "🏆 30 total sessions — milestone"),
+        bank: await enforceOutboundTruth(USER.id, "whatsapp:+27000000403", "Kam, Week 5 — 24 sessions in the bank."),
+        truthful: await enforceOutboundTruth(USER.id, "whatsapp:+27000000404", "That's 2 sessions this week — let's build on it."),
+        lying: await enforceOutboundTruth(USER.id, "whatsapp:+27000000405", "Strong week — that's 4 sessions in the bag."),
+      };
+      delete g.__KAMLIFE_STUB_ROWS;
+      return r;
+    });
+
+    // THE THREE THAT WERE BEING SUPPRESSED.
+    assert.ok(out.card.ok,
+      `the weekly Report Card was blocked by its own target: ${out.card.detail}`);
+    assert.ok(out.milestone.ok,
+      `a lifetime milestone was judged against a 7-day count: ${out.milestone.detail}`);
+    assert.ok(out.bank.ok,
+      `a lifetime total was judged against a 7-day count: ${out.bank.detail}`);
+    // …AND THE RULE STILL DOES ITS JOB. Without this the fix could be "adjudicate nothing".
+    assert.ok(out.truthful.ok, `a truthful windowed count was blocked: ${out.truthful.detail}`);
+    assert.ok(!out.lying.ok && out.lying.reason === "session_count_contradicts_record",
+      "a false session count reached a client — the rule this floor exists for is gone");
+    assert.match(String(out.lying.detail), /said 4, record holds 2/,
+      `the block names the wrong number: ${out.lying.detail}`);
+  });
+
+  // The claim reader on its own, so a future change to the message bodies cannot quietly move the
+  // property. Each line is a real string from a real sender.
+  check("floor . the claim reader tells a count from a target from a lifetime", async () => {
+    const { adjudicableSessionCounts } = await import("../server/brain/reply-verifier");
+    // ADJUDICABLE — a plain count of completed sessions.
+    assert.deepEqual(adjudicableSessionCounts("Strong week — that's 4 sessions in the bag."), [4]);
+    assert.deepEqual(adjudicableSessionCounts("💪 Training: 2/4 sessions"), [2],
+      "the denominator of N/M is the target, not a second claim");
+    // NOT ADJUDICABLE — a span the 7-day ledger cannot speak to.
+    for (const lifetime of ["🏆 30 total sessions — milestone", "Week 5 — 24 sessions in the bank",
+                            "12 sessions since you started", "8 sessions altogether"]) {
+      assert.deepEqual(adjudicableSessionCounts(lifetime), [],
+        `a lifetime count was offered up for a 7-day comparison: ${lifetime}`);
+    }
+    // NOT ADJUDICABLE — a target, named as one.
+    for (const target of ["Target for this week: 4 sessions", "3 of 4 planned sessions done"]) {
+      assert.deepEqual(adjudicableSessionCounts(target), [],
+        `a target was read as a claim about completed sessions: ${target}`);
+    }
+    // SEGMENT-WISE. A lifetime line must not silence the adjudicable line beside it.
+    assert.deepEqual(
+      adjudicableSessionCounts("🏆 30 total sessions — milestone\nThat's 4 sessions in the bag."),
+      [4], "one lifetime line swallowed the whole message");
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/script/reply-context-verifier-tests.ts
+++ b/script/reply-context-verifier-tests.ts
@@ -14,10 +14,36 @@ const reported = verifyBrainReply(
 );
 assert.equal(reported.ok, true);
 
-const question = verifyBrainReply(
+// PHRASING IS NOT PROVENANCE (assertion repaired 2026-08-25).
+//
+// This asserted that asking "how many steps have I done today?" made ANY figure in the reply
+// valid — the rule `if (isExplicitStepQuery(clientMessage)) return { ok: true }`, deliberately
+// deleted on 2026-08-21 because it let the coach confirm a number nobody held as long as the
+// client had phrased their message as a question. The reason is recorded in reply-verifier.ts
+// beside the removal.
+//
+// So the case has been RED on main ever since, and nothing showed it: decision-engine-p0 is
+// path-triggered on six files and no PR touched one until today. The test outlived the rule it
+// was written for.
+//
+// What is asserted now is the contract that replaced it — validity comes from what we HOLD, not
+// from how the client asked. Both directions, so this cannot pass by refusing everything.
+const questionWithoutEvidence = verifyBrainReply(
   "You are on 12,770 steps today.",
   { goalType: "fat_loss", clientMessage: "How many steps have I done today?" },
 );
-assert.equal(question.ok, true);
+assert.equal(questionWithoutEvidence.ok, false,
+  "a step figure nobody held passed because the client happened to ask a question");
 
-console.log("reply-context-verifier-tests: 3/3 passed");
+const questionWithEvidence = verifyBrainReply(
+  "You are on 12,770 steps today.",
+  {
+    goalType: "fat_loss",
+    clientMessage: "How many steps have I done today?",
+    evidence: { stepsToday: 12770 },
+  },
+);
+assert.equal(questionWithEvidence.ok, true,
+  "a figure we actually hold for today was refused — recital is not invention");
+
+console.log("reply-context-verifier-tests: 4/4 passed");

--- a/server/brain/reply-verifier.ts
+++ b/server/brain/reply-verifier.ts
@@ -284,7 +284,7 @@ function isExplicitStepQuery(text: string): boolean {
  * happened — and the CLIENT_DID_IT guard below is what stops that becoming a hole, because
  * "you've done three sessions this week" says a target word and is still an attribution.
  */
-const TARGET_MARKER = /\btargets?\b|\bgoals?\b|\baim\s+for\b|\/\s*day\b|\bper\s+day\b|\ba\s+day\b|\bnon-negotiable\b|\/\s*week\b|\bper\s+week\b|\ba\s+week\b|\bweekly\b/i;
+const TARGET_MARKER = /\btargets?\b|\bgoals?\b|\bplanned\b|\baim\s+for\b|\/\s*day\b|\bper\s+day\b|\ba\s+day\b|\bnon-negotiable\b|\/\s*week\b|\bper\s+week\b|\ba\s+week\b|\bweekly\b/i;
 
 /**
  * …and it stops being prescriptive the moment it also says the CLIENT DID IT. "You did 6,000
@@ -306,6 +306,64 @@ function withoutTargetSegments(reply: string): string {
 }
 
 /**
+ * WHICH SESSION NUMBERS MAY BE ADJUDICATED AGAINST A WINDOWED COUNT (2026-08-25).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE DEFECT THIS EXISTS TO STOP
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * The outbound truth floor (PR #54) took EVERY session-shaped number out of a message and
+ * required all of them to equal the 7-day ledger count. `sessionCountsIn` is a pure extractor —
+ * it answers "what session numbers appear here", which is not the same question as "what does
+ * this message CLAIM about completed sessions in the window we hold".
+ *
+ * Given authority over outbound communication without that distinction, the floor suppressed
+ * legitimate messages. Measured against a ledger genuinely holding 2 sessions:
+ *
+ *   "💪 Training: 2/4 sessions"     → extracted [2, 4] → BLOCKED (4 is the TARGET)
+ *   "🏆 30 total sessions"          → extracted [30]   → BLOCKED (30 is a LIFETIME)
+ *
+ * The first of those is the weekly Report Card, blocked for every client whose sessions did not
+ * exactly equal their target — which is nearly all of them, every week, since #54 merged.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE RULE
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Only validate a number the message presents as a COUNT OF COMPLETED SESSIONS in the window the
+ * record represents. Two things are therefore removed before extraction, both segment-wise so a
+ * neighbouring line cannot lend its meaning:
+ *
+ *   the denominator of N/M    "2/4 sessions" states one count and one target. The count is 2.
+ *   a lifetime segment        "30 total sessions", "24 in the bank" — real numbers about a span
+ *                             the 7-day ledger cannot speak to. Refusing to adjudicate is not
+ *                             the same as approving: it means this rule is not the right judge.
+ *
+ * A segment naming a TARGET is dropped whole rather than partially read. That is the conservative
+ * direction on purpose: the cost of not adjudicating is a number that goes unchecked by THIS rule,
+ * and the cost of mis-adjudicating is a true message the client never receives.
+ *
+ * Everything else still adjudicates, so the case this floor was built for is untouched:
+ * "that's 4 sessions in the bag" against a record of 1 is still refused.
+ *
+ * NO NEW MATCHERS. Both halves of this already had an owner in this file — TARGET_MARKER for "this
+ * segment is prescriptive" and OUT_OF_WINDOW for "this names a span we do not hold". Writing a
+ * third and a fourth would have been the exact duplication the day-bucket cut just finished
+ * removing, so each was extended by the forms it was missing instead: `planned` on the first,
+ * and the session-specific lifetime phrasings on the second. Both extensions are session-shaped
+ * or unambiguous, so neither widens what the step verifier rejects.
+ */
+export function adjudicableSessionCounts(text: string): number[] {
+  return String(text || "")
+    .split(/(\n+|(?<=[.!?])\s+)/)
+    .filter(seg => !OUT_OF_WINDOW.test(seg) && !TARGET_MARKER.test(seg))
+    // "2/4 sessions" — keep the numerator, drop the denominator. The trailing space matters:
+    // without it "2/4" would become "24".
+    .map(seg => seg.replace(/(\d{1,2})\s*\/\s*\d{1,2}/g, "$1 "))
+    .flatMap(seg => sessionCountsIn(seg));
+}
+
+/**
  * DOES THIS CLAIM NAME A WINDOW WE MEASURED? One question, one owner (merged 2026-08-22).
  *
  * Steps are held as a DAILY total, sessions as a rolling multi-day count, and the failure is
@@ -315,7 +373,7 @@ function withoutTargetSegments(reply: string): string {
  * matcher gave each rule half a guard — the step rule could not see "this month" and the session
  * rule could not see "this morning" — so it is one list of the windows we do not hold.
  */
-const OUT_OF_WINDOW = /\b(?:before|after|by)\s+(?:lunch|breakfast|dinner|noon|midday|\d{1,2}\s?(?:am|pm))\b|\bthis (?:morning|afternoon|evening)\b|\bin the (?:morning|afternoon|evening)\b|\bper hour\b|\bsince (?:lunch|breakfast|this morning)\b|\b(?:this|last|the past|next)\s+month\b|\bin total\b|\ball[\s-]?time\b|\bsince you (?:started|began|joined)\b|\bthis year\b|\baltogether\b/i;
+const OUT_OF_WINDOW = /\b(?:before|after|by)\s+(?:lunch|breakfast|dinner|noon|midday|\d{1,2}\s?(?:am|pm))\b|\bthis (?:morning|afternoon|evening)\b|\bin the (?:morning|afternoon|evening)\b|\bper hour\b|\bsince (?:lunch|breakfast|this morning)\b|\b(?:this|last|the past|next)\s+month\b|\bin total\b|\ball[\s-]?time\b|\bsince you (?:started|began|joined)\b|\bthis year\b|\baltogether\b|\blifetime\b|\bin the bank\b|\btotal\s+(?:workouts?|sessions?|trainings?)\b/i;
 
 function verifyStepAttribution(reply: string, clientMessage: string, evidence?: VerifierFacts["evidence"]): VerifierResult {
   const replySteps = extractStepNumbers(withoutTargetSegments(reply));

--- a/server/outbound-authority.ts
+++ b/server/outbound-authority.ts
@@ -37,9 +37,9 @@
  * missed message, so a proactive send that fails this floor is dropped and recorded.
  */
 
-import { sessionCountsIn } from "./utils";
 import { isDuplicateOutbound } from "./reply-hygiene";
 import { readHeldConstraints, asksForFoodToday, asksForTrainingToday } from "./held-constraints";
+import { adjudicableSessionCounts } from "./brain/reply-verifier";
 
 export interface OutboundVerdict {
   /** May this leave the building? */
@@ -70,16 +70,25 @@ export async function enforceOutboundTruth(
   //    history the log denies since 2026-08-22; a weekly or programme message asserting the same
   //    number was never checked at all. Opt-in: this only reads the ledger when the text actually
   //    asserts a count, so the common send pays nothing.
-  const claimed = sessionCountsIn(body);
+  // ONLY WHAT THIS RULE CAN ACTUALLY JUDGE (2026-08-25). This called sessionCountsIn — a pure
+  // extractor answering "what session numbers appear here", which is NOT "what does this message
+  // claim about completed sessions in the window we hold". The difference blocked the weekly
+  // Report Card for every client whose sessions did not exactly equal their target, because
+  // "Training: 2/4 sessions" reads as a claim of both 2 AND 4. See adjudicableSessionCounts.
+  const claimed = adjudicableSessionCounts(body);
   if (claimed.length > 0 && userId) {
     try {
       const { sessionsSince } = await import("./day-ledger");
       const held = await sessionsSince(userId, SESSION_WINDOW_DAYS);
-      if (!claimed.every(n => n === held)) {
+      const wrong = claimed.find(n => n !== held);
+      if (wrong !== undefined) {
         return {
           ok: false,
           reason: "session_count_contradicts_record",
-          detail: `said ${claimed[0]}, record holds ${held} in ${SESSION_WINDOW_DAYS} days`,
+          // THE NUMBER THAT ACTUALLY FAILED. This printed claimed[0], so a body claiming [2, 4]
+          // against a record of 2 was refused with "said 2, record holds 2" — a log line that
+          // reads as the floor malfunctioning at random and hides which claim was the problem.
+          detail: `said ${wrong}, record holds ${held} in ${SESSION_WINDOW_DAYS} days`,
         };
       }
     } catch (e: any) {


### PR DESCRIPTION
From `main@246d77f3`. Fixes a **live defect I introduced in PR #54**.

## What is broken on `main` right now

`enforceOutboundTruth` rule 1 called `sessionCountsIn` — a pure extractor answering *"what session numbers appear here"* — and required **all** of them to equal the 7-day ledger count.

That is not the same question as *"what does this message claim about completed sessions in the window we hold"*. Measured against a ledger genuinely holding 2 sessions:

```
Sunday Report Card   ok=false  session_count_contradicts_record  said 2, record holds 2 in 7 days
Friday wrap-up       ok=true
Milestone line       ok=false  session_count_contradicts_record  said 30, record holds 2 in 7 days
```

`"💪 Training: 2/4 sessions"` parses as `[2, 4]`. The count matches; the **target** cannot.

- **The weekly Report Card has been blocked for every client whose sessions ≠ target** — nearly all of them, every week, since #54 merged.
- **Every lifetime count is blocked**: `🏆 30 total sessions`, `24 sessions in the bank`, `N sessions done`. Affects `programme.ts` phase advancement and the Week-4/weekly check-ins, `monday.ts`, and `business.ts`'s payment-pause alert.
- **The diagnostic hid it.** `detail` printed `claimed[0]`, so a body claiming `[2, 4]` against a record of 2 was refused with *"said 2, record holds 2"* — reading as random malfunction rather than a rule with a bug.

Three bugs in one rule, all mine.

## The rule now

> Only validate a number the message presents as a **count of completed sessions in the window the record represents.**

Removed before extraction, segment-wise so a neighbouring line cannot lend its meaning:

| removed | why |
|---|---|
| the denominator of `N/M` | `2/4 sessions` states one count and one target. The count is 2. |
| a lifetime segment | a span the 7-day ledger cannot speak to. Refusing to adjudicate ≠ approving — it means this rule is not the right judge. |

Dropping a target segment whole is the conservative direction **on purpose**: an unchecked number costs less than a true message the client never receives.

Everything the floor was built for is untouched — `"that's 4 sessions in the bag"` against a record of 1 is still refused, and the block now names **4**.

## No new matchers

Both halves already had an owner in `reply-verifier.ts`: `TARGET_MARKER` ("this segment is prescriptive") and `OUT_OF_WINDOW` ("this names a span we do not hold").

My first attempt wrote a third and a fourth — exactly the duplication the day-bucket cut just removed — and `regexLiterals` went **449 → 451**. Rather than raise the budget, each existing matcher was extended by the forms it lacked: `planned` on the first, the session-specific lifetime phrasings on the second. Both are session-shaped or unambiguous, so neither widens what the step verifier rejects. **`regexLiterals` back to 449.**

## Acceptance

Real message bodies, through the real floor:

| body | expected |
|---|---|
| the full Report Card, ledger = 2 | **passes** |
| `🏆 30 total sessions — milestone` | **passes** |
| `Week 5 — 24 sessions in the bank` | **passes** |
| `That's 2 sessions this week` , ledger = 2 | **passes** |
| `that's 4 sessions in the bag`, ledger = 2 | **refused**, detail says `said 4, record holds 2` |

Plus the claim reader alone, including the segment-wise case — a lifetime line must not silence the adjudicable line beside it.

**Negative control run:** restoring `sessionCountsIn` turns the Report Card case RED.

## Known, and deliberately not fixed here

`verifySessionAttribution` in the reactive path shares the blind spot — same extractor, same `claimed[0]` in its violation message. It fires only on model-authored replies carrying a session count, so the blast radius is far smaller. Reported rather than bundled, per the scope you set.

## Suite

`26/28`, the known baseline. No file grew; no counter rose. `check-file-sizes` and `check-architecture` show the same lines as #53–#56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_