### PR TITLE
The distance answer contains the distance

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -522,6 +522,76 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * THE ANSWER MUST CONTAIN THE FACT IT WAS ASKED FOR (2026-08-27, live phone trace).
+   *
+   * "How far am I from my goal?" is claimed correctly — GOAL_DISTANCE in misc-commands owns it and
+   * says so in its own comment: "must not fall through to GPT or to the plan menu". It then answers
+   * a different question. Measured on main 31444ce, for a client holding 92kg with an 85kg target:
+   *
+   *     Kam — Scale: down 6.0kg since you started. This week: 0/3 sessions.
+   *     Today's protein: 200g / 180g.
+   *
+   *     That's the distance. The next move is still one thing.
+   *
+   * The target is never named. The gap is never named. The reply asserts "that's the distance" while
+   * containing no distance. This is not a claim-precedence defect like the meal request above — the
+   * right owner answered — it is the owner reciting adjacent progress instead of the fact asked for.
+   *
+   * The gap now comes from getWeightTruth, the documented single reader of what the scale says,
+   * which already held the current weight and the client's target. Graded on the reply the client
+   * reads, with both directions of over-fire controlled: no target and a withheld scale must each
+   * leave the answer exactly as it was.
+   */
+  {
+    const goalTurn = async (message: string, opts?: { target?: string | null; doNotMention?: string }) => {
+      freshTurn();
+      // Ascending by loggedAt — getWeightTruth orders that way and the stub does not sort, so a
+      // reversed seed reads as a 6kg GAIN and would have this suite grading a fiction.
+      const weighIns = Array.from({ length: 9 }, (_, i) => ({
+        id: `w${i}`, userId: USER.id, weight: 98 - i * 0.75, weightKg: 98 - i * 0.75,
+        loggedAt: new Date(dayStart.getTime() - (8 - i) * 7 * 86_400_000),
+      }));
+      g.__KAMLIFE_STUB_USER = {
+        ...USER, todayWater: "0", currentWeight: 92,
+        targetWeightKg: opts?.target === undefined ? "85" : opts.target,
+        doNotMention: opts?.doNotMention || "",
+      };
+      g.__KAMLIFE_STUB_ROWS = new Map([
+        [schema.mealLogs, []], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, weighIns],
+      ]);
+      g.__KAMLIFE_STUB_WRITES = [];
+      return String(await handleMessage(USER.phoneNumber, message).catch(() => ""));
+    };
+    const ASK = "How far am I from my goal?";
+    const statesADistance = (r: string) => /\bto (?:go|gain)\b|at your goal weight/i.test(r);
+
+    // THE DEFECT: 92kg now, 85kg the goal — the answer must carry the 7kg and the target.
+    {
+      const r = await goalTurn(ASK);
+      const said = numbersIn(r);
+      if (!said.has(7)) failures.push(`A distance question was answered without the distance — 92kg now, 85kg the goal: "${r.replace(/\n/g, " ⏎ ")}"`);
+      if (!said.has(85)) failures.push(`A distance question was answered without naming the goal weight: "${r.replace(/\n/g, " ⏎ ")}"`);
+    }
+
+    // CONTROL — NO TARGET SET. There is no distance to state, so none may be invented, and the
+    // answer is the one this handler always gave.
+    {
+      const r = await goalTurn(ASK, { target: null });
+      if (statesADistance(r)) failures.push(`A client with no goal weight was told a distance anyway: "${r.replace(/\n/g, " ⏎ ")}"`);
+      if (!/that's the distance/i.test(r)) failures.push(`A client with no goal weight lost the GOAL_DISTANCE answer entirely: "${r.replace(/\n/g, " ⏎ ")}"`);
+    }
+
+    // CONTROL — THE CLIENT ASKED US TO DROP THE SCALE. do_not_mention is honoured by exactly one
+    // reader; a distance is a weight figure, and stating it here would walk straight through that.
+    {
+      const r = await goalTurn(ASK, { doNotMention: "weight" });
+      if (statesADistance(r) || numbersIn(r).has(85)) {
+        failures.push(`A withheld scale still produced a weight distance: "${r.replace(/\n/g, " ⏎ ")}"`);
+      }
+    }
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -403,6 +403,12 @@ export interface ProgressWeight {
   withheld: boolean;
   /** The first weigh-in in the window — what "since you started" is measured from. */
   startKg: number | null;
+  /**
+   * HOW FAR THEY STILL HAVE TO GO. Signed, same convention as changeKg: NEGATIVE MEANS DOWN THE
+   * SCALE — still to lose — and positive means still to gain. null when no target weight is set,
+   * when there is no weigh-in to measure from, or when the scale is withheld.
+   */
+  toGoalKg: number | null;
   /** Days between the first and last weigh-in. 0 when there are fewer than two. */
   spanDays: number;
   /** Every weigh-in in the window, oldest first. Empty when withheld. For a chart or a trend. */
@@ -461,7 +467,7 @@ export async function getWeightTruth(
   // still leave the rows one careless destructure away from a caller; not asking is the honest
   // shape of standing down, and it is cheaper.
   if (withheld) {
-    return { known: false, currentKg: null, changeKg: null, withheld: true, startKg: null, spanDays: 0, points: [] };
+    return { known: false, currentKg: null, changeKg: null, withheld: true, startKg: null, toGoalKg: null, spanDays: 0, points: [] };
   }
 
   const rows = await db.select({ weight: weightLogs.weight, at: weightLogs.loggedAt })
@@ -479,12 +485,26 @@ export async function getWeightTruth(
     ? Math.max(1, Math.round((points[points.length - 1].at.getTime() - points[0].at.getTime()) / 86_400_000))
     : 0;
 
+  // THE DISTANCE BELONGS TO THE SCALE'S OWNER (2026-08-27, live: "How far am I from my goal?").
+  //
+  // GOAL_DISTANCE answered that question with a progress recital — change since start, sessions
+  // this week, protein today — and closed on "That's the distance" while never naming the target
+  // or the gap. The fact was not missing from the system; it was missing from the one reader that
+  // holds both halves. It is computed here rather than at the mouth because three inline copies of
+  // this arithmetic already exist (trajectory.ts, handlers/weight.ts, scheduler/jobs/monday.ts)
+  // and a fourth at a call site is how that happens a fifth time.
+  const targetKg = Number(user?.targetWeightKg);
+  const toGoalKg = Number.isFinite(latest) && Number.isFinite(targetKg) && targetKg > 0
+    ? Math.round((targetKg - latest) * 10) / 10
+    : null;
+
   return {
     known: change !== null,
     currentKg: Number.isFinite(latest) ? latest : null,
     changeKg: change,
     withheld: false,
     startKg: points.length ? points[0].kg : null,
+    toGoalKg,
     spanDays,
     points,
   };

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -92,6 +92,24 @@ export async function handleMiscCommands(ctx: {
       const bits: string[] = [];
       const change = truth.weight.changeKg;
       const scaleOff = /\b(weight|scale|weigh)\b/i.test(String(user.doNotMention || ""));
+      // THE DISTANCE FIRST — it is the question (2026-08-27, live phone trace).
+      //
+      // This block already ended on "That's the distance" and never contained one: it recited the
+      // change since start, the week's sessions and today's protein, and left a client holding
+      // 92kg with an 85kg target no closer to knowing they had 7kg to go. The gap now comes from
+      // getWeightTruth, the one reader that owns what the scale says, so this mouth and every
+      // other surface cannot disagree about it.
+      //
+      // It leads, and the recital still follows: they asked how far, and the rest is the context
+      // that makes the number mean something. When there is no target or no weigh-in there is no
+      // distance to state, and the answer is exactly what it was before.
+      const toGoal = truth.weight.toGoalKg;
+      if (!scaleOff && toGoal !== null && truth.weight.currentKg !== null) {
+        const kg = Math.abs(toGoal);
+        bits.push(kg < 0.1
+          ? `You're at your goal weight — ${truth.weight.currentKg}kg.`
+          : `${kg.toFixed(1)}kg to ${toGoal < 0 ? "go" : "gain"}: ${truth.weight.currentKg}kg now, ${Number(user.targetWeightKg)}kg the goal.`);
+      }
       if (!scaleOff && truth.weight.known && change !== null) {
         bits.push(change < 0
           ? `Scale: down ${Math.abs(change).toFixed(1)}kg since you started.`


### PR DESCRIPTION
## The customer failure

Traced through `handleMessage` on main `31444ce`, before any change. A client holding 92kg with an 85kg target:

```
Kam — Scale: down 6.0kg since you started. This week: 0/3 sessions.
Today's protein: 200g / 180g.

That's the distance. The next move is still one thing.
```

The target is never named. The gap is never named. The reply asserts *"that's the distance"* and contains none.

## One correction to the framing

The master map has this as *"the existing trajectory capability is bypassed by the miscellaneous goal-distance mouth."* The trace says otherwise, and the difference matters for the fix.

There is a **dedicated `GOAL_DISTANCE` handler** (`server/handlers/misc-commands.ts:81`) with its own regex and its own `logChat(…, "GOAL_DISTANCE")`, carrying this comment:

> *Distance to goal is a progress-truth question, not the daily-direction card. "How far am I from my goal???" must not fall through to GPT or to the plan menu.*

It claims the question **correctly**. This is not a claim-precedence defect like #81 — the right owner answered, and recited adjacent progress instead of the fact it was asked for. So the fix is not routing; it is giving the owner the fact.

## The correction

`getWeightTruth` (`day-ledger.ts:450`) is the documented single reader of what the scale says — *"ONE DEFINITION OF WHAT THE SCALE SAYS"* — and already held both halves: the latest weigh-in, and the client's target on the user row. It now returns `toGoalKg`, with the same sign convention as the `changeKg` beside it (negative means down the scale). `GOAL_DISTANCE` states it, and the existing recital follows:

```
Kam — 7.0kg to go: 92kg now, 85kg the goal. Scale: down 6.0kg since you started.
This week: 0/3 sessions. Today's protein: 200g / 180g.

That's the distance. The next move is still one thing.
```

**Computed at the owner, not the mouth.** Three inline copies of this arithmetic already exist — `trajectory.ts:108`, `handlers/weight.ts:433`, `scheduler/jobs/monday.ts:107` — and a fourth at a call site is how there comes to be a fifth.

No new handler, no new module. The governor sits at `modules 239/239`, where a new module would be a **new** failure rather than a pre-existing one. `+39 / −1` across two files.

## Controls

| control | result |
|---|---|
| delete the mouth's distance line | **RED** — reproduces the trace verbatim |
| make the owner return `toGoalKg: null` | **RED** — the owner half is load-bearing |
| compute a distance with no target set | **RED** — `"12.0kg to go: 92kg now, 0kg the goal"` |
| withheld scale (`do_not_mention`) | **over-determined — see below** |

### The one control that does not prove what it looks like it proves

The withheld-scale assertion checks that a client who asked us to drop the scale is never told a distance. It passes — but it does **not** prove the guards in this diff are load-bearing. I removed the mouth's `!scaleOff` check *and* made the owner return a distance despite `withheld: true`, and the suite stayed green.

The reason: `"kg"` is a member of the weight topic cluster (`reply-verifier.ts:837`), so the outbound forbidden-topic stripper removes any sentence containing it for that client. The withheld case is protected by **three** independent layers and the third alone suffices.

The assertion is kept because the customer-visible outcome is worth pinning. It is labelled here as an outcome assertion, not a guard proof, rather than being presented as a fourth biting control.

## A false positive worth recording

My first trace showed `"Scale: up 6.0kg since you started"` for a client who went 98 → 92kg — an apparent sign inversion. It was my fixture: I seeded weigh-ins newest-first, but `getWeightTruth` queries `.orderBy(weightLogs.loggedAt)` — ascending — and the stub does not sort. The product is correct. The suite's fixture carries a comment so the next person does not re-seed it backwards.

## Suite state

```
✓ tracking-contract-tests
suites: 32/35 green, 1 covered nothing in 100s
ownership: OK — one owner per declared question, one reader per declared fact
```

Governors, unchanged from main `31444ce`:

```
messageDeciders 32/31 · looksLikePredicates 21/20 · authorshipPoints 425/420
gpt.ts 1476 · food-context.ts 1484 · media.ts 1560 · routes.ts 1501 · utils.ts 1386
```

No budget raised, no suppression, no new module.

## Found while tracing — NOT fixed here

Two other phrasings of the same customer intent, both reproduced, both outside this cut:

- `"how much more do I need to lose"` is claimed by the calorie/macro card owner and answered with `2000/2700 kcal` and a food card — a food answer to a weight question. This *is* a claim-precedence defect, the #81 shape.
- `"am I on track for my goal?"` reaches the trajectory door at `routes.ts:1328`, which returns null offline because `getTrajectoryForUser` runs raw `pool.query`. **Unverifiable offline** — not claimed as a defect either way.

Neither is touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_