### PR TITLE
The step write has one owner, and the answer quotes it

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -172,12 +172,72 @@ const MUST_WRITE: [string, string][] = [
     }
   }
 
-  const total = MUST_NOT_WRITE.length + MUST_WRITE.length;
+  /**
+   * LAW 3 — THE ANSWER MUST QUOTE THE LEDGER, NOT THE MESSAGE (2026-08-26, issue #63).
+   *
+   * The write owner returns the count the day now HOLDS. Where a second write path existed, that
+   * distinction was exactly what it lost: with 9 000 already logged, "walked 3000 steps today"
+   * correctly kept the row at 9 000 and then congratulated the client on 3 000 — the ledger and
+   * the mouth disagreeing inside one turn, which is the outbound-truth failure in miniature.
+   *
+   * Graded both ways, because "keep the higher" and "a correction wins downward" are the two
+   * halves of one rule and a guard that only satisfies the first is wrong in the other direction.
+   */
+  const dayStart = (await import("../server/utils")).sastDayStart();
+
+  /** Every number the client can read, thousands separators folded away. Deliberately NOT a
+   *  `\b9000\b` test on a de-spaced string: "9 000 steps" collapses to "9000steps", where there
+   *  is no word boundary after the zero and the assertion passes for the wrong reason. The
+   *  separator class excludes newlines, so numbers on separate lines never fuse into one. */
+  function numbersIn(text: string): Set<number> {
+    return new Set([...text.matchAll(/\d[\d ,\u00a0\u202f]*\d|\d/g)]
+      .map(mm => Number(mm[0].replace(/[ ,\u00a0\u202f]/g, "")))
+      .filter(n => Number.isFinite(n)));
+  }
+
+  async function turnOnDayAt9k(message: string): Promise<{ reply: string; stored: number }> {
+    g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
+    g.__KAMLIFE_STUB_ROWS = new Map([[schema.stepLogs, [
+      { id: "s1", userId: USER.id, steps: 9000, loggedAt: new Date(dayStart.getTime() + 3_600_000) },
+    ]]]);
+    g.__KAMLIFE_STUB_WRITES = [];
+    g.__KAMLIFE_STUB_UPDATES = [];
+    const reply = String(await handleMessage(USER.phoneNumber, message).catch(() => ""));
+    // The day holds 9 000 unless this turn changed it — by inserting a row, or by updating the one
+    // already there. Both channels must be read, or an update looks exactly like a no-op.
+    const ins = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === schema.stepLogs);
+    const upd = (g.__KAMLIFE_STUB_UPDATES || []).filter((w: any) => w.table === schema.stepLogs);
+    const changed = ins.length ? ins[0].values?.steps
+      : upd.length ? upd[upd.length - 1].set?.steps : undefined;
+    delete g.__KAMLIFE_STUB_UPDATES;
+    return { reply, stored: changed === undefined ? 9000 : Number(changed) };
+  }
+
+  // A LOWER re-log leaves the day at 9 000 — so the answer may not say 3 000.
+  {
+    const { reply, stored } = await turnOnDayAt9k("walked 3000 steps today");
+    const said = numbersIn(reply);
+    const first = reply.split("\n")[0];
+    if (stored !== 9000) failures.push(`A lower re-log overwrote the day: stored ${stored}, expected 9000`);
+    if (said.has(3000)) failures.push(`The reply quoted the message, not the ledger: day holds 9000, reply said 3 000 — "${first}"`);
+    if (!said.has(9000)) failures.push(`The reply never quoted the stored count: day holds 9000 — "${first}"`);
+  }
+
+  // An explicit CORRECTION still wins downward, and the answer quotes the corrected number.
+  {
+    const { reply, stored } = await turnOnDayAt9k("3000 steps not 9000");
+    const said = numbersIn(reply);
+    const first = reply.split("\n")[0];
+    if (stored !== 3000) failures.push(`A correction failed to write downward: stored ${stored}, expected 3000`);
+    if (!said.has(3000)) failures.push(`A correction was not quoted back: day now holds 3000 — "${first}"`);
+  }
+
+  const total = MUST_NOT_WRITE.length + MUST_WRITE.length + 2;
   if (failures.length > 0) {
     for (const f of failures) console.log(`✗ ${f}`);
     console.log(`\n✗ tracking contract: ${failures.length}/${total} violations`);
     process.exit(1);
   }
