### PR TITLE
Two ways of asking the same plate question reach one owner

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -519,6 +519,45 @@ const MUST_WRITE: [string, string][] = [
         failures.push(`The meal-plan door lost its message: "send me a meal plan" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
       }
     }
+
+    /**
+     * SAME CUSTOMER MEANING -> SAME CLAIMANT (2026-08-27, live trace on main 6d6b92f).
+     *
+     * "What can I eat?" and "What should I eat?" are one question. They reached two mouths:
+     *
+     *     "what can I eat?"    -> Next Meal Suggestion, against today's remaining calories
+     *     "what should I eat?" -> a 3-day meal plan with a weekly grocery budget
+     *
+     * Same shape as the meal-for-calories defect above: a door ~9 handlers EARLIER in the pipeline
+     * claimed it first. Every other term in that door's vocabulary names a plan — meal plan, eating
+     * plan, diet plan, weekly meals, nutrition plan — and "what should i eat" named none. It stands
+     * down for the bare plate-ask; the owner's recogniser drops a `next` suffix it never needed.
+     *
+     * Graded on the CLASS of answer for every equivalent phrasing, with the plan door as the
+     * control: a fix that simply gutted the plan vocabulary would satisfy the convergence and cost
+     * every client their meal plan.
+     */
+    {
+      // The unpunctuated form is a SEPARATE case, not a cosmetic variant: the plan door holds an
+      // exact-match list checked with .includes(m), which "what should I eat?" can never hit and
+      // "what should i eat" hits exactly. Grading only the question-mark form leaves half the
+      // claimant untested.
+      const plateAsks = ["what can I eat?", "what should I eat?", "what should i eat",
+        "what should I eat next?", "I'm hungry"];
+      for (const ask of plateAsks) {
+        const r = await answered(ask);
+        if (!isMealSuggestion(r)) {
+          failures.push(`A plate-ask did not reach the next-meal owner: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+        }
+      }
+      // THE CONTROL: a request that actually asks for a PLAN still gets the plan.
+      for (const ask of ["give me a meal plan", "my meal plan", "eating plan"]) {
+        const r = await answered(ask);
+        if (!/meal plan/i.test(r) || isMealSuggestion(r)) {
+          failures.push(`A plan request was diverted to the next-meal owner: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+        }
+      }
+    }
   }
 
   /**

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -557,6 +557,15 @@ const MUST_WRITE: [string, string][] = [
           failures.push(`A plan request was diverted to the next-meal owner: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
         }
       }
+      // THE ADJACENCY THIS CUT CREATED. A separate door owns "what should i eat THIS WEEK", and the
+      // recogniser above now matches the bare phrase inside that longer one. Only pipeline order
+      // keeps them apart — early-commands runs before misc — so the ordering is graded, not assumed.
+      for (const ask of ["what should I eat this week", "what should i eat this week"]) {
+        const r = await answered(ask);
+        if (isMealSuggestion(r)) {
+          failures.push(`A week-long plan request was claimed by the next-meal owner: "${ask}" -> "${r.replace(/\n/g, " ").slice(0, 80)}"`);
+        }
+      }
     }
   }
 

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -942,7 +942,7 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
   }
 
   // ---- PERSONALISED MEAL PLAN — built from actual user profile + recent food logs ----
-  // Triggers: "meal plan", "my meal plan", "give me a meal plan", "what should I eat",
+  // Triggers: "meal plan", "my meal plan", "give me a meal plan",
   //           "eating plan", "diet plan", "weekly meals"
   // Generates a static 3-day rotating plan — no GPT, instant, personalised.
   // ONE MEAL IS NOT A PLAN (2026-08-06 sweep). "what should I eat for lunch" matched the bare

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -953,15 +953,27 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
   const asksAboutOneMeal =
     /\b(lunch|breakfast|supper|dinner|brunch|snack)\b/i.test(m)
     && !/\b(meal|eating|diet|food|nutrition)\s*plan\b/i.test(m);
