### PR TITLE
A question in one clause does not erase a report in another

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -10,8 +10,9 @@
  *        -> ONE action          ("what does this change about the coaching?")
  *        -> ONE response        ("what does the client read?")
  *
- * and the contract has four laws. The first two protect the STATE; the second two are what turns
- * a logger into a coach — they are enforced further down, where the code that grades them is:
+ * and the contract has five laws. The first two protect the STATE, the next two are what turns a
+ * logger into a coach, and the fifth is what makes all four survive a real client's phrasing —
+ * they are enforced further down, where the code that grades them is:
  *
  *   LAW 1 — RECOGNISER AND EXTRACTOR MUST AGREE.
  *     If the recogniser says "yes, a step report" and the extractor returns zero, the fact is
@@ -33,6 +34,7 @@
  *
  *   LAW 3 — THE ANSWER QUOTES THE LEDGER, NOT THE MESSAGE.  (graded at "LAW 3" below)
  *   LAW 4 — A DURABLE WRITE IS FOLLOWED BY ONE NEXT MOVE.   (graded at "LAW 4" below)
+ *   LAW 5 — A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER. (at "LAW 5" below)
  *
  * WHY THIS FILE IS BEHAVIOURAL AND NOT A PREDICATE TEST. Both defects above sat in code whose
  * predicates were individually defensible. The steps gate already asked isFutureIntent and got a
@@ -358,12 +360,60 @@ const MUST_WRITE: [string, string][] = [
     if (move) failures.push(`A turn that wrote nothing was given a coaching move: "${quiet}" ended with "${move}"`);
   }
 
-  const total = MUST_NOT_WRITE.length + MUST_WRITE.length + 2 + 10;
+  /**
+   * LAW 5 — A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63).
+   *
+   * Real clients do not send one fact per bubble. "I walked 8,000 steps, what should I eat?" is
+   * the ordinary shape, and the system already UNDERSTOOD the step count — it then threw it away
+   * because a whole-message question guard read the second clause. Measured on main, five of ten
+   * mixed turns lost the fact. Food and workout had each learned this rule separately; steps,
+   * water and weight never had, and each lost it a different way:
+   *
+   *     steps   detectStepLog extracted 8 000, then isQuestionForm matched "should i" anywhere
+   *     water   waterIsQuestion begins with m.includes("?")
+   *     weight  looksLikeWeightReport is anchored ^...$, so a clause was never examined
+   *
+   * THE RULE IS NOT "DOES THE MESSAGE MENTION THE FACT", and that is the whole difficulty. That
+   * version was tried and measured, and it resurrects every false write #73 closed:
+   * journeyMustKeepFacts reports logStepsEvenIfClassifiedQuestion === true for "Is 8000 steps
+   * enough?" and for "I need to do 10000 steps". Naming a fact is what a question does too.
+   *
+   * So: some clause REPORTS the fact, and that clause is itself neither a question nor an
+   * intention — utils.reportedInSomeClause, composing the two floors that already own those
+   * questions. No domain recogniser was added; each fact keeps the one it had.
+   *
+   * GRADED BOTH WAYS IN THE SAME BREATH. Every widening here is one regex away from re-opening
+   * Law 2, so the MUST_NOT_WRITE list above is this law's negative control as much as its own —
+   * and the two run against the same pipeline. A fix that preserves the fact by loosening the
+   * floors fails there, loudly, on "I need to do 10000 steps".
+   */
+  const MIXED: [string, string][] = [
+    ["steps", "walked 8000 steps. what should I eat?"],
+    ["water", "2 litres of water. what should I eat?"],
+    ["weight", "84kg. what should I eat?"],
+    ["workout", "workout done. what should I eat?"],
+    ["food", "I had eggs. what should I eat?"],
+    ["steps", "walked 8000 steps. how am I doing?"],
+    ["water", "2 litres of water. how am I doing?"],
+    ["weight", "84kg. how am I doing?"],
+    ["workout", "workout done. how am I doing?"],
+    ["food", "I had eggs. how am I doing?"],
+    ["water", "drank 1 litre. what is a portion of rice?"],
+    ["steps", "10k steps done. is that enough?"],
+  ];
+  for (const [surface, message] of MIXED) {
+    const wrote = await wroteFor(message);
+    if (!wrote.has(surface)) {
+      failures.push(`A question in one clause erased a ${surface} report in another: "${message}" wrote ${[...wrote].join(", ") || "nothing"}`);
+    }
+  }
+
+  const total = MUST_NOT_WRITE.length + MUST_WRITE.length + 2 + 10 + MIXED.length;
   if (failures.length > 0) {
     for (const f of failures) console.log(`✗ ${f}`);
     console.log(`\n✗ tracking contract: ${failures.length}/${total} violations`);
     process.exit(1);
   }
