### PR TITLE
One question, one owner: "is the client training today?"

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2894,6 +2894,67 @@ async function main() {
     assert.equal(out.after.workoutStreak, 3, "the batch logger incremented the streak");
   });
 
+  // ── ONE QUESTION, ONE OWNER: "IS THE CLIENT TRAINING TODAY?" (2026-08-25) ─────────────────
+  //
+  // THE HANDSET FAILURE. Coach sent the session with buttons [Done | Too hard | Skip today].
+  //
+  //   Client: "No I moved yesterdays workout to today"
+  //   Coach:  "Kam, no stress — rest today, hit it fresh tomorrow 💪"
+  //
+  // He answered our own menu, told us he was training, and we told him to rest. Six readers
+  // decided this question independently and MOVED INTO TODAY was a shape none of them held, so
+  // the leading "No" plus "workout" plus "today" read as a refusal.
+  //
+  // These are customer sentences, not helper booleans — the first fixtures of the matrix.
+  check("training day . the six readers now give one answer", async () => {
+    const { readTrainingDay, trainingDayIsDeclined } = await import("../server/one-action");
+
+    // THE SCREENSHOT. This is the case the whole cut exists for.
+    assert.equal(readTrainingDay("No I moved yesterdays workout to today"), "moved_to_today",
+      "the sentence from the handset is still read as a refusal");
+    assert.equal(trainingDayIsDeclined("No I moved yesterdays workout to today"), false,
+      "…and the DayState input still carries it as a constraint against training");
+
+    // THE ADJACENT SHAPES, which is what makes the answer meaningful rather than a special case.
+    const expect: Array<[string, string]> = [
+      ["I'm doing yesterday's session today", "moved_to_today"],
+      ["rest day", "declined"],
+      ["taking a rest day", "declined"],
+      ["no gym today", "declined"],
+      ["I'm not training today, ok?", "declined"],
+      ["Can I do my workout tomorrow instead?", "move_request"],
+      ["I'll train tomorrow", "deferred"],
+      ["I missed gym on Monday", "missed"],
+      ["I didn't do my workout", "missed"],
+      // …and the words that merely CONTAIN "skip" but ask a different question entirely.
+      ["skip the numbers", "none"],
+      ["I'm done eating for today", "none"],
+      ["I trained today", "none"],
+      ["I didn't skip the gym today", "none"],
+      ["Show me tomorrow's workout", "none"],
+      ["Is today a rest day?", "none"],
+    ];
+    for (const [sentence, want] of expect) {
+      assert.equal(readTrainingDay(sentence), want, `"${sentence}" read as ${readTrainingDay(sentence)}, expected ${want}`);
+    }
+  });
+
+  // THE OUTCOME, not the classification. A sentence that says "I am training today" must not be
+  // answered with a rest-day reply — which is what the client actually saw.
+  check("training day . a session moved into today is not answered with 'rest today'", async () => {
+    const reply = await serialise(() => say("No I moved yesterdays workout to today"));
+    assert.ok(!/rest today|hit it fresh tomorrow|rest day is part of the programme/i.test(reply),
+      `the client said they are training today and was told to rest: ${reply.slice(0, 160)}`);
+  });
+
+  // THE CONTROL. A genuine refusal must still be honoured, or the case above passes by making
+  // the coach incapable of hearing "no".
+  check("training day control . a genuine rest day is still honoured", async () => {
+    const reply = await serialise(() => say("rest day today"));
+    assert.ok(!/Week \d|Next Session|Send \*?DONE/i.test(reply),
+      `a rest day was answered with the session: ${reply.slice(0, 120)}`);
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -36,6 +36,7 @@ import { getMenuText } from "../onboarding";
 import { SA_FOODS_SEED } from "../foods";
 import { scanForSAFoods, weeklyNetLine } from "./food-scanner";
 import { getWeightTruth } from "../day-ledger";
+import { readTrainingDay } from "../one-action";
 
 export async function handleLifecycle(ctx: {
   phone: string;
@@ -1323,8 +1324,11 @@ export async function handleLifecycle(ctx: {
   }
 
   // ---- REST DAY HANDLER ----
-  const isRestDayMsg =
-    /\b(rest day|no gym today|off today|taking a rest|rest today|not training today|skipping gym|not going to gym|day off|recovery day|active recovery|not working out today|off day)\b/i.test(m);
+  // ONE READER FOR "IS THE CLIENT TRAINING TODAY?" (2026-08-25). This held its own rest-day
+  // vocabulary — and "No I moved yesterdays workout to today" was read as a refusal elsewhere
+  // while this file had no opinion on it at all. The reply below is unchanged; only the question
+  // moved to its owner. See readTrainingDay.
+  const isRestDayMsg = readTrainingDay(m) === "declined";
 
   if (isRestDayMsg) {
     const name = spaceName(user);
@@ -1339,8 +1343,8 @@ export async function handleLifecycle(ctx: {
   }
 
   // ---- MISSED WORKOUT / SKIPPED SESSION HANDLER ----
-  const isMissedWorkout =
-    /\b(missed.*(?:workout|session|gym|training)|couldn.?t.*(?:train|gym|workout)|skipped.*(?:gym|session|workout|training)|didn.?t.*(?:train|go to gym|workout)|missed.*gym|didn.?t make it|couldn.?t make it|no gym yesterday|missed yesterday|no training today|didn.?t train)\b/i.test(m);
+  // Same owner, the "a session did not happen" answer. (2026-08-25.)
+  const isMissedWorkout = readTrainingDay(m) === "missed";
 
   // A SINGLE-FACT HANDLER MAY NOT CLAIM A MULTI-PART TURN (2026-08-10, Work Order 2).
   //

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -23,6 +23,7 @@ import { sastDayKey } from "../sast";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
 import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen } from "../utils";
 import { applyRetroSessionState } from "../day-ledger";
+import { readTrainingDay } from "../one-action";
 import { invalidatePatternCache } from "../cache";
 import { getTodayWorkoutState, getTodaySlot, weekStartForTrainingClaim, attributableWeekSessionDates } from "../workout-state";
 import { handleWeightLog } from "./weight";
@@ -286,7 +287,15 @@ export async function handleWorkoutCommands(ctx: {
     /\b(trained|did\s+(?:my\s+)?(?:workout|session|training|gym|legs?|upper(?:\s+body)?|lower(?:\s+body)?|chest|back|push|pull|cardio|arms?|shoulders?|squats?)|workout\s+(?:done|complete[d]?|finished)|session\s+(?:done|complete[d]?|finished)|training\s+(?:done|complete[d]?|finished)|gym\s+(?:done|complete[d]?|finished))\b/i.test(m)
     || /\b(?:done|finished|complete[d]?)\b.{0,40}\b(?:workout|session|training|gym|legs?|upper|lower|chest|back|push|pull|cardio)\b/i.test(m)
     || /\b(?:workout|session|training|gym|legs?|upper|lower|chest|back|push|pull|cardio)\b.{0,40}\b(?:done|finished|complete[d]?)\b/i.test(m);
-  const hasMissWord = /\b(missed?|couldn.?t|skipped?|didn.?t|won.?t|rest\s+day|sick|injur|cancel)\b/i.test(m);
+  // TWO QUESTIONS, NOT ONE (2026-08-25). This regex conflated "did they report a training miss"
+  // — which readTrainingDay owns — with "are they sick or injured", which is a health question and
+  // is not this owner's to answer. The training half now comes from the owner; the health half
+  // stays local and is named for what it is. Proven equivalent on a 17-string battery before the
+  // swap: the retro-logging guard behaves identically.
+  const _trainingRead = readTrainingDay(m);
+  const reportsMiss = _trainingRead === "missed" || _trainingRead === "declined";
+  const hasHealthBlock = /\b(sick|injur|cancel)\b/i.test(m);
+  const hasMissWord = reportsMiss || hasHealthBlock;
 
   // Question guard uses the shared looksLikeQuestion (not a bare "?" check): a voice
   // transcript that drops the mark — "is yesterday's session logged", "should that

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -248,9 +248,108 @@ const LATE = 17; // from 5pm, "log today" and "get a walk in" start to make sens
  * The inverse must survive untouched: "I trained today" is a REPORT and is still written as
  * today's session — that is why completion words disqualify.
  */
+/**
+ * IS THE CLIENT TRAINING TODAY? ONE READER (2026-08-25).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * THE HANDSET FAILURE THIS EXISTS TO STOP
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ *   Coach:  [today's session] … Done 💪 | Too hard — modify | Skip today
+ *   Client: "No I moved yesterdays workout to today"
+ *   Coach:  "Kam, no stress — rest today, hit it fresh tomorrow 💪"
+ *
+ * He answered our own button menu, told us he was training, and we told him to rest. The old
+ * matcher saw "No" … "workout" … "today" and called it a refusal — because MOVED INTO TODAY was
+ * a shape none of the readers represented.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ * WHY A CLASSIFIER AND NOT ANOTHER BOOLEAN
+ * ═══════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Six places decided this question independently and each held a different piece of it:
+ *
+ *   one-action     trainingDayIsDeclined   refusal
+ *   routes         _isWorkoutRefusal       called the owner and DISCARDED the result
+ *   routes         _isWorkoutMoveRequest   "can I shift it?"
+ *   routes         _isWorkoutDeferral      "I'll do it later"
+ *   lifecycle      isRestDayMsg            rest day
+ *   lifecycle      isMissedWorkout         reported a past miss
+ *   workout        hasMissWord             don't retro-log a miss as a completion
+ *
+ * Every one of them is a partial answer to "is this client training today". Kept apart, a fix to
+ * any single one reaches none of the others — which is precisely why this defect kept returning
+ * after each patch. One reader returns the whole answer; the callers keep their own actions.
+ *
+ * ORDER IS THE WHOLE DESIGN. `moved_to_today` is tested BEFORE `declined`, because the sentence
+ * that broke carries both signals and only one of them is what he meant.
+ *
+ * HONEST BOUND: this is still pattern matching, and pattern matching has an unbounded failure
+ * surface — a phrasing nobody thought of will get through. What it no longer has is SIX surfaces.
+ * The next step is for the classifier to lead and this to be the narrow safety net beneath it.
+ */
+export type TrainingDayRead =
+  | "declined"        // not training today, in their own words
+  | "moved_to_today"  // another day's session pulled INTO today — they ARE training
+  | "move_request"    // asking permission to shift it
+  | "deferred"        // stating they will do it later
+  | "missed"          // reporting a session that did not happen
+  | "none";
+
+export function readTrainingDay(text: string): TrainingDayRead {
+  const t = String(text || "");
+  if (!t.trim()) return "none";
+  // The vocabulary this question is asked in. REST_SHAPE is the half lifecycle's isRestDayMsg
+  // held and this owner did not: "rest day", "day off", "recovery day" name the same decision
+  // without ever using a training word.
+  const TRAINING = /(?:train(?:ing)?|workout|work\s*out|session|gym|exercis(?:e|ing))/i;
+  const REST_SHAPE = /\b(?:rest\s+day|day\s+off|off\s+day|recovery\s+day|active\s+recovery|taking\s+a\s+rest|rest\s+today|off\s+today)\b/i;
+  if (REST_SHAPE.test(t) && !/\?/.test(t)) return "declined";
+  if (!TRAINING.test(t)) return "none";
+
+  // 1. MOVED INTO TODAY — they are training, whatever else the sentence contains. This must
+  //    outrank the refusal test: "No I moved yesterdays workout to today" satisfies both.
+  if (/\b(?:moved?|moving|shifted?|swapped?|pushed|bumped|brought)\b[^.!?]{0,40}?\b(?:to|into|for)\s+(?:today|now|this\s+(?:morning|afternoon|evening))\b/i.test(t)
+      || /\b(?:doing|i'?m\s+doing|did)\b[^.!?]{0,40}?\b(?:yesterday'?s|monday'?s|tuesday'?s|wednesday'?s|thursday'?s|friday'?s|saturday'?s|sunday'?s|missed|skipped)\b[^.!?]{0,30}?\b(?:today|now)\b/i.test(t)) {
+    return "moved_to_today";
+  }
+
+  // 2. ASKING PERMISSION TO SHIFT IT. Modal + first person, and not a request to SEE it.
+  if (/^\s*(?:can|could|may|should|is\s+it\s+ok\s+(?:if\s+)?)\s*i\b/i.test(t.trim())
+      && /\b(?:tomorrow|later|tonight|this\s+evening|after\s+work|next\s+week|another\s+day|a\s+different\s+day|2moro|2morrow)\b/i.test(t)
+      && !/\b(?:show|send|see|view|what'?s|what\s+is|give\s+me)\b/i.test(t)
+      && !/\b(?:tomorrow|next\s+week)'?s\s+(?:workout|work\s*out|session|training)\b/i.test(t)) {
+    return "move_request";
+  }
+
+  if (trainingDayIsDeclined(t)) return "declined";
+
+  // 3. STATING A LATER PLAN — a deferral is a plan, not a constraint on today.
+  if (!t.includes("?")
+      && /\b(?:i'?ll|i\s+will|i'?m\s+going\s+to|i\s+am\s+going\s+to|gonna|going\s+to|plann?ing\s+(?:to|on)|plan\s+to)\b/i.test(t)
+      && /\b(?:tomorrow|later|tonight|this\s+evening|after\s+work|in\s+the\s+morning|next\s+week|2moro|2morrow)\b/i.test(t)
+      && !/\b(?:done|finished|completed|already\s+did|just\s+did|did\s+my|smashed|crushed)\b/i.test(t)) {
+    return "deferred";
+  }
+
+  // 4. A SESSION THAT DID NOT HAPPEN. Past tense, and not a negated cessation ("didn't skip").
+  if (!/\b(?:not|never|didn'?t|don'?t)\b[^.!?]{0,20}?\b(?:skip|skipping|skipped|miss|missing|missed)\b/i.test(t)
+      && (/\b(?:missed|skipped|couldn'?t|could\s+not|didn'?t\s+(?:make|get|train|go))\b/i.test(t)
+          // "I didn't do my workout" — a negation anywhere near the training word. Absorbed from
+          // workout.ts's hasMissWord, which had this reach and this owner did not.
+          || /\b(?:didn'?t|did\s+not|couldn'?t|won'?t|will\s+not|haven'?t|hasn'?t)\b[^.!?]{0,40}?(?:train|workout|work\s*out|session|gym|exercis)/i.test(t))) {
+    return "missed";
+  }
+  return "none";
+}
+
 export function trainingDayIsDeclined(text: string): boolean {
   const t = String(text || "");
   if (!t.trim()) return false;
+  // MOVED INTO TODAY IS NOT A REFUSAL. Checked here too, because this function is the DayState
+  // input and is called directly by the decision — it must not read "I moved it to today" as a
+  // constraint against training just because readTrainingDay happens to be the richer door.
+  if (/\b(?:moved?|moving|shifted?|swapped?|pushed|bumped|brought)\b[^.!?]{0,40}?\b(?:to|into|for)\s+(?:today|now|this\s+(?:morning|afternoon|evening))\b/i.test(t)) return false;
   // A REQUEST IS INTERROGATIVE-LED; A TAG QUESTION IS STILL A STATEMENT (2026-08-24, own review).
   // Excluding every "?" made "I'm not training today, ok?" not a refusal — two characters away
   // from the live failure this owner exists to stop. The distinction is grammar: "Can I train

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -48,7 +48,7 @@ import { handleReminderCommand } from "./handlers/reminders-handler";
 import { handleGptBlock } from "./handlers/gpt-block";
 import { runMeaningEngineLive, engineLive, resumeEngineConfirm } from "./understanding/live";
 import { parseMessyIntake, withKnownFood, mentionedWalkWithoutCount, newTurnLedger, commitFact, resolveTurn, detectStepLog, journeyMustKeepFacts, durableDomains } from "./understanding/messy-intake";
-import { foodDayIsClosed, trainingDayIsDeclined } from "./one-action";
+import { foodDayIsClosed, readTrainingDay } from "./one-action";
 import { backfillAttributedDays } from "./backfill";
 import { isCoachCriticism } from "./reaction-guard";
 import { bareReactionFallback } from "./reaction-guard";
@@ -938,7 +938,12 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // none of it and got a full session, post-workout nutrition and "Send DONE" over an explicit
   // refusal. trainingDayIsDeclined is the twin of foodDayIsClosed — the latest explicit constraint
   // about today, owned in one-action.
-  const _isWorkoutRefusal = trainingDayIsDeclined(_origWO);
+  // ONE READER (2026-08-25). This computed a refusal into an underscore-prefixed local that
+  // NOTHING read — a seventh opinion on "is the client training today" that never reached a
+  // decision. Recorded rather than quietly deleted: it is the clearest example of why six
+  // separate readers of one question produced six different answers.
+  const _trainingDay = readTrainingDay(_origWO);
+  const _isWorkoutRefusal = _trainingDay === "declined";
   // A REQUEST TO MOVE A WORKOUT IS A SCHEDULE DECISION, NOT A REQUEST TO RENDER IT (2026-08-24).
   //
   //   "Can I do my workout tomorrow instead?"  →  *Week 5 — Next Session (Day 1)*
@@ -949,21 +954,8 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // a modal + first person is asking to MOVE it ("can I do my workout tomorrow?"), while a view
   // request names the object without asking permission ("show me tomorrow's workout",
   // "tomorrow's workout?") and must still reach the renderer.
-  const _isWorkoutMoveRequest =
-    /^\s*(?:can|could|may|should|is\s+it\s+ok\s+(?:if\s+)?)\s*i\b/i.test(_origWO.trim())
-    && /\b(?:workout|work\s*out|train(?:ing)?|session|gym|exercise|leg\s+day|chest\s+day|upper\s+body|lower\s+body|push\s+day|pull\s+day)\b/i.test(_origWO)
-    && /\b(?:tomorrow|later|tonight|this\s+evening|after\s+work|next\s+week|another\s+day|a\s+different\s+day|2moro|2morrow)\b/i.test(_origWO)
-    && !/\b(?:show|send|see|view|what'?s|what\s+is|give\s+me)\b/i.test(_origWO)
-    // POSSESSIVE NAMES THE OBJECT; A BARE DAY PROPOSES A TIME. "Can I get tomorrow's session?"
-    // asks to SEE the thing; "Can I do my workout tomorrow?" asks to MOVE it. Grammar, so it
-    // covers see/get/have without a verb list.
-    && !/\b(?:tomorrow|next\s+week)'?s\s+(?:workout|work\s*out|session|training)\b/i.test(_origWO);
-  const _isWorkoutDeferral =
-    !_origWO.includes("?")
-    && /\b(i'?ll|i\s+will|i'?m\s+going\s+to|i\s+am\s+going\s+to|gonna|going\s+to|plann?ing\s+(?:to|on)|plan\s+to)\b/i.test(_origWO)
-    && /\b(workout|work\s*out|train(?:ing)?|session|gym|exercise|programme|program|leg\s+day|chest\s+day|upper\s+body|lower\s+body|push\s+day|pull\s+day)\b/i.test(_origWO)
-    && /\b(tomorrow|later|tonight|this\s+evening|after\s+work|in\s+the\s+morning|next\s+week|2moro|2morrow)\b/i.test(_origWO)
-    && !/\b(done|finished|completed|already\s+did|just\s+did|did\s+my|smashed|crushed)\b/i.test(_origWO);
+  const _isWorkoutMoveRequest = _trainingDay === "move_request";
+  const _isWorkoutDeferral = _trainingDay === "deferred";
   if (_isWorkoutMoveRequest) {
     const _mvName = getDisplayName(user);
     const _mvLater = !/\b(tomorrow|next\s+week|another\s+day|a\s+different\s+day|2moro|2morrow)\b/i.test(_origWO);


### PR DESCRIPTION
From `main@4676a78c`. First cut of the comprehension consolidation. **One customer question only.**

## The handset failure

Coach sent the session with buttons `[Done | Too hard — modify | Skip today]`.

> **Client:** *"No I moved yesterdays workout to today"*
> **Coach:** *"Kam, no stress — rest today, hit it fresh tomorrow 💪"*

He answered our own menu, told us he was training, and we told him to rest.

## Why patching it again would not have helped

**Six places decided this question independently**, each holding a different piece:

| reader | file | holds |
|---|---|---|
| `trainingDayIsDeclined` | `one-action.ts` | refusal |
| `_isWorkoutRefusal` | `routes.ts` | called the owner and **discarded the result** |
| `_isWorkoutMoveRequest` | `routes.ts` | *"can I shift it?"* |
| `_isWorkoutDeferral` | `routes.ts` | *"I'll do it later"* |
| `isRestDayMsg` | `lifecycle.ts` | rest day — **its own vocabulary** |
| `isMissedWorkout` | `lifecycle.ts` | a session that did not happen |
| `hasMissWord` | `workout.ts` | don't retro-log a miss as a completion |

**MOVED INTO TODAY was a shape none of them held**, so `"No"` + `"workout"` + `"today"` read as a refusal. A fix to any one reader reaches none of the others — which is exactly why this defect kept returning after each patch.

## The owner

`readTrainingDay` returns the whole answer: `declined | moved_to_today | move_request | deferred | missed | none`. Callers keep their own actions.

**Order is the design:** `moved_to_today` is tested *before* `declined`, because the sentence that broke carries both signals and only one is what he meant.

Absorbed rather than duplicated:
- `lifecycle`'s rest-day vocabulary — *"rest day"*, *"day off"*, *"recovery day"* name this decision **without using a training word**, which is why the owner previously missed them
- `workout.ts`'s wider negation reach — *"I didn't do my workout"*

**`hasMissWord` conflated two questions** — a training miss *and* sick/injured. The training half moved to the owner; the health half stays local and is named for what it is. **Proven equivalent on a 17-string battery before the swap**, because changing the retro-logging guard silently is exactly how this class of bug gets made.

**`mentionsNotDone` deliberately not migrated** — it guards steps and cardio logging too (*"didn't hit 8000 steps"*), so it is a different question.

## Fixtures are customer sentences, not helper booleans

The screenshot sentence **end to end through `handleMessage`**, asserting the client is not told to rest. Plus the adjacent shapes that make the answer mean something:

```
"I'm doing yesterday's session today"    → moved_to_today
"rest day" / "taking a rest day"         → declined
"Can I do my workout tomorrow instead?"  → move_request
"I'll train tomorrow"                    → deferred
"I didn't do my workout"                 → missed
"skip the numbers" / "I trained today"   → none
"I didn't skip the gym today"            → none
```

**Negative control run:** forcing `moved_to_today` → `declined` reproduces the handset text **verbatim** — *"Kam, no stress — rest today, hit it fresh tomorrow 💪"*.

**Control in the other direction:** a genuine rest day is still honoured, so the fix cannot pass by making the coach unable to hear *"no"*.

## Honest bound

This is still pattern matching, and pattern matching has an unbounded failure surface — a phrasing nobody thought of will get through. What it no longer has is **six** surfaces. Step 3 (classifier leads, this becomes the narrow safety net) is where that changes.

## Suite

**1,430 characters of duplicated predicate in `routes.ts` replaced with 123.** `routes.ts` **1424 → 1416**.

```
production-parity  127/127
run-suites         30/32 — known baseline, no counter moved
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_