-  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer`);
+  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer, the answer quoted the ledger both ways`);
   process.exit(0);
 })();

--- a/server/db.ts
+++ b/server/db.ts
@@ -159,6 +159,16 @@ function makeStubDb(): any {
           if (prop === "values" && Array.isArray((globalThis as any).__KAMLIFE_STUB_WRITES)) {
             (globalThis as any).__KAMLIFE_STUB_WRITES.push({ table: state.table, values: args[0] });
           }
+          // UPDATES ARE OBSERVABLE TOO (2026-08-26, issue #63) — and separately, on purpose.
+          // __KAMLIFE_STUB_WRITES records inserts only, so no suite could see a row being CHANGED:
+          // "an explicit correction overwrites the day's step count downward" was ungradeable, and
+          // an upsert that took its update branch looked identical to one that did nothing. This
+          // is a second channel rather than more entries in the first because `db.update(users)
+          // .set({ lastActiveAt })` runs on nearly every turn — folding those in would add a row
+          // to every write assertion in every suite. Opt in by assigning an array; unset: no-op.
+          if (prop === "set" && Array.isArray((globalThis as any).__KAMLIFE_STUB_UPDATES)) {
+            (globalThis as any).__KAMLIFE_STUB_UPDATES.push({ table: state.table, set: args[0] });
+          }
           return chain(state);
         };
       },

--- a/server/handlers/steps.ts
+++ b/server/handlers/steps.ts
@@ -8,10 +8,22 @@ import { stepBurnKcal } from "../targets";
 import { sastDayStart } from "../utils";
 
 /**
- * STRUCTURED STEP WRITE (2026-07-19) — the executor's reuse point, mirroring the routes.ts
- * inline upsert exactly: one row per SAST day, keep the HIGHER count (clients re-log a
- * growing daily total) unless it's an explicit correction. Additive — routes keeps its
- * own path; this is a clean callable for the action executor. Returns the day's count.
+ * THE STEP WRITE — all of it, for every door (2026-07-19; bypass removed 2026-08-26, issue #63).
+ *
+ * One row per SAST day, keep the HIGHER count (clients re-log a growing daily total) unless it is
+ * an explicit correction. Returns the count the day now HOLDS, which is not always the count that
+ * was passed in — that return value is the point, and it is what a caller must put in front of the
+ * client.
+ *
+ * This shipped as "the executor's reuse point, mirroring the routes.ts inline upsert exactly.
+ * Additive — routes keeps its own path." Both halves of that sentence were the defect. A mirror is
+ * a copy, and the copy drifted where it mattered most: routes carried the count from the MESSAGE
+ * into its reply instead of the count from the LEDGER, so a client with 9 000 already logged who
+ * sent "walked 3000 steps today" kept their 9 000 (right) and was congratulated on 3 000 (wrong).
+ * Two write paths for one fact, disagreeing about what the client is told.
+ *
+ * Every conversational door now comes through here. If you are about to add another upsert for
+ * this fact, that is the bug — call this instead, and answer the client with what it returns.
  */
 export async function logStepsForUser(userId: string, steps: number, opts?: { correction?: boolean; at?: Date }): Promise<number> {
   const at = opts?.at || new Date();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,7 +4,7 @@ import crypto from "crypto";
 import path from "path";
 import { db, pool } from "./db";
 import { users, weightLogs, workoutLogs, stepLogs, chatHistory, clothingCheckins, bodyMeasurements, weeklyCheckins, exerciseLogs, progressPhotos, escalations, abAssignments, mealLogs } from "../shared/schema";
-import { eq, desc, asc, and, gte, lt, sql, count } from "drizzle-orm";
+import { eq, desc, asc, and, gte, sql, count } from "drizzle-orm";
 import OpenAI from "openai";
 import twilio from "twilio";
 import { SA_FOODS_SEED, type SAFood } from "./foods";
@@ -21,7 +21,7 @@ import { recordClientFacts } from "./memory";
 import { generateVoiceNote, getVoiceFilePath, voiceFileExists } from "./tts";
 import { sendWhatsApp } from "./scheduler";
 import { recordConversion } from "./ab";
-import { getStepStreak, getStepResponse as _getStepResponse } from "./handlers/steps";
+import { getStepStreak, getStepResponse as _getStepResponse, logStepsForUser } from "./handlers/steps";
 import { captureFriction } from "./friction";
 import { getSleepResponse } from "./handlers/sleep";
 import { handleMediaMessage, bumpVoiceFailure, clearVoiceFailure } from "./handlers/media";
@@ -55,7 +55,7 @@ import { mustStayDeterministic } from "./understanding/action-router";
 import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { recordMessageSeen, recordReplyPath } from "./self-check";
 import { normalizerFidelity } from "./normalizer-fidelity";
-import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
+import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
 import { invalidatePatternCache } from "./cache";
 import { mentionsConditionOrMedication, conditionWelcome } from "./condition-welcome";
 import { captureSymptom } from "./quality-signals";
@@ -1196,12 +1196,6 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
       );
       const stepIsRetro = isRetroactiveMeal(message);
       const stepLoggedAt = stepIsRetro ? parseMealDate(message) : new Date();
