### PR TITLE
Phase 2.1 — a session moved into today is delivered, through one renderer

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2996,8 +2996,35 @@ async function main() {
       got: /Week \d|Next Session|Send \*?DONE|sets?\b|reps?\b/i,
       notGot: /rest today|hit it fresh tomorrow|rest day is part of the programme/i,
       because: "a client who says they moved a session into today must be given that session",
-      pending: "#63 — moved_to_today is computed by readTrainingDay and consumed by nothing",
     });
+  });
+
+  // ONE MOUTH, NOT TWO SYNCHRONISED COPIES (2026-08-25, Phase 2.1).
+  //
+  // The weak version of this fix is a second composition site that happens to agree today.
+  // sessionHeaderLine had exactly that — two call sites — and they diverged, which is how
+  // "*Week 1 — Session 25*" reached a handset weeks after the header was "fixed".
+  //
+  // So this asserts the property that a synchronised copy cannot offer: the session BODY the
+  // moved-session path sends is the same string renderSession() produces. Change the renderer and
+  // both callers move together; fork one of them and this goes red on the next run.
+  check("one mouth . the moved session is the renderer's output, not a lookalike", async () => {
+    const { renderSession } = await import("../server/programme");
+    const { getTodaySlot } = await import("../server/workout-state");
+    const g = globalThis as any;
+    const moved = await serialise(async () => {
+      g.__KAMLIFE_STUB_USER = { ...USER, trainingDaysPerWeek: 6 };
+      try { return String(await handleMessage(USER.phoneNumber, "No I moved yesterdays workout to today") ?? ""); }
+      finally { g.__KAMLIFE_STUB_USER = { ...USER }; }
+    });
+    const canonical = renderSession({ ...USER, trainingDaysPerWeek: 6 },
+      { slot: getTodaySlot({ ...USER, trainingDaysPerWeek: 6 }), doneHint: "Send *done* when finished." });
+    // The exercise block is the part a second copy would drift on — compare that, not the intro.
+    const body = canonical.split("\n\n").filter(p => /\d/.test(p) && p.length > 40)[0] || "";
+    assert.ok(body.length > 40, "the renderer produced no session body to compare against");
+    assert.ok(moved.includes(body),
+      `the moved-session reply is not the renderer's output — a second composition site has appeared.\n`
+      + `      renderer: ${body.slice(0, 120)}\n      moved:    ${moved.slice(0, 200)}`);
   });
 
   // THE CONTROL. A genuine refusal must still be honoured, or the case above passes by making

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -5,7 +5,7 @@ import { reportCardMarker } from "../report-card";
 import { users, workoutLogs, chatHistory, mealLogs, stepLogs } from "../../shared/schema";
 import { eq, and, gte, desc, count, sql } from "drizzle-orm";
 import { SA_FOODS_SEED } from "../foods";
-import { buildDayWorkout, buildFullProgramme, getKamlifeProgramme, sessionHeaderLine } from "../programme";
+import { buildDayWorkout, buildFullProgramme, getKamlifeProgramme, sessionHeaderLine, renderSession } from "../programme";
 import { calculateTargets, stepBurnKcal, recalcTargetsForProfile } from "../targets";
 import { askCoachK } from "../gpt";
 import { getShoppingList, formatShoppingList } from "../shopping-lists";
@@ -588,21 +588,13 @@ export async function handleEarlyCommands(ctx: {
     }
 
     // NORMAL — scheduled training day, nothing done yet
-    const todaySlot = getTodaySlot(user);
-    const workout = buildDayWorkout({ ...effectiveUser, programmeDayInWeek: todaySlot });
-    const week = user.programmeWeek || 1;
-    const sessionNum = user.totalWorkoutsCompleted || 0;
-    const weekNote = `${sessionHeaderLine(week, sessionNum)}\n\n`;
-    const injuryNote = user.injuries && user.injuries.trim() && user.injuries.toLowerCase() !== "none"
-      ? `\n\n⚠️ *Active injury noted (${user.injuries}):* Skip any exercise that causes sharp pain. Reply *injury* for safe alternatives.`
-      : "";
-    const workoutGifUrl = getPrimaryWorkoutGifUrl(workout);
-    const gifMarker = workoutGifUrl ? `\n[MEDIA:${workoutGifUrl}]` : "";
-    // BUTTONS ANSWER A QUESTION (2026-08-07 live-model gauntlet). A workout is a DELIVERY, and
-    // three buttons under it were a menu nobody was offered. They are the answers to one
-    // question, so the question is now asked — the sweep's rule, applied to the path that
-    // taught us the rule and then broke it.
-    const reply = `${sickViewHeader}${weekNote}${workout}${injuryNote}\n\n${doneHint}\n\nHow's that looking?${gifMarker}[BUTTONS:Done 💪|Too hard — modify|Skip today]`;
+    // ONE MOUTH (2026-08-25, Phase 2.1). This composition used to live here, which was fine while
+    // the `workout` command was its only caller. It is now renderSession() in programme.ts, so the
+    // moved-session path reaches the SAME rendering rather than a second copy of it — see the
+    // comment there for why a flag into this file was the wrong shape.
+    const reply = renderSession({ ...effectiveUser, injuries: user.injuries,
+      programmeWeek: user.programmeWeek, totalWorkoutsCompleted: user.totalWorkoutsCompleted },
+      { slot: getTodaySlot(user), intro: sickViewHeader, doneHint });
     await logChat(user.id, message, reply.replace(/\[MEDIA:[^\]]+\]|\[BUTTONS:[^\]]+\]/g, "").trim(), "WORKOUT_VIEW");
     return reply;
   }

