### PR TITLE
Positive-outcome law: "the bad response disappeared" is not evidence

### DIFF
--- a/script/outcome.ts
+++ b/script/outcome.ts
@@ -1,0 +1,81 @@
+/**
+ * THE POSITIVE-OUTCOME LAW (issue #63, item 1.2).
+ *
+ *   A customer-facing test must prove the intended outcome OCCURRED.
+ *   "The bad response disappeared" is not evidence that the client was served.
+ *
+ * WHY THIS IS A HELPER AND NOT A CONVENTION. #61 shipped green. Its fixture read:
+ *
+ *     assert.ok(!/rest today|hit it fresh tomorrow/i.test(reply), …)
+ *
+ * The wrong answer was gone, the check passed, and the customer was asked about food instead of
+ * being given the session they had just said they moved. Comprehension was correct
+ * (`readTrainingDay` returns `moved_to_today`), no downstream owner consumed it, and the turn fell
+ * to the generic ladder. A negative assertion cannot see that, because "not rest today" is
+ * satisfied by silence, by a crash fallback, and by an answer to a different question.
+ *
+ * Conventions do not survive a tired afternoon. A signature that will not compile without a
+ * positive expectation does.
+ */
+
+import assert from "node:assert/strict";
+
+export interface Outcome {
+  /** What the client must actually receive. REQUIRED — this is the whole point. */
+  got: RegExp | ((reply: string) => boolean);
+  /** What must not appear. Optional, and never sufficient on its own. */
+  notGot?: RegExp;
+  /** The customer sentence in one line: what should have happened, and why it matters. */
+  because: string;
+  /**
+   * A KNOWN PRODUCT DEFECT this assertion is waiting on, e.g. "#63 moved_to_today has no consumer".
+   *
+   * Reports instead of failing — but only in one direction. If a pending outcome starts PASSING it
+   * fails loudly, so a fixed defect cannot leave a permanent excuse behind in the suite. That is
+   * what stops this from becoming a way to mute assertions.
+   */
+  pending?: string;
+}
+
+/** Collected so a suite can print what it did not enforce. Never silent. */
+export const PENDING: Array<{ because: string; pending: string }> = [];
+
+export function assertCustomerOutcome(reply: string, spec: Outcome): void {
+  const text = String(reply ?? "");
+  const hit = typeof spec.got === "function" ? spec.got(text) : spec.got.test(text);
+
+  if (spec.pending) {
+    if (hit) {
+      throw new Error(
+        `PENDING OUTCOME NOW PASSES — remove the pending marker.\n` +
+        `      ${spec.because}\n      was waiting on: ${spec.pending}\n` +
+        `      Leaving it pending would let this regress again unnoticed.`);
+    }
+    PENDING.push({ because: spec.because, pending: spec.pending });
+    return;
+  }
+
+  // A crash fallback satisfies almost any negative assertion, so it is refused first and by name.
+  assert.ok(text.trim().length > 0, `no reply at all — ${spec.because}`);
+  assert.ok(!/something went wrong on my side|give me a second and try again/i.test(text),
+    `the pipeline crashed and returned its apology, which passes any "the bad string is absent" ` +
+    `check — ${spec.because}:\n      ${text.slice(0, 160)}`);
+
+  assert.ok(hit,
+    `the client did not get the outcome. ${spec.because}\n` +
+    `      Note: the forbidden response may well be absent — that is not the same as being served.\n` +
+    `      got: ${text.slice(0, 220)}`);
+
+  if (spec.notGot) {
+    assert.ok(!spec.notGot.test(text),
+      `the forbidden response is present. ${spec.because}\n      got: ${text.slice(0, 220)}`);
+  }
+}
+
+/** Printed at the end of a suite so an unenforced outcome is visible on every run. */
+export function reportPending(): void {
+  if (!PENDING.length) return;
+  console.log(`\n⊘ ${PENDING.length} customer outcome(s) asserted but NOT ENFORCED — known defects:`);
+  for (const p of PENDING) console.log(`  ⊘ ${p.because}\n      waiting on: ${p.pending}`);
+  console.log("  These are the outcomes a client is not getting today.");
+}

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -39,6 +39,7 @@ import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { DOMAIN_OWNERS } from "./domain-owners";
+import { assertCustomerOutcome, reportPending } from "./outcome";
 
 let passed = 0;
 const failures: string[] = [];
