### PR TITLE
Water joins the durable-write contract

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -267,13 +267,20 @@ const MUST_WRITE: [string, string][] = [
    * just logged 8 000 steps is not told to go for a walk. That is not a detail — it is the #71
    * defect, and the negative control below proves the assertion is sensitive to it.
    *
-   * WATER IS NOT COVERED, AND THAT IS A STATED GAP, NOT AN OVERSIGHT. Water persists by updating
-   * users.todayWater and records no turn mutation, so durableDomains() — the turn's own record of
-   * what it wrote — cannot see it, and a water log still ends in a bare "2L of water — good. 👌".
-   * Closing it means giving water a durable-write record, which changes what resolveTurn reports
-   * as `committed` and therefore when a turn continues to the coach. That is a behavioural change
-   * to the turn resolver and belongs in its own cut with its own controls, not smuggled into this
-   * one. Four of the five tracked facts are covered here; water is the fifth and is next.
+   * WATER JOINED LAST, AND IT IS THE REASON THE OTHER FOUR WERE NOT ENOUGH. Water persists by
+   * UPDATEing users.todayWater rather than inserting a row, and it recorded nothing on the turn —
+   * so durableDomains(), the turn's own record of what it wrote, could not see it. It was the one
+   * tracked fact invisible to that record, and a water log therefore ended in a bare
+   * "2L of water — good. 👌" while the other four earned a move. The fix is not special-casing
+   * water in the coaching turn; it is water telling the truth about itself, after which the
+   * existing mechanism covers it with no change of its own.
+   *
+   * That made `committed` able to say "water", which changes when a turn CONTINUES to the coach —
+   * alsoAsksCoach is durableDomains().length > 0 — and when the educational mouths stand down.
+   * Both move in the intended direction (write, then coach; do not lecture over a log), and both
+   * are behaviour, so they are graded here rather than assumed.
+   *
+   * All five tracked facts now travel one path: write -> state -> decision -> response.
    */
   const EVIDENCED_DAYS = 5;   // underPolicy prescribes only for a client it can actually read
   async function coachingTurn(message: string, opts?: { seeWrites?: boolean }) {
@@ -299,7 +306,20 @@ const MUST_WRITE: [string, string][] = [
     return blocks.length > 1 && !last.includes("?") && !/\[(?:BUTTONS|MEDIA)/i.test(last) ? last : "";
   };
 
-  // A bare receipt must gain exactly one move.
+  // A bare receipt must gain exactly one move — on EVERY tracked fact that writes durably.
+  // Water is listed explicitly: it was the fact this law could not reach, and a regression there
+  // would look exactly like the bare receipt this whole cut exists to end.
+  for (const [surface, message] of [
+    ["water", "2 litres of water"],
+    ["water", "drank 3 litres today"],
+    ["weight", "84kg"],
+  ] as [string, string][]) {
+    const reply = await coachingTurn(message);
+    if (!closingMove(reply)) {
+      failures.push(`A durable ${surface} write ended with a receipt and no next move: "${reply.replace(/\n/g, " ⏎ ")}"`);
+    }
+  }
+
   {
     const reply = await coachingTurn("walked 8000 steps today");
     const move = closingMove(reply);
@@ -338,7 +358,7 @@ const MUST_WRITE: [string, string][] = [
     if (move) failures.push(`A turn that wrote nothing was given a coaching move: "${quiet}" ended with "${move}"`);
   }
 
-  const total = MUST_NOT_WRITE.length + MUST_WRITE.length + 2 + 7;
+  const total = MUST_NOT_WRITE.length + MUST_WRITE.length + 2 + 10;
   if (failures.length > 0) {
     for (const f of failures) console.log(`✗ ${f}`);
     console.log(`\n✗ tracking contract: ${failures.length}/${total} violations`);

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -763,6 +763,7 @@ export async function handleMediaMessage(ctx: {
               waterLastResetDate: todayStr,
             }).where(eq(users.id, user.id)).returning({ todayWater: users.todayWater });
             const newTotal = Math.round((Number(waterUpdated[0]?.todayWater) || litres) * 10) / 10;
+            turnMutation(`UPDATE water +${litres}L (day ${newTotal}L)`, "[WATER_LOG]");
             const remaining = Math.max(0, Math.round((waterTarget - newTotal) * 10) / 10);
             const targetHit = newTotal >= waterTarget;
             const bottleReply = targetHit

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -7,7 +7,7 @@ import { db } from "../db";
 import { users } from "../../shared/schema";
 import { neverSilentLine } from "../reply-hygiene";
 import { eq, sql } from "drizzle-orm";
-import { logChat } from "./chat-log";
+import { logChat, turnMutation } from "./chat-log";
 import { sastToday, mentionsNotDone, digitizeSpokenAmounts } from "../utils";
 import { waterTargetLitres } from "../targets";
 import { scanForSAFoods } from "./food-scanner";
@@ -68,6 +68,16 @@ export async function tryLogWater(ctx: {
       waterLastResetDate: today,
     }).where(eq(users.phoneNumber, phone)).returning({ todayWater: users.todayWater });
     const newTotal = Math.round((Number(waterUpdated[0]?.todayWater) || 0) * 10) / 10;
+    // WATER IS A DURABLE WRITE AND NOW SAYS SO (2026-08-26, issue #63). It persists by UPDATEing
+    // users.todayWater, and recorded nothing on the turn — so durableDomains(), the turn's own
+    // record of what it wrote, could not see it. Water was the one tracked fact invisible to that
+    // record, which is why a water log ended in a bare receipt while the other four earned a
+    // coaching move. UPDATE, not INSERT, because that is honestly what happened: the day has one
+    // running total, not a row per sip.
+    // The AMOUNT ADDED leads, because it is the value this turn actually knows: the day total
+    // comes back from the UPDATE's returning() and reads 0 if that read fails, which would put a
+    // number in the forensic record that never happened.
+    turnMutation(`UPDATE water +${litres}L (day ${newTotal}L)`, "[WATER_LOG]");
     const currentWater = Math.max(0, newTotal - litres);
 
     const yesterdaySAST = new Date(Date.now() + 2 * 3_600_000 - 86_400_000).toISOString().slice(0, 10);

--- a/server/understanding/messy-intake.ts
+++ b/server/understanding/messy-intake.ts
@@ -446,6 +446,11 @@ export const FEELING_ACK = "Heard you on how you're feeling. Showing up still co
 const DURABLE_WRITE: Array<[string, RegExp]> = [
   ["food", /INSERT meal/i], ["steps", /INSERT steps/i],
   ["workout", /INSERT workout/i], ["weight", /INSERT weight/i],
+  // Water is an UPDATE, not an INSERT — the day carries one running total rather than a row per
+  // sip — so it needs its own pattern rather than sharing the INSERT shape (2026-08-26, #63).
+  // Note the anchor: "TURN committed water", which this very function's caller writes back onto
+  // the turn, must NOT read as a fifth durable write. Matching the verb keeps the two apart.
+  ["water", /UPDATE water/i],
 ];
 
 export function durableDomains(writes: string[]): string[] {


### PR DESCRIPTION
Water was the one deliberate hole in Law 4. Not because the water coach is missing — it exists — but because water persists by `UPDATE`ing `users.todayWater` and recorded **nothing** on the turn. `durableDomains()`, the turn's own record of what it wrote, could not see it, so the write → next move mechanism had no idea the client had logged anything:

```
"2 litres of water"  ->  "2L of water — good. 👌"     (and nothing else)
```

## The fix is not special-casing water

Nothing in the coaching turn changed. Water simply tells the truth about itself, and the existing mechanism covers it:

- `water.ts` records `UPDATE water +2L (day 3.4L)` when it writes.
- `media.ts` does the same. It already recorded `INSERT steps` and `INSERT meal`; water was the one write on that door that told the turn nothing, and leaving it silent would have recreated this bug on the photo path.
- `messy-intake`'s `DURABLE_WRITE` gains `["water", /UPDATE water/i]`.

`UPDATE`, not `INSERT`, because that is honestly what happens — the day carries one running total, not a row per sip. The verb is also what keeps the pattern from matching `"TURN committed water"`, which `resolveTurn`'s own caller writes back onto the turn and which must never read as a fifth durable write.

**The amount added leads in the record, not the day total.** The total comes back from the `UPDATE`'s `returning()` and reads `0` if that read fails; `litres` is the value this turn actually knows. A forensic record should not be able to contain a number that never happened.

## Measured after

```
"2 litres of water"                         -> receipt + one move
"I had eggs and 2 litres of water"          -> [TURN] committed food+water
"I walked 8000 steps and drank 2 litres…"   -> committed food+steps+water, one move
water questions and intentions              -> still write nothing (Law 2 holds)
```

**Two controls, each reproducing main's exact bare receipt.** Strip the mutation from `water.ts`, or remove water from the map — either one, and both water cases fail with *"A durable water write ended with a receipt and no next move"*.

## Blast radius — checked, not assumed

Making `committed` able to say `water` also feeds `alsoAsksCoach` and the misc stand-down. Both were measured, and both turn out to be **unreachable for water today**: a pure water log returns at the water exit before misc runs, and a mixed water-plus-question turn never reaches the write at all (below). The predicted change is real in the code and inert in practice — stated so nobody has to rediscover it.

## Found, not fixed — water is lost on mixed turns

**Pre-existing. Verified on main, not introduced here:**

| message | reply | water |
|---|---|---|
| `2 litres of water, what should I eat?` | 3-day meal plan | **untouched** |
| `2 litres of water. How am I doing?` | water lecture | **untouched** |
| `drank 1 litre. what is a portion of rice?` | portion guide | **untouched** |

**This is NOT a routing defect.** An earlier reading of this PR said a broad upstream owner claimed the turn before the water handler ran. That was inferred from the replies rather than traced, and it is wrong. `handleWater` called **directly**, with nothing upstream involved, declines all three and accepts the pure log. The cause is inside `water.ts`:

```ts
const waterIsQuestion = m.includes("?") || ...
```

A bare `?` anywhere in the message vetoes the write. The meal plan and portion guide answer only because water declined first and the turn fell through.

So this is the rule already fixed twice, one surface later. `workout.ts` names it:

> *"A QUESTION IN ONE CLAUSE DOES NOT DELETE A FACT IN ANOTHER — the food door's rule, applied to the domain next to it (2026-08-22) … The override is `journeyMustKeepFacts`."*

Food has it. Workout has it. **Water never got it** — and `journeyMustKeepFacts` confirms it, returning `food/steps/workout` with no water field at all. That is the next cut, and it extends an owner that already exists rather than adding claim-ordering machinery.

Also seen: the food scanner counts water as a food item (`"Got it — Eggs and Water"`), so a logged litre is both a water log and a meal entry.

## The stack is now coherent

```
food / steps / water / weight / workout  ->  write -> state -> decision -> response
```

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing`
- RED: `check-file-sizes`, `check-architecture` — the same two as main
- Governor identical: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`

**One over-budget file grew**, and I am not going to pretend otherwise: `media.ts` 1559 → 1560. One functional line, no commentary. It cannot be zero — a silent water write on the photo door would reinstate exactly the defect this closes. `routes.ts` and `utils.ts` are unchanged.