--- a/server/programme.ts
+++ b/server/programme.ts
@@ -3,7 +3,7 @@
 // All workout programme content and builder functions
 // ============================================================
 
-import { resolveExerciseSlug } from "./exercise-media";
+import { resolveExerciseSlug, getPrimaryWorkoutGifUrl } from "./exercise-media";
 import { validateProgramme } from "./verifiers/programme-validator";
 import { adaptTraining, trainingAdjustHeader, applySetsDelta, trainingStateFromUser, type TrainingInput } from "./adaptive-training";
 import { enforceMessageBudget, MESSAGE_BUDGET } from "./reply-contract";
@@ -1694,6 +1694,51 @@ export function sessionHeaderLine(week: number, sessionsDone: number): string {
   return done > 0 ? `*Week ${w} — Session ${done + 1} overall*` : `*Week ${w}*`;
 }
 
+/**
+ * THE ONE MOUTH FOR A DELIVERED SESSION (2026-08-25, issue #63 Phase 2.1).
+ *
+ * Until now the only way to receive today's session was the `workout` command, composed inline in
+ * early-commands.ts. That was fine while there was one caller. It stopped being fine the moment a
+ * second question needed the same answer:
+ *
+ *     "No I moved yesterdays workout to today"
+ *
+ * readTrainingDay() reads that correctly as `moved_to_today`, and NOTHING consumed it. routes.ts
+ * branches on `move_request`, `deferred` and `declined` — three siblings of the same enum, each
+ * with a real consumer — while `moved_to_today` sat between them with none, so the turn fell to
+ * the generic ladder and the client was asked what they ate. Correct comprehension, no action.
+ *
+ * The tempting fix was a flag that early-commands reads. That would have produced a SECOND route
+ * to the same rendering, which is the architecture being removed, not added to: `sessionHeaderLine`
+ * had exactly two composition sites and they diverged, which is how "*Week 1 — Session 25*" reached
+ * a handset after the header had supposedly been fixed six weeks earlier.
+ *
+ * So both questions now end at one function. Change the session's wording here and BOTH the
+ * `workout` command and the moved-session path change together — that is the property worth
+ * having, and the one a synchronised copy can never offer.
+ */
+export function renderSession(user: any, opts: {
+  slot: number;
+  /** Anything that belongs above the header — a sickness view note, or a moved-day acknowledgement. */
+  intro?: string;
+  /** Walk-only clients get a different closer; the caller knows the training mode. */
+  doneHint: string;
+}): string {
+  const workout = buildDayWorkout({ ...user, programmeDayInWeek: opts.slot });
+  const header = sessionHeaderLine(user.programmeWeek || 1, user.totalWorkoutsCompleted || 0);
+  const injuries = String(user.injuries || "").trim();
+  const injuryNote = injuries && injuries.toLowerCase() !== "none"
+    ? `\n\n⚠️ *Active injury noted (${injuries}):* Skip any exercise that causes sharp pain. Reply *injury* for safe alternatives.`
+    : "";
+  const gif = getPrimaryWorkoutGifUrl(workout);
+  const gifMarker = gif ? `\n[MEDIA:${gif}]` : "";
+  // BUTTONS ANSWER A QUESTION (2026-08-07 live-model gauntlet). A workout is a DELIVERY, and three
+  // buttons under it were a menu nobody was offered. They are the answers to one question, so the
+  // question is asked — the sweep's rule, applied to the path that taught us the rule.
+  return `${opts.intro || ""}${header}\n\n${workout}${injuryNote}\n\n${opts.doneHint}\n\n`
+    + `How's that looking?${gifMarker}[BUTTONS:Done 💪|Too hard — modify|Skip today]`;
+}
+
 export function buildDayWorkout(user: any): string {
   return withSafetyNote(buildDayWorkoutInner(user), user);
 }
