### PR TITLE
The cardio step write goes through the owner

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -301,6 +301,70 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
+   *
+   * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep
+   * the higher count unless it is an explicit correction. The cardio door did not go through it —
+   * it ran a bare INSERT with no day-window read — so a client whose day already held 8 000 steps
+   * and sent "ran 5km" ended the turn with TWO rows, 8 000 and 5 500.
+   *
+   * NO CUSTOMER-VISIBLE DIVERGENCE WAS DEMONSTRATED FOR THAT, and this test does not pretend one
+   * was: the direct step query, the streak, the weekly average and a later same-day log all
+   * returned identical answers with one row and with two. What is proven is the contract breach,
+   * plus a real latent risk — both day-row reads are `.limit(1)` with NO ORDER BY, so once a
+   * second row exists, which count the client is told depends on which row Postgres returns. The
+   * cardio door is what creates that precondition. The harness cannot exercise the ambiguity
+   * because the stub always returns the first seeded row, so it is named here, not asserted.
+   *
+   * The conversion (km × 1100 running, × 1300 walking) is untouched — only the write door moved.
+   */
+  {
+    const cardioRows = async (existing: number | null) => {
+      freshTurn();
+      const { handleWorkoutCommands } = await import("../server/handlers/workout");
+      const seeded = existing === null ? []
+        : [{ id: "s1", userId: USER.id, steps: existing, loggedAt: new Date(dayStart.getTime() + 3_600_000) }];
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      g.__KAMLIFE_STUB_ROWS = new Map([
+        [schema.stepLogs, seeded], [schema.workoutLogs, []], [schema.mealLogs, []], [schema.weightLogs, []],
+      ]);
+      g.__KAMLIFE_STUB_WRITES = []; g.__KAMLIFE_STUB_UPDATES = [];
+      const reply = String(await handleWorkoutCommands(
+        { phone: USER.phoneNumber, message: "ran 5km", m: "ran 5km", user: { ...USER } } as any,
+      ).catch(() => ""));
+      const ins = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === schema.stepLogs);
+      const upd = (g.__KAMLIFE_STUB_UPDATES || []).filter((w: any) => w.table === schema.stepLogs);
+      delete g.__KAMLIFE_STUB_UPDATES;
+      return {
+        reply,
+        rows: (existing === null ? 0 : 1) + ins.length,
+        held: ins.length ? Number(ins[0].values?.steps)
+          : upd.length ? Number(upd[upd.length - 1].set?.steps) : existing,
+      };
+    };
+
+    // THE CONTRACT: one row per day, whatever the day already held.
+    for (const [existing, expectRows, expectHeld, why] of [
+      [null, 1, 5500, "an empty day takes the derived count"],
+      [8000, 1, 8000, "a higher existing count is kept, and nothing is written"],
+      [3000, 1, 5500, "a lower existing count is raised, still in one row"],
+    ] as [number | null, number, number, string][]) {
+      const r = await cardioRows(existing);
+      if (r.rows !== expectRows) {
+        failures.push(`Cardio broke one-row-per-day (${why}): day held ${existing}, ended with ${r.rows} rows`);
+      }
+      if (r.held !== expectHeld) {
+        failures.push(`Cardio wrote the wrong count (${why}): day held ${existing}, now ${r.held}, expected ${expectHeld}`);
+      }
+      // EXISTING CUSTOMER BEHAVIOUR IS PRESERVED. The cardio reply never quoted steps and must not
+      // start to — this cut moves a write, it does not change what the client reads.
+      if (!/5\s*km/i.test(r.reply) || !/kcal/i.test(r.reply)) {
+        failures.push(`Cardio reply changed: "${r.reply.split("\n")[0]}"`);
+      }
+    }
+  }
+
+  /**
    * LAW 4 — A DURABLE WRITE IS FOLLOWED BY ONE NEXT MOVE (2026-08-26, issue #63).
    *
    * The contract's last two stages are "one action -> one response", and the product was stopping

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from "../db";
-import { users, workoutLogs, stepLogs, chatHistory } from "../../shared/schema";
+import { users, workoutLogs, chatHistory } from "../../shared/schema";
 import { eq, and, gte, lt, desc } from "drizzle-orm";
 import { classifyWorkoutFeedback, workoutFeedbackReply } from "../workout-feedback";
 import { parseSessionReport, sessionReportReply, sessionMemoryLine, type SessionReport } from "../session-report";
@@ -27,6 +27,7 @@ import { readTrainingDay } from "../one-action";
 import { invalidatePatternCache } from "../cache";
 import { getTodayWorkoutState, getTodaySlot, weekStartForTrainingClaim, attributableWeekSessionDates } from "../workout-state";
 import { handleWeightLog } from "./weight";
+import { logStepsForUser } from "./steps";
 import { calculateTargets } from "../targets";
 import { getPrimaryWorkoutGifUrl } from "../exercise-media";
 import { sendWhatsApp, saveState } from "../scheduler/shared";
@@ -210,14 +211,25 @@ export async function handleWorkoutCommands(ctx: {
         ? Math.round(distanceKm * (/run|ran|jog|parkrun/i.test(m) ? 72 : 55) * weightFactor)
         : null;
 
-    // km → steps: log to stepLogs so step streak / target tracking reflects the activity
+    // km → steps: log to stepLogs so step streak / target tracking reflects the activity.
+    //
+    // THROUGH THE OWNER, NOT AROUND IT (2026-08-26, issue #63). This was a bare INSERT with no
+    // day-window read, so it broke the one rule logStepsForUser exists to hold — one row per SAST
+    // day. Measured: a client whose day already held 8 000 steps sent "ran 5km" and ended the turn
+    // with TWO rows, 8 000 and 5 500, where the owner would have kept 8 000 and written nothing.
+    //
+    // Two rows also make the day's own read non-deterministic: both day-row reads are `.limit(1)`
+    // with no ORDER BY, so which count the client is told becomes a matter of which row Postgres
+    // hands back. No customer-visible divergence was demonstrated for that — stated plainly, it
+    // was not — but the precondition is created here and the unordered read is real.
+    //
+    // The conversion stays exactly as it was; only the write door changes.
     if (distanceKm && distanceKm > 0 && distanceKm < 120) {
       const stepsPerKm = /run|ran|jog|parkrun/i.test(m) ? 1100 : 1300;
       const derivedSteps = Math.round(distanceKm * stepsPerKm);
       try {
-        await db.insert(stepLogs).values({ userId: user.id, steps: derivedSteps });
-        turnMutation("INSERT steps", "[WRITE]");
-      } catch (e) { console.warn("[CARDIO] step insert failed:", e); }
+        await logStepsForUser(user.id, derivedSteps);
+      } catch (e) { console.warn("[CARDIO] step write failed:", e); }
     }
 
     // Log workout session


### PR DESCRIPTION
The one **proven** write-door violation from the measurement, and only that. The two `media.ts` writers are untouched — no divergence has been demonstrated for them, and the vision path they sit behind cannot be executed offline.

## What was proven

`logStepsForUser` holds one rule no caller can hold for itself: **one row per SAST day**, keep the higher count unless it is an explicit correction. The cardio door ran a bare `INSERT` with no day-window read:

```
day already holds 8000, client sends "ran 5km"
  before : INSERT 5500  ->  TWO rows for one day, 8000 and 5500
  owner  : keeps 8000, writes nothing
```

## What was not proven — and is not claimed

**No customer-visible divergence.** The direct step query, the streak, the weekly average and a later same-day log all returned identical answers with one row and with two. The breach is of the contract, not of anything a client could read.

The latent risk *is* real and is named rather than asserted: both day-row reads are `.limit(1)` with **no `ORDER BY`**, so once a second row exists, which count the client is told depends on which row Postgres hands back. The cardio door is what creates that precondition. The stub always returns the first seeded row, so the harness cannot exercise the ambiguity — that is written into the suite as a stated limit, not tested.

## The cut

`db.insert(stepLogs)` → `logStepsForUser(user.id, derivedSteps)`.

The km→steps conversion is untouched (×1100 running, ×1300 walking). The now-dead `stepLogs` import is removed, because leaving the table in scope is the invitation to write around the owner again.

No new writer, handler, router, or authority. No redesign of the step domain.

## Graded — three states of the day

| day holds | rows after | day holds after | |
|---|---|---|---|
| empty | 1 | 5500 | derived count taken |
| 8000 | 1 | 8000 | higher kept, nothing written |
| 3000 | 1 | 5500 | lower raised, still one row |

**The customer reply is asserted unchanged in all three** — this moves a write, it does not change what the client reads.

**Control:** reverting to the bare `INSERT` fails three of those assertions, including the exact two-row case measured on main:

```
✗ Cardio broke one-row-per-day: day held 8000, ended with 2 rows
✗ Cardio wrote the wrong count: day held 8000, now 5500, expected 8000
✗ Cardio broke one-row-per-day: day held 3000, ended with 2 rows
```

## One consequence worth naming

The owner records a turn mutation only on `INSERT`, so a cardio turn that *keeps* or *raises* an existing row no longer marks `steps` as durably written. The turn is still durable via its workout `INSERT`, and a later steps door in the same turn now goes through keep-higher rather than writing a second row — which is the correct direction.

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing`
- RED: `check-file-sizes`, `check-architecture` — the same two as main, same values
- Governor identical: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`
- **No over-budget file grew.** `workout.ts` +12, well inside its budget; `routes.ts` 1501 and `utils.ts` 1386 unchanged from main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_