### PR TITLE
A meal request reaches the meal owner

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -301,6 +301,84 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * ONE CUSTOMER MEANING -> ONE OWNER. Claim precedence, not capability (2026-08-26, live trace).
+   *
+   * The capability was never missing. SMART NEXT MEAL answers "what should I eat next" against the
+   * day's remaining calories, and has since long before this. What went wrong on a real phone is
+   * that a door ~145 lines EARLIER in the pipeline claimed the turn first:
+   *
+   *     client: "Give me a meal for my last 668 calories"
+   *     coach : "Kam, today: 2032/2700 kcal · 150g/180g protein. 668 kcal left." + a card
+   *
+   * He asked for a MEAL and was handed a NUMBER. The totals branch matched on "my … calories" and
+   * ended the turn; the owner never ran. Same disease as #70, one phrasing further out — that guard
+   * recognised only INTERROGATIVE food questions ("what can I eat"), and this is the IMPERATIVE.
+   *
+   * BOTH HALVES ARE THE CUT, and the first attempt proved why. Stopping the wrong claimant alone
+   * left the message with NO owner — it fell through to the model and came back "Eish Coach K had
+   * a moment." A precedence fix is only finished when the right door actually takes the turn, so
+   * the owner's recogniser learned the same request verbs the guard uses.
+   *
+   * GRADED BOTH WAYS, because the failure mode here is symmetric: divert too little and the client
+   * still gets a number; divert too much and a genuine "how many calories do I have left?" stops
+   * being answerable. "show me my calories" is the case that pins it — same request verb, no meal.
+   */
+  {
+    const answered = async (message: string) => {
+      freshTurn();
+      const todayMeal = [{
+        id: "cm0", userId: USER.id, items: ["chicken", "rice"], mealLabel: "lunch",
+        loggedAt: new Date(dayStart.getTime() + 3_600_000), corrected: false,
+        kcalInt: 2032, proteinInt: 150, kcal: 2032, protein: 150, carbs: 0, fat: 0,
+      }];
+      g.__KAMLIFE_STUB_USER = { ...USER };
+      g.__KAMLIFE_STUB_ROWS = new Map([
+        [schema.mealLogs, todayMeal], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+      ]);
+      g.__KAMLIFE_STUB_WRITES = [];
+      return String(await handleMessage(USER.phoneNumber, message).catch(() => ""));
+    };
+    const isMealSuggestion = (r: string) => /next meal suggestion/i.test(r);
+    const isTotalsReadout = (r: string) => /\d+\s*\/\s*\d+\s*kcal|kcal\b.*\bleft\b|still available/i.test(r);
+
+    // A MEAL REQUEST REACHES ITS OWNER.
+    for (const ask of [
+      "Give me a meal for my last 668 calories",
+      "give me a meal",
+      "suggest a meal for my remaining calories",
+      "what can I eat with my remaining calories?",
+    ]) {
+      const r = await answered(ask);
+      if (!isMealSuggestion(r)) {
+        failures.push(`A meal request did not reach SMART NEXT MEAL: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+      }
+    }
+
+    // A CALORIE QUESTION STILL REACHES THE TOTALS OWNER — the control that stops this from being
+    // "fixed" by diverting everything that mentions food.
+    for (const ask of [
+      "Today's calories",
+      "how many calories do I have left?",
+      "my calorie target",
+      "show me my calories",
+    ]) {
+      const r = await answered(ask);
+      if (!isTotalsReadout(r) || isMealSuggestion(r)) {
+        failures.push(`A calorie question was diverted away from the totals owner: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+      }
+    }
+
+    // AND THE MEAL-PLAN DOOR IS UNTOUCHED. "send me a meal plan" contains the request verb AND the
+    // meal noun, so a careless guard would strip it from the branch that owns it.
+    {
+      const r = await answered("send me a meal plan");
+      if (!/meal plan/i.test(r)) {
+        failures.push(`The meal-plan door lost its message: "send me a meal plan" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+      }
+    }
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -185,7 +185,32 @@ export async function handleEarlyCommands(ctx: {
   // than ending the turn, so the message falls through to the specialists below. A genuinely
   // multi-part question is already excluded by !isMultiPartAsk(m) inside the condition, so what
   // reaches here is a single food question the totals list mis-claimed.
-  const alsoAsksFood = /\b(?:(?:what|which|where)\b[^?]{0,60}\b(?:can|should|do) i (?:eat|have|buy|order|get)|taxi rank|spaza|shisa nyama|kota|takeaway|restaurant|canteen|braai)\b/i.test(m);
+  // A PERSON CAN ASK BY INSTRUCTING (2026-08-26, live phone trace). This recognised only
+  // INTERROGATIVE food questions — "what can I eat" — so the imperative form walked straight into
+  // the totals branch:
+  //
+  //     client: "Give me a meal for my last 668 calories"
+  //     coach : "Kam, today: 2032/2700 kcal · 150g/180g protein. 668 kcal left." + a card
+  //
+  // He asked for a MEAL and was handed a number. SMART NEXT MEAL — the owner of that question —
+  // sits ~145 lines further down the pipeline and never ran, because this branch had already
+  // claimed the turn on "my … calories".
+  //
+  // The vocabulary is not invented here: utils.isAskingNotReporting already treats
+  // give/send/show/suggest/recommend as asking-by-instructing, and was written for exactly this
+  // blind spot ("Give me a dinner suggestion" reaching the food LOGGER). That predicate cannot
+  // decide precedence at this door, because it is equally true of "how many calories do I have
+  // left?" — a genuine totals question. What separates them is whether a MEAL or a NUMBER was
+  // asked for, which is the question this guard already exists to answer. So the same request
+  // verbs are applied to the food noun this guard already deals in, as one more alternative.
+  //
+  // SCOPED TO WHAT THE OWNER WILL TAKE. The first version of this covered breakfast/lunch/dinner/
+  // supper/snack/plate/food too, and that was wrong in the other direction: SMART NEXT MEAL
+  // EXCLUDES the named meals, so stopping the totals claim on "give me a dinner" would have left
+  // the message with no owner at all — trading a wrong answer for none. Only "meal" is covered
+  // here, because only "meal" is what the owner below accepts.
+  const alsoAsksFood = /\b(?:(?:what|which|where)\b[^?]{0,60}\b(?:can|should|do) i (?:eat|have|buy|order|get)|taxi rank|spaza|shisa nyama|kota|takeaway|restaurant|canteen|braai)\b/i.test(m)
+    || /\b(?:give|send|show|suggest|recommend)\s+(?:me\s+)?(?:a|an|another|the)?\s*meal\b/i.test(m);
 
   if (
     !alsoAsksFood && (

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -276,7 +276,12 @@ export async function handleMiscCommands(ctx: {
   }
 
   // ---- SMART NEXT MEAL — "what should I eat next?" based on daily gap ----
-  if (/\b(what should i eat next|next meal|suggest.?a?\s*meal|what.?s? next|what to eat now|what can i eat|what must i eat|hungry|starving|i.?m hungry|what now)\b/i.test(m) && !/\b(breakfast|lunch|dinner|supper|braai|social)\b/i.test(m)) {
+  // A PERSON CAN ASK BY INSTRUCTING (2026-08-26, live phone trace). This accepted "suggest a meal"
+  // but not "give me a meal", so the imperative form reached no owner at all once the totals
+  // branch correctly stopped claiming it. Stopping the wrong claimant is only half the fix — the
+  // right one has to take the turn. Same request verbs as the guard in early-commands, so the two
+  // doors agree on what a meal request looks like.
+  if (/\b(what should i eat next|next meal|(?:suggest|give|send|show|recommend)(?:\s+me)?\s*a?n?\s*meal|what.?s? next|what to eat now|what can i eat|what must i eat|hungry|starving|i.?m hungry|what now)\b/i.test(m) && !/\b(breakfast|lunch|dinner|supper|braai|social)\b/i.test(m)) {
     const todayStr = sastToday();
     const todayCals = user.todayCaloriesDate === todayStr ? (user.todayCalories || 0) : 0;
     const todayProt = user.todayCaloriesDate === todayStr ? (user.todayProteinG || 0) : 0;


### PR DESCRIPTION
Cut A from the live phone trace, and only that. Cards, `GOAL_DISTANCE`, trajectory and food-day closure are untouched.

## The capability was never missing

SMART NEXT MEAL answers *"what should I eat next"* against the day's remaining calories, and has for a long time. What went wrong on a real phone is that a door **~145 lines earlier** claimed the turn:

```
client: "Give me a meal for my last 668 calories"
coach : "Kam, today: 2032/2700 kcal · 150g/180g protein. 668 kcal left."  + card
```

He asked for a **meal** and was handed a **number**. Confirmed at runtime before any change: the totals branch in `early-commands` matches on `"my … calories"` and ends the turn, so the owner never runs.

Same disease as #70, one phrasing further out. `alsoAsksFood` — the guard in this very door — recognised only **interrogative** food questions (`what can I eat`). This is the **imperative**, and `utils.isAskingNotReporting` already carries that vocabulary for exactly this blind spot: *"a person can ask by instructing."*

That predicate can't decide precedence here, because it's equally true of *"how many calories do I have left?"* — a genuine totals question. What separates them is whether a **meal** or a **number** was asked for, which is what `alsoAsksFood` exists to answer. So the same request verbs are applied to the food noun it already deals in, as one more alternative. **No new predicate.**

## Both halves are the cut, and the first attempt proved why

Stopping the wrong claimant alone left the message with **no owner** — it fell through to the model and came back *"Eish Coach K had a moment. Try that again."* A precedence fix is only finished when the right door actually takes the turn, so SMART NEXT MEAL's recogniser learned the same verbs: it accepted `suggest a meal` but not `give me a meal`.

## Scoped to what the owner will take

The first guard also covered breakfast/lunch/dinner/supper/snack/plate/food — wrong in the other direction. SMART NEXT MEAL **excludes** the named meals, so stopping the totals claim on `"give me a dinner"` would have left that message with no owner at all: a wrong answer traded for none. Only `meal` is covered, because only `meal` is what the owner accepts.

## Graded both ways

The failure mode is symmetric — divert too little and the client still gets a number; divert too much and a real calorie question stops being answerable.

| must reach SMART NEXT MEAL | must reach the totals owner |
|---|---|
| `Give me a meal for my last 668 calories` | `Today's calories` |
| `give me a meal` | `how many calories do I have left?` |
| `suggest a meal for my remaining calories` | `my calorie target` |
| `what can I eat with my remaining calories?` | `show me my calories` |

`show me my calories` is the case that pins it: **same request verb, no meal noun.**

And `send me a meal plan` still reaches the meal-plan door — it carries both the verb *and* the noun, so a careless guard would have stolen it.

**Controls — each half fails on its own:**

```
revert the guard  -> ✗ totals reclaims: "668 kcal left"
revert the owner  -> ✗ nothing takes it: "Eish Coach K had a moment"
both restored     -> exit 0
```

Also fixed by the same guard, surfaced by the control: `"suggest a meal for my remaining calories"` was reaching totals too.

## Gate

- `tsc --noEmit` exit 0
- `suites: 32/35 green, 1 covered nothing`
- RED: `check-file-sizes`, `check-architecture` — the same two as main, same values
- Governor identical: `messageDeciders 32`, `looksLikePredicates 21`, `authorshipPoints 425`
- **No over-budget file grew.** `early-commands` 1366 and `misc-commands` 1462, both well inside their 1850 budget.

## Not in this cut

The other three failures from the trace — the read-generates-a-card seam, `GOAL_DISTANCE` composing its own answer instead of using trajectory, and the closed-day card contradicting the text — are untouched and unmeasured here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_