### PR TITLE
Steps: the recogniser said yes, the extractor said no, and the client's steps vanished

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -3083,6 +3083,69 @@ async function main() {
   // So this asserts the property that a synchronised copy cannot offer: the session BODY the
   // moved-session path sends is the same string renderSession() produces. Change the renderer and
   // both callers move together; fork one of them and this goes red on the next run.
+  // ── TWO PREDICATES FOR ONE QUESTION MUST AGREE (2026-08-26, issue #63) ───────────────────────
+  //
+  // "My steps are 10k today" was RECOGNISED as a step report by looksLikeStepsReport and extracted
+  // as ZERO by detectStepLog. One owner said yes, the other said no, and the client's 10 000 steps
+  // vanished between them — after which the coaching ladder, seeing no steps, told a client who
+  // had just walked 10 000 to go for a walk. That is the reported failure, and neither predicate
+  // was individually "wrong": they simply disagreed on the copula forms (`are|is|was|were`).
+  //
+  // The invariant is the durable part. Fixing the regex fixes one phrasing; asserting that the two
+  // predicates AGREE catches the whole class the next time either is edited alone.
+  check("steps . the recogniser and the extractor agree on what a step report is", async () => {
+    const { looksLikeStepsReport } = await import("../server/utils");
+    const { detectStepLog } = await import("../server/understanding/messy-intake");
+    const reports = [
+      "my steps are 10k today", "my steps are 10000", "steps are 8000", "steps: 9000",
+      "i walked 8000 steps today", "10000 steps", "i did 12k steps", "i've done 10k steps already",
+    ];
+    for (const r of reports) {
+      const recognised = looksLikeStepsReport(r);
+      const extracted = detectStepLog(r).steps;
+      assert.ok(recognised && extracted > 0,
+        `the two owners disagree on "${r}" — recognised=${recognised}, extracted=${extracted}. `
+        + `A step report seen by one and not the other is a client's steps disappearing.`);
+    }
+  });
+
+  check("steps . a client who reports steps has them written, and is told so", async () => {
+    const { stepLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+    const logged = async (msg: string) => {
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      g.__KAMLIFE_STUB_WRITES = [];
+      const out = String(await handleMessage(USER.phoneNumber, msg).catch(() => "") ?? "");
+      const rows = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === stepLogs);
+      delete g.__KAMLIFE_STUB_WRITES;
+      return { out, steps: rows[0]?.values?.steps ?? 0 };
+    };
+    const r = await serialise(() => logged("My steps are 10k today"));
+    assert.equal(r.steps, 10000, `the reported steps were not written: got ${r.steps}`);
+    assertCustomerOutcome(r.out, {
+      got: /10[\s,]?000\s*steps/i,
+      because: "a client who reports 10 000 steps must have them counted, not be asked to walk",
+    });
+  });
+
+  // THE CONTROL. A question about steps is not a report of steps. Widening the extractor must not
+  // turn "how many steps should I do?" into a log of zero.
+  check("steps control . a question about steps is never logged as one", async () => {
+    const { stepLogs } = await import("../shared/schema");
+    const g = globalThis as any;
+    for (const q of ["Are steps important?", "How many steps should I do?", "is 8000 steps enough?"]) {
+      const wrote = await serialise(async () => {
+        g.__KAMLIFE_STUB_USER = { ...USER };
+        g.__KAMLIFE_STUB_WRITES = [];
+        await handleMessage(USER.phoneNumber, q).catch(() => "");
+        const rows = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === stepLogs);
+        delete g.__KAMLIFE_STUB_WRITES;
+        return rows.length;
+      });
+      assert.equal(wrote, 0, `a question was logged as a step report: "${q}"`);
+    }
+  });
+
   // ── THE CLAIM MATRIX — who is allowed to answer the customer (2026-08-25, issue #63) ─────────
   //
   // A broad upstream predicate could prevent the correct specialist from ever seeing a message.

