### PR TITLE
The card stops selling food on a day the client closed

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -301,6 +301,90 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * THE CARD MAY NOT CONTRADICT THE DECISION (2026-08-26, live phone trace).
+   *
+   * The client said they were done eating for the day. The text respected it. The card told them
+   * to eat more. Both were produced by the same turn, from the same day-state, by two different
+   * owners of the same question:
+   *
+   *     chooseAction        eat_more and protein rungs, each guarded by !s.foodDayClosed
+   *     nextMoveLine        the SAME two rungs on the card, with no such guard
+   *
+   * Reproduced deterministically on one day-state — fat-loss client, 19:00, protein 60 of 180:
+   *
+   *     text: "Get today's session done."                    (closure respected)
+   *     card: "Get a real protein into your next two meals"  (still selling food)
+   *
+   * The fix adds no prose. A closed day is a finished day, and nextMoveLine already owned four
+   * close-out lines for the after-20:00 case — "That's the day. Tomorrow get a real protein in at
+   * breakfast" is exactly right for someone who stopped eating short of protein. Closure enters
+   * the same branch the clock does.
+   *
+   * GRADED THROUGH THE REAL PATH, not just the pure function: the card markers read closure from
+   * held-constraints, the same durable owner canonicalDecision consults. That read goes through
+   * raw pool.query, so it is seeded here via __KAMLIFE_STUB_PGROWS — the seam that exists because
+   * "the client said at 08:00 they are not training today" could not otherwise be expressed
+   * offline. Without it this test would only prove the parameter works, not that anything passes it.
+   */
+  {
+    const { nextMoveLine, mealCard } = await import("../server/macro-card-attach");
+    const { chooseAction } = await import("../server/one-action");
+    const { readHeldConstraints } = await import("../server/held-constraints");
+
+    const rows = [
+      { label: "Calories", current: 1400, target: 2700 },
+      { label: "Protein", current: 60, target: 180 },
+      { label: "Fat", current: 40, target: 80 },
+      { label: "Carbs", current: 100, target: 300 },
+    ] as any;
+    const dayState = (closed: boolean) => ({
+      goal: "fat_loss", weeksOnProgramme: 5, daysSinceAnyLog: 0, daysSinceWeighIn: 1,
+      loggedToday: true, proteinPct: 60 / 180, caloriePct: 1400 / 2700,
+      sessionsThisWeek: 2, sessionsTarget: 3, stepsToday: 6000, stepsTarget: 10000,
+      hour: 19, atKeyboard: true, foodDayClosed: closed,
+    }) as any;
+    const sells = (line: string) => /\beat\b|\bnext meal\b|next two meals|proper protein|add eggs|yoghurt|boiled egg/i.test(line)
+      && !/tomorrow/i.test(line);
+
+    // THE DEFECT: on a closed day the card must not sell food while the text stands down.
+    {
+      const textMove = chooseAction(dayState(true)).todo;
+      const cardMove = mealCard({
+        firstName: "Kam", mealName: "Today", rows, isBulk: false, usesNumbers: true,
+        hour: 19, foodDayClosed: true,
+      }).sub;
+      if (sells(cardMove)) {
+        failures.push(`The card sold food on a closed day while the text stood down — text: "${textMove}" / card: "${cardMove}"`);
+      }
+    }
+
+    // THE CONTROL: an OPEN day is untouched. A guard that silences the card always would pass the
+    // assertion above and leave every ordinary day without its next move.
+    {
+      const cardMove = mealCard({
+        firstName: "Kam", mealName: "Today", rows, isBulk: false, usesNumbers: true,
+        hour: 19, foodDayClosed: false,
+      }).sub;
+      if (!sells(cardMove)) {
+        failures.push(`An open day lost its card instruction: "${cardMove}"`);
+      }
+    }
+
+    // AND THE MARKERS ACTUALLY READ THE OWNER. Without this the parameter above could be correct
+    // and permanently false in production.
+    {
+      g.__KAMLIFE_STUB_PGROWS = [{ message_in: "I'm done eating for the day", created_at: new Date(Date.now() - 600_000) }];
+      const held = await readHeldConstraints(USER.phoneNumber, USER as any).catch(() => ({ foodDayClosed: false } as any));
+      delete g.__KAMLIFE_STUB_PGROWS;
+      if (!held.foodDayClosed) {
+        failures.push(`held-constraints did not see the closure the card now depends on — the card's read is wired to a fact that never becomes true`);
+      }
+    }
+
+    void nextMoveLine;
+  }
+
+  /**
    * ONE CUSTOMER MEANING -> ONE OWNER. Claim precedence, not capability (2026-08-26, live trace).
    *
    * The capability was never missing. SMART NEXT MEAL answers "what should I eat next" against the

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -320,68 +320,127 @@ const MUST_WRITE: [string, string][] = [
    * breakfast" is exactly right for someone who stopped eating short of protein. Closure enters
    * the same branch the clock does.
    *
-   * GRADED THROUGH THE REAL PATH, not just the pure function: the card markers read closure from
-   * held-constraints, the same durable owner canonicalDecision consults. That read goes through
-   * raw pool.query, so it is seeded here via __KAMLIFE_STUB_PGROWS — the seam that exists because
-   * "the client said at 08:00 they are not training today" could not otherwise be expressed
-   * offline. Without it this test would only prove the parameter works, not that anything passes it.
+   * GRADED THROUGH THE PRODUCTION MARKER, NOT A HAND-PASSED BOOLEAN.
+   *
+   * The first version of this test called nextMoveLine(rows, ..., foodDayClosed) directly and
+   * asserted on the string. That proved the parameter works and NOTHING about whether production
+   * supplies it — delete both `foodDayClosed: await dayClosedFor(...)` lines from the markers and
+   * that test stays green while the client keeps reading "eat more" on a day they closed. A test
+   * that can be green while the customer is wrong is not evidence.
+   *
+   * So the graded path is the real one, end to end:
+   *
+   *     dailyMacroCardMarker(user) -> dayClosedFor -> readHeldConstraints -> nextMoveLine -> PNG
+   *
+   * The card's words are rasterised into that PNG and cannot be read back, so the assertion is on
+   * BYTES: render the two cards this day-state can produce, then check which one the production
+   * marker actually emitted. Byte equality is exact — it pins the specific close-out line, not
+   * merely "some different card".
+   *
+   * Three things had to be pinned for those bytes to mean anything:
+   *   - THE CLOCK. nextMoveLine takes the same branch after 20:00 on its own, so at 20:00 a broken
+   *     wiring would look fixed. Date.now is frozen at 19:00 SAST on a fixed date — the #82 rule:
+   *     a test must not change its answer because of when it ran.
+   *   - THE LEDGER. An empty day, so the rows are known and the protein rung is the one in play.
+   *   - THE CLOSURE. readHeldConstraints goes through raw pool.query, seeded via
+   *     __KAMLIFE_STUB_PGROWS — the seam that exists because a constraint stated at 08:00 cannot
+   *     otherwise be expressed offline.
    */
   {
-    const { nextMoveLine, mealCard } = await import("../server/macro-card-attach");
-    const { chooseAction } = await import("../server/one-action");
+    const { mealCard, todayRows, dailyMacroCardMarker, macroCardMarker } = await import("../server/macro-card-attach");
+    const { _resetDumpWindow: resetDump } = await import("../server/card-policy");
+    const { renderAchievementCard } = await import("../server/achievement-card");
+    const { getCard } = await import("../server/card-store");
+    const { getNumbersMode } = await import("../server/numbers-mode");
+    const { getGoalProfile } = await import("../server/goal-profiles");
     const { readHeldConstraints } = await import("../server/held-constraints");
+    const { mealLogs, stepLogs } = await import("../shared/schema");
 
-    const rows = [
-      { label: "Calories", current: 1400, target: 2700 },
-      { label: "Protein", current: 60, target: 180 },
-      { label: "Fat", current: 40, target: 80 },
-      { label: "Carbs", current: 100, target: 300 },
-    ] as any;
-    const dayState = (closed: boolean) => ({
-      goal: "fat_loss", weeksOnProgramme: 5, daysSinceAnyLog: 0, daysSinceWeighIn: 1,
-      loggedToday: true, proteinPct: 60 / 180, caloriePct: 1400 / 2700,
-      sessionsThisWeek: 2, sessionsTarget: 3, stepsToday: 6000, stepsTarget: 10000,
-      hour: 19, atKeyboard: true, foodDayClosed: closed,
-    }) as any;
-    const sells = (line: string) => /\beat\b|\bnext meal\b|next two meals|proper protein|add eggs|yoghurt|boiled egg/i.test(line)
-      && !/tomorrow/i.test(line);
+    const realNow = Date.now;
+    const FROZEN = Date.parse("2026-03-11T17:00:00Z");   // 19:00 SAST, before the 20:00 close-out
+    const priorRows = g.__KAMLIFE_STUB_ROWS;
+    Date.now = () => FROZEN;
+    g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[mealLogs, []], [stepLogs, []]]);
+    try {
+      const pngOf = (marker: string) => {
+        const t = marker.match(/\/card\/([^.]+)\.png/);
+        return t ? getCard(t[1]) : null;
+      };
+      const closure = () => [{ message_in: "I'm done eating for the day", created_at: new Date(FROZEN - 600_000) }];
 
-    // THE DEFECT: on a closed day the card must not sell food while the text stands down.
-    {
-      const textMove = chooseAction(dayState(true)).todo;
-      const cardMove = mealCard({
-        firstName: "Kam", mealName: "Today", rows, isBulk: false, usesNumbers: true,
-        hour: 19, foodDayClosed: true,
-      }).sub;
-      if (sells(cardMove)) {
-        failures.push(`The card sold food on a closed day while the text stood down — text: "${textMove}" / card: "${cardMove}"`);
+      const today = await todayRows(USER, false);
+      const cardFor = (mealName: string, foodDayClosed: boolean) => mealCard({
+        firstName: "Kam", mealName, rows: today!.rows, isBulk: today!.isBulk,
+        usesNumbers: getNumbersMode(USER) !== "low" && getGoalProfile(USER.goalType).usesMacros,
+        foodDayClosed,
+      });
+      const openCard = cardFor("Today", false), closedCard = cardFor("Today", true);
+      const sells = (line: string) => /\beat\b|\bnext meal\b|next two meals|proper protein|add eggs|yoghurt|boiled egg/i.test(line)
+        && !/tomorrow/i.test(line);
+
+      // BOTH CALL SITES. The wiring is two lines in two functions, and grading one of them leaves
+      // the other free to be deleted with the suite still green — which is the whole defect this
+      // block exists to catch. The meal-log card is the one a client sees most: it rides every
+      // food log they send.
+      const MARKERS: [string, string, () => Promise<string>][] = [
+        ["the daily-calories card", "Today", () => dailyMacroCardMarker(USER)],
+        ["the meal-log card", "Chicken and rice", () => macroCardMarker({ user: USER, mealName: "Chicken and rice", mealKcal: 600 })],
+      ];
+      for (const [what, mealName, emit] of MARKERS) {
+        delete g.__KAMLIFE_STUB_PGROWS;
+        resetDump();                       // the dump window collapses repeat cards to one
+        const openA = pngOf(await emit());
+        resetDump();
+        const openB = pngOf(await emit());
+        g.__KAMLIFE_STUB_PGROWS = closure();
+        resetDump();
+        const closed = pngOf(await emit());
+        delete g.__KAMLIFE_STUB_PGROWS;
+
+        if (!openA || !openB || !closed) {
+          failures.push(`${what} produced no image, so its closed-day wiring is ungraded — this proves nothing`);
+          continue;
+        }
+        // WITHOUT THIS the "closed differs from open" assertion would pass on rendering noise.
+        if (!openA.equals(openB)) {
+          failures.push(`Two identical renders of ${what} differ byte-for-byte — the comparison below cannot mean anything`);
+          continue;
+        }
+        // THE WIRING. Remove `foodDayClosed: await dayClosedFor(...)` from this marker and the
+        // closed run becomes identical to the open one, and this fails.
+        if (closed.equals(openA)) {
+          failures.push(`A held closed-day constraint did not reach ${what}: it emitted the same image as an open day — card said "${cardFor(mealName, false).sub}"`);
+        }
+        // AND IT IS THE CLOSED-DAY CARD SPECIFICALLY, not merely a different one.
+        if (!closed.equals(renderAchievementCard(cardFor(mealName, true)))) {
+          failures.push(`${what} did not emit the closed-day card — expected the close-out "${cardFor(mealName, true).sub}"`);
+        }
+        if (!openA.equals(renderAchievementCard(cardFor(mealName, false)))) {
+          failures.push(`${what} did not emit the open-day card — expected "${cardFor(mealName, false).sub}"`);
+        }
       }
-    }
-
-    // THE CONTROL: an OPEN day is untouched. A guard that silences the card always would pass the
-    // assertion above and leave every ordinary day without its next move.
-    {
-      const cardMove = mealCard({
-        firstName: "Kam", mealName: "Today", rows, isBulk: false, usesNumbers: true,
-        hour: 19, foodDayClosed: false,
-      }).sub;
-      if (!sells(cardMove)) {
-        failures.push(`An open day lost its card instruction: "${cardMove}"`);
-      }
-    }
-
-    // AND THE MARKERS ACTUALLY READ THE OWNER. Without this the parameter above could be correct
-    // and permanently false in production.
-    {
-      g.__KAMLIFE_STUB_PGROWS = [{ message_in: "I'm done eating for the day", created_at: new Date(Date.now() - 600_000) }];
+      g.__KAMLIFE_STUB_PGROWS = closure();
       const held = await readHeldConstraints(USER.phoneNumber, USER as any).catch(() => ({ foodDayClosed: false } as any));
       delete g.__KAMLIFE_STUB_PGROWS;
-      if (!held.foodDayClosed) {
-        failures.push(`held-constraints did not see the closure the card now depends on — the card's read is wired to a fact that never becomes true`);
-      }
-    }
 
-    void nextMoveLine;
+      // THE CUSTOMER OUTCOME, on the card the production path actually emitted.
+      if (sells(closedCard.sub)) {
+        failures.push(`The card sold food on a closed day: "${closedCard.sub}"`);
+      }
+      // THE CONTROL: an OPEN day keeps its instruction. A guard that silences the card always
+      // would satisfy every assertion above and leave every ordinary day without a next move.
+      if (!sells(openCard.sub)) {
+        failures.push(`An open day lost its card instruction: "${openCard.sub}"`);
+      }
+      // Which half broke, when it breaks: the marker not reading, or the fact never becoming true.
+      if (!held.foodDayClosed) {
+        failures.push(`held-constraints did not see the closure the card depends on — the card's read is wired to a fact that never becomes true`);
+      }
+    } finally {
+      Date.now = realNow;
+      delete g.__KAMLIFE_STUB_PGROWS;
+      if (priorRows === undefined) delete g.__KAMLIFE_STUB_ROWS; else g.__KAMLIFE_STUB_ROWS = priorRows;
+    }
   }
 
   /**

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -157,7 +157,7 @@ function stripWrapQuotes(s: string): string {
 // so "Good start 👌" reached the founder as "Good start ☐" (2026-08-04 live, one hour after I
 // put them in). Emoji belong in the CHAT text, where WhatsApp renders them; on the card they
 // are a tofu box. His register survives without them — the words were always the voice.
-export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false): string {
+export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false): string {
   const r = (label: string) => rows.find(x => x.label === label);
   if (isPastDay) return "Yesterday's log — today's plate is a separate day";
   const ratio = (x?: Row) => (x && x.target > 0 ? x.current / x.target : 0);
@@ -174,7 +174,21 @@ export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), is
   // So after 20:00 the directive stops being a to-do and becomes a close-out that faces
   // tomorrow. Same principle — one instruction, one lever, his voice — chosen from WHEN the
   // report arrived rather than from an ideal real-time flow nobody actually lives.
-  if (hour >= 20) {
+  // THE CARD MAY NOT SELL FOOD TO A CLIENT WHO SAID THEY ARE DONE (2026-08-26, live phone trace).
+  //
+  // chooseAction guards its eat_more and protein rungs with `!s.foodDayClosed`. This function is
+  // the SAME two rungs, on the card, and it had no such guard — so on one day-state the client
+  // read both of these in one turn:
+  //
+  //     text: "Get today's session done."                    <- closure respected
+  //     card: "Get a real protein into your next two meals"  <- still selling food
+  //
+  // Two owners of "what should they do next", one closure-aware and one blind. The fix is not new
+  // prose: a closed day is a finished day, and this function already owns the four close-out lines
+  // for that — "That's the day. Tomorrow get a real protein in at breakfast" is exactly the right
+  // coaching for a client who has stopped eating short of protein. So closure enters the SAME
+  // branch the clock does, and the lines below are unchanged.
+  if (foodDayClosed || hour >= 20) {
     return !isBulk && ratio(cal) > 1.05 ? "Day's done. Tomorrow, first meal before you leave the house"
       : protLeft >= 35 ? "That's the day. Tomorrow get a real protein in at breakfast"
       : isBulk && calLeft > 500 ? "Day's wrapped. Tomorrow, eat earlier — that's the whole fix"
@@ -423,6 +437,8 @@ export function mealCard(opts: {
   firstName: string; mealName: string; rows: Row[]; isBulk: boolean; usesNumbers: boolean;
   hour?: number;
   isPastDay?: boolean;
+  /** They said they are done eating today. The card's next move must agree with the decision's. */
+  foodDayClosed?: boolean;
 }): AchievementCardData {
   const r = (label: string) => opts.rows.find(x => x.label === label);
   const prot = r("Protein");
@@ -442,8 +458,22 @@ export function mealCard(opts: {
     figure: opts.usesNumbers ? `${protSoFar}g` : verdict,
     unit: opts.usesNumbers ? (opts.isPastDay ? "protein yesterday" : "protein today") : (opts.isPastDay ? "yesterday" : "so far today"),
     line: `${opts.firstName ? opts.firstName + ": " : ""}${opts.mealName} logged.`,
-    sub: nextMoveLine(opts.rows, opts.isBulk, opts.hour, !!opts.isPastDay),
+    sub: nextMoveLine(opts.rows, opts.isBulk, opts.hour, !!opts.isPastDay, !!opts.foodDayClosed),
   };
+}
+
+/**
+ * DID THEY CLOSE THE DAY? Read from held-constraints — the same durable owner canonicalDecision
+ * consults, so the card and the text cannot disagree about it. A constraint outlives the sentence
+ * that stated it, which is why this is a stored read and not a look at the current message.
+ * Fail-open to "not closed": a card is a bonus, never a blocker, and the pre-existing behaviour
+ * on an unreadable constraint is exactly what it was before.
+ */
+async function dayClosedFor(user: any): Promise<boolean> {
+  try {
+    const { readHeldConstraints } = await import("./held-constraints");
+    return !!(await readHeldConstraints(user?.phoneNumber, user)).foodDayClosed;
+  } catch { return false; }
 }
 
 export async function macroCardMarker(opts: { user: any; mealName: string; mealKcal: number; forDate?: Date; achievementStreak?: number }): Promise<string> {
@@ -473,6 +503,7 @@ export async function macroCardMarker(opts: { user: any; mealName: string; mealK
       firstName: firstNameOf(opts.user),
       mealName: opts.mealName || "Meal",
       rows: today.rows,
+      foodDayClosed: isPastDay ? false : await dayClosedFor(opts.user),
       isBulk: today.isBulk,
       usesNumbers: getNumbersMode(opts.user) !== "low" && getGoalProfile(opts.user?.goalType).usesMacros,
       isPastDay,
@@ -512,6 +543,7 @@ export async function dailyMacroCardMarker(user: any): Promise<string> {
       firstName: firstNameOf(user),
       mealName: "Today",
       rows: today.rows,
+      foodDayClosed: await dayClosedFor(user),
       isBulk: today.isBulk,
       usesNumbers: getNumbersMode(user) !== "low" && getGoalProfile(user?.goalType).usesMacros,
     });


### PR DESCRIPTION
## The customer failure

Live phone trace, 2026-08-26. The client said they were done eating for the day. One turn answered them twice, from the same day-state:

```
text: "Get today's session done."                    <- closure respected
card: "Get a real protein into your next two meals"  <- still selling food
```

## The mechanism (runtime, not static)

Two owners of the same question — "what should they do next":

| owner | rungs | closure guard |
|---|---|---|
| `chooseAction` (`one-action.ts`) | `eat_more`, `protein` | `!s.foodDayClosed` |
| `nextMoveLine` (`macro-card-attach.ts`) | the **same two rungs**, on the card | none |

## The correction

No new prose, no new owner, no new module. `nextMoveLine` already owned four close-out lines for the after-20:00 case, and one of them — *"That's the day. Tomorrow get a real protein in at breakfast"* — is exactly the right coaching for someone who has stopped eating short of protein. So **closure enters the same branch the clock does**, and the four lines below it are untouched:

```ts
if (foodDayClosed || hour >= 20) {
```

The card markers read closure from `held-constraints` — the same durable owner `canonicalDecision` consults. The read fails open to "not closed": a card is a bonus, never a blocker.

`+38 / −3` in production code, one file.

## What is proven — stated precisely

**The card no longer sells food when a closed-day constraint is held**, and the closure reaches it through the real production path. That is the claim.

This does **not** claim that the card and the text choose the same next move in general, and it does not address same-turn closure. Those are separate questions and are untouched here.

## The proof runs through the production marker

The first version of this proof called `nextMoveLine(rows, …, foodDayClosed)` directly. Grok's question 4 killed it: delete both `foodDayClosed: await dayClosedFor(...)` lines from the markers and every assertion stayed green while the client kept reading "eat more" on a day they closed. A test that can be green while the customer is wrong is not evidence.

The graded path is now the real one, end to end:

```
dailyMacroCardMarker / macroCardMarker
  -> dayClosedFor -> readHeldConstraints -> nextMoveLine -> PNG
```

The card's words are rasterised into that PNG and cannot be read back, so the assertion is on **bytes**: render the two cards this day-state can produce, then check which one the marker actually emitted. Byte equality is exact — it pins the specific close-out line, not merely "some different card".

**Both call sites are graded.** Grading only one left the other deletable with the suite still green — the same defect one call site along. The meal-log card is the one that rides every food log a client sends.

Three things are pinned so the bytes mean something: the **clock** (frozen at 19:00 SAST on a fixed date — after 20:00 the branch is taken anyway, so broken wiring would look fixed), the **ledger** (an empty day), and the **closure** (seeded through the raw `pool.query` seam, since a constraint stated at 08:00 cannot otherwise be expressed offline).

## Controls — six, each failing independently

| control | result |
|---|---|
| delete the meal-log marker's wiring | **RED** |
| delete the daily-card marker's wiring | **RED** |
| remove `foodDayClosed \|\|` from the branch | **RED** — reproduces the live trace verbatim |
| drop the `mealCard` pass-through | **RED** |
| over-guard the branch with `if (true)` | **RED** — "An open day lost its card instruction" |
| unpin the clock to 21:00 SAST | **RED** — the pin is load-bearing, not decoration |

Every failure message carries the customer-visible string, e.g.:

```
✗ A held closed-day constraint did not reach the meal-log card: it emitted the
  same image as an open day — card said "Get a real protein into your next two meals"
```

## Suite state

```
✓ tracking-contract-tests
suites: 32/35 green, 1 covered nothing
ownership: OK — one owner per declared question, one reader per declared fact
```

Governors, unchanged from main `d978d00`:

```
messageDeciders 32/31 · looksLikePredicates 21/20 · authorshipPoints 425/420
gpt.ts 1476 · food-context.ts 1484 · media.ts 1560 · routes.ts 1501 · utils.ts 1386
```

No budget raised, no suppression, no new module. The PNG renderer is already exercised by `unit-tests` in CI, so this adds no new build dependency.

## Commits

| SHA | scope |
|---|---|
| `63d930c` | production: closure enters the close-out branch |
| `68b1bb8` | test-only: the proof runs through the production marker |

## Carried forward, not silently closed

Cut C (goal-distance → trajectory owner) and the step-raise coaching hole from the same evidence set are untouched, per the locked stage order.