### PR TITLE
The test harness could not express time — and two checks were passing vacuously

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -81,6 +81,14 @@ function serialise<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 const sastDayKeyOf = (d: Date) => new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg", year: "numeric", month: "2-digit", day: "2-digit" }).format(d);
+/** Midday on the most recent past Saturday — for fixtures that correct a named weekday. */
+function lastSaturday(): Date {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  const back = (d.getDay() - 6 + 7) % 7 || 7;   // never today: "from Saturday" means a past one
+  d.setDate(d.getDate() - back);
+  return d;
+}
 const NOW = Date.now();
 const USER = {
   id: "test-user-production-parity",
@@ -1985,9 +1993,17 @@ async function main() {
       typicalPortionCalories: 5, typicalPortionProtein: 0, carbsPer100g: 0, fatPer100g: 0 }];
     const g = globalThis as any;
     const scoped = await serialise(async () => {
+      // BOTH DAYS ARE SEEDED, and they have to be (2026-08-25, issue #63). This seeded only a
+      // YESTERDAY row and then asserted that a TODAY-scoped amend succeeded. It passed because the
+      // stub ignored `where`, so a today-scoped query was handed yesterday's row. Against a stub
+      // that honours the window, a correct implementation finds nothing — so the assertion below
+      // could never have failed for the right reason. One row per day is what the check meant.
       g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [{
         id: "parity-day-row", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
         carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: new Date(NOW - 86_400_000),
+      }, {
+        id: "parity-day-row-today", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
+        carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: new Date(NOW - 3600_000),
       }]]]);
       const yesterday = new Date(Date.now() - 86_400_000);
       const out = {
@@ -2010,9 +2026,19 @@ async function main() {
     const { mealLogs } = await import("../shared/schema");
     const g = globalThis as any;
     const replies = await serialise(async () => {
+      // One row per day the check corrects — see 2b. A single yesterday row made the today case
+      // vacuous under a stub that could not filter.
       g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [{
         id: "parity-day-row-2", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
         carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: new Date(NOW - 86_400_000),
+      }, {
+        id: "parity-day-row-2-today", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
+        carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: new Date(NOW - 3600_000),
+      }, {
+        // …and the named day the check corrects. Computed, not hard-coded, so the fixture does not
+        // depend on which weekday the suite happens to run.
+        id: "parity-day-row-2-sat", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
+        carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: lastSaturday(),
       }]]]);
       const out = {
         today: await say("You missed the black coffee"),
@@ -3020,6 +3046,39 @@ async function main() {
     if (/Session/.test(header)) {
       assert.match(header, /Session \d+ overall/,
         `a session number without its clock named: ${header}`);
+    }
+  });
+
+  // ── THE HARNESS MUST BE ABLE TO EXPRESS TIME ──────────────────────────────────────────────
+  //
+  // Until 2026-08-25 the stub's `.where()` discarded its condition, so a today-scoped query and an
+  // all-time query returned the same rows. Two checks in this file (2b, 2c) asserted that a
+  // TODAY-scoped correction succeeded while seeding only a YESTERDAY row — they passed because the
+  // window was never applied, and could not have failed for the right reason.
+  //
+  // Every temporal assertion in this suite now rests on that filter working, which is exactly why
+  // it gets its own check: if the evaluator silently stops matching, the failure mode is not a red
+  // suite, it is a green one that has quietly stopped testing days again.
+  check("harness: a day-scoped query does not see another day's row", async () => {
+    const { db } = await import("../server/db");
+    const { mealLogs } = await import("../shared/schema");
+    const { gte } = await import("drizzle-orm");
+    const g = globalThis as any;
+    const before = g.__KAMLIFE_STUB_ROWS;
+    try {
+      g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [
+        { id: "h-today", loggedAt: new Date(NOW - 3600_000) },
+        { id: "h-yesterday", loggedAt: new Date(NOW - 30 * 3600_000) },
+      ]]]);
+      const scoped: any[] = await db.select().from(mealLogs)
+        .where(gte(mealLogs.loggedAt, new Date(NOW - 12 * 3600_000)));
+      assert.deepEqual(scoped.map(r => r.id), ["h-today"],
+        `the window returned ${scoped.length} rows — the stub is ignoring \`where\` again`);
+      // …and an unfiltered read must still see everything, or the filter has become a truncation.
+      const all: any[] = await db.select().from(mealLogs);
+      assert.equal(all.length, 2, "an unscoped read lost rows");
+    } finally {
+      if (before) g.__KAMLIFE_STUB_ROWS = before; else delete g.__KAMLIFE_STUB_ROWS;
     }
   });
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -14,8 +14,104 @@ const { Pool } = pg;
 // reassign __KAMLIFE_STUB_USER per case (routing-audit already does).
 const STUB = process.env.KAMLIFE_DB_STUB === "1";
 
