### PR TITLE
Replay the production front door offline — or say plainly that we did not

### DIFF
--- a/script/normalizer-replay-tests.ts
+++ b/script/normalizer-replay-tests.ts
@@ -42,11 +42,14 @@ async function check(name: string, fn: () => Promise<void> | void) {
 
 async function main() {
   if (!existsSync(CORPUS_PATH)) {
+    // THE MARKER MATTERS AS MUCH AS THE MESSAGE (2026-08-25). Exiting 0 with a printed notice made
+    // run-suites report `✓ normalizer-replay-tests` — a green tick on a suite that asserted
+    // nothing, which is the exact vacuous pass this file exists to prevent, reproduced by the file
+    // itself. run-suites reads this marker and renders ⊘, and counts it as not covered.
     console.log(
-      `\n⊘ normalizer-replay: SKIPPED — no recording at ${CORPUS_PATH}.\n` +
-      `  The production front door is therefore NOT covered by any offline suite.\n` +
+      `SUITE_SKIPPED: no recording at ${CORPUS_PATH} — the production front door is NOT covered\n` +
       `  Record it once with a real key:  OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts\n` +
-      `  ${CORPUS.length} corpus inputs are waiting. This is a stated gap, not a pass.\n`);
+      `  ${CORPUS.length} corpus inputs are waiting. This is a stated gap, not a pass.`);
     process.exit(0);
   }
 

--- a/script/normalizer-replay-tests.ts
+++ b/script/normalizer-replay-tests.ts
@@ -1,0 +1,147 @@
+/**
+ * NORMALIZER REPLAY — run the production front door offline, or say plainly that you did not.
+ *
+ * Issue #63, item 1.1. Production applies the normalizer to every message before any handler sees
+ * it. Eight deterministic harnesses set NORMALIZER=off because it needs a live model, so the
+ * transformation that reaches production FIRST has never been exercised offline. This suite
+ * replays recordings of the real model so that stops being true.
+ *
+ * THE ONE THING THIS SUITE MUST NEVER DO is pass while covering nothing. Three separate defects
+ * found on 2026-08-25 were tests that could not fail for the right reason — a stub that ignored
+ * `where`, a fixture that asserted only the absence of a wrong answer, and two checks seeded with
+ * the wrong day. So:
+ *
+ *   - with no recording present it reports SKIPPED, loudly, and asserts nothing;
+ *   - with a recording present it runs STRICT, so an input that was never recorded THROWS rather
+ *     than falling through to the offline shim and grading a reply the normalizer never touched;
+ *   - if the prompt or model has moved since the recording, it says so, because a stale recording
+ *     asserts yesterday's behaviour while claiming to assert today's.
+ */
+
+process.env.KAMLIFE_DB_STUB = "1";
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "sk-test-offline";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.APP_URL = "https://kamlife-coach-production.up.railway.app";
+process.env.NODE_ENV = "production";
+// THE POINT OF THE SUITE: the front door is ON here, unlike every other offline harness.
+delete process.env.NORMALIZER;
+process.env.NORMALIZER_FIXTURES_STRICT = "1";
+
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { CORPUS, CORPUS_PATH, recordingFingerprint } from "./record-normalizer";
+
+let passed = 0;
+const failures: string[] = [];
+async function check(name: string, fn: () => Promise<void> | void) {
+  try { await fn(); passed++; } catch (e: any) { failures.push(`  ✗ ${name}\n    ${e?.message || e}`); }
+}
+
+async function main() {
+  if (!existsSync(CORPUS_PATH)) {
+    console.log(
+      `\n⊘ normalizer-replay: SKIPPED — no recording at ${CORPUS_PATH}.\n` +
+      `  The production front door is therefore NOT covered by any offline suite.\n` +
+      `  Record it once with a real key:  OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts\n` +
+      `  ${CORPUS.length} corpus inputs are waiting. This is a stated gap, not a pass.\n`);
+    process.exit(0);
+  }
+
+  const recorded = JSON.parse(readFileSync(CORPUS_PATH, "utf-8"));
+  (globalThis as any).__KAMLIFE_INTENT_FIXTURES = recorded.entries;
+
+  const fp = recordingFingerprint(readFileSync("server/gpt.ts", "utf-8"));
+  if (fp.promptHash !== recorded.promptHash || fp.model !== recorded.model) {
+    console.log(`⚠ STALE: recorded against ${recorded.model}/${recorded.promptHash}, `
+      + `now ${fp.model}/${fp.promptHash}. Re-record — these assertions describe the old front door.`);
+  }
+
+  const missing = CORPUS.filter(c => !(c.input.toLowerCase() in recorded.entries));
+  await check("every corpus input has a recording", () => {
+    assert.equal(missing.length, 0,
+      `${missing.length} corpus inputs were never recorded: ${missing.map(m => m.input.slice(0, 40)).join(" | ")}`);
+  });
+
+  // ── THE INVARIANT THAT MATTERS: a rewrite may not destroy what a downstream owner needs ──────
+  //
+  // #63 established the mechanism: a multi-day note is a SINGLE-DOMAIN note, so `multiFact` is
+  // false and the brake that stops the normalizer speaking for a multi-fact message never engages.
+  // The batch logger itself is correct — it answers "Logged 3 days ✅" on the raw text. The risk is
+  // entirely that the raw text never reaches it.
+  await check("a multi-day batch keeps its days through the front door", () => {
+    const batch = CORPUS.find(c => /Monday I had pap/i.test(c.input))!;
+    const rec: any = recorded.entries[batch.input.toLowerCase()];
+    if (!rec) return;                       // already reported by the coverage check above
+    const canon = String(rec.canonical || "");
+    if (!canon) return;                     // no rewrite is the safe outcome — nothing destroyed
+    const days = ["monday", "tuesday", "wednesday"].filter(d => canon.toLowerCase().includes(d));
+    assert.equal(days.length, 3,
+      `the rewrite kept ${days.length}/3 named days — a multi-day note collapsed at the front door, `
+      + `which is how three days of meals land on one: ${canon}`);
+  });
+
+  await check("a correction keeps the day it names", () => {
+    const rec: any = recorded.entries["you missed the black coffee yesterday"];
+    if (!rec?.canonical) return;
+    assert.match(String(rec.canonical), /yesterday/i,
+      `the rewrite dropped the day being corrected: ${rec.canonical}`);
+  });
+
+  // ── AND THE NUMBERS BRAKE, ASSERTED ON REAL RECORDINGS ──────────────────────────────────────
+  // routes.ts refuses a canonical whose numbers are not in the original. That guard is only as
+  // good as the rewrites it actually sees.
+  await check("no rewrite invents a number the client did not write", () => {
+    for (const [key, rec] of Object.entries<any>(recorded.entries)) {
+      const canon = String(rec.canonical || "");
+      if (!canon) continue;
+      for (const n of canon.match(/\d+/g) || []) {
+        assert.ok(key.includes(n) || /^(1|2)$/.test(n),
+          `the rewrite of "${key.slice(0, 50)}" invented the number ${n}: ${canon}`);
+      }
+    }
+  });
+
+  // ── AND THROUGH THE PRODUCTION PATH, WHICH IS THE WHOLE POINT ────────────────────────────────
+  //
+  // The checks above grade the RECORDINGS. This drives real turns with the front door ON and the
+  // recordings replayed — the arrangement no offline suite has ever run. STRICT is set, so if a
+  // turn reaches the classifier with an input that was not recorded it throws rather than quietly
+  // falling through to the offline shim and grading a reply the normalizer never touched.
+  //
+  // The assertion is deliberately POSITIVE (item 1.2): not "the bad string is absent" but "the
+  // client got an answer at all". #61 shipped green on a negative assertion while the coach
+  // changed the subject, and that is the failure this form exists to prevent.
+  const { handleMessage } = await import("../server/routes");
+  const NOW = Date.now();
+  const USER = {
+    id: "norm-replay", phoneNumber: "whatsapp:+27000000031", name: "Kam",
+    onboardingState: "COMPLETE", onboardingComplete: true, subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(NOW - 30 * 86_400_000),
+    goalType: "fat_loss", currentWeight: 95, targetWeight: 85, heightCm: 180, age: 35,
+    gender: "male", activityLevel: "moderate", trainingMode: "gym", trainingDaysPerWeek: 3,
+    programmePhase: 1, programmeWeek: 1, programmeDayInWeek: 2, totalWorkoutsCompleted: 24,
+    programmeStartDate: new Date(NOW - 35 * 86_400_000), injuries: "none", medicalConditions: "none",
+    awaitingInputType: null, profileNotes: "", calorieTarget: 2700, proteinTarget: 180,
+    stepTarget: 10000, lastActiveAt: new Date(NOW - 3600_000), createdAt: new Date(NOW - 35 * 86_400_000),
+  };
+  for (const { input } of CORPUS.filter(c => c.input.toLowerCase() in recorded.entries)) {
+    await check(`through the front door: ${input.slice(0, 44)}`, async () => {
+      (globalThis as any).__KAMLIFE_STUB_USER = { ...USER };
+      const reply = String(await handleMessage(USER.phoneNumber, input) ?? "");
+      assert.ok(reply.trim().length > 0, "the turn produced no reply at all");
+      assert.ok(!/something went wrong on my side|give me a second and try again/i.test(reply),
+        `the pipeline crashed with the normalizer on — this path is only reachable here:\n      ${reply.slice(0, 160)}`);
+    });
+  }
+
+  console.log(`\nnormalizer-replay: ${passed}/${passed + failures.length} passed `
+    + `(${Object.keys(recorded.entries).length} recorded normalizations)`);
+  if (failures.length) { console.log("\nFailures:\n" + failures.join("\n")); process.exit(1); }
+  console.log("✓ the production front door was exercised, not skipped");
+  process.exit(0);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/script/record-normalizer.ts
+++ b/script/record-normalizer.ts
@@ -1,0 +1,99 @@
+/**
+ * RECORD THE NORMALIZER — capture production's real rewrites once, replay them free forever.
+ *
+ * WHY (issue #63, item 1.1). The front-door normalizer is ON in production and OFF in eight
+ * deterministic harnesses, including `gauntlet` — the grader that reports 351/355. So the
+ * transformation that reaches production FIRST has never been exercised by an offline suite, and
+ * "351/355 green" describes a path production does not run for messy input.
+ *
+ * It cannot simply be switched on: `classifyIntent` calls gpt-4o-mini, so every local run would
+ * become paid and non-deterministic. And the fast paths cannot stand in for it — they classify and
+ * never return a `canonical`, which is the half that rewrites, and therefore the half that can
+ * destroy information before the capability built for it is reached.
+ *
+ * So: record once against the real model, replay deterministically.
+ *
+ *   OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts
+ *
+ * THE FIXTURES ARE NOT HAND-WRITTEN, AND MUST NEVER BE. Inventing what the model "would" return
+ * produces a fixture that agrees with the test author instead of with production — a suite that
+ * cannot fail for the right reason, which is the exact defect #63 found three times over. If this
+ * script has not been run, the replay suite says so out loud and does not pretend to cover it.
+ *
+ * STALENESS. The recording is only valid for the prompt and model that produced it. Both are
+ * fingerprinted into the file; the replay suite compares and reports when they have moved, because
+ * a stale recording is a test asserting yesterday's behaviour while claiming to assert today's.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const CORPUS_PATH = "script/fixtures/normalizer-corpus.json";
+
+/**
+ * THE CORPUS — real customer language, not invented phrasing.
+ *
+ * Seeded with the traced conversations from #63. It grows from inputs surfaced by the turn-triage
+ * dashboard (#64), so the corpus stays tied to what people actually send rather than to what a
+ * test author imagines they send.
+ *
+ * Each entry says WHY it is here, because a corpus nobody can justify becomes a corpus nobody
+ * dares change.
+ */
+export const CORPUS: Array<{ input: string; why: string }> = [
+  { input: "No I moved yesterdays workout to today",
+    why: "#63: comprehension is correct (moved_to_today) and nothing consumes it — the reply is a food prompt" },
+  { input: "My dinner is the same as the last meal",
+    why: "#63: reported as logged from yesterday; a back-reference whose day resolution is the risk" },
+  { input: "No I'm just fine with this meal",
+    why: "#63: a plain decline answered with 'I didn't catch that one' — reproduces offline" },
+  { input: "My steps are 10k today",
+    why: "#63: evidence stated, action contradicted it ('get a 20-minute walk in')" },
+  { input: "Monday I had pap and chicken, eggs and bread for breakfast, and rice with beef stew for dinner. Tuesday was oats, a chicken salad, and pasta with mince. Wednesday I had eggs and bacon, a burger and chips, and lamb chops with rice.",
+    why: "#63 (Bonolo): three days in one batch. multiFact is false for a single-domain note, so the rewrite brake does not engage — this is the input that must not collapse into one day" },
+  { input: "I had a burger and chips last night, I feel like I ruined everything",
+    why: "gauntlet: mouth-layer failure, 5 sentences where 3 are the rule" },
+  { input: "Work is stressing me out and I ate takeaways again tonight",
+    why: "gauntlet: 6 sentences where 3 are the rule, and the stress is never acknowledged" },
+  { input: "is today a rest day",
+    why: "gauntlet: 3 sentences where 2 are the rule" },
+  { input: "I'm doing yesterday's session today",
+    why: "the adjacent shape of moved_to_today — a rewrite must not turn this into a refusal" },
+  { input: "you missed the black coffee yesterday",
+    why: "a correction naming a past day; the day must survive the rewrite" },
+];
+
+/** The prompt text and model this recording is only valid for. */
+export function recordingFingerprint(gptSource: string): { model: string; promptHash: string } {
+  const model = (gptSource.match(/model:\s*"(gpt-[^"]+)"[^}]*?max_tokens:\s*110/s) || [])[1] || "unknown";
+  const prompt = (gptSource.match(/You are the message-understanding brain[\s\S]*?`/) || [""])[0];
+  return { model, promptHash: createHash("sha256").update(prompt).digest("hex").slice(0, 16) };
+}
+
+async function main() {
+  if (!process.env.OPENAI_API_KEY || /test|offline/i.test(process.env.OPENAI_API_KEY)) {
+    console.error("Refusing to record without a real OPENAI_API_KEY — a recording made against the\n"
+      + "offline shim would be a fixture full of OTHER/no-canonical, which is worse than none.");
+    process.exit(1);
+  }
+  const { classifyIntent } = await import("../server/gpt");
+  const fp = recordingFingerprint(readFileSync("server/gpt.ts", "utf-8"));
+  const entries: Record<string, unknown> = {};
+
+  for (const { input, why } of CORPUS) {
+    const out = await classifyIntent(input);
+    entries[input.toLowerCase()] = { ...out, _input: input, _why: why };
+    console.log(`${out.intent.padEnd(13)} ${out.canonical ? `→ ${out.canonical}` : "(no rewrite)"}`);
+  }
+
+  mkdirSync(dirname(CORPUS_PATH), { recursive: true });
+  writeFileSync(CORPUS_PATH, JSON.stringify({
+    recordedAt: new Date().toISOString(), ...fp, entries,
+  }, null, 2) + "\n");
+  console.log(`\nRecorded ${CORPUS.length} normalizations to ${CORPUS_PATH} (model ${fp.model}, prompt ${fp.promptHash}).`);
+}
+
+if (process.argv[1]?.endsWith("record-normalizer.ts")) {
+  main().catch(e => { console.error(e); process.exit(1); });
+}

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -72,8 +72,16 @@ for (const name of SUITES) {
   const output = `${r.stdout || ""}${r.stderr || ""}`;
   const timedOut = r.status === null;
   const ok = !timedOut && r.status === 0;
-  results.push({ name, ok, ms, output, note: timedOut ? `TIMED OUT after ${PER_SUITE_TIMEOUT_MS / 1000}s` : "" });
-  console.log(`${ok ? "✓" : "✗"} ${name} (${(ms / 1000).toFixed(1)}s)${ok ? "" : "  ← see below"}`);
+  // A SUITE THAT COVERED NOTHING IS NOT A SUITE THAT PASSED (2026-08-25).
+  // normalizer-replay exits 0 when its recording is absent — correctly, because a missing
+  // recording is not a product failure. But it was rendering as `✓`, and a green tick on a suite
+  // that asserted nothing is precisely the vacuous pass this chain exists to catch. A suite that
+  // stood down says so, every run, so the gap cannot quietly become "covered".
+  const skipped = ok && /^SUITE_SKIPPED:/m.test(output);
+  const reason = skipped ? (output.match(/^SUITE_SKIPPED:\s*(.*)$/m) || [])[1] || "" : "";
+  results.push({ name, ok, ms, output, note: timedOut ? `TIMED OUT after ${PER_SUITE_TIMEOUT_MS / 1000}s` : (skipped ? `SKIPPED — ${reason}` : "") });
+  console.log(`${skipped ? "⊘" : ok ? "✓" : "✗"} ${name} (${(ms / 1000).toFixed(1)}s)`
+    + `${skipped ? `  ← covered nothing: ${reason}` : ok ? "" : "  ← see below"}`);
 }
 
 const failures = results.filter(r => !r.ok);
@@ -82,8 +90,14 @@ for (const f of failures) {
   console.log(f.output.trimEnd() || "(no output)");
 }
 
+const stoodDown = results.filter(r => r.note.startsWith("SKIPPED"));
 console.log(`\n${"═".repeat(78)}`);
-console.log(`suites: ${results.length - failures.length}/${results.length} green in ${((Date.now() - started) / 1000).toFixed(0)}s`);
+console.log(`suites: ${results.length - failures.length - stoodDown.length}/${results.length} green`
+  + `${stoodDown.length ? `, ${stoodDown.length} covered nothing` : ""} in ${((Date.now() - started) / 1000).toFixed(0)}s`);
+for (const s of stoodDown) {
+  console.log(`⊘ ${s.name} — ${s.note.replace(/^SKIPPED — /, "")}`);
+  console.log("  Green here would mean this surface is tested. It is not.");
+}
 if (failures.length > 0) {
   console.log(`RED: ${failures.map(f => f.name).join(", ")}`);
   console.log("Every suite ran. Nothing below a failure was skipped.");

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -48,7 +48,7 @@ export const SUITES = [
   "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests",
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
-  "turn-triage-tests",
+  "turn-triage-tests", "normalizer-replay-tests",
   "production-parity", "check-architecture",
 ];
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -236,3 +236,37 @@ const stubPool = {
 // Cast stubs to the real types so type inference across the codebase is unchanged.
 export const pool = (STUB ? (stubPool as unknown) : makeRealPool()) as ReturnType<typeof makeRealPool>;
 export const db = (STUB ? (makeStubDb() as unknown) : makeRealDb(pool)) as ReturnType<typeof makeRealDb>;
+
+/**
+ * RECORDED NORMALIZATION — the front door, replayed offline (2026-08-25, issue #63 item 1.1).
+ *
+ * Production runs the normalizer on every message before any handler sees it. Eight deterministic
+ * harnesses set NORMALIZER=off because it calls a live model, so the transformation that reaches
+ * production FIRST has never been exercised by an offline suite — "351/355 green" describes a path
+ * production does not run for messy input. The classifier's regex fast paths cannot stand in for
+ * it: they classify and never return a `canonical`, and the rewrite is the half that can destroy
+ * information before the capability built for it is reached.
+ *
+ * So the real model is recorded once (script/record-normalizer.ts) and replayed here — production's
+ * actual rewrite, with no key and no bill per run.
+ *
+ * IT LIVES HERE, beside the DB stub, because this file is where offline test doubles belong. A
+ * seam scattered into gpt.ts is a test concern sitting in the middle of a production code path,
+ * and the next reader has to work out whether it can fire in production. It cannot: it returns
+ * undefined unless a suite has explicitly installed fixtures.
+ *
+ * STRICT IS THE IMPORTANT HALF. Under replay, an input that was never recorded THROWS. Falling
+ * through would reach the offline model shim, return OTHER with no canonical, and the test would
+ * pass having exercised nothing — the vacuous-pass trap that #63 found three times in one day.
+ */
+export function recordedIntent<T>(message: string): T | undefined {
+  const fixtures = (globalThis as any).__KAMLIFE_INTENT_FIXTURES as Record<string, T> | undefined;
+  if (!fixtures) return undefined;
+  const hit = fixtures[message.trim().toLowerCase()];
+  if (hit) return hit;
+  if (process.env.NORMALIZER_FIXTURES_STRICT === "1") {
+    throw new Error(`[NORMALIZER_FIXTURES] no recorded normalization for ${JSON.stringify(message)}`
+      + ` — re-record with script/record-normalizer.ts`);
+  }
+  return undefined;
+}

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 import { readHealthState } from "./health-state";
-import { db } from "./db";
+import { db, recordedIntent } from "./db";
 import { users, chatHistory, weightLogs, stepLogs, workoutLogs, mealLogs, gptCosts } from "../shared/schema";
 import { eq, desc, and, gte, lt, sql } from "drizzle-orm";
 import { COACH_K_SYSTEM } from "./coach-prompt";
@@ -1380,6 +1380,11 @@ export async function classifyIntent(message: string, userId?: string): Promise<
   for (const [pattern, intent] of INTENT_FAST_PATHS) {
     if (pattern.test(m)) return { intent, confidence: 0.95 };
   }
+
+  // RECORDED NORMALIZATION (issue #63 item 1.1) — the offline replay of production's own rewrite.
+  // The seam lives with the other test doubles in db.ts; see recordedIntent() for why.
+  const recorded = recordedIntent<IntentClassification>(m);
+  if (recorded) return recorded;
 
   if (m.length > 500) return { intent: "OTHER", confidence: 0 };
 


### PR DESCRIPTION
Issue #63, mandate item **1.1**.

## The gap

The normalizer is **on in production** and applied to every message before any handler sees it. It is **off in eight deterministic harnesses** — including `gauntlet`, the grader that reports 351/355 — because `classifyIntent` calls `gpt-4o-mini`.

So the transformation that reaches production *first* has never been exercised by an offline suite, and **351/355 describes a path production does not run for messy input.**

The regex fast paths cannot stand in for it: they return `{intent, confidence}` with **no `canonical`**. They classify and never rewrite — and the rewrite is the half that can destroy information before the capability built for it is reached.

## The approach: record once, replay forever

```
OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts
```

**Fixtures are never hand-written.** Inventing what the model "would" return produces a fixture that agrees with the test author instead of with production — a test that cannot fail for the right reason, which is exactly what #63 found three times in one day. This PR ships the machinery and the corpus; **the recording itself needs one run by someone with a key.**

Four properties, each closing a specific way this could have become another test that lies:

| property | what it prevents |
|---|---|
| **Unrecorded ⇒ SKIPPED, loudly** | Reporting a pass it did not earn. It prints that the front door is *not* covered and asserts nothing. |
| **STRICT under replay** | An unrecorded input **throws**. Falling through would reach the offline shim, return `OTHER` with no canonical, and pass having exercised nothing. |
| **Prompt + model fingerprinted** | A stale recording asserting yesterday's behaviour while claiming to assert today's. |
| **Corpus entries carry a `why`** | A corpus nobody can justify becomes a corpus nobody dares change. |

## What it will catch

**The Bonolo mechanism, asserted directly.** #63 established that `multiFact` is false for a single-domain note, so the brake that stops the normalizer speaking for a multi-fact message never engages — while the batch logger itself is **correct** (`Logged 3 days ✅` on raw text). The risk is entirely that the raw text never reaches it.

So the suite asserts a multi-day batch keeps its named days through the rewrite. If the front door collapses three days into one, this now says so instead of a customer discovering it at 7,700 kcal.

## And through the production path

Recorded inputs are driven through `handleMessage` **with the front door on** — the arrangement no offline suite has ever run. The assertion is deliberately **positive** (item 1.2): *the client got an answer*, not merely that a bad string is absent. #61 shipped green on a negative assertion while the coach changed the subject.

## Where the seam lives

In `db.ts`, beside the other offline test doubles — **not** in `gpt.ts`. A test seam sitting in the middle of a production code path makes the next reader work out whether it can fire in production. It cannot (it returns `undefined` unless a suite installs fixtures), and it should not be sitting there inviting the question.

This also kept `gpt.ts` at **+5 lines instead of +19** on an already-over-budget file.

## Controls — run against a synthetic recording that was then deleted

An invented corpus must never ship, so the machinery was proven against a throwaway and the fixture directory removed before commit:

- a **day-collapsing rewrite** turns the multi-day check red: `the rewrite kept 0/3 named days`
- a **moved prompt** trips the staleness warning
- **missing entries** are reported by name
- the two **end-to-end turns passed** — the first offline execution of the pipeline with the normalizer enabled

## Verification

- Full chain: **32/34** — same two governors red as `main`, same numbers
- `modules` **239/239** unchanged; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — none moved
- `gpt.ts` **1471 → 1476** (+5), already over budget — disclosed, not hidden
- `tsc --noEmit` clean
- **No product behaviour changed.** `recordedIntent()` returns `undefined` unless a suite installs fixtures.

## What remains open

**The corpus is not yet recorded**, so as of this merge the front door is still uncovered — the suite says so on every run rather than letting it be forgotten. That single recording run is the same class of outstanding item as the production reply audit and the deployed-SHA check: it needs access I do not have.

Item **1.2** (positive-outcome assertions as a reusable law) is not in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_