-  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer, the answer quoted the ledger, and a durable write ended in one next move`);
+  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer, the answer quoted the ledger, and a durable write ended in one next move, and ${MIXED.length} mixed turns kept their fact`);
   process.exit(0);
 })();

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -117,6 +117,31 @@ const MUST_NOT_WRITE: [string, string][] = [
   ["food", "is bread ok?"],
 ];
 
+/**
+ * WATER'S OWN NEGATIVE-INTENT VOCABULARY — graded on the WATER surface only, and the reason for
+ * that narrowing is stated rather than hidden.
+ *
+ * These are not asking, and isFutureIntent does not own them: "trying to" is excluded from that
+ * floor ON PURPOSE, because a report can carry it ("trying to lose weight, weighed 84kg this
+ * morning"), and the obligation forms have no pronoun for the asking floor to key on. So water
+ * refuses them itself. These cases exist because the first version of this cut deleted that
+ * vocabulary as a "duplicate" and two of them began writing water.
+ *
+ * WHY NOT MUST_NOT_WRITE, WHICH FORBIDS EVERY SURFACE: because on these inputs the FOOD scanner
+ * claims the message and logs a meal called "Water" — on main too, unchanged by this cut. That is
+ * a real Law 2 violation on a different surface, with its own cause (the food door's planning
+ * vocabulary has the same gap, and water is treated as a food at all). Asserting it here would
+ * mean fixing the food door in a water cut. Asserting "nothing wrote" and quietly deleting the
+ * case would mean hiding it. So it is graded where this cut has authority, and the food claim is
+ * REPORTED on every run below so it cannot be forgotten.
+ */
+const WATER_INTENT: string[] = [
+  "trying to drink 2 litres of water",
+  "must drink 2 litres of water",
+  "should drink 2 litres of water",
+  "will drink 2 litres of water",
+];
+
 /** THE NEGATIVE CONTROL. Real reports, in the shapes clients actually send. Every one must still
  *  reach its writer — a guard that passes the list above by refusing everything fails here.
  *  The "trying to lose weight" line is deliberate: it carries an intention AND a measurement, and
@@ -142,6 +167,32 @@ const MUST_WRITE: [string, string][] = [
   const g = globalThis as any;
   const { handleMessage } = await import("../server/routes");
   const schema = await import("../shared/schema");
+  // EVERY GRADED TURN STARTS FROM CLEAN PROCESS STATE, and this is not housekeeping — without it
+  // the suite grades a different product further down than it does at the top.
+  //
+  //   the pattern summary  is memoised per user for an hour, in module state.
+  //   the GPT rate limiter allows 10 calls per user per 60s, in module state — and this suite
+  //                        runs ~65 turns in ten seconds.
+  //   the card dump window suppresses a second macro card for the same client inside the window.
+  //                        This is CORRECT product behaviour — six photos in ninety seconds get
+  //                        one card — but it meant the "a card owns the next action" case only
+  //                        held for the FIRST food turn of the run. Adding cases above it turned
+  //                        the card off, the reply became a bare receipt, Law 4 correctly appended
+  //                        a move, and the assertion failed for a reason that had nothing to do
+  //                        with what it tests.
+  //
+  // A suite whose verdict depends on how many turns ran before it is not measuring the product,
+  // and it fails in the worst direction — silently changing behaviour rather than erroring.
+  // The limiter is reset through its own exported function with a zero window, so no production
+  // code exists solely to be testable.
+  const { invalidatePatternCache } = await import("../server/cache");
+  const { checkGptRateLimit } = await import("../server/utils");
+  const { _resetDumpWindow } = await import("../server/card-policy");
+  const freshTurn = () => {
+    invalidatePatternCache(USER.id);
+    checkGptRateLimit(USER.id, 1_000_000, 0);
+    _resetDumpWindow();
+  };
   const NAME = new Map<any, string>([
     [schema.stepLogs, "steps"], [schema.weightLogs, "weight"],
     [schema.workoutLogs, "workout"], [schema.mealLogs, "food"],
@@ -152,6 +203,7 @@ const MUST_WRITE: [string, string][] = [
    *  read of it silently reports "no write" — which is how a water false-write could hide from a
    *  probe that looked clean. "Did todayWater move off the seeded 0" is the honest test. */
   async function wroteFor(message: string): Promise<Set<string>> {
+    freshTurn();
     g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
     g.__KAMLIFE_STUB_WRITES = [];
     await handleMessage(USER.phoneNumber, message).catch(() => "");
@@ -169,6 +221,15 @@ const MUST_WRITE: [string, string][] = [
     if (wrote.size > 0) {
       failures.push(`A question mutated tracking state: ${surface} | "${message}" wrote ${[...wrote].join(", ")}`);
     }
+  }
+
+  const knownFoodClaim: string[] = [];
+  for (const message of WATER_INTENT) {
+    const wrote = await wroteFor(message);
+    if (wrote.has("water")) {
+      failures.push(`An intention wrote water: "${message}" — water's own negative vocabulary is gone`);
+    }
+    if (wrote.has("food")) knownFoodClaim.push(message);
   }
 
   for (const [surface, message] of MUST_WRITE) {
@@ -202,6 +263,7 @@ const MUST_WRITE: [string, string][] = [
   }
 
   async function turnOnDayAt9k(message: string): Promise<{ reply: string; stored: number }> {
+    freshTurn();
     g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
     g.__KAMLIFE_STUB_ROWS = new Map([[schema.stepLogs, [
       { id: "s1", userId: USER.id, steps: 9000, loggedAt: new Date(dayStart.getTime() + 3_600_000) },
@@ -287,9 +349,21 @@ const MUST_WRITE: [string, string][] = [
   const EVIDENCED_DAYS = 5;   // underPolicy prescribes only for a client it can actually read
   async function coachingTurn(message: string, opts?: { seeWrites?: boolean }) {
     const meals = Array.from({ length: EVIDENCED_DAYS }, (_, i) => ({
-      id: `m${i}`, userId: USER.id, kcalInt: 1800, proteinInt: 70, items: ["chicken"],
-      mealLabel: "lunch", loggedAt: new Date(dayStart.getTime() - i * 86_400_000 + 3_600_000), corrected: false,
+      id: `m${i}`, userId: USER.id, items: ["chicken"], mealLabel: "lunch",
+      loggedAt: new Date(dayStart.getTime() - i * 86_400_000 + 3_600_000), corrected: false,
+      // BOTH THE COLUMN NAME AND THE SELECT ALIAS. The stub returns raw rows and does not apply
+      // drizzle projections, so `db.select({ kcal: mealLogs.kcalInt })` reads undefined and the
+      // client silently looked like they had logged NOTHING today — which quietly moved the
+      // coaching ladder onto its "log something" rung and made both ordering assertions below
+      // pass without proving anything. Seeding only kcalInt is how that hid.
+      // PROTEIN IS AT TARGET ON PURPOSE. At 70g against a 180g target the ladder stops on the
+      // protein rung, which outranks every step-sensitive rung — so whether the decision could
+      // see this turn's step write made no difference to the move, and BOTH ordering assertions
+      // below passed while proving nothing. The client has to be one where the property is
+      // actually observable.
+      kcalInt: 2000, proteinInt: 200, kcal: 2000, protein: 200, carbs: 0, fat: 0,
     }));
+    freshTurn();
     g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
     g.__KAMLIFE_STUB_ROWS = new Map([
       [schema.mealLogs, meals], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
@@ -331,12 +405,20 @@ const MUST_WRITE: [string, string][] = [
     if (/\bwalk\b/i.test(move)) failures.push(`The move ignored the row this turn wrote — 8 000 steps logged, and the coach said: "${move}"`);
   }
 
-  // NEGATIVE CONTROL FOR THE ORDERING. Deny the decision sight of the write and the same turn
-  // must produce the wrong move — proving the assertion above grades ordering, not just presence.
+  // NEGATIVE CONTROL FOR THE ORDERING. Deny the decision sight of the write and the move must
+  // CHANGE — that is the property, and it is what proves the assertion above grades ordering
+  // rather than mere presence.
+  //
+  // It asserted the blind move contained "walk" and that was too specific: which rung the ladder
+  // reaches depends on state this suite does not fully pin (the pattern cache carries across
+  // turns in-process), so simply adding cases ABOVE this one flipped the blind move to the log
+  // rung and the control started failing for a reason that had nothing to do with ordering. A
+  // control that breaks when unrelated tests are added is not measuring what it claims.
   {
+    const sighted = closingMove(await coachingTurn("walked 8000 steps today"));
     const blind = closingMove(await coachingTurn("walked 8000 steps today", { seeWrites: false }));
-    if (blind && !/\bwalk\b/i.test(blind)) {
-      failures.push(`The ordering control did not reproduce the defect: a decision blind to the write still said "${blind}", so the check above proves nothing`);
+    if (sighted && blind && sighted === blind) {
+      failures.push(`The ordering control did not reproduce the defect: a decision blind to the write produced the SAME move ("${blind}"), so the check above proves nothing`);
     }
   }
 
@@ -414,6 +496,12 @@ const MUST_WRITE: [string, string][] = [
     console.log(`\n✗ tracking contract: ${failures.length}/${total} violations`);
     process.exit(1);
   }
-  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer, the answer quoted the ledger, and a durable write ended in one next move, and ${MIXED.length} mixed turns kept their fact`);
+  if (knownFoodClaim.length > 0) {
+    console.log(`⚠ KNOWN, NOT FIXED HERE — the food door logs a meal on ${knownFoodClaim.length} water INTENTION(s):`);
+    for (const m of knownFoodClaim) console.log(`    "${m}" -> a meal called "Water" is written`);
+    console.log(`  Unchanged from main. Water correctly refuses these; the food door's planning`);
+    console.log(`  vocabulary has the same gap, and treats water as a food at all. Its own cut.`);
+  }
+  console.log(`✓ tracking contract: ${MUST_NOT_WRITE.length} questions wrote nothing, ${MUST_WRITE.length} reports reached their writer, the answer quoted the ledger, and a durable write ended in one next move, and ${MIXED.length} period-separated mixed turns kept their fact (the COMMA form is not covered — see LAW 5)`);
   process.exit(0);
 })();

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -8,7 +8,7 @@ import { users } from "../../shared/schema";
 import { neverSilentLine } from "../reply-hygiene";
 import { eq, sql } from "drizzle-orm";
 import { logChat, turnMutation } from "./chat-log";
-import { sastToday, mentionsNotDone, digitizeSpokenAmounts } from "../utils";
+import { sastToday, mentionsNotDone, reportedInSomeClause, digitizeSpokenAmounts } from "../utils";
 import { waterTargetLitres } from "../targets";
 import { scanForSAFoods } from "./food-scanner";
 
@@ -50,9 +50,31 @@ export async function tryLogWater(ctx: {
     || /^\s*is\s+\d/i.test(m);
   const waterNotConsumed = mentionsNotDone(m)  // couldn't/skipped/didn't finish my water — never consumed
     || /\b(need\s+to|should\s+(?:i|drink)|must\s+drink|gonna|going\s+to|will\s+drink|plan\s+to|trying\s+to|still\s+need)\b/i.test(m);
-  if (waterMatch && hasWaterKeyword && !isNonWaterDrink && !waterIsQuestion && !waterNotConsumed) {
-    const amount = parseFloat(waterMatch[1]);
-    const unit = waterMatch[2].toLowerCase();
+  // ONE WATER-REPORT SHAPE, APPLIED TO WHATEVER TEXT IT IS GIVEN — the same amount/keyword/drink
+  // tests as above, so there is no second water recogniser; only the text they read changes.
+  //
+  // IT DOES NOT RE-CHECK "IS THIS A QUESTION OR AN INTENTION". It is only ever called through
+  // reportedInSomeClause, which refuses any clause that is asking or intending before this runs.
+  // Asking twice was measured and it made that floor unfalsifiable — the suite stayed green with
+  // the floor deleted, because this copy was quietly doing its job. One owner, one test.
+  const waterReportIn = (t: string) => !!t.match(/(\d+(?:\.\d+)?)\s*(l|litre|liter|litres|liters|ml|millilitre|milliliter|glass(?:es)?|cup(?:s)?|bottle(?:s)?)\b/i)
+    && WATER_WORDS.test(t)
+    && !/\b(wine|beer|whisky|brandy|rum|vodka|gin|shots?|alcohol|henny|hennessy|smirnoff|hunters|savanna|castle|black label|flying fish|brutal fruit|cider|juice|coffee|tea|milo|milk|cooldrink|cool drink|fanta|sprite|coke|pepsi|energy drink|redbull|monster|cream soda|softdrink|soda water|tonic)\b/i.test(t)
+    // "haven't had my 2L yet" is a NEGATION, not a question or an intention — no floor owns it.
+    && !mentionsNotDone(t);
+  // A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63).
+  // waterIsQuestion begins with `m.includes("?")`, so a single question mark ANYWHERE in the
+  // bubble refused the write: "2 litres of water, what should I eat?" logged no water at all, and
+  // the meal plan answered only because this door had already declined. Re-read per clause, and
+  // only when the whole-message read said no, so nothing that logs today changes.
+  const wholeIsReport = !!waterMatch && hasWaterKeyword && !isNonWaterDrink && !waterIsQuestion && !waterNotConsumed;
+  const waterClause = wholeIsReport ? null : reportedInSomeClause(message, c => waterReportIn(c.toLowerCase()));
+  const waterText = waterClause ? waterClause.toLowerCase() : m;
+  if (wholeIsReport || waterClause) {
+    // The amount comes from the sentence that reported it, never from elsewhere in the bubble.
+    const clauseMatch = waterText.match(/(\d+(?:\.\d+)?)\s*(l|litre|liter|litres|liters|ml|millilitre|milliliter|glass(?:es)?|cup(?:s)?|bottle(?:s)?)\b/i)!;
+    const amount = parseFloat(clauseMatch[1]);
+    const unit = clauseMatch[2].toLowerCase();
     let litres = amount;
     if (unit === "ml" || unit === "millilitre" || unit === "milliliter") litres = amount / 1000;
     else if (unit === "glass" || unit === "glasses") litres = amount * 0.25;

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -53,14 +53,26 @@ export async function tryLogWater(ctx: {
   // ONE WATER-REPORT SHAPE, APPLIED TO WHATEVER TEXT IT IS GIVEN — the same amount/keyword/drink
   // tests as above, so there is no second water recogniser; only the text they read changes.
   //
-  // IT DOES NOT RE-CHECK "IS THIS A QUESTION OR AN INTENTION". It is only ever called through
-  // reportedInSomeClause, which refuses any clause that is asking or intending before this runs.
+  // IT DOES NOT RE-CHECK ASKING, OR THE INTENT FORMS THE FLOORS OWN. It is only ever called
+  // through reportedInSomeClause, which refuses any clause that is asking or intending first.
   // Asking twice was measured and it made that floor unfalsifiable — the suite stayed green with
-  // the floor deleted, because this copy was quietly doing its job. One owner, one test.
+  // the floor deleted, because a full copy of it here was quietly doing the job.
+  //
+  // BUT DELETING THE WHOLE COPY WAS TOO MUCH: "trying to drink 2 litres of water" and "must drink
+  // 2 litres of water" then WROTE. What stays below is exactly what no floor owns —
+  //   trying to     isFutureIntent excludes it ON PURPOSE, because a report can carry it:
+  //                 "trying to lose weight, weighed 84kg this morning". Water has no such
+  //                 counterpart — "trying to drink 2L" is never a report of having drunk it.
+  //   must/should/will drink   obligation with no pronoun, so the asking floor has nothing to key
+  //                 on and isFutureIntent's forms ("I'll", "I will") do not match.
+  //   mentionsNotDone   "haven't had my 2L yet" is a NEGATION, neither question nor intention.
+  // Everything else — gonna, going to, plan to, need to, should I — is left to the floors, and
+  // deleting them there still turns this suite red.
   const waterReportIn = (t: string) => !!t.match(/(\d+(?:\.\d+)?)\s*(l|litre|liter|litres|liters|ml|millilitre|milliliter|glass(?:es)?|cup(?:s)?|bottle(?:s)?)\b/i)
     && WATER_WORDS.test(t)
     && !/\b(wine|beer|whisky|brandy|rum|vodka|gin|shots?|alcohol|henny|hennessy|smirnoff|hunters|savanna|castle|black label|flying fish|brutal fruit|cider|juice|coffee|tea|milo|milk|cooldrink|cool drink|fanta|sprite|coke|pepsi|energy drink|redbull|monster|cream soda|softdrink|soda water|tonic)\b/i.test(t)
-    // "haven't had my 2L yet" is a NEGATION, not a question or an intention — no floor owns it.
+    && !/\btrying\s+to\b/i.test(t)
+    && !/\b(?:must|should|will)\s+drink\b/i.test(t)
     && !mentionsNotDone(t);
   // A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63).
   // waterIsQuestion begins with `m.includes("?")`, so a single question mark ANYWHERE in the

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -21,7 +21,7 @@ import { generateMilestoneVoiceScript } from "../gpt";
 import { logChat, turnMutation, turnAlreadyWrote } from "./chat-log";
 import { sastDayKey } from "../sast";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
-import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen } from "../utils";
+import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, reportedInSomeClause, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen } from "../utils";
 import { applyRetroSessionState } from "../day-ledger";
 import { readTrainingDay } from "../one-action";
 import { invalidatePatternCache } from "../cache";
@@ -85,11 +85,22 @@ export async function handleWorkoutCommands(ctx: {
 
   // ---- WEIGHT LOG — standalone "84kg" or brief weight check-in ----
   // Only fires if message is clearly about body weight, not exercise weight
+  // ONE WEIGH-IN SHAPE, APPLIED TO WHATEVER TEXT IT IS GIVEN. Factored out of the two inline
+  // tests below so the same recogniser can read a single clause — no second weight recogniser.
+  const weighInShape = (t: string) => /^(\d{2,3}(?:\.\d+)?)\s*kg[.!]?$/i.test(t)
+    || /\b(?:weigh(?:ed|s|ing)?|morning weight|body weight|on the scale|scale said|scale reads|weighed in|my weight)\b.*\b(\d{2,3}(?:\.\d+)?)\s*kg\b/i.test(t)
+    || /\b(\d{2,3}(?:\.\d+)?)\s*kg\b.*\b(?:today|this morning|just weighed)\b/i.test(t);
   const isStandaloneWeight = /^(\d{2,3}(?:\.\d+)?)\s*kg[.!]?$/i.test(m);
   const isWeightCheckIn = (
     /\b(?:weigh(?:ed|s|ing)?|morning weight|body weight|on the scale|scale said|scale reads|weighed in|my weight)\b.*\b(\d{2,3}(?:\.\d+)?)\s*kg\b/i.test(m)
     || /\b(\d{2,3}(?:\.\d+)?)\s*kg\b.*\b(?:today|this morning|just weighed)\b/i.test(m)
   );
+  // A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63). The two
+  // tests above are anchored to the WHOLE bubble, so "84kg. how am I doing?" was not a weigh-in at
+  // all — the scale reading was simply not seen. Re-read per clause, only when the whole-message
+  // read already said no, and only for a clause that is neither a question nor an intention.
+  const weightClause = (isStandaloneWeight || isWeightCheckIn) ? null
+    : reportedInSomeClause(message, c => weighInShape(c.toLowerCase()));
   // Retrospective brake: "I weighed 83kg last week", "I started at 95kg", "used to be 90kg"
   // are HISTORICAL — they must not overwrite today's weight or recalc targets off a past number.
   const isRetrospectiveWeight = /\b(last\s+(?:week|month|year|time)|used\s+to|back\s+(?:then|in|when)|previously|a\s+(?:week|month|year)\s+ago|(?:weeks?|months?|years?)\s+ago|started\s+(?:at|on|out|off)|when\s+i\s+(?:started|began))\b/i.test(m);
@@ -103,8 +114,14 @@ export async function handleWorkoutCommands(ctx: {
   // protein targets off it, and replied "🏆 you hit 85kg — that's the goal, done." The two
   // branches either side of this one — the session report above and the cardio log below — have
   // always asked isFutureIntent. This one never did; that asymmetry was the whole defect.
-  if ((isStandaloneWeight || isWeightCheckIn) && !isRetrospectiveWeight && !isFutureIntent(m) && !looksLikeQuestion(m) && !EXERCISE_PATTERN.test(m)) {
-    const kgMatch = m.match(/(\d{2,3}(?:\.\d+)?)\s*kg/i);
+  // When the weigh-in came from a clause, the clause is the text every guard below reads: the
+  // whole-bubble question test is precisely what was wrong, and the number must come from the
+  // sentence that reported it.
+  const weightText = weightClause ? weightClause.toLowerCase() : m;
+  if ((isStandaloneWeight || isWeightCheckIn || !!weightClause)
+      && !isRetrospectiveWeight && !isFutureIntent(weightText)
+      && !looksLikeQuestion(weightText) && !EXERCISE_PATTERN.test(weightText)) {
+    const kgMatch = weightText.match(/(\d{2,3}(?:\.\d+)?)\s*kg/i);
     if (kgMatch) {
       const kg = parseFloat(kgMatch[1]);
       if (Number.isFinite(kg) && kg >= 30 && kg <= 250) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,7 +55,7 @@ import { mustStayDeterministic } from "./understanding/action-router";
 import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { recordMessageSeen, recordReplyPath } from "./self-check";
 import { normalizerFidelity } from "./normalizer-fidelity";
-import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
+import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, reportedInSomeClause, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
 import { invalidatePatternCache } from "./cache";
 import { mentionsConditionOrMedication, conditionWelcome } from "./condition-welcome";
 import { captureSymptom } from "./quality-signals";
@@ -681,10 +681,20 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
 
   const statedFacts = journeyMustKeepFacts(message);
   const foodIsWritable = scannerSawFood;
+  // WATER AND WEIGHT ARE OWED TOO (2026-08-26, issue #63). This tracked three facts, so on
+  // "2 litres of water. what should I eat?" nothing was outstanding, mayEndTurn said yes, and
+  // early-commands ended the turn before the water door ever ran. The same message with STEPS
+  // survived because steps WAS owed — that asymmetry was the defect, not the meal plan.
+  // Stated-ness is read per clause, so a pure question can never make a fact "owed".
+  const statedWater = () => !!reportedInSomeClause(message, c => looksLikeWaterReport(c.toLowerCase()));
+  const statedWeight = () => !!reportedInSomeClause(message, c => looksLikeWeightReport(c.toLowerCase()));
   const factsStillOwed = (): string[] => {
     const written = durableDomains(turnMutations());
-    return (["food", "steps", "workout"] as const)
-      .filter(d => (d === "food" ? statedFacts.food && foodIsWritable : (statedFacts as any)[d])
+    return (["food", "steps", "workout", "water", "weight"] as const)
+      .filter(d => (d === "food" ? statedFacts.food && foodIsWritable
+        : d === "water" ? statedWater()
+        : d === "weight" ? statedWeight()
+        : (statedFacts as any)[d])
         && !written.includes(d));
   };
   /** May THIS handler's reply end the turn, or is a fact the client stated still unwritten? */
@@ -1170,7 +1180,19 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // ALL STEP PARSING HAS ONE OWNER (Cut 5b). ~50 lines of regexes and the number arithmetic
   // lived here, beside messy-intake's own extractStepCount — two step parsers for one fact, in
   // two files. Moved whole; the guards that need this function's context stay here.
-  const sd = detectStepLog(m);
+  let sd = detectStepLog(m);
+  // A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63). On
+  // "walked 8000 steps. what should I eat?" the extractor found 8 000 and threw it away, because
+  // isQuestionForm matches "should i" ANYWHERE in the bubble. Re-read per clause, only when the
+  // whole-message read already said no, and the clause's own parse becomes the parse — so the
+  // number stays tied to the sentence that reported it. See tracking-contract-tests, LAW 5.
+  if (!sd.loggableByForm) {
+    const stepClause = reportedInSomeClause(m, c => {
+      const d = detectStepLog(c);
+      return d.matched && d.loggableByForm && d.isExplicitLog;
+    });
+    if (stepClause) sd = detectStepLog(stepClause);
+  }
   // Future-intent guard: "I'll walk 10k tomorrow" slips past the question check — must not log
   // today. Explicit "walked 8,000 steps" is a log even if the classifier tagged the note a
   // QUESTION because they also said "I'm exhausted" (live 2026-08-19 mixed note — steps dropped).

--- a/server/understanding/messy-intake.ts
+++ b/server/understanding/messy-intake.ts
@@ -473,6 +473,21 @@ export function resolveTurn(
 
 
 /**
+ * THE SENTENCES OF A BUBBLE (2026-08-26, issue #63) — named because four surfaces need it.
+ *
+ * The food door has split on sentence boundaries since 2026-08-22 to stop a planning clause
+ * suppressing a report clause. Steps, water and weight had the same defect and no splitter, so
+ * this is lifted out of the food fallback verbatim rather than written again three times.
+ *
+ * Pure, and it stays here because this module has no imports by design. It does not decide
+ * anything — deciding whether a clause REPORTS a fact needs the asking and intent floors, which
+ * live in utils; that composition is utils.reportedInSomeClause, and it calls this.
+ */
+export function clausesOf(message: string): string[] {
+  return String(message || "").split(/(?<=[.!?])\s+|\n+/).map(c => c.trim()).filter(c => c.length > 3);
+}
+
+/**
  * REBUILD GATE — the three facts in a messy note cannot be dropped because a classifier
  * called the whole turn a question. This is the product, not a helper.
  */
@@ -493,9 +508,8 @@ export function journeyMustKeepFacts(message: string): {
   // the same defect as the door-level question veto, one layer down. Only the negative case is
   // re-examined and only per sentence, so nothing that already parsed as a fact changes, and a
   // pure ask ("what should I eat for lunch?") still has no clause that reports a meal.
-  const byClause = r.hasFoodReport ? null : String(message || "")
-    .split(/(?<=[.!?])\s+|\n+/).map(c => c.trim()).filter(c => c.length > 3)
-    .map(c => parseMessyIntake(c)).find(c => c.hasFoodReport);
+  const byClause = r.hasFoodReport ? null
+    : clausesOf(message).map(c => parseMessyIntake(c)).find(c => c.hasFoodReport);
   const explicitSteps = r.stepCount != null && r.stepCount > 100;
   return {
     food: r.hasFoodReport || !!byClause,

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -28,6 +28,7 @@ export function buildContentVariables(vars?: Record<string, string | number | nu
 // codebase. These two stay as re-exports so the existing call sites keep working unchanged while
 // they migrate; new code should import from ./sast directly.
 import { sastDayKey, sastDayStart } from "./sast";
+import { clausesOf } from "./understanding/messy-intake";
 export { sastDayStart };
 export const sastToday = sastDayKey;
 
@@ -1157,7 +1158,12 @@ export function digitizeSpokenAmounts(m: string): string {
 export function looksLikeWaterReport(raw: string): boolean {
   const m = digitizeSpokenAmounts(raw);
   return /\b(?:drank|drinking|had)\b.{0,24}\b\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?|glass(?:es)?|bottles?)\s*(?:of\s+)?(?:water)?\b/i.test(m)
-    || /^\s*\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?)(?:\s+(?:of\s+)?water)?\s*$/i.test(m)
+    // A FULL STOP IS NOT A DISQUALIFIER (2026-08-26, issue #63). This anchored to end-of-string,
+    // so "2 litres of water." was not a water report while "2 litres of water" was — and once
+    // clauses carry their own terminator, that made the first sentence of every mixed bubble
+    // invisible here. looksLikeWeightReport, its sibling, has always ended `[.!]?\s*$`; this now
+    // matches it. "?" stays out: a question mark is a disqualifier, and must remain one.
+    || /^\s*\d+(?:[.,]\d+)?\s*(?:ml|l|litres?|liters?)(?:\s+(?:of\s+)?water)?\s*[.!]?\s*$/i.test(m)
     // THE COPULA FORM (2026-08-26, issue #63). "My water is 2 litres" reported nothing to the
     // water owner — it needed `drank/drinking/had` or a bare amount — so it fell past Water to
     // FoodContext, where the scanner logged a FOOD called "Water" with a macro card and todayWater
@@ -1213,6 +1219,27 @@ export function isAskingNotReporting(message: string): boolean {
   if (/\b(?:any|some|a few)\s+(?:suggestions?|ideas?|options?|recommendations?)\b/i.test(s)) return true;
   if (/\b(?:suggestion|recommendation)s?\b/i.test(s) && !/\bi (?:had|ate|have eaten|just had)\b/i.test(s)) return true;
   return false;
+}
+
+/**
+ * A QUESTION IN ONE CLAUSE MUST NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63).
+ *
+ * Some clause REPORTS the fact, and that clause is itself neither a question nor an intention.
+ * NOT "does the message mention the fact" — that was measured and it re-opens every false write
+ * #73 closed, because naming a fact is what a question does too.
+ *
+ * Composes the two floors that already own those questions and adds no domain knowledge:
+ * `isReport` stays with the caller, so each fact keeps its ONE recogniser. Callers must NOT
+ * re-check asking/intent themselves — that duplication made this floor unfalsifiable once.
+ * Lives beside the floors; messy-intake owns the splitter and is import-free by design.
+ * Rationale and both-ways grading: script/tracking-contract-tests.ts, LAW 5.
+ */
+export function reportedInSomeClause(message: string, isReport: (clause: string) => boolean): string | null {
+  for (const clause of clausesOf(message)) {
+    if (isAskingNotReporting(clause) || isFutureIntent(clause)) continue;
+    if (isReport(clause)) return clause;
+  }
+  return null;
 }
 
 // Goal-change vocabulary gate for the normalizer. A GOAL_CHANGE canonical rewrites


### PR DESCRIPTION
Real clients do not send one fact per bubble. *"I walked 8,000 steps, what should I eat?"* is the ordinary shape — and the system **already understood** the step count, then threw it away because a whole-message question guard read the second clause.

## Measured on main — 5 of 10 mixed turns lost the fact

| surface | `…what should I eat?` | `…how am I doing?` |
|---|---|---|
| food | keep | keep |
| workout | keep | keep |
| **steps** | **LOST** | keep |
| **water** | **LOST** | **LOST** |
| **weight** | **LOST** | **LOST** |

Food and workout had each learned this rule separately. The other three never had, and each lost the fact its own way — all three a whole-message read discarding something a clause plainly states:

- **steps** — `detectStepLog` extracted 8 000, then `isQuestionForm` matched `should i` anywhere and set `loggableByForm` false.
- **water** — `waterIsQuestion` begins with `m.includes("?")`.
- **weight** — `looksLikeWeightReport` is anchored `^…$`, so a clause is never read.

## The rule is *not* "does the message mention the fact"

That version was tried and measured first, and it re-opens every false write #73 closed:

```
journeyMustKeepFacts("Is 8000 steps enough?")   -> logStepsEvenIfClassifiedQuestion = true
journeyMustKeepFacts("I need to do 10000 steps")-> logStepsEvenIfClassifiedQuestion = true
parseMessyIntake("I need to drink 2 litres")    -> hasWaterReport = true
```

Naming a fact is what a question does too. That is very likely why the override has sat computed, unit-tested and **unconsumed**.

**The rule that holds:** some clause *reports* the fact, and that clause is itself neither a question nor an intention. `utils.reportedInSomeClause` composes the two floors that already own those questions — `isAskingNotReporting` and `isFutureIntent` — and adds no domain knowledge; `isReport` stays with the caller, so each fact keeps the one recogniser it had. `messy-intake.clausesOf` is the splitter the food door has used since August, lifted out and named rather than written three more times.

## Two mechanisms, not one

Fixing the handler guards left water and weight still losing `…what should I eat?`. `factsStillOwed` tracked only food/steps/workout — so with nothing outstanding, `mayEndTurn` said yes and early-commands ended the turn before those doors ran. The same message with **steps** survived precisely because steps *was* owed.

**The asymmetry was the defect, not the meal plan.** Water and weight join the owed set, read per clause through the same rule.

Also fixed, found on the way: `looksLikeWaterReport`'s bare-amount branch was anchored to end-of-string, so `"2 litres of water."` was not a water report while `"2 litres of water"` was. Its sibling `looksLikeWeightReport` has always ended `[.!]?\s*$`. Once clauses carry their own terminator, that made the first sentence of every mixed bubble invisible. `?` stays a disqualifier.

## Measured after

**12 of 12 mixed turns keep the fact. 15 questions and intentions still write nothing.**

## Five controls, each biting on its own case

```
remove the clause re-read from steps   -> ✗ steps lost on 2 turns
remove it from water                   -> ✗ water lost on 3 turns
remove it from weight                  -> ✗ weight lost on 2 turns
shrink the owed set back to three      -> ✗ water and weight lost on "what should I eat?"
delete the floors from the shared rule -> ✗ "Is 2 litres of water enough?" WRITES water
```

### The fifth control did not bite at first, and that was the finding

Deleting the floors changed nothing — because `water.ts`'s clause predicate re-checked questions and intentions **itself**. A second copy of the rule, quietly doing the job and making the floor unfalsifiable. The copy is removed; the floor is now the one owner and provably load-bearing, and Law 2 is what catches its absence.

That is the exact failure mode worth guarding against here: *the test stayed green while the guard it was testing did nothing.*

## Law 5

Graded against the same pipeline as Law 2, in the same run — because every widening here is one regex away from re-opening it. A fix that preserves the fact by loosening the floors fails loudly on `"I need to do 10000 steps"`.

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing`
- RED: `check-file-sizes`, `check-architecture` — the same two as main
- Governor identical: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`

**Two over-budget files grew, and I am stating the numbers rather than arguing them away:** `routes.ts` 1479 → 1501, `utils.ts` 1359 → 1386. Rationale was moved into the suite as you asked; what remains is the capability itself — the shared rule, the two clause re-reads, and the owed-set expansion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_