+/**
+ * THE STUB COULD NOT EXPRESS TIME (2026-08-25, issue #63).
+ *
+ * `.where(...)` used to `return chain(state)` — it discarded the condition entirely, so seeded
+ * rows came back for EVERY query on that table whatever the date window. A handler asking "what
+ * did they log today" and a handler asking "what did they log this month" received identical
+ * answers, which means no offline suite could test day attribution, retro-day resolution, or
+ * multi-day catch-up. The one product requirement that is entirely about time had a test double
+ * that had no concept of it.
+ *
+ * That is not a missing fixture. It is a substrate that cannot represent the customer scenario,
+ * and it is why a reproduction of "logged from yesterday" had to be thrown away as an artifact:
+ * the harness handed the handler yesterday's row because it could not filter.
+ *
+ * This walks drizzle's condition tree and evaluates the comparisons a ledger query actually uses.
+ * It is DELIBERATELY PARTIAL. Anything it cannot interpret — a subquery, a function call, an
+ * operator not listed — returns `undefined` and the row is KEPT, so an unrecognised condition
+ * behaves exactly as before rather than silently emptying a result set. A stub that quietly
+ * dropped rows it did not understand would be a worse lie than the one being fixed.
+ */
+type Cmp = ">=" | "<=" | ">" | "<" | "=" | "<>";
+const CMP: Record<Cmp, (a: any, b: any) => boolean> = {
+  ">=": (a, b) => a >= b, "<=": (a, b) => a <= b, ">": (a, b) => a > b,
+  "<": (a, b) => a < b, "=": (a, b) => a === b, "<>": (a, b) => a !== b,
+};
+
+/** Values arrive as Date, string or number; compare on one scale or `>=` is lexicographic. */
+function comparable(v: any): any {
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === "string") {
+    const t = Date.parse(v);
+    if (!Number.isNaN(t) && /\d{4}-\d{2}-\d{2}/.test(v)) return t;
+  }
+  return v;
+}
+
+/**
+ * Returns true (keep), false (drop), or undefined (not interpretable — keep).
+ * `undefined` is distinct from `true` so an AND can tell "passed" from "unknown".
+ */
+function evalCondition(cond: any, row: Record<string, any>): boolean | undefined {
+  if (!cond || typeof cond !== "object") return undefined;
+  const chunks: any[] = cond.queryChunks;
+  if (!Array.isArray(chunks)) return undefined;
+
+  // A composite (and/or) is a chunk list whose own chunks are SQL nodes. Recurse, then combine on
+  // the separator drizzle wrote between them.
+  const nested = chunks.filter(c => c && typeof c === "object" && Array.isArray(c.queryChunks));
+  if (nested.length > 1) {
+    const joiner = chunks.map(c => (typeof c?.value === "string" ? c.value : "")).join(" ").toLowerCase();
+    const results = nested.map(n => evalCondition(n, row));
+    if (joiner.includes(" or ")) {
+      if (results.some(r => r === true)) return true;
+      return results.every(r => r === false) ? false : undefined;
+    }
+    // AND: any definite false drops the row; otherwise unknown unless all definitely true.
+    if (results.some(r => r === false)) return false;
+    return results.every(r => r === true) ? true : undefined;
+  }
+  if (nested.length === 1) return evalCondition(nested[0], row);
+
+  // A leaf: [ StringChunk, Column, StringChunk(" >= "), Param, StringChunk ].
+  // StringChunk.value is a string ARRAY, not a string — reading it as a string silently found no
+  // operator and every row was kept, which is the same "quietly does nothing" failure this whole
+  // change exists to remove.
+  const asText = (c: any): string => {
+    if (typeof c === "string") return c;
+    if (Array.isArray(c?.value)) return c.value.join(" ");
+    if (typeof c?.value === "string") return c.value;
+    return "";
+  };
+  // A StringChunk is identified by SHAPE (its value is a string array), never by whether it
+  // happens to render non-empty. The leading chunk is `[""]`, so testing "did this produce text"
+  // let the empty separator be read as the parameter and every comparison silently became
+  // `undefined` — keep-everything, exactly the behaviour being replaced.
+  let col: any, op: Cmp | undefined, param: any, sawParam = false;
+  for (const c of chunks) {
+    if (typeof c === "string" || Array.isArray(c?.value)) {
+      const m = asText(c).match(/(>=|<=|<>|!=|=|>|<)/);
+      if (m && !op) op = (m[1] === "!=" ? "<>" : m[1]) as Cmp;
+      continue;
+    }
+    if (c && typeof c === "object" && typeof c.name === "string" && c.name && !col) { col = c; continue; }
+    if (c && typeof c === "object" && "value" in c && !sawParam) { param = c.value; sawParam = true; }
+  }
+  if (!col || !op || !sawParam) return undefined;
+
+  // Drizzle columns carry the DB name; seeded rows are written in camelCase, so accept either.
+  const camel = String(col.name).replace(/_([a-z])/g, (_m, c) => c.toUpperCase());
+  const key = camel in row ? camel : (col.name in row ? col.name : undefined);
+  if (key === undefined) return undefined;   // column not seeded — cannot judge, keep
+
+  const fn = CMP[op];
+  return fn ? fn(comparable(row[key]), comparable(param)) : undefined;
+}
+
 function makeStubDb(): any {
-  function chain(state: { table?: any }): any {
+  function chain(state: { table?: any; conds?: any[] }): any {
     const fn: any = () => {};
     return new Proxy(fn, {
       get(_t, prop: string | symbol) {
@@ -28,8 +124,14 @@ function makeStubDb(): any {
           // Needed because "the log says 1, the model said 4" cannot be proved against a log that
           // can only ever say 0.
           const seeded = (globalThis as any).__KAMLIFE_STUB_ROWS as Map<any, any[]> | undefined;
-          const rows = seeded?.get(state.table)
+          const all = seeded?.get(state.table)
             ?? (state.table === (schema as any).users && stubUser ? [{ ...stubUser }] : []);
+          // THE WHERE IS APPLIED (2026-08-25). Only to SEEDED rows: the users row is the pipeline's
+          // own client and is looked up by phone/id in ways the evaluator has no reason to judge,
+          // so narrowing it would break every existing suite for no gain.
+          const rows = (seeded?.get(state.table) && state.conds?.length)
+            ? all.filter(r => state.conds!.every(c => evalCondition(c, r) !== false))
+            : all;
           // `.catch()` USED TO DISCARD THE SEED (fixed 2026-08-25). It returned
           // `Promise.resolve([]).catch(h)` — a resolved promise of the EMPTY array, whatever the
           // suite had seeded. Every query in loadProactiveState ends in `.catch(() => [])`, so a
@@ -41,7 +143,9 @@ function makeStubDb(): any {
           return (res: any, rej: any) => Promise.resolve(rows).then(res, rej);
         }
         return (...args: any[]) => {
-          if (prop === "from" || prop === "into") return chain({ table: args[0] });
+          if (prop === "from" || prop === "into") return chain({ ...state, table: args[0] });
+          // Conditions accumulate: drizzle allows .where() once, but a builder may re-wrap.
+          if (prop === "where" && args[0]) return chain({ ...state, conds: [...(state.conds || []), args[0]] });
           if ((prop === "set" || prop === "values") && state.table === (schema as any).users
               && args[0] && typeof args[0] === "object" && !Array.isArray(args[0])) {
             const stubUser = (globalThis as any).__KAMLIFE_STUB_USER;


### PR DESCRIPTION
Issue #63, mandate item **1.3**. Before any behaviour changes, make the substrate able to represent the scenario we need to test.

## The defect

The stub DB's `.where(...)` returned `chain(state)` — **it discarded the condition entirely.**

Seeded rows came back for every query on that table, whatever the window. A handler asking *"what did they log today"* and one asking *"what did they log this month"* received identical answers. So no offline suite could test day attribution, retro-day resolution, or multi-day catch-up.

**The one product requirement that is entirely about time had a test double with no concept of it.**

This is how it was found: during #63 I reproduced the reported "logged from yesterday" defect, then had to throw the reproduction away — the harness had handed the handler yesterday's row because it could not filter. The discarded reproduction is the finding.

## The fix

Walk drizzle's condition tree and evaluate the comparisons a ledger query actually uses (`eq`, `gte`, `lte`, `gt`, `lt`, `and`, `or`). Applied only to **seeded** rows — the users row is looked up by phone/id in ways the evaluator has no business judging, and narrowing it would break every existing suite for no gain.

**Deliberately partial, and it fails open.** Anything uninterpretable — a subquery, a function call, an unlisted operator — returns `undefined` and the row is **kept**. A stub that silently dropped rows it did not understand would be a worse lie than the one being removed.

Two bugs found while building it, both worth naming because they are the same shape as the defect itself:

- `StringChunk.value` is a string **array**, so reading it as a string never matched an operator and every comparison silently became "keep".
- The leading chunk is `[""]`, so testing *"did this render text"* let the empty separator be read as the parameter. A StringChunk is now identified by **shape**, not by whether it happens to be non-empty.

Both would have produced a filter that appeared to work and quietly did nothing.

## What it immediately caught

Two checks in `production-parity` went red:

```
✗ 2b . a correction lands on the day being corrected, or not at all
✗ 2c . the client is told which day was changed
```

Both seeded **only a yesterday row**, then asserted that a **today-scoped** correction succeeded. They passed because the window was never applied. Against a stub that honours it, a correct implementation finds nothing — **so neither assertion could ever have failed for the right reason.** 2c's *"from Saturday"* case was vacuous the same way.

Fixtures repaired to seed one row per day they correct, including a computed `lastSaturday()` so the check does not depend on which weekday CI runs. They are now the assertions they always claimed to be.

## The substrate gets its own test

Every temporal assertion in the suite now rests on this filter working, and if it stops the failure mode is **not a red suite — it is a green one that has quietly stopped testing days again.**

`harness: a day-scoped query does not see another day's row` asserts both directions: the window excludes the other day, **and** an unscoped read still returns everything (so a filter cannot degrade into a truncation).

**Negative control, run:** reverting to `const rows = all` turns that check red with

> `the window returned 2 rows — the stub is ignoring \`where\` again`

## Verification

- `production-parity`: **131/131** (130 → 131; two repaired, one added)
- Full chain: **31/33** — same two governors red as `main`, same numbers
- `modules` **239/239** unchanged; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — none moved
- `tsc --noEmit` clean
- **No product behaviour changed.** This is test infrastructure only.

## Scope

This is item 1.3 of the mandate. Items 1.1 (a harness that runs the normalizer) and 1.2 (positive-outcome assertions as a rule) are **not** in this PR and remain open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_