### PR TITLE
Two output defects from the handset: the receipt that hid a food, the header that contradicted itself

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2955,6 +2955,74 @@ async function main() {
       `a rest day was answered with the session: ${reply.slice(0, 120)}`);
   });
 
+  // ── OUTPUT DEFECTS FROM THE HANDSET (2026-08-25) ──────────────────────────────────────────
+  //
+  // Two of the five screenshots are NOT comprehension failures. The system understood correctly
+  // and then told the client something else. Both are fixtures now.
+  check("receipt . the confirmation names every food, or says how many it did not", async () => {
+    const { buildFoodLogReply } = await import("../server/handlers/food-scanner");
+    // The voice note, verbatim: four foods, all scanned, all priced, all written.
+    const said = "So my breakfast was, uh, three eggs, three slices of bread, some chakalaka and a piece of chicken";
+    const mk = (lines: string[]) => buildFoodLogReply({
+      foodLines: lines.join("\n"), mealLabel: "breakfast", totalMealCals: 810, totalMealProtein: 72,
+      runningCals: 856, runningProtein: 72, calorieTarget: 3140, proteinTarget: 186,
+      user: { name: "Kam", goalType: "muscle_gain", numbersMode: "low" },
+      userMessage: said, terse: true, isRetro: false,
+    } as any);
+
+    const four = String(await mk(["• Bread: 240 kcal", "• Eggs: 210 kcal",
+      "• Chicken thigh (150g): 280 kcal", "• Chakalaka: 80 kcal"]));
+    assert.match(four, /chakalaka/i,
+      `the receipt dropped a food that was logged — this is what makes clients "correct" us: ${four}`);
+
+    // A cap is still right for a long photo list. What is not right is a cap that HIDES.
+    const six = String(await mk(["• Bread: 1", "• Eggs: 1", "• Chicken thigh: 1",
+      "• Chakalaka: 1", "• Slices: 1", "• Piece: 1"]));
+    assert.match(six, /and 2 more/i, `six foods were truncated with no count: ${six}`);
+    assert.ok(!/Chakalaka\.\s*👌/.test(six) || /more/.test(six),
+      "a truncated list must say how many it left out");
+  });
+
+  check("header . Week and Session are on different clocks, and it says so", async () => {
+    const { sessionHeaderLine } = await import("../server/programme");
+    // THE SCREENSHOT: "*Week 1 — Session 25*". programmeWeek is PHASE-RELATIVE and resets; the
+    // session count is LIFETIME. Both numbers were right and the header was a contradiction.
+    const h = sessionHeaderLine(1, 24);
+    assert.match(h, /Session 25 overall/,
+      `Week and Session still read as one clock: ${h}`);
+    assert.equal(sessionHeaderLine(1, 0), "*Week 1*",
+      "a client with no sessions should not be given a session number at all");
+    assert.equal(sessionHeaderLine(3, 8), "*Week 3 — Session 9 overall*");
+    // …and the string that shipped this morning must not be reachable from the owner.
+    for (const [w, d] of [[1, 24], [3, 8], [5, 2]] as Array<[number, number]>) {
+      assert.ok(!/— Session \d+\*$/.test(sessionHeaderLine(w, d)),
+        `the unqualified header is back: ${sessionHeaderLine(w, d)}`);
+    }
+  });
+
+  // THE OUTCOME, not the owner. The parity USER is already programmeWeek 1 with 24 sessions —
+  // the screenshot's exact state — so the composed message is reachable, and asserting the owner
+  // alone would pass even if no caller used it. This is the string on the handset.
+  check("header outcome . the workout the client is sent does not contradict itself", async () => {
+    const g = globalThis as any;
+    // The parity user trains 3x/week, so "today" is a rest day on most calendar days and the
+    // session is never composed. Six days puts today inside the programme whenever this runs.
+    const reply = await serialise(async () => {
+      g.__KAMLIFE_STUB_USER = { ...USER, trainingDaysPerWeek: 6 };
+      try { return String(await handleMessage(USER.phoneNumber, "workout") ?? ""); }
+      catch (e: any) { return `__THREW__ ${e?.message || e}`; }
+      finally { g.__KAMLIFE_STUB_USER = { ...USER }; }
+    });
+    const header = reply.split("\n").find(l => /\*Week \d/.test(l)) || "";
+    assert.ok(header, `no week header in the workout reply: ${reply.slice(0, 200)}`);
+    assert.ok(!/— Session \d+\*\s*$/.test(header.trim()),
+      `Week and Session are still printed as one clock: ${header}`);
+    if (/Session/.test(header)) {
+      assert.match(header, /Session \d+ overall/,
+        `a session number without its clock named: ${header}`);
+    }
+  });
+
   // ── THE HARNESS ITSELF MUST RUN THE PRODUCTION BRANCH ─────────────────────────────────────
   check("harness: the card branch is enabled, and the verifier is not skipped", async () => {
     const { cardBaseUrl } = await import("../server/macro-card-attach");

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -5,7 +5,7 @@ import { reportCardMarker } from "../report-card";
 import { users, workoutLogs, chatHistory, mealLogs, stepLogs } from "../../shared/schema";
 import { eq, and, gte, desc, count, sql } from "drizzle-orm";
 import { SA_FOODS_SEED } from "../foods";
-import { buildDayWorkout, buildFullProgramme, getKamlifeProgramme } from "../programme";
+import { buildDayWorkout, buildFullProgramme, getKamlifeProgramme, sessionHeaderLine } from "../programme";
 import { calculateTargets, stepBurnKcal, recalcTargetsForProfile } from "../targets";
 import { askCoachK } from "../gpt";
 import { getShoppingList, formatShoppingList } from "../shopping-lists";
@@ -582,7 +582,7 @@ export async function handleEarlyCommands(ctx: {
         : "";
       const workoutGifUrl = getPrimaryWorkoutGifUrl(workout);
       const gifMarker = workoutGifUrl ? `\n[MEDIA:${workoutGifUrl}]` : "";
-      const missedReply = `${catchupIntro}\n\n*Week ${week} — Session ${sessionNum + 1}*\n\n${workout}${injuryNote}\n\n${doneHint}\n\nHow's that looking?${gifMarker}[BUTTONS:Done 💪|Too hard — modify|Skip today]`;
+      const missedReply = `${catchupIntro}\n\n${sessionHeaderLine(week, sessionNum)}\n\n${workout}${injuryNote}\n\n${doneHint}\n\nHow's that looking?${gifMarker}[BUTTONS:Done 💪|Too hard — modify|Skip today]`;
       await logChat(user.id, message, missedReply.replace(/\[MEDIA:[^\]]+\]|\[BUTTONS:[^\]]+\]/g, "").trim(), "WORKOUT_MISSED_CATCHUP");
       return missedReply;
     }
@@ -592,8 +592,7 @@ export async function handleEarlyCommands(ctx: {
     const workout = buildDayWorkout({ ...effectiveUser, programmeDayInWeek: todaySlot });
     const week = user.programmeWeek || 1;
     const sessionNum = user.totalWorkoutsCompleted || 0;
-    const sessionNote = sessionNum > 0 ? ` — Session ${sessionNum + 1}` : "";
-    const weekNote = `*Week ${week}${sessionNote}*\n\n`;
+    const weekNote = `${sessionHeaderLine(week, sessionNum)}\n\n`;
     const injuryNote = user.injuries && user.injuries.trim() && user.injuries.toLowerCase() !== "none"
       ? `\n\n⚠️ *Active injury noted (${user.injuries}):* Skip any exercise that causes sharp pain. Reply *injury* for safe alternatives.`
       : "";

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -905,16 +905,35 @@ export async function buildFoodLogReply(p: {
   // the words they used survive. A name with no overlap at all (a photo, where they typed
   // nothing) is dropped rather than guessed at — "Got it. 👌" is a complete reply and it cannot
   // put a word in their mouth.
+  // ── NEVER REPORT A SUBSET AS IF IT WERE THE WHOLE (2026-08-25) ──────────────────────────────
+  //
+  // THE HANDSET FAILURE. Voice note: "three eggs, three slices of bread, some chakalaka and a
+  // piece of chicken". Four foods were scanned, priced and WRITTEN — the ledger was right, the
+  // 856 kcal was right. The receipt said:
+  //
+  //     "Got it — Bread, Eggs and Chicken. 👌"
+  //
+  // `.slice(0, 3)` dropped the chakalaka silently. The client reads the receipt, sees a food
+  // missing, and corrects us — for something that was never wrong. That is where "the vision
+  // keeps getting my food wrong" comes from: not the scanner, which read it correctly, but a
+  // confirmation that quietly told them otherwise. Then the correction logs it AGAIN.
+  //
+  // A cap is still right — an eight-item photo should not produce an eight-name sentence. What is
+  // not right is a cap that HIDES. Four names, then the count of what is left, so the client can
+  // always tell whether we heard everything.
   const said = String(p.userMessage || "").toLowerCase();
-  const bareNames = String(p.foodLines || "")
+  const allNames = String(p.foodLines || "")
     .split("\n")
     .map(l => l.replace(/^[•\-\s]+/, "").split(/[:(]/)[0].trim())
     .map(name => name.split(/\s+/).filter(w => w.length > 2 && said.includes(w.toLowerCase())).join(" ").trim())
-    .filter(Boolean)
-    .slice(0, 3);
-  const label = bareNames.length > 1
+    .filter(Boolean);
+  const NAMED = 4;
+  const bareNames = allNames.slice(0, NAMED);
+  const hidden = allNames.length - bareNames.length;
+  const joined = bareNames.length > 1
     ? `${bareNames.slice(0, -1).join(", ")} and ${bareNames[bareNames.length - 1]}`
     : bareNames[0] || "";
+  const label = hidden > 0 ? `${bareNames.join(", ")} and ${hidden} more` : joined;
   const line = neverSilentLine("meal", { label, carryingShame: carriesFeelingClause(p.userMessage || "") });
   // The retro day is a FACT the client needs — logging to the wrong day is the one error they
   // cannot see. It rides as a clause, not as a second sentence.

--- a/server/programme.ts
+++ b/server/programme.ts
@@ -1670,6 +1670,30 @@ function filterInjuredGymExercises(exercises: Exercise[], injuries: string): { s
   return { safeEx, skippedNames };
 }
 
+/**
+ * THE SESSION HEADER — two clocks, said as two clocks (2026-08-25).
+ *
+ * THE HANDSET FAILURE: "*Week 1 — Session 25*". Both numbers were correct and the header was a
+ * contradiction, because they are measured on different clocks:
+ *
+ *   programmeWeek           PHASE-RELATIVE. It resets to 1 at every phase change and at a goal
+ *                           change, so "Week 1" can be someone's ninth month.
+ *   totalWorkoutsCompleted  LIFETIME. It never resets.
+ *
+ * The system already knew this — client-snapshot.ts tells the MODEL "week is phase-relative; it
+ * resets each phase; sessions below are the lifetime count" — and never told the client.
+ *
+ * This exact string was patched on 2026-07-16 after "Week 1 — Session 21" reached a client with a
+ * 125kg chest fly. That patch changed the RATIONALE COPY underneath and left the header alone, so
+ * it printed again this morning. Saying which clock each number is on is the fix the copy change
+ * was standing in for.
+ */
+export function sessionHeaderLine(week: number, sessionsDone: number): string {
+  const w = Math.max(1, Number(week) || 1);
+  const done = Math.max(0, Number(sessionsDone) || 0);
+  return done > 0 ? `*Week ${w} — Session ${done + 1} overall*` : `*Week ${w}*`;
+}
+
 export function buildDayWorkout(user: any): string {
   return withSafetyNote(buildDayWorkoutInner(user), user);
 }


### PR DESCRIPTION
Both of these are from this morning's screenshots. Neither is a comprehension failure. In both cases the system understood the client correctly, computed correctly, wrote correctly — and then **told the client something else**. That is a distinct layer from the six PRs before this one, and it is the layer the testers are actually seeing.

## 1. The receipt hid a food it had already logged

`server/handlers/food-scanner.ts`

Voice note, verbatim: *"three eggs, three slices of bread, some chakalaka and a piece of chicken"*.

All four foods were scanned, priced and written. The ledger was right — 856 kcal / 72g was correct. The confirmation said:

> Got it — Bread, Eggs and Chicken. 👌

`.slice(0, 3)` dropped the chakalaka silently.

**This is where "the vision keeps getting my food wrong" comes from.** `scanForSAFoods` returned the chakalaka. The scanner was not wrong. The receipt is what told the client otherwise — so they correct us for something that was never wrong, and the correction then logs the food a second time. One truncation produces a false accuracy complaint *and* a double-log.

A cap is still right; an eight-item photo should not produce an eight-name sentence. What is not right is a cap that **hides**. Four names, then the count of what was left out, so the client can always tell whether we heard everything.

```
2 foods → "Got it — Bread and Eggs. 👌"
4 foods → "Got it — Bread, Eggs, Chicken and Chakalaka. 👌"
6 foods → "Got it — Bread, Eggs, Chicken, Chakalaka and 2 more. 👌"
```

## 2. The header printed two clocks as one

`server/programme.ts`, `server/handlers/early-commands.ts`

> **Week 1 — Session 25**

Both numbers were correct:

| number | clock |
|---|---|
| `programmeWeek` | **phase-relative** — resets to 1 at every phase change and at a goal change, so "Week 1" can be someone's ninth month |
| `totalWorkoutsCompleted` | **lifetime** — never resets |

The system already knew this. `client-snapshot.ts` tells the *model* "week is phase-relative; it resets each phase; sessions below are the lifetime count". It never told the client.

This exact string was patched on **2026-07-16**, after "Week 1 — Session 21" reached a client. That patch changed the rationale copy underneath and left the header alone — so it printed again this morning. Naming which clock each number is on is the fix the copy change was standing in for.

`sessionHeaderLine(week, sessionsDone)` is now the one owner. Both composition sites in `early-commands.ts` (the normal training day and the missed-catchup branch) call it.

**Side effect, named rather than hidden:** the missed-catchup branch used to print "Session 1" for a client with zero sessions completed. It now prints `*Week 1*`, matching the normal branch.

## Negative controls — all three run, all three observed

| control | result |
|---|---|
| restore `.slice(0, 3)` | receipt fixture **RED**, reproducing the screenshot verbatim: `Got it — Bread, Eggs and Chicken. 👌` |
| drop `overall` from the owner | both header fixtures **RED**: `*Week 1 — Session 25*` |
| owner stays correct, the **caller** hand-builds the header again | owner fixture stays **GREEN**, outcome fixture **RED** |

The third control is the one that matters. It is the 2026-07-16 failure mode reproduced exactly — the fix exists, one copy does not get it — and only the end-to-end fixture catches it. An owner-level assertion alone would have passed while the client kept receiving the contradiction.

The header outcome fixture drives a real turn through `handleMessage` and reads the header off the composed reply, not off the helper. The parity user is already `programmeWeek: 1, totalWorkoutsCompleted: 24` — the screenshot's exact state.

## Verification

- `production-parity`: **130/130** (127 before; three fixtures added)
- Full chain: **30/32**, the known baseline
- Architecture and file-size guard failures diffed against a real detached `origin/main` checkout (`3a3c310`), not a stash: **byte-identical**. `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425, five file-size breaches — every one pre-existing, none moved by this change.
- No budget raised, no suppression, no owner deleted.

## Scope

This is the bounded objective as scoped: the two already-reproduced, customer-visible output defects. It starts no consolidation. The production reply audit against `chat_history.message_out` still needs someone with database access — it cannot be run from here — and screenshot 4 (06:00 "4 more this week" vs 10:57 "a week off") is still untraced and deliberately not touched in this cut.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_