@@ -374,8 +375,13 @@ async function main() {
     assert.ok(!week.startsWith("__THREW__"), `handler threw: ${week}`);
     // The model's version closed with "What's one action you can take this week to boost your
     // protein intake?" — the coach handing the decision back to the client.
-    assert.ok(!/\?\s*$/.test(week.trim()),
-      `the weekly answer ends by asking the client what to do:\n      ${week.slice(-140)}`);
+    // POSITIVE FORM (item 1.2): the title claims it ends in an INSTRUCTION, so that is asserted.
+    // "does not end in ?" was satisfied by any statement at all, including a non-answer.
+    assertCustomerOutcome(week, {
+      got: /\b(get|keep|add|hit|log|walk|eat|train|aim|start|stick|focus|send|take|tell|give|reply|show|pick|drop)\b/i,
+      notGot: /\?\s*$/,
+      because: "the week must end in something the client can do, not a question handed back",
+    });
   });
 
   check("progress: every declared owner is reachable and none is the model", () => {
@@ -437,8 +443,13 @@ async function main() {
     // it — the exact defect despair.ts was written for. It must not come back as a numbers dump.
     const struggle = await say("I'm struggling with all of this");
     assert.ok(!struggle.startsWith("__THREW__"), `handler threw: ${struggle}`);
-    assert.ok(!/Days logged|Avg: \*|last 7 days|Sessions:/i.test(struggle),
-      `a life question was answered with a progress scoreboard:\n      ${struggle.slice(0, 200)}`);
+    // POSITIVE FORM: absence of a scoreboard was satisfied by silence or a crash fallback. What
+    // the client needs is to be ANSWERED — the struggle acknowledged in words.
+    assertCustomerOutcome(struggle, {
+      got: /\b(hear|heard|tough|hard|rough|with you|start|small|one thing|talk|going on|not alone)\b/i,
+      notGot: /Days logged|Avg: \*|last 7 days|Sessions:/i,
+      because: "a client saying they are struggling must be answered, not handed a scoreboard",
+    });
   });
 
   // ── PROACTIVE: ONE DECISION OWNER, NO SECOND POLICY ───────────────────────────────────────
@@ -2280,8 +2291,13 @@ async function main() {
     for (const single of ["I had pap and eggs", "I trained chest today. What should I eat now?",
                           "You missed the black coffee"]) {
       const r = await writesFor(single);
-      assert.ok(!/logged across \d+ day/i.test(r.out),
-        `the batch path claimed a single-day turn: ${single} → ${r.out.slice(0, 70)}`);
+      // POSITIVE FORM (item 1.2): "the batch claim is absent" was equally satisfied by the turn
+      // doing nothing at all — which is the failure a regression guard most needs to catch.
+      assertCustomerOutcome(r.out, {
+        got: (t) => t.trim().length > 0,
+        notGot: /logged across \d+ day/i,
+        because: `a single-day message must still be served, unchanged: "${single}"`,
+      });
     }
   });
 