--- a/server/understanding/messy-intake.ts
+++ b/server/understanding/messy-intake.ts
@@ -298,7 +298,13 @@ export function detectStepLog(text: string): StepLogDetection {
   // Device/app references without an explicit "steps" keyword after the number.
   const devRaw = !numMatch ? (
     text.match(/\b(?:fitbit|garmin|apple\s*health|health\s*app|samsung\s*health|google\s*fit|my\s*(?:watch|tracker|band|phone)|strava|polar|whoop|oura|mi\s*band|galaxy\s*watch)\b[^.!?]*?([\d,]+(?:\.\d+)?)\s*(k)?\s*(?:steps?|staps?)?/i)
-    || text.match(/\bsteps?\s*(?:today|count|total|for\s*today)?\s*[:=]\s*([\d,]+(?:\.\d+)?)\s*(k)?\b/i)
+    // THE COPULA FORM (2026-08-26, issue #63). This accepted only `steps: 8000` / `steps = 8000`,
+    // while looksLikeStepsReport — the OTHER predicate for "is this a step report" — has always
+    // accepted `are|is|was|were` too. So "my steps are 10k today" was RECOGNISED as a step report
+    // and then extracted as zero: one owner said yes, the other said no, and the client's steps
+    // vanished between them. The coaching ladder then saw no steps and told a client who had just
+    // walked 10 000 to go for a walk, which is the reported failure.
+    || text.match(/\bsteps?\s*(?:today|count|total|for\s*today)?\s*(?:[:=]|\b(?:are|is|was|were)\b)\s*([\d,]+(?:\.\d+)?)\s*(k)?\b/i)
   ) : null;
   const dev = (devRaw && !/\b(?:heart\s*rate|bpm|pulse|calories?\s*burned|sleep\s*score|blood|oxygen)\b/i.test(text)) ? devRaw : null;
   const km = text.match(/(?:walked|loop|walk)\s+([\d.]+)\s*km/i);


### PR DESCRIPTION
Issue #63. **The last untraced screenshot failure**, now traced and fixed.

## The report

> **Client:** My steps are 10k today
> **Coach:** Get a 20-minute walk in today.

## The cause — two predicates for one question, disagreeing

| owner | accepts |
|---|---|
| `looksLikeStepsReport` (`utils.ts:738`) | `steps (are\|is\|was\|were\|:) N` |
| `detectStepLog` (`messy-intake.ts:301`) | `steps [:=] N` **only** |

So "my steps are 10k today" was **recognised** as a step report and **extracted as zero**. Nothing was written. The coaching ladder then saw a client with no steps and told someone who had just walked 10 000 to go for a walk.

**Neither predicate was wrong on its own.** They differed on the copula forms, and the client's steps fell into the gap.

Measured on the same surface, same client, before the fix:

```
"I walked 8000 steps today"   → STEP_LOG, 8000 written    ✅
"10000 steps"                 → STEP_LOG, 10000 written   ✅
"I did 12k steps"             → STEP_LOG, 12000 written   ✅
"I've done 10k steps already" → STEP_LOG, 10000 written   ✅
"My steps are 10k today"      → UNCLEAR, nothing written  ✗
"My steps are 10000"          → GENERAL, nothing written  ✗
```

## The fix

One alternation — the extractor now accepts the same copulas the recogniser always has. No new predicate, no new module, no counter moved.

## The invariant is the durable part

Fixing the regex fixes one phrasing. The new check asserts the two owners **agree** across a corpus of real phrasings:

```ts
assert.ok(recognised && extracted > 0,
  `the two owners disagree on "${r}" — recognised=${recognised}, extracted=${extracted}.
   A step report seen by one and not the other is a client's steps disappearing.`);
```

That is the general form of this defect: **two predicates answering one customer question, drifting apart, with neither individually wrong.** The next time either is edited alone, the divergence is caught rather than shipped.

This is the same class as the food claim-collision in #70, one layer down — there a broad predicate *preempted* a specialist; here two predicates for one question *disagree*. Both are invisible to wording assertions, because the resulting reply is always well-formed.

## Controls

- **Revert the copula alternation** → both new checks turn red
- **A question about steps is still never logged as one** — "Are steps important?", "How many steps should I do?", "is 8000 steps enough?" all write nothing. Widening an extractor must not turn a question into a log of zero.

## Verification

- `production-parity`: **139/139** (136 → 139)
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239**; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — **none moved**
- `tsc --noEmit` clean
- **Two files changed**, +70/−1. No capability removed.

## Status of the original #63 screenshots

| # | failure | status |
|---|---|---|
| 1 | "rest today" over "moved it to today" | fixed — #61, #68 |
| 2 | receipt dropped a food | fixed — #62 |
| 3 | Week/Session contradiction | fixed — #62 |
| 4 | multi-day logging collapsed (~7,700 kcal) | fixed — #69 |
| 5 | steps stated, walk suggested | **fixed — this PR** |
| 6 | Twilio Sandbox leak | not our code — configuration |
| 7 | "same as last meal" | not reproduced offline |

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_