### PR TITLE
Coach Health: the adjudicated failures, counted from turns we already record

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -378,10 +378,14 @@ interface CoachHealthPayload {
   turns: number;
   flagged: number;
   unresolved: number;
+  historical: number;
+  attribution: string;
   clusters: Array<{
     id: string; label: string; layer: string; fixRef: string; expected: string;
-    occurrences: number; clients: number; asked: number;
+    fixedAt: string; trigger: "request" | "mutation";
+    occurrences: number; historical: number; clients: number; candidates: number;
     examples: Array<{ turnId: string; at: string; version: string | null; input: string; reply: string; status: string | null }>;
+    historicalExamples: Array<{ turnId: string; at: string; version: string | null; input: string; reply: string; status: string | null }>;
   }>;
   cannotSurface: Array<{ id: string; fixRef: string; why: string }>;
 }
@@ -415,8 +419,8 @@ function CoachHealth() {
         <div>
           <h3 className="text-xl font-bold font-display">🩺 Coach Health</h3>
           <p className="text-sm text-muted-foreground mt-1">
-            {data.turns.toLocaleString()} turns · {data.flagged} flagged · {data.unresolved} pattern
-            {data.unresolved === 1 ? "" : "s"} recurring
+            {data.turns.toLocaleString()} turns · {data.flagged} regression
+            {data.flagged === 1 ? "" : "s"} since fix · {data.historical} historical
           </p>
         </div>
         <div className="flex gap-1">
@@ -435,8 +439,9 @@ function CoachHealth() {
 
       {data.flagged === 0 && (
         <div className="text-sm text-muted-foreground mb-4 p-3 rounded-md bg-muted/40">
-          No adjudicated failure recurred in this window. Rules showing <strong>0 asked</strong> below
-          were not exercised at all — that is untested, not proven healthy.
+          No adjudicated failure has recurred since its fix merged. A rule whose denominator is
+          <strong> 0</strong> below was not exercised at all in this window — that is untested,
+          not proven healthy.
         </div>
       )}
 
@@ -459,7 +464,11 @@ function CoachHealth() {
                   {c.occurrences}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                  of {c.asked} asked{c.clients > 0 ? ` · ${c.clients} client${c.clients === 1 ? "" : "s"}` : ""}
+                  {c.trigger === "request"
+                    ? `of ${c.candidates} matching request${c.candidates === 1 ? "" : "s"}`
+                    : `${c.candidates} turn${c.candidates === 1 ? "" : "s"} scanned`}
+                  {c.clients > 0 ? ` · ${c.clients} client${c.clients === 1 ? "" : "s"}` : ""}
+                  {c.historical > 0 ? ` · ${c.historical} before the fix` : ""}
                 </span>
               </div>
             </button>
@@ -467,11 +476,15 @@ function CoachHealth() {
             {open === c.id && (
               <div className="border-t p-3 bg-muted/20 text-sm space-y-3">
                 <p className="text-muted-foreground">Expected: {c.expected}</p>
+                <p className="text-muted-foreground text-xs">
+                  Fixed {new Date(c.fixedAt).toLocaleString("en-ZA")} ({c.fixRef}). Turns before that
+                  are the failure we corrected, not a regression — they are counted separately.
+                </p>
                 {c.examples.length === 0 ? (
                   <p className="text-muted-foreground italic">
-                    {c.asked === 0
-                      ? "Not exercised in this window — no client asked this."
-                      : "Asked, and answered correctly every time in this window."}
+                    {c.candidates === 0
+                      ? "Not exercised in this window — nothing matched this rule at all."
+                      : "Exercised, and answered correctly every time since the fix."}
                   </p>
                 ) : c.examples.map(ex => (
                   <div key={ex.turnId} className="border rounded p-2 bg-background">

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -141,6 +141,9 @@ export default function Dashboard() {
           />
         </div>
 
+        {/* Coach Health — adjudicated failures, counted from the turns we already record */}
+        <CoachHealth />
+
         {/* Scaling Radar — milestone playbook with approach alerts */}
         <ScalingRadar />
 
@@ -351,6 +354,155 @@ function DashboardLoading() {
             </div>
         </DashboardLayout>
     )
+}
+
+// ── Coach Health ────────────────────────────────────────────────────────────────
+// THE FOUNDER STOPS BEING THE SENSOR (2026-08-27).
+//
+// Every defect this product has fixed arrived the same way: Kam saw it on his own phone,
+// screenshotted it, and explained it. That makes one person's attention the limit of what the
+// product can discover about itself. turn_ledger has recorded the mechanism of every turn since
+// 2026-08-10 and the triage page could already read it — but only a HUMAN verdict put a turn in
+// the queue, so nothing was ever found that nobody looked at.
+//
+// This section counts the failures we have ALREADY adjudicated, against real turns. No model
+// judges anything: each rule is the same property its cut's contract test asserts, pointed at
+// production instead of a fixture. A non-zero count is therefore not a new discovery — it is a
+// merged fix that is not holding, which is the more valuable signal.
+//
+// ASKED is shown next to FAILED on purpose. A rule at 0/0 has not been exercised in this window,
+// which is a different statement from "this failure is not happening", and the difference is
+// exactly where a dashboard starts lying. Data: /api/admin/coach-health.
+interface CoachHealthPayload {
+  windowDays: number;
+  turns: number;
+  flagged: number;
+  unresolved: number;
+  clusters: Array<{
+    id: string; label: string; layer: string; fixRef: string; expected: string;
+    occurrences: number; clients: number; asked: number;
+    examples: Array<{ turnId: string; at: string; version: string | null; input: string; reply: string; status: string | null }>;
+  }>;
+  cannotSurface: Array<{ id: string; fixRef: string; why: string }>;
+}
+
+const LAYER_CHIP: Record<string, string> = {
+  Claim: "bg-amber-100 text-amber-700 border-amber-200",
+  Decision: "bg-blue-100 text-blue-700 border-blue-200",
+  Response: "bg-violet-100 text-violet-700 border-violet-200",
+  Coaching: "bg-emerald-100 text-emerald-700 border-emerald-200",
+};
+
+function CoachHealth() {
+  const [open, setOpen] = useState<string | null>(null);
+  const [days, setDays] = useState(1);
+  const { data } = useQuery({
+    queryKey: ["/api/admin/coach-health", days],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/coach-health?days=${days}`, { headers: authHeaders() });
+      if (!res.ok) return null;
+      return res.json() as Promise<CoachHealthPayload>;
+    },
+    refetchInterval: 5 * 60_000,
+    retry: false,
+  });
+
+  if (!data) return null;
+
+  return (
+    <Card className="p-6 border-border/50">
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-5">
+        <div>
+          <h3 className="text-xl font-bold font-display">🩺 Coach Health</h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            {data.turns.toLocaleString()} turns · {data.flagged} flagged · {data.unresolved} pattern
+            {data.unresolved === 1 ? "" : "s"} recurring
+          </p>
+        </div>
+        <div className="flex gap-1">
+          {[1, 7, 30].map(d => (
+            <Button
+              key={d}
+              variant={days === d ? "default" : "outline"}
+              size="sm"
+              onClick={() => setDays(d)}
+            >
+              {d === 1 ? "Today" : `${d}d`}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {data.flagged === 0 && (
+        <div className="text-sm text-muted-foreground mb-4 p-3 rounded-md bg-muted/40">
+          No adjudicated failure recurred in this window. Rules showing <strong>0 asked</strong> below
+          were not exercised at all — that is untested, not proven healthy.
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {data.clusters.map(c => (
+          <div key={c.id} className="border rounded-lg overflow-hidden">
+            <button
+              className="w-full flex items-center justify-between gap-3 p-3 text-left hover:bg-muted/40"
+              onClick={() => setOpen(open === c.id ? null : c.id)}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className={`text-xs px-2 py-0.5 rounded border ${LAYER_CHIP[c.layer] || ""}`}>
+                  {c.layer}
+                </span>
+                <span className="font-medium truncate">{c.label}</span>
+                <span className="text-xs text-muted-foreground shrink-0">{c.fixRef}</span>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className={`text-sm font-bold ${c.occurrences > 0 ? "text-rose-600" : "text-muted-foreground"}`}>
+                  {c.occurrences}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  of {c.asked} asked{c.clients > 0 ? ` · ${c.clients} client${c.clients === 1 ? "" : "s"}` : ""}
+                </span>
+              </div>
+            </button>
+
+            {open === c.id && (
+              <div className="border-t p-3 bg-muted/20 text-sm space-y-3">
+                <p className="text-muted-foreground">Expected: {c.expected}</p>
+                {c.examples.length === 0 ? (
+                  <p className="text-muted-foreground italic">
+                    {c.asked === 0
+                      ? "Not exercised in this window — no client asked this."
+                      : "Asked, and answered correctly every time in this window."}
+                  </p>
+                ) : c.examples.map(ex => (
+                  <div key={ex.turnId} className="border rounded p-2 bg-background">
+                    <div className="text-xs text-muted-foreground mb-1">
+                      {new Date(ex.at).toLocaleString("en-ZA")} · build {ex.version || "?"}
+                      {ex.status ? ` · ${ex.status}` : ""}
+                    </div>
+                    <div className="font-mono text-xs">“{ex.input}”</div>
+                    <div className="font-mono text-xs text-rose-700 mt-1">→ {ex.reply}</div>
+                    <a
+                      className="text-xs text-blue-600 hover:underline mt-1 inline-block"
+                      href={`/admin/turns?turn=${ex.turnId}`}
+                    >
+                      Open the turn →
+                    </a>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {data.cannotSurface.length > 0 && (
+        <div className="mt-4 pt-3 border-t text-xs text-muted-foreground">
+          <strong>Not measurable here:</strong>{" "}
+          {data.cannotSurface.map(c => `${c.fixRef} — ${c.why}`).join(" · ")}
+        </div>
+      )}
+    </Card>
+  );
 }
 
 // ── Scaling Radar ───────────────────────────────────────────────────────────────

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -652,7 +652,34 @@ const MUST_WRITE: [string, string][] = [
    * real output rather than from a sentence describing it.
    */
   {
-    const { COACH_HEALTH_RULES } = await import("../server/routes/admin-turns");
+    const { COACH_HEALTH_RULES, isRegression } = await import("../server/routes/admin-turns");
+
+    /**
+     * A HIT FROM BEFORE THE FIX IS NOT A REGRESSION (2026-08-27, CTO review).
+     *
+     * The first version scanned a 1/7/30-day window and counted every match, so a turn from before
+     * the fix merged — the old behaviour doing exactly what we found it doing — was reported as
+     * "a merged fix is not holding". The count meant the opposite of what the page said. Every
+     * rule's merge instant is graded from both sides, one second apart, so the boundary itself is
+     * the thing under test rather than a comfortable distance either way.
+     */
+    for (const rule of COACH_HEALTH_RULES) {
+      const merged = Date.parse(rule.fixedAt);
+      if (!Number.isFinite(merged)) {
+        failures.push(`Coach Health rule "${rule.id}" has no usable fixedAt ("${rule.fixedAt}") — every hit would be attributed to the wrong side of its fix`);
+        continue;
+      }
+      if (isRegression(rule, new Date(merged - 1000))) {
+        failures.push(`Coach Health counts a PRE-fix turn as a regression for "${rule.id}" — the page would report a fix as not holding using the evidence that justified it`);
+      }
+      if (!isRegression(rule, new Date(merged + 1000))) {
+        failures.push(`Coach Health does not count a POST-fix turn as a regression for "${rule.id}" — a genuine recurrence would be filed as history and never surface`);
+      }
+      // The denominator label is chosen from this, so a wrong value is a false operator statistic.
+      if (rule.trigger !== "request" && rule.trigger !== "mutation") {
+        failures.push(`Coach Health rule "${rule.id}" has no trigger kind — its denominator cannot be labelled honestly`);
+      }
+    }
     const check = (id: string, input: string, reply: string, mutations: string[] = []) => {
       const rule = COACH_HEALTH_RULES.find(r => r.id === id);
       if (!rule) { failures.push(`Coach Health lost the rule "${id}" — the dashboard now watches one fewer adjudicated failure`); return null; }

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -640,6 +640,51 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * COACH HEALTH MUST DETECT THE FAILURES IT CLAIMS TO WATCH (2026-08-27).
+   *
+   * The dashboard's rules are the only thing standing between "we measure our adjudicated failures
+   * in production" and a page of comforting zeros. A rule that matches nothing reports a healthy
+   * product forever, and it fails in the safest-looking direction — which is exactly the shape of
+   * defect this suite exists for.
+   *
+   * So the rules are graded against the STRINGS ACTUALLY OBSERVED in the traces that justified
+   * each cut: the pre-fix reply must flag, and the post-fix reply must not. Both directions, from
+   * real output rather than from a sentence describing it.
+   */
+  {
+    const { COACH_HEALTH_RULES } = await import("../server/routes/admin-turns");
+    const check = (id: string, input: string, reply: string, mutations: string[] = []) => {
+      const rule = COACH_HEALTH_RULES.find(r => r.id === id);
+      if (!rule) { failures.push(`Coach Health lost the rule "${id}" — the dashboard now watches one fewer adjudicated failure`); return null; }
+      return rule.asks(input) && rule.failed({ reply, mutations });
+    };
+    // [message, pre-fix reply that MUST flag, post-fix reply that must NOT, mutations]
+    const OBSERVED: Array<[string, string, string, string, string[]]> = [
+      ["plate-ask-routing", "what should I eat?",
+        "*Your 3-Day Meal Plan*\nGoal: Fat loss · 2700 kcal/day · 180g protein\nBudget: R100–R300/week",
+        "*🍽️ Next Meal Suggestion — Kam*\n\nYou need *100g more protein* today. That is the priority.", []],
+      ["goal-distance-missing", "How far am I from my goal?",
+        "Kam — Scale: down 6.0kg since you started. This week: 0/3 sessions.\n\nThat's the distance. The next move is still one thing.",
+        "Kam — 7.0kg to go: 92kg now, 85kg the goal. Scale: down 6.0kg since you started.", []],
+      ["meal-for-calories-claim", "Give me a meal for my last 668 calories",
+        "Kam, today: *2000/2700 kcal* · *200g/180g* protein. *700 kcal* left.",
+        "*🍽️ Next Meal Suggestion — Kam*\n\nYou need *100g more protein* today.", []],
+      ["step-raise-no-move", "I walked 8500 steps today",
+        "8 500 steps — nice one. 👌",
+        "8 500 steps — nice one. 👌\n\nStand on a scale this morning, before you eat.",
+        ["UPDATE steps=8500 (was 3000)"]],
+    ];
+    for (const [id, input, broken, fixed, mutations] of OBSERVED) {
+      if (check(id, input, broken, mutations) === false) {
+        failures.push(`Coach Health would not have caught the failure it was built from — rule "${id}" passed the observed pre-fix reply: "${broken.replace(/\n/g, " ⏎ ")}"`);
+      }
+      if (check(id, input, fixed, mutations) === true) {
+        failures.push(`Coach Health flags the FIXED reply as a failure — rule "${id}" would report a permanent false positive: "${fixed.replace(/\n/g, " ⏎ ")}"`);
+      }
+    }
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/server/routes/admin-turns.ts
+++ b/server/routes/admin-turns.ts
@@ -136,7 +136,161 @@ export async function purgeExpiredTurns(): Promise<number> {
   }
 }
 
+/**
+ * COACH HEALTH — the adjudicated failures, counted automatically (2026-08-27).
+ *
+ * THE PROBLEM THIS SOLVES. Every failure this project has fixed arrived the same way: the founder
+ * noticed it on his own phone, screenshotted it, and described it. That makes one person the
+ * sensor for the whole product, and it means a failure is only ever as discoverable as his
+ * attention. turn_ledger has been recording the mechanism of every turn since 2026-08-10, and the
+ * triage surface above can already read it — but only a HUMAN verdict (failure_category) puts a
+ * turn in the queue, so nothing is found that nobody looked at.
+ *
+ * WHAT THESE RULES ARE, AND ARE NOT. Each one is a failure we already traced, implemented, proved
+ * with controls, and merged. They are not invented categories and there is no model judging
+ * anything: a rule names a customer meaning as a pattern over the client's own words, and the
+ * property the reply had to have. That is exactly what each cut's contract test asserts — the
+ * same rule, pointed at production instead of a fixture.
+ *
+ * WHY IT LIVES HERE. This file is already the reader of turn_ledger, and the architecture governor
+ * counts modules under server/: a new file for four regexes would be a new architectural failure
+ * to save an import. The rules sit beside the queue they feed.
+ *
+ * A RULE IS ONLY ADDED AFTER ADJUDICATION. Not when a failure is suspected — when it has been
+ * proved, fixed and merged. That keeps the count honest: every row here is a regression watch on
+ * work that is already done, so a non-zero count means the fix is not holding in production.
+ */
+type HealthRule = {
+  id: string;
+  label: string;
+  layer: "Claim" | "Decision" | "Response" | "Coaching";
+  fixRef: string;
+  expected: string;
+  /** Does this turn ask the question the rule is about? Read from the client's own words. */
+  asks: (input: string) => boolean;
+  /** Given it was asked, did the reply fail to carry what was owed? */
+  failed: (turn: { reply: string; mutations: string[] }) => boolean;
+};
+
+const lastBlockIsAMove = (reply: string) => {
+  const blocks = String(reply || "").trim().split(/\n\s*\n/);
+  const last = (blocks[blocks.length - 1] || "").trim();
+  return blocks.length > 1 && !last.includes("?") && !/\[(?:BUTTONS|MEDIA)/i.test(last);
+};
+
+export const COACH_HEALTH_RULES: HealthRule[] = [
+  {
+    id: "plate-ask-routing",
+    label: "Plate-ask reached the meal-plan owner",
+    layer: "Claim", fixRef: "#86",
+    expected: "Next Meal Suggestion, not a 3-day plan",
+    asks: i => /\bwhat (?:can|should|must) i eat\b/i.test(i)
+      && !/\bthis week\b/i.test(i)
+      && !/\b(breakfast|lunch|dinner|supper|braai)\b/i.test(i),
+    failed: t => /3-Day Meal Plan/i.test(t.reply) || !/Next Meal Suggestion/i.test(t.reply),
+  },
+  {
+    id: "goal-distance-missing",
+    label: "Distance question answered without the distance",
+    layer: "Response", fixRef: "#85",
+    expected: "kg to go, and the goal weight",
+    asks: i => /\bhow far (?:am i|are we) (?:from|to)\b/i.test(i) && /\b(goal|target)\b/i.test(i),
+    failed: t => !/\bto (?:go|gain)\b|at your goal weight/i.test(t.reply),
+  },
+  {
+    id: "meal-for-calories-claim",
+    label: "Meal request answered with a calorie readout",
+    layer: "Claim", fixRef: "#81",
+    expected: "a meal, not the day's totals",
+    asks: i => /\b(?:give|send|show|suggest|recommend)\s+(?:me\s+)?(?:a|an|another|the)?\s*meal\b/i.test(i),
+    failed: t => !/Next Meal Suggestion/i.test(t.reply) && /kcal\b.*\bleft\b|\d+\s*\/\s*\d+\s*kcal/i.test(t.reply),
+  },
+  {
+    id: "step-raise-no-move",
+    label: "Step raise ended in a receipt, no next move",
+    layer: "Coaching", fixRef: "#84",
+    expected: "one coaching move after the write",
+    asks: () => true,   // decided by the WRITE, not the wording — see below
+    failed: t => t.mutations.some(mm => /UPDATE steps/i.test(mm)) && !lastBlockIsAMove(t.reply),
+  },
+];
+
+/**
+ * WHAT THIS CANNOT SEE, stated here rather than discovered later.
+ *
+ * The closed-day card contradiction (#83) is NOT in the list above and cannot be. Its failure is
+ * a line of text rendered into a PNG, and turn_ledger stores the marker, not the pixels. A rule
+ * that matched on the marker would count cards, not contradictions — a number that looks like
+ * evidence and is not. It stays a contract-suite property until the card's next-move line is
+ * recorded on the turn.
+ *
+ * The step-raise rule is also the one to read carefully: it is triggered by the MUTATION, not by
+ * the client's words, so `asks` is unconditional and the whole judgement sits in `failed`. That
+ * is correct for a coaching-contract rule and wrong for a claim rule, which is why the two kinds
+ * are not merged into one shape.
+ */
+const CANNOT_SURFACE = [
+  { id: "closed-day-card", fixRef: "#83", why: "the card's next-move line is rendered into a PNG; the ledger stores the marker, not the pixels" },
+];
+
 export function registerAdminTurns(app: Express) {
+  // ── COACH HEALTH ────────────────────────────────────────────────────────────────────────────
+  // Rule-based, no model, no new telemetry: it reads the turns the ledger already holds.
+  app.get("/api/admin/coach-health", requireAdminKey, async (req: any, res) => {
+    try {
+      const days = Math.min(30, Math.max(1, parseInt(String(req.query.days || "1"))));
+      const since = new Date(Date.now() - days * 86_400_000);
+      const rows = await db.select({
+        id: turnLedger.id, userId: turnLedger.userId, createdAt: turnLedger.createdAt,
+        inputText: turnLedger.inputText, reply: turnLedger.reply,
+        mutations: turnLedger.mutations, version: turnLedger.version,
+        lifecycleStatus: turnLedger.lifecycleStatus,
+      })
+        .from(turnLedger)
+        .where(gte(turnLedger.createdAt, since))
+        .orderBy(desc(turnLedger.createdAt))
+        .limit(5000);
+
+      const clusters = COACH_HEALTH_RULES.map(rule => {
+        const hits = rows.filter(r => {
+          const input = String(r.inputText || "");
+          const muts = Array.isArray(r.mutations) ? (r.mutations as string[]).map(String) : [];
+          if (!rule.asks(input)) return false;
+          return rule.failed({ reply: String(r.reply || ""), mutations: muts });
+        });
+        // ASKED vs FAILED, both reported. A rule with 0 failures and 0 asks is untested in
+        // production, which is a different statement from "this failure is not happening".
+        const asked = rows.filter(r => rule.asks(String(r.inputText || ""))).length;
+        return {
+          id: rule.id, label: rule.label, layer: rule.layer, fixRef: rule.fixRef,
+          expected: rule.expected,
+          occurrences: hits.length,
+          clients: new Set(hits.map(h => h.userId)).size,
+          asked,
+          examples: hits.slice(0, 5).map(h => ({
+            turnId: h.id, at: h.createdAt, version: h.version,
+            input: String(h.inputText || "").slice(0, 140),
+            reply: String(h.reply || "").replace(/\n/g, " ").slice(0, 160),
+            status: h.lifecycleStatus,
+          })),
+        };
+      }).sort((a, b) => b.occurrences - a.occurrences);
+
+      await auditRead("coach_health", { days, turns: rows.length });
+      res.json({
+        windowDays: days,
+        turns: rows.length,
+        flagged: clusters.reduce((s, c) => s + c.occurrences, 0),
+        unresolved: clusters.filter(c => c.occurrences > 0).length,
+        clusters,
+        cannotSurface: CANNOT_SURFACE,
+      });
+    } catch (e: any) {
+      console.error("[COACH_HEALTH] failed:", e?.message);
+      res.status(500).json({ message: "Failed to load coach health" });
+    }
+  });
+
   // ── THE LIST ────────────────────────────────────────────────────────────────────────────────
   app.get("/api/admin/turns", requireAdminKey, async (req: any, res) => {
     try {

--- a/server/routes/admin-turns.ts
+++ b/server/routes/admin-turns.ts
@@ -166,6 +166,23 @@ type HealthRule = {
   layer: "Claim" | "Decision" | "Response" | "Coaching";
   fixRef: string;
   expected: string;
+  /**
+   * WHEN THE FIX LANDED ON MAIN — the commit date of the squash merge, not an estimate.
+   *
+   * A COUNT WITHOUT THIS IS A LIE (2026-08-27, CTO review of the first version). The page said a
+   * non-zero count meant "a merged fix is not holding in production". It scanned a 1/7/30-day
+   * window and applied each rule to every row in it, so a turn from BEFORE the fix merged — where
+   * the failure is the expected, already-corrected behaviour — was counted exactly the same as a
+   * genuine regression. "7 failures" could have been seven turns that the fix has since repaired.
+   */
+  fixedAt: string;
+  /**
+   * WHAT PUTS A TURN IN THE DENOMINATOR. A `request` rule is triggered by the client's words, so
+   * the denominator is how many people asked. A `mutation` rule is triggered by what the turn
+   * WROTE, so every scanned turn is a candidate and calling them "asked" would be a false
+   * operator statistic — 88 turns scanned is not 88 people asking for anything.
+   */
+  trigger: "request" | "mutation";
   /** Does this turn ask the question the rule is about? Read from the client's own words. */
   asks: (input: string) => boolean;
   /** Given it was asked, did the reply fail to carry what was owed? */
@@ -178,11 +195,24 @@ const lastBlockIsAMove = (reply: string) => {
   return blocks.length > 1 && !last.includes("?") && !/\[(?:BUTTONS|MEDIA)/i.test(last);
 };
 
+/**
+ * IS THIS HIT A REGRESSION, OR THE FAILURE WE ALREADY FIXED?
+ *
+ * Exported because it is the property the whole page rests on: a turn from before the fix merged
+ * is the old behaviour doing exactly what we found it doing, and counting it as "the fix is not
+ * holding" would make the number mean the opposite of what the page says. Graded in the contract
+ * suite against both sides of each fix's merge instant.
+ */
+export function isRegression(rule: Pick<HealthRule, "fixedAt">, turnAt: Date | string | number): boolean {
+  return new Date(turnAt).getTime() >= Date.parse(rule.fixedAt);
+}
+
 export const COACH_HEALTH_RULES: HealthRule[] = [
   {
     id: "plate-ask-routing",
     label: "Plate-ask reached the meal-plan owner",
     layer: "Claim", fixRef: "#86",
+    fixedAt: "2026-08-27T12:14:47+02:00", trigger: "request",
     expected: "Next Meal Suggestion, not a 3-day plan",
     asks: i => /\bwhat (?:can|should|must) i eat\b/i.test(i)
       && !/\bthis week\b/i.test(i)
@@ -193,6 +223,7 @@ export const COACH_HEALTH_RULES: HealthRule[] = [
     id: "goal-distance-missing",
     label: "Distance question answered without the distance",
     layer: "Response", fixRef: "#85",
+    fixedAt: "2026-08-27T11:03:23+02:00", trigger: "request",
     expected: "kg to go, and the goal weight",
     asks: i => /\bhow far (?:am i|are we) (?:from|to)\b/i.test(i) && /\b(goal|target)\b/i.test(i),
     failed: t => !/\bto (?:go|gain)\b|at your goal weight/i.test(t.reply),
@@ -201,6 +232,7 @@ export const COACH_HEALTH_RULES: HealthRule[] = [
     id: "meal-for-calories-claim",
     label: "Meal request answered with a calorie readout",
     layer: "Claim", fixRef: "#81",
+    fixedAt: "2026-08-27T09:19:40+02:00", trigger: "request",
     expected: "a meal, not the day's totals",
     asks: i => /\b(?:give|send|show|suggest|recommend)\s+(?:me\s+)?(?:a|an|another|the)?\s*meal\b/i.test(i),
     failed: t => !/Next Meal Suggestion/i.test(t.reply) && /kcal\b.*\bleft\b|\d+\s*\/\s*\d+\s*kcal/i.test(t.reply),
@@ -209,6 +241,7 @@ export const COACH_HEALTH_RULES: HealthRule[] = [
     id: "step-raise-no-move",
     label: "Step raise ended in a receipt, no next move",
     layer: "Coaching", fixRef: "#84",
+    fixedAt: "2026-08-27T10:37:40+02:00", trigger: "mutation",
     expected: "one coaching move after the write",
     asks: () => true,   // decided by the WRITE, not the wording — see below
     failed: t => t.mutations.some(mm => /UPDATE steps/i.test(mm)) && !lastBlockIsAMove(t.reply),
@@ -258,16 +291,31 @@ export function registerAdminTurns(app: Express) {
           if (!rule.asks(input)) return false;
           return rule.failed({ reply: String(r.reply || ""), mutations: muts });
         });
-        // ASKED vs FAILED, both reported. A rule with 0 failures and 0 asks is untested in
-        // production, which is a different statement from "this failure is not happening".
-        const asked = rows.filter(r => rule.asks(String(r.inputText || ""))).length;
+        // BEFORE THE FIX IS NOT A REGRESSION. A hit older than the merge is the failure behaving
+        // exactly as it did when we found it — evidence the cut was real, not evidence it is
+        // broken now. Only the after bucket may be called a regression, and the two are never summed.
+        const after = hits.filter(h => isRegression(rule, h.createdAt as any));
+        const before = hits.filter(h => !isRegression(rule, h.createdAt as any));
+        // THE DENOMINATOR MEANS DIFFERENT THINGS FOR THE TWO TRIGGERS, so it is not one number
+        // wearing one label: a request rule counts people who asked, a mutation rule counts turns
+        // scanned. Calling 88 scanned turns "88 asked" would be a false operator statistic.
+        const candidates = rule.trigger === "request"
+          ? rows.filter(r => rule.asks(String(r.inputText || ""))).length
+          : rows.length;
         return {
           id: rule.id, label: rule.label, layer: rule.layer, fixRef: rule.fixRef,
-          expected: rule.expected,
-          occurrences: hits.length,
-          clients: new Set(hits.map(h => h.userId)).size,
-          asked,
-          examples: hits.slice(0, 5).map(h => ({
+          expected: rule.expected, fixedAt: rule.fixedAt, trigger: rule.trigger,
+          occurrences: after.length,
+          historical: before.length,
+          clients: new Set(after.map(h => h.userId)).size,
+          candidates,
+          examples: after.slice(0, 5).map(h => ({
+            turnId: h.id, at: h.createdAt, version: h.version,
+            input: String(h.inputText || "").slice(0, 140),
+            reply: String(h.reply || "").replace(/\n/g, " ").slice(0, 160),
+            status: h.lifecycleStatus,
+          })),
+          historicalExamples: before.slice(0, 3).map(h => ({
             turnId: h.id, at: h.createdAt, version: h.version,
             input: String(h.inputText || "").slice(0, 140),
             reply: String(h.reply || "").replace(/\n/g, " ").slice(0, 160),
@@ -281,9 +329,17 @@ export function registerAdminTurns(app: Express) {
         windowDays: days,
         turns: rows.length,
         flagged: clusters.reduce((s, c) => s + c.occurrences, 0),
+        historical: clusters.reduce((s, c) => s + c.historical, 0),
         unresolved: clusters.filter(c => c.occurrences > 0).length,
         clusters,
         cannotSurface: CANNOT_SURFACE,
+        // ATTRIBUTION IS BY MERGE TIME, NOT BY VERIFIED DEPLOYMENT — said in the payload so the
+        // page cannot quietly overstate it. turn_ledger stores the build SHA that served each
+        // turn, but nothing here knows which SHAs contain a given fix: that is git ancestry, and
+        // there is no deployments table to ask. A turn shortly after a merge may still have run
+        // the old build, so a fresh regression should be read against the build on the example
+        // before it is believed. Building that mapping is a separate cut, not a caveat to bury.
+        attribution: "merge-time",
       });
     } catch (e: any) {
       console.error("[COACH_HEALTH] failed:", e?.message);


### PR DESCRIPTION
## The problem

Every defect this product has fixed arrived the same way: the founder saw it on his own phone, screenshotted it, and explained it. That makes one person's attention the limit of what the product can discover about itself.

`turn_ledger` has recorded the mechanism of every turn since 2026-08-10, and `admin-turns.ts` could already read it — but only a **human verdict** (`failure_category`) put a turn in the queue. Nothing was ever found that nobody looked at.

This adds the missing half: **rule-based detection over the turns already stored.**

## What it does

```
GET /api/admin/coach-health?days=N   ->  clusters, counts, clients, examples
client/src/pages/dashboard.tsx       ->  one card, expandable into the turns
```

```
🩺 Coach Health
1,842 turns · 23 flagged · 3 patterns recurring        [Today] [7d] [30d]

[Claim]    Plate-ask reached the meal-plan owner        #86   11  of 47 asked · 8 clients
[Response] Distance question answered without distance  #85    7  of 12 asked · 5 clients
[Coaching] Step raise ended in a receipt, no next move  #84    5  of 88 asked · 4 clients
[Claim]    Meal request answered with a calorie readout #81    0  of 31 asked
```

Expanding a row shows the offending turns — timestamp, build SHA, the client's words, the reply — each linking into the existing `/admin/turns` triage page.

## Four rules, all already adjudicated

No model judges anything. Each rule is the **same property its cut's contract test asserts**, pointed at production instead of a fixture — from #81, #84, #85, #86.

That inverts what a non-zero count means: it is not a new discovery, it is **a merged fix that is not holding in production.**

A rule is added only *after* adjudication — never when a failure is suspected.

## Honest by construction, in two places

**ASKED is shown beside FAILED.** A rule at `0 of 0 asked` was not exercised in the window. That is *untested*, not healthy, and the page says so. This is where a dashboard starts lying.

**#83 is excluded, and the page says why.** The closed-day card contradiction is a line of text rendered into a PNG; the ledger stores the marker, not the pixels. A rule matching the marker would count *cards*, not contradictions — a number that looks like evidence and isn't. It stays a contract-suite property until the card's next-move line is recorded on the turn.

## Proof

Rules are graded against the **strings actually observed in today's traces**: the pre-fix reply must flag, the post-fix reply must not.

| control | result |
|---|---|
| a rule's `asks` never matches | **RED** — would have reported permanent zeros |
| a rule's `failed` always false | **RED** — "healthy" forever |
| a rule deleted from the library | **RED** — names the lost rule |
| a rule flags everything | **RED** — permanent false positive |

The first two are the dangerous direction: **a blind rule fails by looking good.** Both now break the suite.

## Architecture

**No new module.** The governor counts files under `server/` and `shared/` and sits at exactly `239/239`, so a new file is a *new* failure, not a pre-existing one. The rules live in `admin-turns.ts` — already the reader of `turn_ledger` for failure analysis — beside the queue they feed. The UI is under `client/`, which the governor does not count. File is 526/1200 lines.

**No new telemetry, no second dashboard, no new taxonomy.** `failure_category` and `lifecycle_status` remain the human verdict on top.

```
suites: 32/35 green, 1 covered nothing in 144s
ownership: OK — one owner per declared question, one reader per declared fact
RED: check-file-sizes, check-architecture
  messageDeciders 32 · looksLikePredicates 21 · authorshipPoints 425
  gpt.ts 1476 · food-context.ts 1484 · media.ts 1560 · routes.ts 1501 · utils.ts 1386
```

Baseline-equivalent — identical to main `88bd787`.

## Stated limits

**This V1 detects only failures already fixed.** It answers *"are our fixes holding?"*, not *"what else is broken?"*. It will not discover a novel failure class, so the founder remains the sensor for unknown failures until enough turns accumulate for clustering to be worth building.

**The rules read `turn_ledger` only.** `chat_history.intent` holds the claimant stamp and would name the wrong owner directly, but the two tables have no foreign key — they join on `user_id` plus timestamp proximity. V1 expresses every rule over `input_text` / `reply` / `mutations`, which one row already carries, rather than resting counts on a fuzzy join.

**Coupling accepted deliberately:** a rule library naturally wants its own module. That would cost a governor raise, which the repo's own ledger shows requires a written account that no existing owner could hold it — and `admin-turns.ts` is exactly such an owner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_