@@ -2967,10 +2983,21 @@ async function main() {
 
   // THE OUTCOME, not the classification. A sentence that says "I am training today" must not be
   // answered with a rest-day reply — which is what the client actually saw.
-  check("training day . a session moved into today is not answered with 'rest today'", async () => {
+  // THE CANONICAL CASE FOR THE POSITIVE-OUTCOME LAW (rewritten 2026-08-25, issue #63 item 1.2).
+  //
+  // This check shipped green in #61 asserting only that "rest today" was absent. It was — and the
+  // client was asked what they ate instead of being given the session they had just said they
+  // moved. `readTrainingDay` returns `moved_to_today` correctly; nothing consumes it; the turn
+  // falls to the generic ladder. The old form could not see that, because "not rest today" is
+  // equally satisfied by silence, by a crash fallback, and by an answer to another question.
+  check("training day . a session moved into today is DELIVERED, not merely not-refused", async () => {
     const reply = await serialise(() => say("No I moved yesterdays workout to today"));
-    assert.ok(!/rest today|hit it fresh tomorrow|rest day is part of the programme/i.test(reply),
-      `the client said they are training today and was told to rest: ${reply.slice(0, 160)}`);
+    assertCustomerOutcome(reply, {
+      got: /Week \d|Next Session|Send \*?DONE|sets?\b|reps?\b/i,
+      notGot: /rest today|hit it fresh tomorrow|rest day is part of the programme/i,
+      because: "a client who says they moved a session into today must be given that session",
+      pending: "#63 — moved_to_today is computed by readTrainingDay and consumed by nothing",
+    });
   });
 
   // THE CONTROL. A genuine refusal must still be honoured, or the case above passes by making
@@ -3093,6 +3120,7 @@ async function main() {
 
   await Promise.all(pending); // every async check must land before the tally is printed
   console.log(`\nproduction-parity: ${passed}/${passed + failures.length} passed`);
+  reportPending();
   if (failures.length > 0) {
     console.log("\nFailures:");
     console.log(failures.join("\n\n"));


### PR DESCRIPTION
Issue #63, mandate item **1.2** — the last piece of Phase 1.

> **A customer-facing test must prove the intended outcome occurred.**
> "The bad response disappeared" is not evidence that the client was served.

## Why a helper and not a convention

#61 shipped green. Its fixture read:

```ts
assert.ok(!/rest today|hit it fresh tomorrow/i.test(reply), …)
```

The wrong answer was gone, the check passed, and the client was asked what they ate instead of getting the session they had just said they moved. `readTrainingDay` returns `moved_to_today` correctly, nothing consumes it, and the turn falls to the generic ladder.

A negative assertion cannot see that. **"Not rest today" is equally satisfied by silence, by a crash fallback, and by an answer to a different question.**

Conventions do not survive a tired afternoon; a signature that will not compile without a positive expectation does. `assertCustomerOutcome()` requires `got`, and refuses the crash fallback **by name first** — the friendly apology satisfies almost any "the bad string is absent" check.

## The census — including a correction to my own first number

My initial scan reported **23 of 110** checks as negative-only. **That was wrong.** It counted `assert.ok(!…)` as negative but did not recognise `assert.ok(r.meal, …)` as positive, so fixtures asserting a positive *state* were miscounted as deficient. Reporting it would have been the "raw grep count without semantic classification" that #63 explicitly prohibits.

**Corrected: 12 of 110.**

And the count alone still misleads — **8 of those 12 are legitimately absence-based**, where absence *is* the intended outcome and a positive form would be wrong:

- a hold that aged out no longer speaks
- a scheduler job that must not tell a declined client to train
- a withheld weight that must not reach the model's context
- a deleted calculator that must not grow back

**Four were genuinely deficient**, and all four are converted:

| fixture | what it actually asserted |
|---|---|
| the week ends in an instruction | only "does not end in `?`" — any statement passed, including a non-answer |
| judgment questions not hijacked | only "no scoreboard" — silence passed too |
| P0-2b single-day untouched | only "no batch claim" — a turn that did **nothing at all** passed, the exact regression a guard most needs to catch |
| training day / moved into today | the canonical case |

**Three now pass in their positive form** — the product already behaves; the tests simply never proved it.

## The fourth does not pass, because the defect is real

Phase 2 has not run, so `moved_to_today` still has no consumer. It is marked `pending` with the #63 reference and **reported on every run**:

```
⊘ 1 customer outcome(s) asserted but NOT ENFORCED — known defects:
  ⊘ a client who says they moved a session into today must be given that session
      waiting on: #63 — moved_to_today is computed by readTrainingDay and consumed by nothing
  These are the outcomes a client is not getting today.
```

**`pending` cannot become a mute button.** A pending outcome that starts **passing** fails loudly and demands the marker's removal, so a fixed defect cannot leave a permanent excuse behind in the suite.

**Control run:** forcing the pending assertion to match turns the suite red with

> `PENDING OUTCOME NOW PASSES — remove the pending marker.`
> `Leaving it pending would let this regress again unnoticed.`

## Verification

- `production-parity`: **131/131**, plus 1 outcome reported as not enforced
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239** unchanged; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — none moved
- `tsc --noEmit` clean
- **No product behaviour changed.** Test infrastructure only.

## Phase 1 after this merges

| | | |
|---|---|---|
| 1.1 | normalizer coverage | mechanism ✅ · **corpus ⏳** (needs one run with a real key) |
| 1.2 | positive-outcome law | ✅ |
| 1.3 | temporal substrate | ✅ |

The tests can now model time, exercise the production front door, and are required to prove the customer got the right result. Two gaps remain visible in every build rather than in a document: the unrecorded corpus, and one customer outcome nobody is currently getting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_