@@ -1724,12 +1769,14 @@ function buildDayWorkoutInner(user: any): string {
     const walkerNotes = (user.profileNotes || "").toLowerCase();
     const hasInjury = injuries.trim() !== "" && injuries.toLowerCase() !== "none";
     const isLifestyleWalker = walkerNotes.includes("walk:lifestyle") && !hasInjury;
-    if (isLifestyleWalker && (day === 1 || day === 3)) {
-      const reps = phase === 1 ? "8-10" : phase === 2 ? "10-12" : "12-15";
-      const toneUp = `\n\n*Muscle insurance — 10 min, optional but worth it:*\n2 easy rounds, ${reps} reps each:\n• Bodyweight squats (sit to a chair and stand)\n• Push-ups — on your knees or against a wall is fine\n• Glute bridges\n• Plank — hold 20-30 sec\n\nThis is what keeps the weight you lose as *fat, not muscle*. Skip anything that hurts.`;
-      return `*Phase ${phase}: ${phaseName} — Week ${week}*\nToday: Day ${day}\n\n${walkBlock}${toneUp}\n\nSend DONE when finished.`;
-    }
-    return `*Phase ${phase}: ${phaseName} — Week ${week}*\nToday: Day ${day}\n\n${walkBlock}\n\nSend DONE when finished.`;
+    // ONE SENTENCE, ONE PLACE (2026-08-25). This was written out twice — identical but for whether
+    // ${toneUp} was interpolated — so the walk day had two mouths for one message and a change to
+    // the wording had to be made in both. The tone-up is a BLOCK, not a different reply.
+    const reps = phase === 1 ? "8-10" : phase === 2 ? "10-12" : "12-15";
+    const toneUp = (isLifestyleWalker && (day === 1 || day === 3))
+      ? `\n\n*Muscle insurance — 10 min, optional but worth it:*\n2 easy rounds, ${reps} reps each:\n• Bodyweight squats (sit to a chair and stand)\n• Push-ups — on your knees or against a wall is fine\n• Glute bridges\n• Plank — hold 20-30 sec\n\nThis is what keeps the weight you lose as *fat, not muscle*. Skip anything that hurts.`
+      : "";
+    return `*Phase ${phase}: ${phaseName} — Week ${week}*\nToday: Day ${day}\n\n${walkBlock}${toneUp}\n\nSend DONE when finished.`;
   }
 
   const trainingDays = user.trainingDaysPerWeek || 3;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -956,6 +956,47 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // "tomorrow's workout?") and must still reach the renderer.
   const _isWorkoutMoveRequest = _trainingDay === "move_request";
   const _isWorkoutDeferral = _trainingDay === "deferred";
