### PR TITLE
Retro sessions: one contract, one owner

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2807,6 +2807,93 @@ async function main() {
       "a truthful count was corrected");
   });
 
+  // ── P0-5 · WORKOUT · WHAT A RETROACTIVE SESSION CHANGES (2026-08-25) ──────────────────────
+  //
+  // Five paths write a session row and they disagreed about what else moves. Two defects:
+  // backfillAttributedDays touched `users` not at all, so the ledger and the lifetime counter
+  // answered "how many sessions have I done" differently; and the multi-day retro path set
+  // lastWorkoutDate unconditionally, moving it BACKWARD past a more recent session — while the
+  // sibling single-day path 65 lines above guarded exactly that.
+  check("P0-5 workout . a retro session moves the count, never the cursor, never backwards", async () => {
+    const { applyRetroSessionState } = await import("../server/day-ledger");
+    const g = globalThis as any;
+
+    const held = new Date(NOW - 1 * 86_400_000);   // they last trained YESTERDAY
+    const older = new Date(NOW - 4 * 86_400_000);  // …and now report a session from four days ago
+    const newer = new Date(NOW);
+
+    const run = (attributed: Date[]) => serialise(async () => {
+      g.__KAMLIFE_STUB_USER = {
+        ...USER, id: "retro-contract", totalWorkoutsCompleted: 24, workoutStreak: 3,
+        lastWorkoutDate: held, programmeWeek: 3, programmeDayInWeek: 2,
+      };
+      const before = { ...g.__KAMLIFE_STUB_USER };
+      const out = await applyRetroSessionState(before, attributed);
+      const after = { ...g.__KAMLIFE_STUB_USER };
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      return { out, after, before };
+    });
+
+    // 2. THE LIFETIME COUNT MOVES, once per attributed day.
+    const one = await run([older]);
+    assert.equal(one.out.total, 25, "one attributed session did not move the lifetime count");
+    const two = await run([older, new Date(NOW - 3 * 86_400_000)]);
+    assert.equal(two.out.total, 26, "two attributed sessions must count twice, not once");
+    assert.equal((await run([])).out.total, 24, "an empty attribution changed the count");
+
+    // 3. lastWorkoutDate IS A MAX OVER REAL EVENTS. The negative case is the point: an OLDER
+    //    session must never drag it back past a more recent one.
+    assert.equal(one.out.lastWorkoutDate?.getTime(), held.getTime(),
+      "an older attributed session moved lastWorkoutDate backwards");
+    assert.equal(one.after.lastWorkoutDate ? new Date(one.after.lastWorkoutDate).getTime() : 0, held.getTime(),
+      "…and it was written backwards to the row");
+    const forward = await run([newer]);
+    assert.equal(forward.out.lastWorkoutDate?.getTime(), newer.getTime(),
+      "a genuinely more recent session failed to advance lastWorkoutDate");
+
+    // 4. THE PROGRAMME CURSOR NEVER MOVES. (P0-3.) Which session is due today is decided by the
+    //    schedule and by what was done today; a backfill answers neither question.
+    assert.equal(one.after.programmeWeek, 3, "a retro write advanced the programme week");
+    assert.equal(one.after.programmeDayInWeek, 2, "a retro write advanced the programme day");
+
+    // 5. THE STREAK IS NEVER INCREMENTED HERE. The live rule is `wasYesterday ? +1 : 1`, which is
+    //    only valid for a write about today. A correct historical streak must be derived from the
+    //    ledger — a different owner, deliberately out of this cut.
+    assert.equal(one.after.workoutStreak, 3, "a retro write incremented the streak");
+  });
+
+  // …and the path that had none of it. The defect was that backfill wrote the ledger and left the
+  // counter behind, so this drives the real module and reads the real user row.
+  check("P0-5 workout . the batch logger now carries the derived state", async () => {
+    const { backfillAttributedDays } = await import("../server/backfill");
+    const g = globalThis as any;
+    const day = (n: number) => new Date(NOW - n * 86_400_000)
+      .toLocaleDateString("en-ZA", { weekday: "long", timeZone: "Africa/Johannesburg" });
+
+    const out = await serialise(async () => {
+      const before = {
+        ...USER, id: "backfill-contract", totalWorkoutsCompleted: 24, workoutStreak: 3,
+        lastWorkoutDate: new Date(NOW - 1 * 86_400_000), programmeWeek: 3, programmeDayInWeek: 2,
+      };
+      g.__KAMLIFE_STUB_USER = { ...before };
+      const res = await backfillAttributedDays(
+        before, `${day(4)} pap and chicken. ${day(3)} eggs and toast. ${day(2)} I trained and walked 8000 steps`);
+      const after = { ...g.__KAMLIFE_STUB_USER };
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      return { res, after };
+    });
+
+    const sessions = (out.res?.writes || []).filter(w => w.domain === "workout");
+    assert.equal(sessions.length, 1, `expected one backfilled session, got ${JSON.stringify(sessions)}`);
+    assert.equal(out.after.totalWorkoutsCompleted, 25,
+      "the batch logger wrote a session row and left the lifetime count behind");
+    // The attributed day is OLDER than the held one, so the max rule must hold here too.
+    assert.equal(new Date(out.after.lastWorkoutDate).getTime(), NOW - 1 * 86_400_000,
+      "a backfilled older session moved lastWorkoutDate backwards");
+    assert.equal(out.after.programmeWeek, 3, "the batch logger advanced the programme cursor");
+    assert.equal(out.after.workoutStreak, 3, "the batch logger incremented the streak");
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/backfill.ts
+++ b/server/backfill.ts
@@ -31,7 +31,8 @@
  * A historical write is a statement about that day and about NOTHING ELSE. It may add the row
  * and move lifetime counters, because those are facts about the past. It may not advance the
  * programme cursor, declare today's session done, or move a streak forward — today's questions
- * are answered by today. Nothing here writes to `users` at all.
+ * are answered by today. The `users` write is exactly that permitted half, and it is delegated to
+ * applyRetroSessionState so this module cannot drift from the two retro paths in workout.ts.
  */
 
 import { db } from "./db";
@@ -40,6 +41,7 @@ import { and, eq, gte, lt } from "drizzle-orm";
 import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { journeyMustKeepFacts, detectStepLog } from "./understanding/messy-intake";
 import { turnMutation } from "./handlers/chat-log";
+import { applyRetroSessionState } from "./day-ledger";
 
 export interface BackfillWrite { dayKey: string; domain: "food" | "workout" | "steps"; detail: string; }
 export interface BackfillResult {
@@ -65,7 +67,9 @@ function dayWindow(dayKey: string): { start: Date; end: Date } {
  * `hasMultipleDays` gate: this adds a capability, it does not re-route the product.
  */
 export async function backfillAttributedDays(
-  user: { id: string },
+  // NOT `{ id: string }`. applyRetroSessionState increments FROM the held total, so a caller
+  // passing only an id would reset the lifetime count to the number of days in this message.
+  user: { id: string; phoneNumber?: string | null; totalWorkoutsCompleted?: number | null; lastWorkoutDate?: Date | string | null },
   message: string,
   now: Date = new Date(),
 ): Promise<BackfillResult | null> {
@@ -126,6 +130,21 @@ export async function backfillAttributedDays(
         turnMutation(`INSERT steps=${step.steps} at=${beat.dayKey}`, "[BACKFILL]");
         writes.push({ dayKey: beat.dayKey, domain: "steps", detail: `${step.steps.toLocaleString()} steps` });
       }
+    }
+  }
+
+  // THE DERIVED STATE A SESSION CARRIES (2026-08-25, P0-5 · workout). This module wrote the
+  // ledger row and touched `users` not at all — so a multi-day report moved workoutLogs and left
+  // totalWorkoutsCompleted behind, and two readers answered "how many sessions have I done"
+  // with different numbers. The contract is shared with both retro paths in workout.ts; see
+  // applyRetroSessionState. Only days we ACTUALLY inserted count, so the idempotency guard above
+  // keeps a repeated report from inflating the total.
+  const sessionDays = writes.filter(w => w.domain === "workout").map(w => noonOn(w.dayKey));
+  if (sessionDays.length > 0) {
+    try {
+      await applyRetroSessionState(user, sessionDays);
+    } catch (e: any) {
+      console.warn(`[BACKFILL] retro session state failed for ${String(user.id || "").slice(-6)}: ${e?.message || e}`);
     }
   }
 

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -543,6 +543,68 @@ export interface ProgressTruth {
  * Returns text (YYYY-MM-DD) so it matches sastDayKey's output exactly, and so a caller can join
  * or compare against a TypeScript day key without a cast.
  */
+/**
+ * WHAT A RETROACTIVELY ATTRIBUTED SESSION CHANGES (2026-08-25, P0-5 · workout).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE CONTRACT, AND WHERE IT CAME FROM
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Five paths write a session row. They disagreed about what else changes, so this states the
+ * rule once — derived from what the paths already agreed on, plus the reasons workout.ts had
+ * already written down beside its own retro write:
+ *
+ *   workoutLogs             the caller inserts it. Idempotent per day; not this function's job.
+ *   totalWorkoutsCompleted  +N. A session really happened, and the lifetime count is a fact
+ *                           about the past rather than a claim about today.
+ *   lastWorkoutDate         MAX(held, newest attributed day). It is a max over real events, so
+ *                           logging Monday cannot overwrite a Wednesday already on the record.
+ *   programmeWeek / DayInWeek   NEVER. (P0-3.) Which session is due TODAY is decided by the
+ *                           schedule and by what was done today; a backfill answers neither.
+ *   workoutStreak           NEVER incremented here. The live rule is `wasYesterday ? +1 : 1`,
+ *                           which is only valid for a write about today — a backfilled Tuesday
+ *                           cannot be folded in by incrementing. A correct historical streak has
+ *                           to be DERIVED from the ledger, which is a different owner and a
+ *                           different question. Both retro paths already left it alone; this
+ *                           makes that the stated rule rather than an accident.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE TWO DEFECTS IT CLOSES
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ *   backfillAttributedDays  wrote the ledger row and touched `users` not at all — so a multi-day
+ *                           report moved workoutLogs and left totalWorkoutsCompleted behind, and
+ *                           two readers answered "how many sessions have I done" differently.
+ *   the multi-day retro     set `lastWorkoutDate: last` UNCONDITIONALLY. Reporting a batch of old
+ *                           days moved the field BACKWARD past a more recent session. The guard
+ *                           for exactly this already existed 65 lines above it, in the sibling
+ *                           single-day path, and was not used.
+ *
+ * One owner rather than three patches, because three call sites each re-deriving the rule is
+ * precisely how they came to disagree.
+ */
+export async function applyRetroSessionState(
+  user: { id?: string; phoneNumber?: string | null; totalWorkoutsCompleted?: number | null; lastWorkoutDate?: Date | string | null },
+  attributedDays: Date[],
+): Promise<{ total: number; lastWorkoutDate: Date | null }> {
+  const held = user.lastWorkoutDate ? new Date(user.lastWorkoutDate) : null;
+  if (attributedDays.length === 0) {
+    return { total: Number(user.totalWorkoutsCompleted) || 0, lastWorkoutDate: held };
+  }
+  const total = (Number(user.totalWorkoutsCompleted) || 0) + attributedDays.length;
+  const newest = attributedDays.reduce((a, b) => (b.getTime() > a.getTime() ? b : a));
+  const advances = !held || newest.getTime() > held.getTime();
+  const lastWorkoutDate = advances ? newest : held;
+
+  await db.update(users).set({
+    totalWorkoutsCompleted: total,
+    lastActiveAt: new Date(),
+    ...(advances ? { lastWorkoutDate: newest } : {}),
+  }).where(user.id ? eq(users.id, user.id) : eq(users.phoneNumber, String(user.phoneNumber || "")));
+
+  return { total, lastWorkoutDate };
+}
+
 export function sastDayBucketSql(col: AnyPgColumn) {
   return sql<string>`to_char(${col} + interval '2 hours', 'YYYY-MM-DD')`;
 }

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -22,6 +22,7 @@ import { logChat, turnMutation, turnAlreadyWrote } from "./chat-log";
 import { sastDayKey } from "../sast";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
 import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen } from "../utils";
+import { applyRetroSessionState } from "../day-ledger";
 import { invalidatePatternCache } from "../cache";
 import { getTodayWorkoutState, getTodaySlot, weekStartForTrainingClaim, attributableWeekSessionDates } from "../workout-state";
 import { handleWeightLog } from "./weight";
@@ -338,14 +339,8 @@ export async function handleWorkoutCommands(ctx: {
     //
     // WHAT IT MAY NOT CHANGE: the programme cursor. Which session is due TODAY is decided by the
     // schedule and by what was done today, and a backfill answers neither question.
-    const currentLastWorkout = user.lastWorkoutDate ? new Date(user.lastWorkoutDate).getTime() : 0;
-    const updateLastWorkout = retroDate.getTime() > currentLastWorkout;
-
-    await db.update(users).set({
-      totalWorkoutsCompleted: newTotal,
-      lastActiveAt: new Date(),
-      ...(updateLastWorkout ? { lastWorkoutDate: retroDate } : {}),
-    }).where(eq(users.phoneNumber, phone));
+    // The rule this path already applied, now applied from one place. See applyRetroSessionState.
+    await applyRetroSessionState(user, [retroDate]);
 
     await logChat(user.id, message, `[RETRO WORKOUT: ${dateLabel}]`, "WORKOUT_LOG");
     const n = firstName || "";
@@ -406,12 +401,10 @@ export async function handleWorkoutCommands(ctx: {
       turnMutation(`INSERT workout completed=true at=${sastDayKey(day)}`, "[WORKOUT_LOG]");
     }
     invalidatePatternCache(user.id);
-    const last = dates[dates.length - 1];
-    await db.update(users).set({
-      totalWorkoutsCompleted: (user.totalWorkoutsCompleted || 0) + dates.length,
-      lastWorkoutDate: last,
-      lastActiveAt: new Date(),
-    }).where(eq(users.phoneNumber, phone));
+    // THE SHARED RETRO TRANSITION (2026-08-25). This set `lastWorkoutDate: last` unconditionally,
+    // so reporting a batch of older days moved the field BACKWARD past a more recent session —
+    // while the sibling single-day path 65 lines above guarded exactly that. One owner now.
+    await applyRetroSessionState(user, dates);
     const days = dates.map(d => mealDateLabel(d)).join(", ");
     const ok = `${firstName ? firstName + " — " : ""}logged ${dates.length} sessions (${days}).`;
     await logChat(user.id, message, ok, "WORKOUT_WEEK_LOG");


### PR DESCRIPTION
From `main@af525be0`. Closes the ledger/counter divergence found during the workout investigation.

## The contract

Five paths write a session row and disagreed about what else changes. Derived from what they already agreed on, plus the reasons `workout.ts` had already written beside its own retro write:

| field | rule |
|---|---|
| `workoutLogs` | the caller inserts it, idempotent per day |
| `totalWorkoutsCompleted` | **+N** — a session really happened; the lifetime count is a fact about the past, not a claim about today |
| `lastWorkoutDate` | **MAX(held, newest attributed day)** — a max over real events, so Monday cannot overwrite a Wednesday |
| programme cursor | **never** (P0-3) — which session is due today is decided by the schedule and by what was done today |
| `workoutStreak` | **never incremented here** |

On the streak, since you flagged not to assume "update all four": the live rule is `wasYesterday ? +1 : 1`, which is only valid for a write about *today*. A backfilled Tuesday cannot be folded in by incrementing — a correct historical streak has to be **derived from the ledger**, which is a different owner and a different question. Both retro paths already left it alone; this makes that the *stated* rule rather than an accident. Ledger-derived streak stays out of this cut.

## Two defects, one invariant

- **`backfillAttributedDays`** wrote the ledger row and touched `users` not at all. A multi-day report moved `workoutLogs` and left the lifetime counter behind — two readers answering *"how many sessions have I done"* differently. Proven by direct call: session written, counter **24 → 24**.
- **The multi-day retro path** set `lastWorkoutDate: last` **unconditionally**, dragging it backward past a more recent session. The guard for exactly that already existed **65 lines above it**, in the sibling single-day path, unused.

## One owner, not three patches

`applyRetroSessionState` in `day-ledger.ts` — the declared write door, beside `commitFoodLog`. Three call sites each re-deriving the rule is precisely how they came to disagree, and patching each would have left the fourth free to diverge. `workout.ts` net **shrinks**.

**Caught while wiring it:** `backfillAttributedDays` declared `user: { id: string }`. The helper increments *from* the held total, so a caller honouring that type would have **reset** the lifetime count to the number of days in the message. The parameter now demands the fields it reads.

## Acceptance — the whole contract, both directions

- one attributed day → +1; two → +2; none → unchanged
- **an older session must not move `lastWorkoutDate` backwards** (the negative case)
- a genuinely newer one must advance it
- programme week/day unchanged; streak unchanged
- and the batch logger itself, driven end to end against the real user row

**Negative controls run:** removing the max guard reds *both* cases; disabling the backfill's derived-state write reds the batch case alone.

## Suite

```
production-parity            124/124
decision-engine-p0 suites    4/4
run-suites                   26/28 — known baseline
```

No counter moved. No file grew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_