### PR TITLE
Stop broad predicates preempting the food-decision specialists

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -378,7 +378,7 @@ async function main() {
     // POSITIVE FORM (item 1.2): the title claims it ends in an INSTRUCTION, so that is asserted.
     // "does not end in ?" was satisfied by any statement at all, including a non-answer.
     assertCustomerOutcome(week, {
-      got: /\b(get|keep|add|hit|log|walk|eat|train|aim|start|stick|focus|send|take|tell|give|reply|show|pick|drop)\b/i,
+      got: /\b(get|keep|add|hit|log|walk|eat|train|aim|start|stick|focus|send|take|tell|give|reply|show|pick|drop|do|make|repeat|carry|hold|stay|put|choose|move)\b/i,
       notGot: /\?\s*$/,
       because: "the week must end in something the client can do, not a question handed back",
     });
@@ -3083,6 +3083,85 @@ async function main() {
   // So this asserts the property that a synchronised copy cannot offer: the session BODY the
   // moved-session path sends is the same string renderSession() produces. Change the renderer and
   // both callers move together; fork one of them and this goes red on the next run.
+  // ── THE CLAIM MATRIX — who is allowed to answer the customer (2026-08-25, issue #63) ─────────
+  //
+  // A broad upstream predicate could prevent the correct specialist from ever seeing a message.
+  // Measured before the fix: ONE phrase — "what can i eat" — preempted SIX food specialists.
+  // "What can I eat at Nandos?" got a generic next-meal card while "What should I order at
+  // Nandos?" got the full smart order, from the same client, about the same restaurant.
+  //
+  // This asserts the CLAIMANT, not the wording, because wording assertions cannot see a specialist
+  // being skipped — the generic card is a perfectly well-formed reply. The claimant is read from
+  // the logChat intent tag, which is the handler naming itself.
+  check("claim matrix . a situated food question reaches its specialist, not a generalist", async () => {
+    const { chatHistory } = await import("../shared/schema");
+    const g = globalThis as any;
+    const claimantOf = async (msg: string): Promise<string> => {
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      g.__KAMLIFE_STUB_WRITES = [];
+      await handleMessage(USER.phoneNumber, msg).catch(() => "");
+      const tags = (g.__KAMLIFE_STUB_WRITES || [])
+        .filter((w: any) => w.table === chatHistory && w.values?.intent)
+        .map((w: any) => String(w.values.intent));
+      delete g.__KAMLIFE_STUB_WRITES;
+      return tags.length ? tags[tags.length - 1] : "(untagged)";
+    };
+
+    // THE PAIRS ARE THE POINT. Each row is the same customer question in two phrasings; before the
+    // fix the left column reached a generalist and the right column reached the owner.
+    const pairs: Array<[string, string, string]> = [
+      ["RESTAURANT_GUIDE", "What can I eat at Nandos?", "What should I order at Nandos?"],
+      ["STREET_FOOD_GUIDE", "What can I eat at the taxi rank?", "I'm at the taxi rank, what should I get?"],
+    ];
+    for (const [owner, phrasingA, phrasingB] of pairs) {
+      for (const msg of [phrasingA, phrasingB]) {
+        assert.equal(await serialise(() => claimantOf(msg)), owner,
+          `"${msg}" was not claimed by ${owner} — a broader predicate took the turn first`);
+      }
+    }
+
+    // …and the swap owner, whose trigger word is IN the message and was still being skipped.
+    assert.equal(await serialise(() => claimantOf("What can I eat instead of rice?")), "FOOD_SWAP",
+      "a swap ask naming its own trigger word did not reach the swap owner");
+  });
+
+  // THE CONTROLS. Narrowing a generalist is only correct where a better owner exists; a generalist
+  // that steps aside for nobody has simply been broken. Both directions are asserted.
+  check("claim matrix control . the generalist keeps the questions it should own", async () => {
+    const { chatHistory } = await import("../shared/schema");
+    const g = globalThis as any;
+    const replyTo = async (msg: string) => {
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      g.__KAMLIFE_STUB_WRITES = [];
+      const out = String(await handleMessage(USER.phoneNumber, msg).catch(() => "") ?? "");
+      const tags = (g.__KAMLIFE_STUB_WRITES || [])
+        .filter((w: any) => w.table === chatHistory && w.values?.intent).map((w: any) => String(w.values.intent));
+      delete g.__KAMLIFE_STUB_WRITES;
+      return { out, claimed: tags.length ? tags[tags.length - 1] : "(untagged)" };
+    };
+    // A contextless hunger question is exactly what the next-meal card is for.
+    for (const msg of ["I'm hungry, what should I do?", "What can I eat?"]) {
+      const r = await serialise(() => replyTo(msg));
+      assert.equal(r.claimed, "MEAL_SUGGESTION",
+        `the generalist stopped owning a question it should own: "${msg}" → ${r.claimed}`);
+    }
+    // Pre-workout timing has NO specialist. Standing down here handed it to the food diary
+    // ("No meals logged yet today"), which is worse than the card it replaced.
+    const pre = await serialise(() => replyTo("What can I eat before the gym?"));
+    assert.equal(pre.claimed, "MEAL_SUGGESTION",
+      `a question with no specialist owner was stood down to a worse handler: ${pre.claimed}`);
+
+    // THE BUDGET ANSWER SURVIVES. "what can i eat" was removed from the totals predicate; these
+    // four carry that question and must be untouched.
+    for (const msg of ["How many calories do I have left?", "Can I still eat?", "What's left today?", "calories left"]) {
+      const r = await serialise(() => replyTo(msg));
+      assertCustomerOutcome(r.out, {
+        got: /\d[\d,]*\s*kcal|calories/i,
+        because: `the budget question must still be answered: "${msg}"`,
+      });
+    }
+  });
+
   check("one mouth . the moved session is the renderer's output, not a lookalike", async () => {
     const { renderSession } = await import("../server/programme");
     const { getTodaySlot } = await import("../server/workout-state");

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -168,7 +168,27 @@ export async function handleEarlyCommands(ctx: {
     }
   }
 
+  // A STAND-DOWN MUST NOT END THE TURN FOR EVERYONE ELSE (2026-08-25, issue #63).
+  //
+  // This was computed INSIDE the branch below and answered with `return null`, which exits
+  // handleEarlyCommands entirely — and handleFoodCommands, which owns restaurant / street food /
+  // swaps / grocery, is invoked at the bottom of this same function. So "I don't own the food
+  // half" became "nobody after me may own the food half", and six specialists were unreachable
+  // for any sentence the totals list happened to match.
+  //
+  // Measured before the change: "What can I eat at Nandos?", "…at the taxi rank?", "…instead of
+  // rice?", "…before the gym?" all landed on the generic next-meal card, while the same questions
+  // phrased "what should I order/get" reached their owner and answered well.
+  //
+  // The guard's intent (2026-08-07, Constitution law 20 — answer every part of what they said) is
+  // right and is kept. Only its mechanism changes: it now KEEPS THIS BRANCH FROM CLAIMING rather
+  // than ending the turn, so the message falls through to the specialists below. A genuinely
+  // multi-part question is already excluded by !isMultiPartAsk(m) inside the condition, so what
+  // reaches here is a single food question the totals list mis-claimed.
+  const alsoAsksFood = /\b(?:(?:what|which|where)\b[^?]{0,60}\b(?:can|should|do) i (?:eat|have|buy|order|get)|taxi rank|spaza|shisa nyama|kota|takeaway|restaurant|canteen|braai)\b/i.test(m);
+
   if (
+    !alsoAsksFood && (
     /\b(daily calories|calorie target|calories target|my calories|my calorie|kcal target|daily kcal)\b/i.test(m) ||
     /\b(calorie|calories|kcal)\b.*\b(target|goal|limit|daily|mine|my|remaining|left|still|remain)\b/i.test(m) ||
     // A SINGLE-FACT HANDLER MAY NOT CLAIM A MULTI-PART QUESTION (2026-07-29 live, and this is
@@ -184,7 +204,7 @@ export async function handleEarlyCommands(ctx: {
     !isMultiPartAsk(m) && (
     /\b(daily|my|total|remaining)\b.*\b(calorie|calories|kcal)\b/i.test(m) ||
     /\b(how many|how much).*(calorie|calories|kcal|left|remaining)\b/i.test(m) ||
-    /\b(calories today|today.?s calories|today calories|calories for today|protein today|what.?s left|whats left|calories left|calories remaining|remaining calories|total remaining|how much.*left|how much.*remaining|can i still eat|what can i eat|how much more|am i over|what (have|did) i (eat|ate|log|track)|food today|what i (ate|ate today|had today)|today.?s food|today.?s intake|today.?s totals?|total today|totals today|macros today|today.?s macros?|today.?s progress|progress today|daily progress|today.?s summary|my day so far|how.?s my day|how is my day|how am i doing today|where am i today)\b/i.test(m) ||
+    /\b(calories today|today.?s calories|today calories|calories for today|protein today|what.?s left|whats left|calories left|calories remaining|remaining calories|total remaining|how much.*left|how much.*remaining|can i still eat|how much more|am i over|what (have|did) i (eat|ate|log|track)|food today|what i (ate|ate today|had today)|today.?s food|today.?s intake|today.?s totals?|total today|totals today|macros today|today.?s macros?|today.?s progress|progress today|daily progress|today.?s summary|my day so far|how.?s my day|how is my day|how am i doing today|where am i today)\b/i.test(m) ||
     m === "calories" || m === "calorie" || m === "kcal" || m === "remaining" || m === "what's left" ||
     m === "today's calories" || m === "todays calories" || m === "today's food" || m === "today's intake" ||
     // TODAY beats the week (2026-07-28 live: "Today's progress" found no deterministic owner and
@@ -192,19 +212,11 @@ export async function handleEarlyCommands(ctx: {
     // the one thing that must never happen. The button says "My progress" and means the week;
     // anything carrying "today" means today, and today is the card.)
     m === "today's progress" || m === "todays progress"
-    )
+    ))
   ) {
     const cal = user.calorieTarget || 1800;
     const prot = user.proteinTarget || 120;
     const name = user.name ? `${user.name}, ` : "";
-    // DON'T SWALLOW THE OTHER HALF (2026-08-07, live-model gauntlet). "What can I eat at the
-    // taxi rank AND how many calories do I have left?" matched here, answered the calories, and
-    // returned — the food half was never seen by anything. Constitution law 20 says answer every
-    // part of what they said; a deterministic handler that returns early makes that impossible
-    // for the engine to obey. So when a second, non-numeric question rides along, this stands
-    // down and lets the coach answer both.
-    const alsoAsksFood = /\b(?:(?:what|which|where)\b[^?]{0,60}\b(?:can|should|do) i (?:eat|have|buy|order|get)|taxi rank|spaza|shisa nyama|kota|takeaway|restaurant|canteen|braai)\b/i.test(m);
-    if (alsoAsksFood) return null; // the engine answers both halves — see law 20
 
     // THE DAY THEY NAMED BEATS THE DAY THE SERVER ASSUMES (2026-08-10 directive, P0.1).
     // "What did I eat yesterday?" matched here and was answered with TODAY's totals — the same


### PR DESCRIPTION
Issue #63, Phase 2.3. **Two** measured claim-path defects — not the three that were scoped. The third was measured to be harmful and is not in this PR.

## The defect

```
"What can I eat at Nandos?"       → generic next-meal card
"What should I order at Nandos?"  → full smart order, correct
```

Same client, same restaurant, same question. One phrase preempted **six specialists**: restaurant, street food, swaps, hunger, budget, and pre-workout. Including *"What can I eat **instead of** rice?"* — which never reached the swap owner despite naming its own trigger word.

## Mechanism — both halves in `early-commands.ts`

**1. `what can i eat` sat in the calorie-budget predicate list, and has never been able to answer as one.**

`alsoAsksFood` matches it *by construction* — its first alternative is `(what|which|where)…(can|should|do) i (eat|…)`. Measured:

| phrasing | result |
|---|---|
| "How many calories do I have left?" | ✅ *"Kam, all 2700 kcal…"* |
| "Can I still eat?" / "What's left today?" / "calories left" | ✅ all work |
| **"What can I eat?"** | ✗ next-meal card |

Inert in its own branch, harmful everywhere else. **Removed.**

**2. `alsoAsksFood` then did `return null`** — which exits `handleEarlyCommands` **entirely**, while `handleFoodCommands` (restaurant / street food / swaps / grocery) is invoked at the bottom of that same function.

> *"I don't own the food half"* became *"nobody after me may own the food half."*

The guard's intent (2026-08-07, law 20) is right and is kept. Only its mechanism changes: it now stops **this branch** claiming rather than ending **the turn**. A genuinely multi-part question is already excluded by `!isMultiPartAsk(m)`, so what reaches the guard is a single food question the totals list mis-claimed.

## The third fix was dropped, and that is the more useful result

Narrowing the generic `MEAL_SUGGESTION` gate to stand down on situated context was scoped, implemented, and **measured to make things worse**:

| sentence | narrowed | before |
|---|---|---|
| "I'm still hungry, I'm at the taxi rank" | **`UNCLEAR`** | `MEAL_SUGGESTION` — a real answer |
| "I'm starving, I'm at Checkers" | `HUNGER` | `MEAL_SUGGESTION` |

Standing a generalist down only helps **where a better owner actually claims**. Street-food needs a "what should I get" trigger those sentences don't have, so the narrowing handed them to a fallback. **A generalist that steps aside for nobody has simply been broken.**

Its control run also passed the parity suite *without* the change — fixes 1 and 2 already route every measured case, so the third was unnecessary as well as harmful. Not shipped.

I hit the same error in miniature first: my initial version also excluded pre/post-workout timing, which sent *"What can I eat before the gym?"* to the food **diary** (*"No meals logged yet today"*) — worse than the card it replaced. There is no pre-workout food owner.

## The regression is a claim matrix, not a wording check

Wording assertions cannot see a specialist being skipped — **the generic card is a well-formed reply.** So the new checks assert the **claimant**, read from the `logChat` intent tag, which is the handler naming itself:

```
What can I eat at Nandos?                 → RESTAURANT_GUIDE
What should I order at Nandos?            → RESTAURANT_GUIDE    (paired, must not regress)
What can I eat at the taxi rank?          → STREET_FOOD_GUIDE
I'm at the taxi rank, what should I get?  → STREET_FOOD_GUIDE   (paired, must not regress)
What can I eat instead of rice?           → FOOD_SWAP
```

The **pairs** are the point: before this, the left column reached a generalist and the right column reached the owner.

## Controls, both directions

- **Restore the `return null` stand-down** → claim matrix **RED**
- **The generalist keeps what it should own** — "I'm hungry, what should I do?", "What can I eat?", and "What can I eat before the gym?" all still reach `MEAL_SUGGESTION`
- **The four budget phrasings still answer**, since `what can i eat` left that list

## Verification

- `production-parity`: **136/136** (134 → 136)
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239**; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — **none moved**
- `tsc --noEmit` clean
- **Two files changed**: `early-commands.ts` (+32/−11) and the parity suite. No handler deleted, no capability removed.

Also fixed: the #67 weekly-instruction fixture was flaky — the closing line is randomly picked, and *"**Do** exactly what you did yesterday"* failed a verb list that omitted `do`. Widened; not a product change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_