### PR TITLE
A question cannot mutate tracking state

### DIFF
--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -48,7 +48,7 @@ export const SUITES = [
   "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests",
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
-  "turn-triage-tests", "normalizer-replay-tests",
+  "turn-triage-tests", "normalizer-replay-tests", "tracking-contract-tests",
   "production-parity", "check-architecture",
 ];
 

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1,0 +1,183 @@
+/**
+ * THE CANONICAL TRACKING CONTRACT (2026-08-26, issue #63).
+ *
+ * Every tracked fact — steps, water, weight, workouts, food — travels the same five stages:
+ *
+ *     natural-language report
+ *        -> ONE recogniser      ("is this a report of this fact?")
+ *        -> ONE extractor       ("what is the value?")
+ *        -> ONE write owner     ("commit the state transition")
+ *        -> ONE action          ("what does this change about the coaching?")
+ *        -> ONE response        ("what does the client read?")
+ *
+ * and the contract has exactly two laws:
+ *
+ *   LAW 1 — RECOGNISER AND EXTRACTOR MUST AGREE.
+ *     If the recogniser says "yes, a step report" and the extractor returns zero, the fact is
+ *     destroyed silently between two owners of the same question. That was the live failure in
+ *     #71: "my steps are 10k today" was recognised and extracted as nothing, the coaching ladder
+ *     saw no steps, and a client who had just walked 10 000 was told to go for a walk.
+ *
+ *   LAW 2 — A QUESTION OR AN INTENTION CANNOT MUTATE TRACKING STATE.
+ *     A missed write is visible to the client and correctable by them. A FALSE write is neither:
+ *     it enters the trend, the progress card, the auto-adjust engine and every coaching decision
+ *     downstream, and the client never sees the row that is lying about them. Measured on main
+ *     before this suite existed:
+ *
+ *         "I need to do 10000 steps"  ->  10 000 steps written; client walked none
+ *         "I want to weigh 85kg"      ->  85kg written as today's measurement for a client on
+ *                                         the scale at 95kg, calorie and protein targets
+ *                                         recalculated off it, and the reply was
+ *                                         "🏆 you hit 85kg — that's the goal, done."
+ *
+ * WHY THIS FILE IS BEHAVIOURAL AND NOT A PREDICATE TEST. Both defects above sat in code whose
+ * predicates were individually defensible. The steps gate already asked isFutureIntent and got a
+ * truthful "false" — the vocabulary simply lacked "need to". The weight branch never asked at
+ * all, while the two sibling branches either side of it in the same file always had. Neither is
+ * visible from any one predicate's unit test; both are obvious the moment you ask the only
+ * question that matters — DID THE TURN WRITE? So this suite drives real messages through
+ * handleMessage and reads the writes the stub recorded, in both directions:
+ *
+ *     questions and intentions  -> MUST NOT write   (the invariant)
+ *     real reports              -> MUST still write (the negative control)
+ *
+ * The second half is not optional. Every guard added here can be made to pass by refusing more,
+ * and refusing more trades a false write for a lost one. The control is what stops that trade.
+ *
+ * WHY utils.isFutureIntent STAYS NARROW. It is the shared owner of "this states a plan, not a
+ * report", and the obvious repair — pour every intention-shaped phrase into it — is wrong.
+ * "had to" and "trying to" are excluded on purpose: "I had to walk 5km to the taxi rank" and
+ * "trying to lose weight, weighed 84kg this morning" are REPORTS carrying a real measurement, and
+ * a floor wide enough to eat them has simply moved the damage from a false write to a lost one.
+ * The MUST_WRITE list below holds that line; widen the vocabulary and it is what pushes back.
+ */
+process.env.KAMLIFE_DB_STUB = "1";
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.NORMALIZER = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.NODE_ENV = "production";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.APP_URL = "https://x.up.railway.app";
+
+const NOW = Date.now();
+
+/** A settled client mid-programme: onboarded, subscribed, consented, with a real weight gap
+ *  (95kg now, 85kg target) so a goal-as-measurement write is unmistakable when it happens. */
+const USER = {
+  id: "qa", phoneNumber: "whatsapp:+27000000070", name: "Kam",
+  onboardingState: "COMPLETE", onboardingComplete: true, subscriptionStatus: "active",
+  popiConsent: true, popiConsentAt: new Date(NOW - 30 * 86_400_000),
+  goalType: "fat_loss", currentWeight: 95, targetWeight: 85,
+  heightCm: 180, age: 35, gender: "male", activityLevel: "moderate",
+  trainingMode: "gym", trainingDaysPerWeek: 3,
+  programmePhase: 1, programmeWeek: 1, programmeDayInWeek: 2,
+  programmeStartDate: new Date(NOW - 35 * 86_400_000), totalWorkoutsCompleted: 24,
+  injuries: "none", medicalConditions: "none", awaitingInputType: null, profileNotes: "",
+  todayWater: "0", calorieTarget: 2700, proteinTarget: 180,
+  stepTarget: 10000, stepsTarget: 10000,
+  lastActiveAt: new Date(NOW - 3_600_000), createdAt: new Date(NOW - 35 * 86_400_000),
+};
+
+/** LAW 2. Questions and stated intentions across every tracked surface. None may write. */
+const MUST_NOT_WRITE: [string, string][] = [
+  ["steps", "How many steps have I done?"],
+  ["steps", "Is 8000 steps enough?"],
+  ["steps", "Should I do 10000 steps?"],
+  ["steps", "Do steps matter?"],
+  ["steps", "what are my steps today?"],
+  ["steps", "I need to do 10000 steps"],
+  ["water", "How much water should I drink?"],
+  ["water", "Is 2 litres of water enough?"],
+  ["water", "what is my water today?"],
+  ["water", "I need to drink 2 litres"],
+  ["water", "should I drink 3 litres of water?"],
+  ["weight", "What is my weight?"],
+  ["weight", "Should I weigh 85kg?"],
+  ["weight", "Is 92kg good?"],
+  ["weight", "I want to weigh 85kg"],
+  ["weight", "my target weight is 85kg"],
+  ["workout", "Is my workout done?"],
+  ["workout", "Have I trained today?"],
+  ["workout", "did my workout?"],
+  ["workout", "Should I train today?"],
+  ["workout", "my workout is not done"],
+  ["workout", "I will train later"],
+  ["food", "Did I log breakfast?"],
+  ["food", "What did I eat today?"],
+  ["food", "Should I eat eggs?"],
+  ["food", "I want to eat eggs later"],
+  ["food", "is bread ok?"],
+];
+
+/** THE NEGATIVE CONTROL. Real reports, in the shapes clients actually send. Every one must still
+ *  reach its writer — a guard that passes the list above by refusing everything fails here.
+ *  The "trying to lose weight" line is deliberate: it carries an intention AND a measurement, and
+ *  the measurement is the fact. An intent floor wide enough to eat it is too wide. */
+const MUST_WRITE: [string, string][] = [
+  ["steps", "walked 10000 steps today"],
+  ["steps", "my steps are 10k today"],
+  ["steps", "fitbit says 8500"],
+  ["steps", "10k steps done"],
+  ["steps", "steps: 9200"],
+  ["weight", "84kg"],
+  ["weight", "weighed 84kg this morning"],
+  ["weight", "my weight is 84kg today"],
+  ["weight", "I'm trying to lose weight, weighed 84kg this morning"],
+  ["workout", "workout done"],
+  ["workout", "I trained chest today"],
+  ["workout", "gym done"],
+  ["water", "2 litres of water"],
+  ["water", "drank 3 litres today"],
+];
+
+(async () => {
+  const g = globalThis as any;
+  const { handleMessage } = await import("../server/routes");
+  const schema = await import("../shared/schema");
+  const NAME = new Map<any, string>([
+    [schema.stepLogs, "steps"], [schema.weightLogs, "weight"],
+    [schema.workoutLogs, "workout"], [schema.mealLogs, "food"],
+  ]);
+
+  /** What did this turn actually commit? Water is the odd one out: it persists through a raw
+   *  `sql` CASE expression, so the stub holds an SQL object rather than a number and any numeric
+   *  read of it silently reports "no write" — which is how a water false-write could hide from a
+   *  probe that looked clean. "Did todayWater move off the seeded 0" is the honest test. */
+  async function wroteFor(message: string): Promise<Set<string>> {
+    g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
+    g.__KAMLIFE_STUB_WRITES = [];
+    await handleMessage(USER.phoneNumber, message).catch(() => "");
+    const wrote = new Set<string>(
+      (g.__KAMLIFE_STUB_WRITES || []).map((w: any) => NAME.get(w.table)).filter(Boolean),
+    );
+    if (String((g.__KAMLIFE_STUB_USER || {}).todayWater ?? "0") !== "0") wrote.add("water");
+    return wrote;
+  }
+
+  const failures: string[] = [];
+
+  for (const [surface, message] of MUST_NOT_WRITE) {
+    const wrote = await wroteFor(message);
+    if (wrote.size > 0) {
+      failures.push(`A question mutated tracking state: ${surface} | "${message}" wrote ${[...wrote].join(", ")}`);
+    }
+  }
+
+  for (const [surface, message] of MUST_WRITE) {
+    const wrote = await wroteFor(message);
+    if (!wrote.has(surface)) {
+      failures.push(`A real report was lost: ${surface} | "${message}" wrote ${[...wrote].join(", ") || "nothing"}`);
+    }
+  }
+
+  const total = MUST_NOT_WRITE.length + MUST_WRITE.length;
+  if (failures.length > 0) {
+    for (const f of failures) console.log(`✗ ${f}`);
+    console.log(`\n✗ tracking contract: ${failures.length}/${total} violations`);
+    process.exit(1);
+  }
+  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer`);
+  process.exit(0);
+})();

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -98,7 +98,12 @@ export async function handleWorkoutCommands(ctx: {
   // logging it silently recalculates calorie & protein targets and can flip the goal,
   // all off a message the user framed as a question. Let it reach GPT; a clean "84kg"
   // still logs.
-  if ((isStandaloneWeight || isWeightCheckIn) && !isRetrospectiveWeight && !looksLikeQuestion(m) && !EXERCISE_PATTERN.test(m)) {
+  // Intent brake: "I want to weigh 85kg" / "I need to be 85kg" is a GOAL. Without this it wrote
+  // 85kg as today's measurement for a client on the scale at 95kg, recalculated their calorie and
+  // protein targets off it, and replied "🏆 you hit 85kg — that's the goal, done." The two
+  // branches either side of this one — the session report above and the cardio log below — have
+  // always asked isFutureIntent. This one never did; that asymmetry was the whole defect.
+  if ((isStandaloneWeight || isWeightCheckIn) && !isRetrospectiveWeight && !isFutureIntent(m) && !looksLikeQuestion(m) && !EXERCISE_PATTERN.test(m)) {
     const kgMatch = m.match(/(\d{2,3}(?:\.\d+)?)\s*kg/i);
     if (kgMatch) {
       const kg = parseFloat(kgMatch[1]);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,7 +38,6 @@ import { captureSignupSource } from "./signup-capture";
 import { JUNK_WORDS as _JUNK_WORDS, checkFoodPatterns, getDamageControlNote, checkPerfectDay } from "./handlers/checks";
 import { scanForSAFoods, parseFoodLogTotalsFromMessageOut, sanitizeCoachReply, recomputeTodayFoodTotals } from "./handlers/food-scanner";
 import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence } from "./handlers/chat-log";
-import { handleWeightLog } from "./handlers/weight";
 import { handleWorkoutCommands } from "./handlers/workout";
 import { getTodayWorkoutState } from "./workout-state";
 import { handleMiscCommands } from "./handlers/misc-commands";

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -262,9 +262,10 @@ export function stripInventedRetroDate(canonical: string, original: string): str
 // done. Used by the step and cardio loggers, which match the activity + number
 // regardless of tense. Note: i'll requires the apostrophe so "ill"/"I feel ill"
 // does not match; voice transcripts that drop it are covered by tomorrow/going to.
+// Narrow on purpose: widening this loses real reports. See script/tracking-contract-tests.ts (#63).
 export function isFutureIntent(message: string): boolean {
   const m = message.toLowerCase();
-  return /\bi'll\b|\bi\s+will\b|\b(?:wanna|gonna)\b|\bgoing\s+to\b|\bplann?ing\s+to\b|\bplan\s+to\b|\babout\s+to\b|\bhoping\s+to\b|\bwant\s+to\b|\btomorrow\b|\bnext\s+week\b|\blater\s+today\b/i.test(m);
+  return /\bi'll\b|\bi\s+will\b|\b(?:wanna|gonna)\b|\bgoing\s+to\b|\bplann?ing\s+to\b|\bplan\s+to\b|\babout\s+to\b|\bhoping\s+to\b|\bwant\s+to\b|\bneeds?\s+to\b|\bhas\s+to\b|\bhave\s+to\b|\bsupposed\s+to\b|\baiming\s+(?:to|for)\b|\bmeant\s+to\b|\bthinking\s+(?:of|about)\b|\btomorrow\b|\bnext\s+week\b|\blater\s+today\b/i.test(m);
 }
 
 /**


### PR DESCRIPTION
Formalises the canonical tracking contract from the four proven cases in #63, and enforces its second law behaviourally.

## The contract

Every tracked fact — steps, water, weight, workouts, food — travels one path:

```
report -> one recogniser -> one extractor -> one write owner -> one action -> one response
```

Two laws hold it together:

1. **Recogniser and extractor must agree.** Disagreement destroys the fact silently between two owners of the same question (this was #71 and #72).
2. **A question or an intention cannot mutate tracking state.**

Law 2 is the dangerous one. A missed write is visible to the client and correctable by them. A false write is neither — it enters the trend, the progress card, the auto-adjust engine and every coaching decision downstream, and the client never sees the row that is lying about them.

## Measured on main

27 question and intent forms across all five tracked surfaces, driven through `handleMessage`, reading what the turn actually committed. Two wrote:

| message | what it wrote |
|---|---|
| `I need to do 10000 steps` | 10 000 steps, for a client who walked none |
| `I want to weigh 85kg` | 85kg as today's measurement for a client on the scale at 95kg — calorie and protein targets recalculated off it, and the reply was *"🏆 you hit 85kg — that's the goal, done."* |

Both were traced at runtime to their write site, not inferred from the source.

## Two repairs, both to existing owners

No new predicate was added. `utils.isFutureIntent` already owns *"this states a plan, not a report"*, and the steps write gate already consulted it.

- **`utils.isFutureIntent`** carried `want to` but not `need to`. The steps gate asked it and got a truthful `false` on a word it simply did not carry. Vocabulary widened to the obligation forms — held narrow on purpose: `had to` and `trying to` stay **out**, because *"I had to walk 5km to the taxi rank"* and *"trying to lose weight, weighed 84kg this morning"* are real reports.
- **`handlers/workout.ts` weight branch** never asked `isFutureIntent`, while the session branch above it and the cardio branch below it always had. That asymmetry was the entire weight defect. It now asks.

Also removes an unused `handleWeightLog` import from `routes.ts`, which made the recogniser census read five where four are real.

## New suite, graded both ways

`script/tracking-contract-tests.ts` drives real messages through `handleMessage` and reads the writes the turn committed — behaviour and state, never source strings:

- **27 questions and intentions must write nothing** — the invariant.
- **14 real reports must still reach their writer** — the negative control.

The second half is not optional. Every guard here can be made to pass by refusing more, and refusing more trades a false write for a lost one. The control is what stops that trade.

**Proof it can fail:** reverting either repair alone turns the suite red on exactly its own case.

```
revert isFutureIntent   -> ✗ "I need to do 10000 steps" wrote steps
revert workout guard    -> ✗ "I want to weigh 85kg" wrote weight
both restored           -> ✓ 41/41
```

Registered in `run-suites`, so `npm test` and CI cover it with no workflow change.

## A probe correction worth naming

Water persists through a raw `sql` CASE expression, so the stub holds an SQL object rather than a number, and any numeric read of it reports "no write". A water false-write could have hidden from a probe that looked clean. Both directions now test whether `todayWater` moved off the seeded zero.

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing` — `normalizer-replay-tests` still skipped, awaiting the recorded corpus
- RED: `check-file-sizes`, `check-architecture` — **the same two as main, unchanged**
- Governor identical on both sides: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`. No budget raised, nothing suppressed.
- `routes.ts` −1 line

## Follow-up found, not fixed here

The surface audit turned up a real second write owner: the conversational steps path inserts into `stepLogs` inline at `routes.ts` rather than calling `handlers/steps.logStepsForUser`, which is the shared owner every other caller uses. That is a contract violation of the ">1 write owner" kind and belongs in its own cut, not bundled into this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_