### PR TITLE
"My water is 2 litres" logged a food called Water. "Is my workout done?" logged a workout.

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -3083,6 +3083,74 @@ async function main() {
   // So this asserts the property that a synchronised copy cannot offer: the session BODY the
   // moved-session path sends is the same string renderSession() produces. Change the renderer and
   // both callers move together; fork one of them and this goes red on the next run.
+  // ── "MY X IS N" — THE SHARED REPORTING PATTERN (2026-08-26, issue #63) ──────────────────────
+  //
+  // Three of four tracking surfaces mishandled the same ordinary construction, each differently:
+  //   steps   — recogniser said yes, extractor said no (#71)
+  //   water   — the water owner's own question-guard classified the report as a question, so it
+  //             fell past Water and the FOOD scanner logged a food called "Water"
+  //   workout — the completion matcher was anchored to the bare "workout done"
+  //   weight  — worked throughout
+  //
+  // It is ordinary phrasing, arguably more natural than "I drank 2 litres". These assert the whole
+  // family in one place so the next tracker cannot quietly miss it.
+  check("my-X-is-N . a report in copula form reaches its tracker, on every surface", async () => {
+    const S = await import("../shared/schema");
+    const g = globalThis as any;
+    const run = async (msg: string) => {
+      g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
+      g.__KAMLIFE_STUB_WRITES = [];
+      const out = String(await handleMessage(USER.phoneNumber, msg).catch(() => "") ?? "");
+      const w = g.__KAMLIFE_STUB_WRITES || [];
+      const hit = (t: any) => w.filter((x: any) => x.table === t).length > 0;
+      delete g.__KAMLIFE_STUB_WRITES;
+      return { out, steps: hit(S.stepLogs), weight: hit(S.weightLogs), workout: hit(S.workoutLogs), meal: hit(S.mealLogs) };
+    };
+
+    const steps = await serialise(() => run("My steps are 8000"));
+    assert.ok(steps.steps, "\"My steps are 8000\" did not reach the step tracker");
+
+    const weight = await serialise(() => run("My weight is 92kg"));
+    assert.ok(weight.weight, "\"My weight is 92kg\" did not reach the weight tracker");
+
+    const workout = await serialise(() => run("My workout is done"));
+    assert.ok(workout.workout, "\"My workout is done\" did not reach the workout tracker");
+
+    // WATER IS THE ONE THAT CORRUPTED STATE. Asserting the food table stays EMPTY is the point:
+    // the failure was not silence, it was a food called "Water" written to the client's record.
+    const water = await serialise(() => run("My water is 2 litres"));
+    assert.ok(!water.meal, "a water report was logged as FOOD — the client's record now carries an invented meal");
+    assertCustomerOutcome(water.out, {
+      got: /\d+(?:\.\d+)?\s*L\b|litre/i,
+      because: "a client who reports their water must have it counted as water",
+    });
+  });
+
+  // THE CONTROLS. Widening a report matcher must not turn a QUESTION into a write. A false log is
+  // worse than a missed one: it tells the client they did something they did not.
+  check("my-X-is-N control . asking is never writing", async () => {
+    const S = await import("../shared/schema");
+    const g = globalThis as any;
+    const wrote = async (msg: string) => {
+      g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
+      g.__KAMLIFE_STUB_WRITES = [];
+      await handleMessage(USER.phoneNumber, msg).catch(() => "");
+      const n = (g.__KAMLIFE_STUB_WRITES || [])
+        .filter((x: any) => [S.stepLogs, S.weightLogs, S.workoutLogs].includes(x.table)).length;
+      delete g.__KAMLIFE_STUB_WRITES;
+      return n;
+    };
+    // "Is my workout done?" WROTE A SESSION before this cut — a fabricated workout, pre-existing.
+    for (const q of ["Is my workout done?", "did my workout?", "Have I trained today?",
+                     "my workout is not done", "How much water should I drink?", "Is 2 litres of water enough?"]) {
+      assert.equal(await serialise(() => wrote(q)), 0, `a question or negation was written as a report: "${q}"`);
+    }
+    // …and the report forms these guards sit beside must still write.
+    for (const r of ["did my workout", "workout done"]) {
+      assert.ok(await serialise(() => wrote(r)) > 0, `a genuine report stopped writing: "${r}"`);
+    }
+  });
+
   // ── TWO PREDICATES FOR ONE QUESTION MUST AGREE (2026-08-26, issue #63) ───────────────────────
   //
   // "My steps are 10k today" was RECOGNISED as a step report by looksLikeStepsReport and extracted

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -42,7 +42,12 @@ export async function tryLogWater(ctx: {
   // Question ("is 500ml enough water?", "how much is 2 litres?") must NOT log — reaches
   // the water-question handler below or GPT. Negation/intent ("haven't had my 2L of water
   // yet", "need to drink 2 litres") must NOT log water that was never consumed.
-  const waterIsQuestion = m.includes("?") || /\b(how much|how many|should i|do i need|is\s+\d|enough|too much|target|recommend)\b/i.test(m);
+  // `is\s+\d` WAS UNANCHORED (2026-08-26, issue #63). It exists to catch "is 500ml enough?",
+  // but it also matched "my water IS 2 litres" — a report — so the copula form was classified as
+  // a question and never logged. The client's water went to the food scanner instead, which
+  // logged a FOOD called "Water". Anchored: a question opens with "is", a report does not.
+  const waterIsQuestion = m.includes("?") || /\b(how much|how many|should i|do i need|enough|too much|target|recommend)\b/i.test(m)
+    || /^\s*is\s+\d/i.test(m);
   const waterNotConsumed = mentionsNotDone(m)  // couldn't/skipped/didn't finish my water — never consumed
     || /\b(need\s+to|should\s+(?:i|drink)|must\s+drink|gonna|going\s+to|will\s+drink|plan\s+to|trying\s+to|still\s+need)\b/i.test(m);
   if (waterMatch && hasWaterKeyword && !isNonWaterDrink && !waterIsQuestion && !waterNotConsumed) {
@@ -119,7 +124,12 @@ export async function handleWater(ctx: {
   // in tryLogWater now, so these are no longer in scope here).
   const waterMatch = m.match(/(\d+(?:\.\d+)?)\s*(l|litre|liter|litres|liters|ml|millilitre|milliliter|glass(?:es)?|cup(?:s)?|bottle(?:s)?)\b/i);
   const hasWaterKeyword = WATER_WORDS.test(m);
-  const waterIsQuestion = m.includes("?") || /\b(how much|how many|should i|do i need|is\s+\d|enough|too much|target|recommend)\b/i.test(m);
+  // `is\s+\d` WAS UNANCHORED (2026-08-26, issue #63). It exists to catch "is 500ml enough?",
+  // but it also matched "my water IS 2 litres" — a report — so the copula form was classified as
+  // a question and never logged. The client's water went to the food scanner instead, which
+  // logged a FOOD called "Water". Anchored: a question opens with "is", a report does not.
+  const waterIsQuestion = m.includes("?") || /\b(how much|how many|should i|do i need|enough|too much|target|recommend)\b/i.test(m)
+    || /^\s*is\s+\d/i.test(m);
   const waterNotConsumed = mentionsNotDone(m)  // couldn't/skipped/didn't finish my water — never consumed
     || /\b(need\s+to|should\s+(?:i|drink)|must\s+drink|gonna|going\s+to|will\s+drink|plan\s+to|trying\s+to|still\s+need)\b/i.test(m);
 

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -463,12 +463,28 @@ export async function handleWorkoutCommands(ctx: {
   const isDone = !alreadyLoggedThisTurn && when.when === "today" && (reportsOneSession || (
     /^(done|finished|complete|completed|trained)[.!?]?$/i.test(m)
     || /^done\s*[💪✅🔥][.!?]?$/.test(m)
-    || /^(?:workout|session|training|gym)\s+(?:done|complete|finished)[.!?]?$/i.test(m)
+    // THE COPULA FORM (2026-08-26, issue #63). This was anchored to the bare "workout done", so
+    // "my workout is done" and "my session is done" — ordinary phrasing — matched nothing here and
+    // fell all the way to the model, which logged no session. Same construction that broke steps
+    // (#71) and water: three of four tracking surfaces missed "my X is/are …".
+    // Still fully anchored, so it claims a short completion report and nothing longer.
+    || /^(?:my\s+)?(?:workout|session|training|gym)\s+(?:is\s+|was\s+)?(?:done|complete|completed|finished)[.!?]?$/i.test(m)
     || /^(?:just\s+)?(?:done|finished)\s+(?:my\s+)?(?:workout|session|training|gym)[.!?]?$/i.test(m)
     || m === "done today" || m === "finished today"
   ) && !looksLikeQuestion(m)  // "done?" / "workout done?" is asking, not reporting — the [.!?]? anchors otherwise allow a trailing ?
     && !/\b(?:steps?|km|walked|walk)\b/i.test(m)
-    && !/\b(?:ate|had|food|meal|eaten|eating|calories)\b/i.test(m));
+    && !/\b(?:ate|had|food|meal|eaten|eating|calories)\b/i.test(m))
+    // ASKING WHETHER IT IS DONE IS NOT REPORTING THAT IT IS (2026-08-26, issue #63, pre-existing).
+    //
+    // "Is my workout done?" WROTE A SESSION. reportsOneSession waives the question guard when
+    // statedWorkout is true — reasonable for "did my workout", which is a report — but that waiver
+    // also covered the interrogative form, so a client checking their own record had one
+    // fabricated. A false write is worse than a missed one: it tells the client they trained when
+    // they did not, and the session count carries the invention forward.
+    //
+    // Anchored on BOTH the opening interrogative and a question mark, so "did my workout" (a
+    // report, no mark) still logs while "did my workout?" and "is my workout done?" do not.
+    && !(m.includes("?") && /^\s*(?:is|are|was|were|am|have|has|did|do|does)\b/i.test(m.trim()));
 
   if (isDone) {
     const todayStart = sastDayStart();

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -1156,7 +1156,20 @@ export function digitizeSpokenAmounts(m: string): string {
 export function looksLikeWaterReport(raw: string): boolean {
   const m = digitizeSpokenAmounts(raw);
   return /\b(?:drank|drinking|had)\b.{0,24}\b\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?|glass(?:es)?|bottles?)\s*(?:of\s+)?(?:water)?\b/i.test(m)
-    || /^\s*\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?)(?:\s+(?:of\s+)?water)?\s*$/i.test(m);
+    || /^\s*\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?)(?:\s+(?:of\s+)?water)?\s*$/i.test(m)
+    // THE COPULA FORM (2026-08-26, issue #63). "My water is 2 litres" reported nothing to the
+    // water owner — it needed `drank/drinking/had` or a bare amount — so it fell past Water to
+    // FoodContext, where the scanner logged a FOOD called "Water" with a macro card and todayWater
+    // stayed at 0. Wrong data written to the client's record, not merely a missed reply.
+    //
+    // The same construction broke steps (#71) and workout. It is ordinary phrasing — arguably more
+    // natural than "I drank 2 litres" — and three of four tracking surfaces mishandled it.
+    //
+    // A QUESTION IS NOT A REPORT: "how much water should I drink" and "is 2 litres enough" carry
+    // the same words and must not log. The leading-verb guard below is what separates them.
+    || (/\bwater(?:\s+intake)?\s*(?:[:=]|\b(?:is|was|were|are)\b)\s*\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?|glass(?:es)?|bottles?)\b/i.test(m)
+        && !/^(?:how|what|why|when|should|shouldn.?t|is|are|can|could|do|does|don.?t|must)\b/i.test(m.trim())
+        && !/\b(?:enough|too much|too little|target|goal|supposed to|meant to)\b/i.test(m));
 }
 
 export function looksLikeWeightReport(m: string): boolean {


### PR DESCRIPTION
Issue #63, continuing the cross-surface sweep. **Two tracking defects and one pre-existing false write.**

## The pattern

Three of four tracking surfaces mishandled the same ordinary construction — **"my X is/are N"** — each for a different reason:

| surface | cause | status |
|---|---|---|
| steps | recogniser said yes, extractor said no | fixed in #71 |
| **water** | the owner's own question-guard classified the report as a question | **this PR** |
| **workout** | completion matcher anchored to the bare "workout done" | **this PR** |
| weight | — | worked throughout |

It is normal phrasing, arguably more natural than "I drank 2 litres".

## Water — wrong data written, not a missed reply

```
"My water is 2 litres"  →  Got it — Water. 👌 [MEDIA: macro card]
```

The **food scanner logged a food called "Water"** while `todayWater` stayed at 0. The client's record now carried an invented meal.

Two causes, both in the water owner:

1. `looksLikeWaterReport` required `drank|drinking|had` or a bare amount — the copula form wasn't a water report at all.
2. `tryLogWater`'s question guard contained an **unanchored `is\s+\d`**, meant for *"is 500ml enough?"*. It also matched *"my water **is 2** litres"* — so even once recognised, the report was classified as a question and never logged.

**The food scanner was not touched.** Once water claims the sentence it never reaches food, so there was no generalist to narrow. #70's rule — *prove the specialist claims before constraining anyone else* — was satisfied by fixing the specialist alone.

## Workout

`^(?:workout|session|training|gym)\s+(done|…)$` didn't cover *"my workout is done"* or *"my session is done"*, so both fell to the model and logged nothing. Widened, still fully anchored.

## And a pre-existing false write, found while verifying

```
"Is my workout done?"  →  a session was LOGGED
```

`reportsOneSession` waives the question guard when `statedWorkout` is true — right for *"did my workout"*, wrong for the interrogative. **A client checking their own record had one fabricated**, and the session count carried the invention forward.

**Verified against `main` before my change: it logged there too.** Not a regression I introduced — I checked before attributing it, and a false write is worse than a missed one, so it's fixed here rather than filed.

Now guarded on **both** an opening interrogative **and** a question mark, so *"did my workout"* (a report) still logs while *"did my workout?"* and *"is my workout done?"* do not.

## Controls, each isolated to its own check

| control | result |
|---|---|
| revert the water anchor | copula check **red** |
| revert the workout question guard | "asking is never writing" check **red** |
| questions & negations write nothing | "Is my workout done?", "did my workout?", "Have I trained today?", "my workout is not done", "How much water should I drink?", "Is 2 litres of water enough?" |
| genuine reports still write | "did my workout", "workout done" |
| food logging untouched | "I had 2 slices of bread" still logs a meal |

The water assertion checks the **food table stays empty** — the failure wasn't silence, it was an invented meal.

## Verification

- `production-parity`: **141/141** (139 → 141)
- Full chain: **31/34 green, 1 covered nothing** — same two governors red as `main`, same numbers
- `modules` **239/239**; `messageDeciders` 32, `looksLikePredicates` 21, `authorshipPoints` 425 — **none moved**
- `tsc --noEmit` clean
- Four files, +112/−5. No handler deleted, no capability removed, no generalist narrowed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_