-      const stepDayStart = sastDayStart(stepLoggedAt);
-      const stepDayEnd = new Date(stepDayStart.getTime() + 86_400_000);
-      const existingStep = await db.select({ id: stepLogs.id, steps: stepLogs.steps })
-        .from(stepLogs)
-        .where(and(eq(stepLogs.userId, user.id), gte(stepLogs.loggedAt, stepDayStart), lt(stepLogs.loggedAt, stepDayEnd)))
-        .limit(1);
       // Allow a downward CORRECTION ("8000 steps not 50000", "wrong, 6k steps") to overwrite the
       // day's count. Normally we keep only the HIGHER number (clients re-log a growing daily
       // total), but an explicit correction must win in either direction. For "X not Y", X is the
@@ -1213,14 +1207,16 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
       }
       const isStepCorrection = !!stepNotMatch
         || /\b(wrong|actually|correction|i\s+meant|meant|should\s+be|mistake|typo|miscount|oops|my\s+bad)\b/i.test(m);
-      if (existingStep.length > 0) {
-        if (steps > (existingStep[0].steps ?? 0) || isStepCorrection) {
-          await db.update(stepLogs).set({ steps }).where(eq(stepLogs.id, existingStep[0].id));
-        }
-      } else {
-        await db.insert(stepLogs).values({ userId: user.id, steps, loggedAt: stepLoggedAt });
-        turnMutation("INSERT steps", "[WRITE]");
-      }
+      // ONE WRITE OWNER FOR THE STEP FACT (2026-08-26, issue #63). This built its own day-window
+      // query and upsert — twenty lines that logStepsForUser already was, and steps.ts said so at
+      // the top of itself: "mirroring the routes.ts inline upsert exactly ... Additive, routes
+      // keeps its own path." A mirror is a copy, and this one had already drifted on the half that
+      // reaches the client: the owner returns the count now STORED, while this path carried the
+      // count from the MESSAGE into the reply. With 9 000 already logged, "walked 3000 steps
+      // today" correctly left the row at 9 000 and answered "3 000 steps — nice one", quoting a
+      // number the ledger does not hold. So the write moves to the owner AND the answer is built
+      // from what the owner returns — that second half is the only reason the bypass mattered.
+      const storedSteps = await logStepsForUser(user.id, steps, { correction: isStepCorrection, at: stepLoggedAt });
       await db.update(users).set({ lastActiveAt: new Date() }).where(eq(users.phoneNumber, phone));
       invalidatePatternCache(user.id);
       const sevenDaysAgo = new Date(Date.now() - 7 * 86_400_000);
@@ -1238,9 +1234,9 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
         ? Math.round(recentStepLogs.reduce((s, r) => s + r.steps, 0) / recentStepLogs.length)
         : undefined;
       void stepGoalCtx; // used by getStepResponse via user.goalType
-      const stepReply = getStepResponse(steps, target, parseFloat(user.currentWeight as string || "75") || 75, streak, weeklyAvg, user, workedOutToday);
+      const stepReply = getStepResponse(storedSteps, target, parseFloat(user.currentWeight as string || "75") || 75, streak, weeklyAvg, user, workedOutToday);
       const stepRetroNote = stepIsRetro ? `\n_Logged to ${mealDateLabel(stepLoggedAt)}._` : "";