+
+  // A SESSION MOVED INTO TODAY IS A DELIVERY (2026-08-25, issue #63 Phase 2.1).
+  //
+  //   "No I moved yesterdays workout to today"  →  "Kam — one thing today: tell me what you ate."
+  //
+  // readTrainingDay read that correctly as `moved_to_today` and NOTHING consumed it. Its three
+  // siblings above — move_request, deferred, declined — each end in a reply; this one fell past
+  // them to the generic ladder, which picked the highest unmet thing and asked about food. The
+  // comprehension was right and the client still did not get their session.
+  //
+  // That is the shape Phase 2 exists to remove: an interpretation is not a feature until its
+  // downstream action is defined, reachable and tested end to end. The session is rendered by the
+  // same owner the `workout` command uses, so the two answers cannot drift apart.
+  if (_trainingDay === "moved_to_today") {
+    const { renderSession } = await import("./programme");
+    const { getTodaySlot, getTodayWorkoutState } = await import("./workout-state");
+    const _mvState = await getTodayWorkoutState(user).catch(() => null);
+    // ONLY an already-logged session stands this down. A SCHEDULED REST DAY DOES NOT.
+    //
+    // The first version of this branch also refused on REST — "today's a rest day, do it
+    // Wednesday" — and that is the original defect wearing better manners: comprehension correct,
+    // session still not delivered. The programme's rest day is OUR schedule; a client saying they
+    // moved a session into today has already decided they are training. Arguing with them is the
+    // behaviour that made them repeat themselves in the first place.
+    if (_mvState?.type === "ALREADY_DONE") {
+      const _mvNote = `Today's session is already logged ✅ — that's the moved one counted.`;
+      await logChat(user.id, message, _mvNote, "WORKOUT_MOVED_ALREADY_DONE");
+      return _mvNote;
+    }
+    const _mvFirst = getDisplayName(user);
+    const _mvDone = (user.trainingMode === "walk_only" || user.trainingMode === "walk")
+      ? `Send *done* when you finish, or just tell me how it went (e.g. "25 min, felt strong").`
+      : `Send *done* when finished.`;
+    const movedReply = renderSession(user, {
+      slot: getTodaySlot(user),
+      intro: `${_mvFirst ? _mvFirst + ", g" : "G"}ood — moved into today. Here it is 💪\n\n`,
+      doneHint: _mvDone,
+    });
+    await logChat(user.id, message, movedReply.replace(/\[MEDIA:[^\]]+\]|\[BUTTONS:[^\]]+\]/g, "").trim(), "WORKOUT_MOVED_TO_TODAY");
+    return movedReply;
+  }
   if (_isWorkoutMoveRequest) {
     const _mvName = getDisplayName(user);
     const _mvLater = !/\b(tomorrow|next\s+week|another\s+day|a\s+different\s+day|2moro|2morrow)\b/i.test(_origWO);


### PR DESCRIPTION
Issue #63, **Phase 2.1**. The first orphaned meaning, closed end to end.

## The defect

> **Client:** No I moved yesterdays workout to today
> **Coach:** Kam — one thing today: *Tell me what you ate today — one line is enough.*

`readTrainingDay()` read it **correctly** as `moved_to_today`, and nothing consumed it.

`routes.ts` branches on `move_request`, `deferred` and `declined` — three siblings of the same enum, each ending in a real reply — while `moved_to_today` sat between them with **no consumer**. The turn fell through to the generic ladder, which picked the highest unmet thing and asked about food. `workout.ts` read the same owner and used it only for `reportsMiss`, dropping it a second time.

**Correct comprehension, no action — twice, in two files.**

## One renderer, not a second copy

The cheap fix was a flag that `early-commands` reads. That would have produced a *second route to the same rendering* — the architecture being removed, not added to. `sessionHeaderLine` had exactly two composition sites and they diverged, which is how `*Week 1 — Session 25*` reached a handset weeks after the header was "fixed".

So the composition moved out of `early-commands.ts` into **`renderSession()` in `programme.ts`**, beside `buildDayWorkout` and `sessionHeaderLine` which it already uses. Both the `workout` command and the moved-session path end there.

## A scheduled rest day does not stand this down

My first version of the branch also refused on `REST` — *"today's a rest day, do it Wednesday"*. That is **the original defect wearing better manners**: comprehension correct, session still not delivered.

The programme's rest day is *our* schedule. A client who says they moved a session into today has already decided they are training, and arguing with them is the behaviour that made them repeat themselves in the first place. Only an `ALREADY_DONE` session stands it down, because re-delivering a logged session is a different error.

## The pending marker is gone

#67 recorded this outcome as asserted-but-not-enforced. The defect is fixed, so **the assertion is now enforced** — which is exactly what the self-clean check was built to force.

## Three controls, all run

| control | result |
|---|---|
| remove the consumer | outcome **RED** and one-mouth **RED** |
| fork a lookalike renderer | outcome **PASSES**, one-mouth **RED** |
| change the one renderer | `workout` **and** moved-session both change together |

**The second is the one that matters.** I wrote a plausible second renderer — it says "moved into today", carries the header, reads fine — and it **satisfied the customer-outcome test completely** (131/132). Only the one-mouth assertion caught it.

That is the difference between one mouth and two synchronised copies, and it is now a permanent check rather than a thing I verified once:

```
✗ one mouth . the moved session is the renderer's output, not a lookalike
    the moved-session reply is not the renderer's output —
    a second composition site has appeared.
```

## Paid for, not raised

`authorshipPoints` rose **425 → 426**: `renderSession` is a *named* client-facing mouth where the old inline composition was not. The counter is measuring honestly.

Offset by collapsing a genuine duplicate in the same file — the walk-day reply was written out **twice**, identical but for whether a tone-up block was interpolated, so one message had two mouths and a wording change had to be made in both. Back to **425, unraised**.

Restructuring `renderSession` to dodge the counter's regex was considered and rejected: that is optimising the score instead of the architecture, which the RAISES ledger explicitly forbids.

## Verification

- `production-parity`: **132/132**, including the new one-mouth check, with the moved-session outcome **enforced**
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239**; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` **425** — none moved
- `routes.ts` 1418 → 1459, already over budget — disclosed, not hidden
- `tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_