### PR TITLE
A step raise earns the same next move as a first report

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -657,7 +657,7 @@ const MUST_WRITE: [string, string][] = [
    * week; the ordering control alone asks for `proteinAtTarget`, and it is the only case that
    * depends on which day it runs.
    */
-  async function coachingTurn(message: string, opts?: { seeWrites?: boolean; proteinAtTarget?: boolean; weeksOnProgramme?: number }) {
+  async function coachingTurn(message: string, opts?: { seeWrites?: boolean; proteinAtTarget?: boolean; weeksOnProgramme?: number; stepsAlready?: number }) {
     // BOTH THE COLUMN NAME AND THE SELECT ALIAS. The stub returns raw rows and does not apply
     // drizzle projections, so `db.select({ kcal: mealLogs.kcalInt })` reads undefined and the
     // client silently looked like they had logged NOTHING today — which quietly moved the ladder
@@ -673,8 +673,11 @@ const MUST_WRITE: [string, string][] = [
       ...USER, todayWater: "0",
       ...(opts?.weeksOnProgramme === undefined ? {} : { programmeWeek: opts.weeksOnProgramme + 1 }),
     };
+    // A step row ALREADY on today, for the turns that grade a raise over an existing count.
+    const steps = opts?.stepsAlready === undefined ? []
+      : [{ id: "s1", userId: USER.id, steps: opts.stepsAlready, loggedAt: new Date(dayStart.getTime() + 3_600_000) }];
     g.__KAMLIFE_STUB_ROWS = new Map([
-      [schema.mealLogs, meals], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+      [schema.mealLogs, meals], [schema.stepLogs, steps], [schema.workoutLogs, []], [schema.weightLogs, []],
     ]);
     // The decision reads state that INCLUDES this turn's write — the production ordering.
     if (opts?.seeWrites !== false) g.__KAMLIFE_STUB_REFLECT_WRITES = 1;
@@ -711,6 +714,52 @@ const MUST_WRITE: [string, string][] = [
     // …and the move must have read the write. Telling a client who just logged 8 000 steps to
     // walk is the defect this ordering exists to prevent.
     if (/\bwalk\b/i.test(move)) failures.push(`The move ignored the row this turn wrote — 8 000 steps logged, and the coach said: "${move}"`);
+  }
+
+  /**
+   * A RAISE IS A DURABLE WRITE (2026-08-27, traced through handleMessage on main 5e38582).
+   *
+   * Steps are one row per SAST day that a client tops up through the day — "5k so far" at noon,
+   * "9k" at night. logStepsForUser recorded a mutation on the INSERT and not on the UPDATE, so
+   * the SAME client sending the SAME message on the SAME day got a coach or a receipt depending
+   * only on whether they had logged earlier:
+   *
+   *     no row yet   -> "8 500 steps — nice one. 👌 ⏎⏎ Stand on a scale this morning, before you eat."
+   *     3 000 stored -> "8 500 steps — nice one. 👌"
+   *
+   * The day moved from 3 000 to 8 500 in both. closeCoachingTurn asked durableDomains what this
+   * turn changed, was told nothing, and stood down — Law 4 exempting the commonest shape of step
+   * report there is. Graded as a PAIR: the contrast between the two is the evidence, and grading
+   * the raise alone would pass on a build where neither gets a move.
+   */
+  {
+    const first = await coachingTurn("walked 8500 steps today");
+    const raise = await coachingTurn("walked 8500 steps today", { stepsAlready: 3000 });
+    if (!closingMove(first)) {
+      failures.push(`A first step report of the day ended with a receipt and no next move: "${first.replace(/\n/g, " ⏎ ")}"`);
+    }
+    if (!closingMove(raise)) {
+      failures.push(`A step RAISE (3 000 -> 8 500) ended with a receipt and no next move, while the same message on an empty day earned one: "${raise.replace(/\n/g, " ⏎ ")}"`);
+    }
+  }
+
+  /**
+   * AND THE CONTROL: a report the day does NOT take is not a durable write.
+   *
+   * The client holds 9 000 and sends 3 000 — an earlier reading arriving late. logStepsForUser
+   * keeps the 9 000 and answers with it (Law 3, proven above). Nothing changed, so nothing is
+   * owed. Recording the mutation unconditionally instead of inside the raise branch would satisfy
+   * every assertion above and manufacture a coaching move out of a read.
+   */
+  {
+    const reply = await coachingTurn("walked 3000 steps today", { stepsAlready: 9000 });
+    const move = closingMove(reply);
+    if (move) {
+      failures.push(`A report the day did not take produced a next move anyway — nothing was written: "${move}"`);
+    }
+    if (!numbersIn(reply).has(9000)) {
+      failures.push(`A superseded step report was not answered from the ledger — the day holds 9 000: "${reply.replace(/\n/g, " ⏎ ")}"`);
+    }
   }
 
   // NEGATIVE CONTROL FOR THE ORDERING. Deny the decision sight of the write and the move must

--- a/server/handlers/steps.ts
+++ b/server/handlers/steps.ts
@@ -35,9 +35,25 @@ export async function logStepsForUser(userId: string, steps: number, opts?: { co
     .limit(1);
   if (existing.length > 0) {
     if (steps > (existing[0].steps ?? 0) || opts?.correction) {
+      const was = existing[0].steps ?? 0;
       await db.update(stepLogs).set({ steps }).where(eq(stepLogs.id, existing[0].id));
+      // THE RAISE IS A DURABLE WRITE TOO (2026-08-27, traced through handleMessage).
+      //
+      // Only the INSERT below recorded a mutation, so the same client sending the same message
+      // on the same day got a coach or a receipt depending on whether they had logged earlier:
+      //
+      //     no row yet   -> "8 500 steps — nice one. Stand on a scale this morning, before you eat."
+      //     3 000 stored -> "8 500 steps — nice one."
+      //
+      // The day moved from 3 000 to 8 500 either way. closeCoachingTurn asks durableDomains what
+      // this turn changed, got nothing, and stood down — the coaching contract's "durable write ->
+      // one next move" silently exempting the commonest shape of step report, the client topping
+      // up a total they already sent. Water is the precedent: its durable write is an UPDATE too.
+      turnMutation(`UPDATE steps=${steps} (was ${was})`, "[STEP_LOG]");
       return steps;
     }
+    // NOT a durable write: the day already holds a higher count and nothing changed. Recording a
+    // mutation here would manufacture a next move out of a read, which is the opposite defect.
     return existing[0].steps ?? steps;
   }
   await db.insert(stepLogs).values({ userId, steps, loggedAt: at });

--- a/server/understanding/messy-intake.ts
+++ b/server/understanding/messy-intake.ts
@@ -444,7 +444,11 @@ export const FEELING_ACK = "Heard you on how you're feeling. Showing up still co
  * that can be false is worse than no internal truth, because everything downstream believes it.
  */
 const DURABLE_WRITE: Array<[string, RegExp]> = [
-  ["food", /INSERT meal/i], ["steps", /INSERT steps/i],
+  ["food", /INSERT meal/i],
+  // Steps are one row per day that a client tops up ("5k so far" at noon, "9k" at night), so the
+  // RAISE is as durable as the first report and owes the same next move (2026-08-27). Same anchor
+  // discipline as water below: the verb is what keeps "TURN committed steps" out of this.
+  ["steps", /(?:INSERT|UPDATE) steps/i],
   ["workout", /INSERT workout/i], ["weight", /INSERT weight/i],
   // Water is an UPDATE, not an INSERT — the day carries one running total rather than a row per
   // sip — so it needs its own pattern rather than sharing the INSERT shape (2026-08-26, #63).


### PR DESCRIPTION
## The customer failure

Traced through `handleMessage` on main `5e38582`, before any change. Same client, same message, same day — three outcomes decided only by what was already stored:

| turn | stored today | reply |
|---|---|---|
| **A** first report (INSERT) | none | `8 500 steps — nice one. 👌`<br><br>`Stand on a scale this morning, before you eat.` |
| **B** raise (UPDATE) | 3 000 | `8 500 steps — nice one. 👌` |
| **C** superseded (no change) | 9 000 | `9 000 steps — nice one. 👌` |

The day moved from 3 000 to 8 500 in **B** exactly as it moved from nothing to 8 500 in **A**. The client got a coach in one and a receipt in the other.

## The mechanism

`logStepsForUser` (`server/handlers/steps.ts`) has three exits and only one of them spoke:

```ts
if (steps > (existing[0].steps ?? 0) || opts?.correction) {
  await db.update(stepLogs).set({ steps })…    // state changed, silence
  return steps;
}
return existing[0].steps ?? steps;             // no change, silence is correct
…
await db.insert(stepLogs).values(…);
turnMutation(`INSERT steps=…`);                // only this one records
```

`closeCoachingTurn` asks `durableDomains(turnMutations())` what the turn changed, got nothing, and stood down. So Law 4 — *a durable write is followed by one next move* — was exempting the commonest shape of step report there is: a client topping up a total they already sent, "5k so far" at noon, "9k" at night.

## The correction

Two lines. No new owner, no new module.

1. The raise branch records its write, the way the INSERT already did.
2. `DURABLE_WRITE` matches it — following **water's** precedent, the existing entry for a domain whose durable write is an UPDATE. The verb stays the anchor, so `"TURN committed steps"` still cannot read as a write.

The no-change branch stays silent **on purpose**, and that is graded: a report the day does not take is not a durable write, and manufacturing a coaching move out of a read is the opposite defect.

## Proof

Graded as a **pair** — the contrast is the evidence. Grading the raise alone would pass on a build where neither turn gets a move.

| control | result |
|---|---|
| delete the mutation from the raise branch | **RED** — reproduces the trace verbatim: `"8 500 steps — nice one. 👌"` |
| revert `DURABLE_WRITE` to `/INSERT steps/i` | **RED** — same failure, proving the pattern half is load-bearing too |
| record the mutation unconditionally | **RED** — the superseded report invents a move: `"Make your next meal a proper protein meal."` |

Both halves of the fix fail independently, and the over-fire direction is guarded.

## Suite state

```
✓ tracking-contract-tests
suites: 32/35 green, 1 covered nothing in 99s
ownership: OK — one owner per declared question, one reader per declared fact
```

Governors, unchanged from main `5e38582`:

```
messageDeciders 32/31 · looksLikePredicates 21/20 · authorshipPoints 425/420
gpt.ts 1476 · food-context.ts 1484 · media.ts 1560 · routes.ts 1501 · utils.ts 1386
```

No budget raised, no suppression, no new module.

## Found while tracing — NOT fixed here, and NOT yet proven

`turnAlreadyWrote` (`server/handlers/chat-log.ts:557`) holds a **second** domain→pattern map that still reads `/INSERT steps/i`. It answers a different question — "has a door already written this domain this turn, so a later door should stand down?" — and this change does not alter its behaviour, since the new mutation string does not match its regex.

But it means a step **raise** is invisible to the duplicate-write guard. Whether that is reachable is **unverified**: I have not traced a path where the multi-day dating owner produces an UPDATE and a downstream single-day door then writes again. On this repo static candidates have been ~100% false positives, so it is recorded as a candidate, not a defect, and deliberately not acted on inside this cut.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_