### PR TITLE
run-suites: cover the same surface CI does

### DIFF
--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -9,13 +9,46 @@ import { existsSync } from "node:fs";
 
 /**
  * The one list. check-architecture's suite-liveness guard reads this same array.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * IT HAS TO BE EVERY SUITE CI RUNS, NOT MOST OF THEM (2026-08-25)
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * `npm test` is the working signal — the thing a change is verified against before it is pushed.
+ * Four suites ran in CI and not here: decision-state-tests, decision-runtime-tests,
+ * reply-context-verifier-tests and decision-doctrine-guard, in the `decision-engine-p0` workflow.
+ *
+ * That workflow is PATH-TRIGGERED on six files, so it fires only when one of them changes — and
+ * nothing had touched them between #52 and #57. In that window,
+ * script/reply-context-verifier-tests was RED on main: it asserted a rule deliberately deleted on
+ * 2026-08-21 (`isExplicitStepQuery` — "phrasing is not provenance"). Verified by checking out
+ * main directly and running it. A month of green PRs, each honestly reporting "26/28, the known
+ * baseline", none of which had run it.
+ *
+ * The defect was not the workflow and not the suites. It was that local green and CI green meant
+ * different things, so "26/28" was never a complete statement for a change touching those paths.
+ * A working signal that is a subset of the real one teaches you to trust the subset.
+ *
+ * These four are cheap — about a second and a half together — and there is no reason for them to
+ * be reachable only by a path filter.
+ *
+ * WHAT IS STILL NOT HERE, AND WHY. Three suites run in CI and deliberately do not run in
+ * `npm test`: drill-battery (model-drill.yml), gauntlet (coach-voice-gauntlet.yml) and
+ * reality-test (reality-test.yml). All three grade the LIVE model and are gated on a real
+ * OPENAI_API_KEY secret; putting them here would make every local run need a key and spend money.
+ * That is an exclusion, not an oversight — but it is the reason `npm test` green does not mean
+ * "the coach's WORDS are good", only "the deterministic surface holds". Stated so the next person
+ * reading a green run knows exactly what it covered.
  */
 export const SUITES = [
   "unit-tests", "integration-tests", "food-scanner-tests", "safety-audit", "golden-regression",
   "routing-audit", "gap-tests", "onboarding-e2e", "video-path-verify", "phrasing-battery",
   "check-file-sizes", "check-pricing", "check-schema-safety", "check-sast", "check-names",
   "check-reach", "check-prompt-integrity", "hunger-gauntlet", "decision-boundary-tests",
-  "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests", "production-parity", "check-architecture",
+  "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests",
+  // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
+  "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
+  "production-parity", "check-architecture",
 ];
 
 const PER_SUITE_TIMEOUT_MS = 10 * 60_000;


### PR DESCRIPTION
From `main@43fdb0f7`. One file. No product code.

## The broken feedback loop

`npm test` is the working signal — what a change is verified against before it is pushed. Four suites ran in CI and not here, in the `decision-engine-p0` workflow:

```
decision-state-tests   decision-runtime-tests
reply-context-verifier-tests   decision-doctrine-guard
```

That workflow is **path-triggered on six files**, so it fires only when one of them changes — and nothing touched them between #52 and #57. In that window `script/reply-context-verifier-tests` was **RED on main**: it asserted a rule deliberately deleted on 2026-08-21 (`isExplicitStepQuery` — *"phrasing is not provenance"*). Verified by checking out main directly and running it.

A month of green PRs, each honestly reporting *"26/28, the known baseline"*, none of which had run it.

**The defect was not the workflow and not the suites.** It was that local green and CI green meant different things, so `26/28` was never a complete statement for a change touching those paths. A working signal that is a subset of the real one teaches you to trust the subset.

## Baseline moves 26/28 → 30/32

All four new suites pass. The two red are the same structural guards with identical lines. Cost: **~1.5s**.

```
✓ decision-state-tests (0.4s)          ✓ decision-runtime-tests (0.4s)
✓ reply-context-verifier-tests (0.4s)  ✓ decision-doctrine-guard (0.3s)

suites: 30/32 green in 84s
RED: check-file-sizes, check-architecture
```

## What is still not here, and why

I measured this across **every** workflow rather than only the one that caught me. Three suites run in CI and deliberately do not run in `npm test`:

| suite | workflow |
|---|---|
| `drill-battery` | model-drill.yml |
| `gauntlet` | coach-voice-gauntlet.yml |
| `reality-test` | reality-test.yml |

All three grade the **live model** and are gated on a real `OPENAI_API_KEY` secret. Adding them would make every local run need a key and spend money. That is an exclusion, not an oversight — and it is now stated in the file, because it means:

> `npm test` green means *"the deterministic surface holds"*, not *"the coach's words are good"*.

## Not done here

A guard enforcing this parity — so the next workflow added cannot drift the same way — is the durable version of this fix. It is ~15 lines in `check-architecture` and it is exactly the *"a check existing is not enough; the path has to reach it"* principle. **Not in this cut**, per scope. Flagging it as the obvious follow-up if you want it.

No counter moved, no file grew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_