+  // "WHAT SHOULD I EAT" IS A PLATE-ASK, NOT A PLAN REQUEST (2026-08-27, live trace).
+  //
+  // Every other term in both lists below names a plan — meal plan, eating plan, diet plan, weekly
+  // meals, nutrition plan. "What should I eat" named none, and this door runs ~9 handlers earlier
+  // than the one that owns the question, so two ways of asking the SAME thing split in two:
+  //
+  //     "what can I eat?"    -> Next Meal Suggestion, against today's remaining calories
+  //     "what should I eat?" -> a 3-day meal plan with a weekly grocery budget
+  //
+  // Same customer meaning, two mouths. The plan door stands down for the bare plate-ask and keeps
+  // every phrasing that actually asks for a plan; "meal plan" and friends are untouched, and
+  // asksAboutOneMeal above still routes "what should I eat for lunch" exactly as it did.
   const isMealPlanRequest = !asksAboutOneMeal && (
     ["meal plan", "my meal plan", "mealplan", "eating plan", "diet plan", "weekly meals",
-      "what should i eat", "give me a meal plan", "i need a meal plan", "i want a meal plan",
+      "give me a meal plan", "i need a meal plan", "i want a meal plan",
       "food plan", "my food plan", "weekly meal plan",
       // "Nutrition side?" asked right after a workout got the WORKOUT re-sent
       // (2026-07-05 audit) — the eating half of the plan had no aliases here.
       "nutrition side", "nutrition side?", "nutrition plan", "my nutrition plan",
       "food side", "food side?", "eating side", "eating side?", "nutrition?"].includes(m)
-    || /\b(give me a meal plan|my meal plan|send.*meal plan|meal plan please|eating plan|what should i eat|i need a meal plan|diet plan|weekly meals|nutrition (side|plan))\b/i.test(m)
+    || /\b(give me a meal plan|my meal plan|send.*meal plan|meal plan please|eating plan|i need a meal plan|diet plan|weekly meals|nutrition (side|plan))\b/i.test(m)
   );
   if (isMealPlanRequest) {
     // Fetch last 7 days of meal logs to surface recently eaten foods

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -299,7 +299,10 @@ export async function handleMiscCommands(ctx: {
   // branch correctly stopped claiming it. Stopping the wrong claimant is only half the fix — the
   // right one has to take the turn. Same request verbs as the guard in early-commands, so the two
   // doors agree on what a meal request looks like.
-  if (/\b(what should i eat next|next meal|(?:suggest|give|send|show|recommend)(?:\s+me)?\s*a?n?\s*meal|what.?s? next|what to eat now|what can i eat|what must i eat|hungry|starving|i.?m hungry|what now)\b/i.test(m) && !/\b(breakfast|lunch|dinner|supper|braai|social)\b/i.test(m)) {
+  // `what should i eat` (not `...next`): the bare form is the SAME plate-ask as "what can I eat",
+  // which this door already owns. Requiring the suffix is what sent it to the meal-plan door
+  // instead (2026-08-27). Dropping one word covers both, and adds no new vocabulary.
+  if (/\b(what should i eat|next meal|(?:suggest|give|send|show|recommend)(?:\s+me)?\s*a?n?\s*meal|what.?s? next|what to eat now|what can i eat|what must i eat|hungry|starving|i.?m hungry|what now)\b/i.test(m) && !/\b(breakfast|lunch|dinner|supper|braai|social)\b/i.test(m)) {
     const todayStr = sastToday();
     const todayCals = user.todayCaloriesDate === todayStr ? (user.todayCalories || 0) : 0;
     const todayProt = user.todayCaloriesDate === todayStr ? (user.todayProteinG || 0) : 0;


### PR DESCRIPTION
## The customer failure

Traced through `handleMessage` on main `6d6b92f`. Two phrasings of one question, two mouths:

| message | answer |
|---|---|
| `"what can I eat?"` | 🍽️ Next Meal Suggestion, against today's remaining calories |
| `"what should I eat?"` | *Your 3-Day Meal Plan* — with a weekly grocery budget |

## The mechanism

The same shape as the meal-for-calories defect (#81): a door **~9 handlers earlier** in the pipeline claimed it first.

`early-commands.ts:956` builds `isMealPlanRequest` from an exact-match list and a regex. Every term in both names a plan — *meal plan, eating plan, diet plan, weekly meals, nutrition plan* — except one, which names no plan at all: `"what should i eat"`. Meanwhile the door that owns the plate-ask listed only `what should i eat next`, so the bare form matched nothing there and fell through to the plan door.

## The correction

**Two subtractions. No new vocabulary.**

1. The plan door drops `"what should i eat"` from both its exact-match list and its regex, standing down for the bare plate-ask while keeping every phrasing that actually requests a plan.
2. The owner's recogniser drops a `next` suffix it never needed — `what should i eat next` → `what should i eat` — so the bare and suffixed forms are one case.

This serves the invariant directly rather than accreting synonyms: **same customer meaning → same claimant → same decision owner.**

## After

```
"what can I eat?"         -> 🍽️ Next Meal Suggestion — "You need 100g more protein today"
"what should I eat?"      -> identical
"what should i eat"       -> identical
"what should I eat next?" -> identical
"I'm hungry"              -> identical

"give me a meal plan"     -> *Your 3-Day Meal Plan*
"send me a meal plan"     -> *Your 3-Day Meal Plan*
"my meal plan"            -> *Your 3-Day Meal Plan*
"eating plan"             -> *Your 3-Day Meal Plan*
```

They agree on the **content**, not merely the claimant — the converged answer is computed against the client's real remaining protein.

## Controls — four, each failing independently

| control | result |
|---|---|
| restore the term to the plan **regex** | **RED** — `"what should I eat?"` splits back to the meal plan |
| restore it to the **exact-match list** | **RED** — the *unpunctuated* form splits back |
| restore the `next` suffix on the owner | **RED** — the bare form leaves the owner |
| gut the plan vocabulary instead | **RED** — `"eating plan"` loses its answer entirely |

That fourth control is the one that matters most: a "fix" that simply deleted the plan door's vocabulary would satisfy the convergence assertions and cost every client their meal plan.

**The unpunctuated form is graded separately on purpose.** The plan door's exact-match list is checked with `.includes(m)`, which `"what should I eat?"` can never hit and `"what should i eat"` hits exactly. Grading only the question-mark form left half the claimant untested — the first control run passed for that reason, and the phrasing was added rather than the control dropped.

## Found unchanged, NOT fixed here

`"what should I eat for lunch"` (and `"…for dinner"`) reach the food door's clarify prompt: *"Got it — you ate something. Tell me the items in one line…"*.

**Verified identical on unmodified main before this change** — both files reverted to `HEAD`, same phrasings, same output. The existing `asksAboutOneMeal` guard already excluded meal-named phrasings from the plan door, and the `breakfast|lunch|dinner` guard already excluded them from the next-meal owner. Pre-existing, not caused by this cut, and its own cut.

## Suite state

```
✓ tracking-contract-tests
suites: 32/35 green, 1 covered nothing in 102s
ownership: OK — one owner per declared question, one reader per declared fact
```

Governors, unchanged from main `6d6b92f`:

```
messageDeciders 32/31 · looksLikePredicates 21/20 · authorshipPoints 425/420
gpt.ts 1476 · food-context.ts 1484 · media.ts 1560 · routes.ts 1501 · utils.ts 1386
```

No budget raised, no suppression, no new module. Net **−2 lines** of vocabulary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_