### PR TITLE
Reactive verifier: the same claim reader as the outbound door

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2772,6 +2772,41 @@ async function main() {
       [4], "one lifetime line swallowed the whole message");
   });
 
+  // ── THE REACTIVE MOUTH READS CLAIMS THE SAME WAY THE DOOR DOES (2026-08-25) ───────────────
+  //
+  // #57 fixed the proactive floor. verifySessionAttribution composed its own half of the same
+  // rule — sessionCountsIn(withoutTargetSegments(reply)) — so it still read "Training: 2/4
+  // sessions" as a claim of 4, and still offered a lifetime total up against a 7-day count.
+  // Same defect, smaller blast radius: this runs on model prose only.
+  check("verifier . a model reply is judged on the counts it actually claims", async () => {
+    const { verifyBrainReply } = await import("../server/brain/reply-verifier");
+    const facts = (extra: Record<string, unknown> = {}) => ({
+      goalType: "fat_loss",
+      clientMessage: "how am I doing this week?",
+      evidence: { modelAuthored: true, sessionsWindow: 2, sessionsWindowDays: 7, ...extra },
+    });
+
+    // A TARGET IS NOT A CLAIM. The record holds 2; the reply states 2 done against a target of 4.
+    assert.ok(verifyBrainReply("You're at 2/4 sessions this week — one more and you're close.", facts()).ok,
+      "the model was corrected for naming its own target");
+
+    // A LIFETIME IS NOT A 7-DAY CLAIM — the whole-reply OUT_OF_WINDOW rule owns that refusal, and
+    // it must refuse rather than mis-compare. Either way it must not say "you said 30, we hold 2".
+    const lifetime = verifyBrainReply("That's 30 total sessions since you started.", facts());
+    assert.ok(!/says the client has done 30 training session/.test(lifetime.violation || ""),
+      `a lifetime total was compared against a 7-day count: ${lifetime.violation}`);
+
+    // THE RULE STILL BITES, and now names the number that failed.
+    const lying = verifyBrainReply("Strong week — that's 4 sessions in the bag.", facts());
+    assert.ok(!lying.ok, "a false session count passed the reactive mouth");
+    assert.match(lying.violation || "", /has done 4 training session/,
+      `the violation quotes the wrong figure: ${lying.violation}`);
+
+    // …and a truthful count still passes.
+    assert.ok(verifyBrainReply("That's 2 sessions this week — solid.", facts()).ok,
+      "a truthful count was corrected");
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/brain/reply-verifier.ts
+++ b/server/brain/reply-verifier.ts
@@ -445,10 +445,18 @@ function verifyStepAttribution(reply: string, clientMessage: string, evidence?: 
 function verifySessionAttribution(reply: string, clientMessage: string, evidence?: VerifierFacts["evidence"]): VerifierResult {
   // Deterministic replies recite counts they read themselves. Only model prose is held to this.
   if (!evidence?.modelAuthored) return { ok: true };
-  // ONE OWNER for "how many sessions does this text assert" — the same reader the workout writer
-  // consults before it refuses to invent rows. See utils.sessionCountsIn.
-  const claimed = sessionCountsIn(withoutTargetSegments(reply));
-  if (claimed.length === 0) return { ok: true };
+  // THE SAME CLAIM READER AS THE OUTBOUND FLOOR (2026-08-25). This composed
+  // sessionCountsIn(withoutTargetSegments(reply)) itself, which is one of the two halves — so
+  // "Training: 2/4 sessions" still read as a claim of 4 (the denominator is not a target SEGMENT,
+  // it is a number inside an otherwise ordinary one), and "30 total sessions" was offered up for
+  // comparison against a 7-day count. Identical to the defect that blocked the weekly Report Card
+  // at the proactive door; smaller blast radius here only because this runs on model prose.
+  // DOES THIS REPLY ASSERT A SESSION COUNT AT ALL — before deciding which ones are comparable.
+  // The order matters and an existing case proved it: dropping the lifetime segments FIRST made
+  // `claimed` empty for "1 workout in total since you started", which returned ok and shipped a
+  // count for a window we never measured. Out-of-window is a REFUSAL here, not an abstention.
+  const asserted = sessionCountsIn(withoutTargetSegments(reply));
+  if (asserted.length === 0) return { ok: true };
 
   const held = evidence?.sessionsWindow;
   const windowDays = Number(evidence?.sessionsWindowDays) || 0;
@@ -456,8 +464,16 @@ function verifySessionAttribution(reply: string, clientMessage: string, evidence
     if (OUT_OF_WINDOW.test(reply)) {
       return { ok: false, violation: `Your reply states a training count for a period we did not count. What the record holds is ${held} session(s) in the last ${windowDays} days — nothing about a month, a year, or a lifetime total. Say the window we actually know, or say nothing about the count.` };
     }
-    if (claimed.every(n => n === held)) return { ok: true };
-    return { ok: false, violation: `Your reply says the client has done ${claimed[0]} training session(s), but the record holds ${held} in the last ${windowDays} days. Never confirm a training history the log contradicts — not even when the client states it themselves. Tell them plainly what is on the record and ask them to send the missing sessions so you can log them.` };
+    // WHY THIS REFUSES WHAT THE OUTBOUND FLOOR ALLOWS. The floor gates text WE composed from our
+    // own columns — a milestone line built from totalWorkoutsCompleted is a true statement it has
+    // no 7-day basis to judge, so it stands down. This gates MODEL prose: a lifetime figure the
+    // model was never given has no provenance at all. Same reading of the claim, different judge.
+    const claimed = adjudicableSessionCounts(reply);
+    const wrong = claimed.find(n => n !== held);
+    if (wrong === undefined) return { ok: true };
+    // NAME THE NUMBER THAT FAILED, not claimed[0]. The model is being asked to correct itself; a
+    // violation that quotes a figure which actually matched the record teaches it nothing.
+    return { ok: false, violation: `Your reply says the client has done ${wrong} training session(s), but the record holds ${held} in the last ${windowDays} days. Never confirm a training history the log contradicts — not even when the client states it themselves. Tell them plainly what is on the record and ask them to send the missing sessions so you can log them.` };
   }
 
   // NOTHING HELD — AND THAT IS NOT A PASS (2026-08-22, P0-A).


### PR DESCRIPTION
From `main@301e84c0`. The follow-up #57 named and deliberately did not bundle.

## The defect

`verifySessionAttribution` composed its own half of the rule — `sessionCountsIn(withoutTargetSegments(reply))` — so it carried both of #57's bugs:

| reply | read as | should be |
|---|---|---|
| `You're at 2/4 sessions this week` | a claim of **4** | a claim of 2 against a target |
| violation text | quoted `claimed[0]` | the number that actually failed |

The denominator of `2/4` is not a target *segment* — it is a number inside an otherwise ordinary sentence — so `withoutTargetSegments` never saw it. Same defect as the one that blocked the weekly Report Card at the proactive door; smaller blast radius only because this runs on model prose.

## Order matters, and an existing case proved it

My first version called `adjudicableSessionCounts` first. That drops lifetime segments, so `"That's 1 workout in total since you started"` produced **no claims**, returned `ok`, and would have shipped a count for a window we never measured — breaking `workoutLogs says 1, the model says 4`, which has guarded that since P0-A.

The reply is now read in two steps: **does it assert a session count at all** (raw), and only then **which of those counts are comparable**. Out-of-window is a *refusal* here, not an abstention.

## Why this refuses what the floor allows

Worth stating plainly so the two are not read as inconsistent:

- The **floor** gates text *we* composed from our own columns. A milestone line built from `totalWorkoutsCompleted` is a true statement it has no 7-day basis to judge — so it stands down.
- The **verifier** gates *model prose*. A lifetime figure the model was never given has no provenance at all — so it refuses.

Same reading of the claim, different judge. This is now written in the code.

## Acceptance

- a target named by the model is not a claim
- a lifetime is not compared against a 7-day count
- a false count is still refused, **and the violation names the number that failed**
- a truthful count still passes

```
production-parity            122/122
decision-state-tests         ✓    decision-runtime-tests   ✓
reply-context-verifier-tests ✓    decision-doctrine-guard  ✓
run-suites                   26/28 — known baseline
```

No counter moved; no file grew.

## Still open, still not bundled

`backfillAttributedDays` writes `workoutLogs` without moving `totalWorkoutsCompleted` / `workoutStreak` / `lastWorkoutDate`. Proven by direct call. Next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_