-      const stepPart = (isStepCorrection ? `Fixed ✅ — step count updated to *${steps.toLocaleString()}*.\n\n` : "") + stepReply + stepRetroNote + (perfectDay || "");
+      const stepPart = (isStepCorrection ? `Fixed ✅ — step count updated to *${storedSteps.toLocaleString()}*.\n\n` : "") + stepReply + stepRetroNote + (perfectDay || "");
       commitFact(turn, "steps", stepPart);
       await logChat(user.id, message, stepPart, "STEP_LOG");
 


### PR DESCRIPTION
Removes the second step write path found by the #63 surface audit. This is a **removal, not a new tracking architecture** — `logStepsForUser` already exists and is already used by `distance-log.ts` and `understanding/executor.ts`. This deletes the bypass around it.

## Why it mattered — measured, not assumed

The bypass was documented at the moment it was created, in `steps.ts`'s own docstring:

> *"mirroring the routes.ts inline upsert **exactly** … **Additive — routes keeps its own path**."*

A mirror is a copy, and this copy had already drifted on the half that reaches the client. `logStepsForUser` returns the count the day now **holds**; the inline path carried the count from the **message** into its reply.

With 9 000 already logged today:

```
client : "walked 3000 steps today"
stored : still 9000                    ← correct, keep the higher
reply  : "3 000 steps — nice one. 👌"  ← a number the ledger does not hold
forensics: [TURN_OWED] steps stood down — steps stated and not yet written
```

Ledger, internal audit, and mouth — three answers inside one turn.

## The cut

- `routes.ts` calls `logStepsForUser` instead of building its own day-window query and upsert (~20 lines deleted).
- **The response is built from what the call returns**, not from what the message said. That second half is the only reason the bypass mattered.
- The mutation label converges on the owner's `INSERT steps=N at=…`, so `turn_ledger` stops describing one fact two ways. It still matches the `/INSERT steps/i` that `turnAlreadyWrote` gates on, so the multi-day stand-down is unchanged.
- `steps.ts`'s docstring no longer advertises a second path, and says plainly that another upsert for this fact is the bug.
- Two imports left dead by the deletion (`sastDayStart`, `lt`) are removed.

## Law 3 added to the contract suite

**The answer must quote the ledger, not the message.** Graded both ways, because *"keep the higher"* and *"a correction wins downward"* are two halves of one rule, and a guard satisfying only the first is wrong in the other direction:

| input (day holds 9 000) | state must be | reply must |
|---|---|---|
| `walked 3000 steps today` | still 9 000 | say 9 000, **not** 3 000 |
| `3000 steps not 9000` | 3 000 | say 3 000 |

**Each half fails on its own when reverted:**

```
revert only the response change  -> ✗ reply quoted the message, not the ledger
revert only the correction flag  -> ✗ "Fixed ✅ — step count updated to *9,000*"
                                      (the mouth confirming a correction that never happened)
both restored                    -> ✓ 43/43
```

## Harness gap this exposed

The stub recorded **inserts only**, so no suite could observe a row being *changed* — an upsert taking its update branch looked identical to a no-op, which is precisely why the correction rule had never been testable. Updates now record to a separate `__KAMLIFE_STUB_UPDATES` channel.

Separate on purpose: `db.update(users).set({ lastActiveAt })` runs on nearly every turn, so folding those into the existing array would add a row to every write assertion in every suite.

Also fixes an assertion of mine that had been passing for the wrong reason: `"9 000 steps"` de-spaced to `"9000steps"`, where `/\b9000\b/` finds no word boundary. Numbers are now parsed with separators folded and newlines excluded, so two lines never fuse into one value.

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing` — `normalizer-replay-tests` still awaiting its recorded corpus
- RED: `check-file-sizes`, `check-architecture` — **the same two as main, same values**
- Governor unchanged: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`
- `server/routes.ts` **1479 → 1475**

## Still outstanding, deliberately not in this cut

`media.ts` carries two more inline `stepLogs` upserts (screenshot and voice paths) and `workout.ts` one (`derivedSteps` from cardio distance). Same bypass, different doors — but only the `routes.ts` path had proven divergence, and bundling four doors into one cut is how a consolidation turns into a rewrite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_