### PR TITLE
Phase 2.2 — several days is several reports, and the front door may not speak for them

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2286,6 +2286,81 @@ async function main() {
 
   });
 
+  // ── PHASE 2.2 · THE FRONT DOOR MAY NOT COLLAPSE DAYS ────────────────────────────────────────
+  //
+  // Issue #63 mechanism 2: a correct capability made unreachable by an earlier transformation.
+  // The multi-fact brake counts DOMAINS (factTypes.length >= 2), so three days of meals is
+  // `["food"]` — length 1 — and a catch-up note sailed past it. The batch logger downstream is
+  // correct; it never saw the raw text.
+  //
+  // SCOPE, STATED HONESTLY. This grades the DETERMINISTIC rule: given a message that names several
+  // days, is the rewrite refused? It does NOT establish what the live model returns for that
+  // message — that needs the recorded corpus, and normalizer-replay-tests reports the production
+  // surface as uncovered until it exists. Two different claims; only the first is proven here.
+  check("2.2 . a note naming several days is never spoken for by one canonical", async () => {
+    const { attributeMultiDayReport } = await import("../server/understanding/day-relative-situation");
+    const bonolo = "Monday I had pap and chicken, eggs and bread for breakfast, and rice with beef stew "
+      + "for dinner. Tuesday was oats, a chicken salad, and pasta with mince. Wednesday I had eggs "
+      + "and bacon, a burger and chips, and lamb chops with rice.";
+
+    // The premise the old brake missed: this IS one domain, which is why multiFact could not see it.
+    const { parseMessyIntake } = await import("../server/understanding/messy-intake");
+    assert.deepEqual(parseMessyIntake(bonolo).factTypes, ["food"],
+      "if this ever becomes multi-domain the original brake covers it and this check is moot");
+    assert.equal(parseMessyIntake(bonolo).factTypes.length >= 2, false,
+      "multiFact must still be FALSE here — that is the hole this closes");
+
+    // …and the day owner does see it. The brake now consults this, rather than a second opinion.
+    assert.equal(attributeMultiDayReport(bonolo).hasMultipleDays, true,
+      "the day owner did not see three days — the brake has nothing to consult");
+
+    // THE CONTROL. A single-day note must still be rewritable, or the fix is just a global veto
+    // that disables the normalizer for everything and calls it preservation.
+    for (const single of ["i had pap and eggs for breakfast", "yesterday I had chicken and rice"]) {
+      assert.equal(attributeMultiDayReport(single).hasMultipleDays, false,
+        `a single-day note was treated as multi-day, which would disable the rewrite wholesale: "${single}"`);
+    }
+  });
+
+  // AND THE BRAKE ACTUALLY FIRES — the effect, not the premise.
+  //
+  // The brake only runs with the normalizer ON, which every offline harness disables. So this uses
+  // the replay seam from #66 to hand the front door a canonical that COLLAPSES the three days, and
+  // asserts the client's meal still lands as three days — i.e. the raw text reached the batch owner.
+  //
+  // The fixture is synthetic ON PURPOSE and that is legitimate here: the claim under test is "given
+  // a rewrite that destroys days, does the brake refuse it", not "this is what gpt-4o-mini returns".
+  // The second claim needs the recorded corpus and is asserted in normalizer-replay-tests, which
+  // reports the production surface as uncovered until that recording exists.
+  check("2.2 outcome . a collapsing rewrite is refused and the days survive to the logger", async () => {
+    const g = globalThis as any;
+    const bonolo = "Monday I had pap and chicken, eggs and bread for breakfast, and rice with beef stew "
+      + "for dinner. Tuesday was oats, a chicken salad, and pasta with mince. Wednesday I had eggs "
+      + "and bacon, a burger and chips, and lamb chops with rice.";
+    const collapsed = "i had pap and chicken, eggs and bread, rice with beef stew, oats, chicken salad, "
+      + "pasta with mince, eggs and bacon, burger and chips, lamb chops and rice";
+
+    const out = await serialise(async () => {
+      const prevNorm = process.env.NORMALIZER;
+      delete process.env.NORMALIZER;                       // front door ON, as in production
+      g.__KAMLIFE_INTENT_FIXTURES = {
+        [bonolo.toLowerCase()]: { intent: "FOOD_LOG", confidence: 0.95, canonical: collapsed },
+      };
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      try { return String(await handleMessage(USER.phoneNumber, bonolo) ?? ""); }
+      finally {
+        delete g.__KAMLIFE_INTENT_FIXTURES;
+        if (prevNorm === undefined) delete process.env.NORMALIZER; else process.env.NORMALIZER = prevNorm;
+      }
+    });
+
+    assertCustomerOutcome(out, {
+      got: /across \d+ day|logged 3 days|3 days/i,
+      because: "three days of meals reported in one message must be logged as three days, not one — "
+        + "a rewrite that names no day must never be allowed to speak for all of them",
+    });
+  });
+
   check("P0-2b . a single-day message is untouched by the batch path", async () => {
     // The gate is hasMultipleDays. Every existing single-day route must behave exactly as before.
     for (const single of ["I had pap and eggs", "I trained chest today. What should I eat now?",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -53,6 +53,7 @@ import { backfillAttributedDays } from "./backfill";
 import { isCoachCriticism } from "./reaction-guard";
 import { bareReactionFallback } from "./reaction-guard";
 import { mustStayDeterministic } from "./understanding/action-router";
+import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { recordMessageSeen, recordReplyPath } from "./self-check";
 import { normalizerFidelity } from "./normalizer-fidelity";
 import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
@@ -742,6 +743,26 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
       // however faithful it looks. Fidelity below stays a tripwire for single-fact notes.
       if (multiFact && canon) {
         console.log(`[NORMALIZER] ${turnFacts.factTypes.join("+")} — multi-fact note is never rewritten; raw text proceeds`);
+        canon = "";
+      }
+      // …AND SEVERAL DAYS IS SEVERAL REPORTS (2026-08-25, issue #63 Phase 2.2).
+      //
+      // The brake above counts DOMAINS: multiFact is factTypes.length >= 2. Three days of meals is
+      // one domain — `["food"]`, length 1 — so a client catching up on Monday, Tuesday and
+      // Wednesday sailed straight past it and the rewrite was free to speak for all three days at
+      // once. The batch logger downstream is CORRECT: it answers "Logged 3 days ✅" on the raw
+      // text. It simply never saw the raw text.
+      //
+      // That is mechanism 2 in #63 — a capability made unreachable by an earlier transformation,
+      // rather than a wrong rule anywhere. The reported failure is ~7,700 kcal landing on a single
+      // day against a ~2,700 target.
+      //
+      // The day question already has an owner — attributeMultiDayReport, which backfill.ts uses to
+      // decide the same thing — so this consults it rather than adding a second opinion about what
+      // "multiple days" means. The comment above states the principle exactly; it was only ever
+      // applied to one of the two ways a note can carry more than one report.
+      if (canon && attributeMultiDayReport(originalMBeforeNorm).hasMultipleDays) {
+        console.log(`[NORMALIZER] multi-DAY note is never rewritten; raw text proceeds — "${originalMBeforeNorm.slice(0, 60)}"`);
         canon = "";
       }
       if (ACTION_INTENTS.has(pre.intent) && pre.confidence >= 0.75 && canon.length >= 3 && canon.length <= message.length * 2.5 + 20) {


### PR DESCRIPTION
Issue #63, **mechanism 2 — preserve meaning.** A correct capability made unreachable by an earlier transformation, rather than a wrong rule anywhere.

## The defect

The normalizer's rewrite brake counted **domains**:

```ts
const multiFact = turnFacts.factTypes.length >= 2;
```

Three days of meals is **one domain** — `factTypes` is `["food"]`, length 1 — so a client catching up on Monday, Tuesday and Wednesday sailed past the brake, and the rewrite was free to speak for all three days at once.

**The batch logger downstream is correct.** It answers `Logged 3 days ✅` on the raw text. It simply never saw the raw text.

The brake's own comment already stated the principle exactly:

> *"A canonical is ONE command; this note is several facts, so any rewrite is a deletion however faithful it looks."*

That is equally true of several **days**. It had only ever been applied to one of the two ways a note can carry more than one report.

## The fix consults the existing owner

"Does this message span several days" already has one — `attributeMultiDayReport` in `understanding/day-relative-situation.ts`, which `backfill.ts` uses to decide the same thing. The brake asks it rather than forming a second opinion about what "multiple days" means.

One line of behaviour, no new reader, no new module.

## The mechanism is now traced, not reconstructed

#63 could only *reconstruct* the Bonolo failure. Removing this brake and replaying a collapsing rewrite reproduces it exactly:

```
Got it — Rice, Oats, Bread, Pasta and 9 more. 👌
```

Thirteen foods, three days, **logged as one**. That is the ~7,700 kcal report, offline and deterministic. #63's instalment 2 can be upgraded on this point.

## Two claims, and only one is proven here

| | claim | status |
|---|---|---|
| **A** | Given a rewrite that destroys days, the system refuses it and the days survive | **PROVEN** — end to end through `handleMessage` with the front door **on**, using the replay seam from #66 |
| **B** | The live model's rewrite preserves the days | **NOT PROVEN** — needs the recorded corpus |

The fixture for A is **synthetic on purpose, and legitimately so**: the claim under test is the *brake's reaction to a canonical*, not what `gpt-4o-mini` returns. B is asserted in `normalizer-replay-tests`, which reports the production surface as uncovered until the recording exists — and the build says so on every run:

```
⊘ normalizer-replay-tests — the production front door is NOT covered
```

I am not merging those two claims into one green tick.

## Controls

- **Remove the brake** → outcome check red, with the reproduction above
- **The premise is asserted too** — `multiFact` must still be **false** for this message, or the original brake would cover it and this one is moot
- **A single-day note must still be rewritable** — otherwise the "fix" is a global veto that disables the normalizer and calls it preservation

## Verification

- `production-parity`: **134/134** (132 → 134)
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239**; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — **none moved**
- `tsc --noEmit` clean

## Note on CI

Actions has created no run since **524**. If that is still true when this is reviewed, this PR has local verification only — same position as #68, and the decision to merge without a remote result is yours.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_