### PR TITLE
Proactive coaching gets one answer to "may we prescribe?"

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -2895,7 +2895,11 @@ test("sweep: the >7-day client's decision is used, not computed and discarded", 
   assert.ok(/return formatOneAction\(underPolicy\(chooseAction\(\{/.test(morning),
     "a drifting client must not get silence because a ledger read timed out — and the fallback "
     + "must reach the decision owner through the policy contract, not around it");
-  assert.ok(/evidenced: false/.test(morning),
+  // The shape changed on 2026-08-28 when the gate stopped taking a pre-computed verdict and
+  // started taking the evidence itself, so that it and decideProactive reach one answer through
+  // one function. The property this line protects is unchanged: the degraded fallback claims NO
+  // evidence, because the state read is what just failed.
+  assert.ok(/foodSufficient: false, weightSufficient: false/.test(morning),
     "…with evidence stated honestly: the state read is what just failed");
 });
 

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -883,6 +883,43 @@ const MUST_WRITE: [string, string][] = [
         failures.push(`A well-evidenced client was held silent by the gate — it now refuses to coach at all`);
       }
     }
+
+    /**
+     * ILLNESS CONSTRAINS THE LADDER, NOT THE PROSE.
+     *
+     * The distinction the whole cut rests on. If chooseAction could still pick `train` for a sick
+     * client and a wrapper rewrote the sentence afterwards, we would have replaced one
+     * contradiction with a politer one — the decision would still be wrong, and only the words
+     * would agree. Illness is rung 2 of the ladder, ahead of every prescriptive rung, so the
+     * refusal happens where the decision is made.
+     *
+     * Graded from states that DO reach a prescription when healthy, so the assertion cannot pass
+     * because nothing was going to be prescribed anyway.
+     */
+    for (const [label, over] of [
+      ["would train", { workout: { sessionsLast7d: 0, sessionsThisWeek: 0 }, evidence: { foodSufficient: true, weightSufficient: true } }],
+      ["would walk", { steps: { avg7d: 500 }, today: { kcal: 1200, protein: 70, steps: 200, logged: true, hour: 14 }, evidence: { foodSufficient: true, weightSufficient: true } }],
+      ["would protein", { today: { kcal: 1200, protein: 20, steps: 2000, logged: true, hour: 9 }, evidence: { foodSufficient: true, weightSufficient: true } }],
+    ] as [string, any][]) {
+      const healthy = chooseAction(dayStateFrom(stateOf(over), profile, { hour: 9 }));
+      const sick = chooseAction(dayStateFrom(stateOf({ ...over, health: { sick: true } }), profile, { hour: 9 }));
+      if (healthy.kind === "hold" || healthy.kind === "rest") {
+        failures.push(`The "${label}" fixture no longer reaches a prescription when healthy (${healthy.kind}) — the illness assertion below would pass for the wrong reason`);
+      }
+      if (sick.kind !== "rest") {
+        failures.push(`The decision ladder prescribed "${sick.todo}" to a sick client — illness is not constraining the decision, only the wording`);
+      }
+    }
+    // AND THE GATE DOES NOT RE-WORD WHAT THE LADDER DECIDED. Object identity, not string equality:
+    // a gate that rebuilt an equivalent action would be a second author of the same decision.
+    {
+      const s = stateOf({ health: { sick: true } });
+      const raw = chooseAction(dayStateFrom(s, profile, { hour: 9 }));
+      const passed = underPolicy(raw, { foodSufficient: false, weightSufficient: false, dreamGoal: null });
+      if (passed !== raw) {
+        failures.push(`The policy gate returned a different object than the ladder chose — it is re-authoring the decision, not applying a policy to it`);
+      }
+    }
   }
 
   /**

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -812,6 +812,80 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * ONE CLIENT STATE -> ONE PROACTIVE ANSWER (2026-08-28, traced through both policy paths).
+   *
+   * underPolicy and decideProactive both answer "may we prescribe?" and answered it differently.
+   * Measured on ONE state — sick, two of seven days logged, 09:00:
+   *
+   *     decideProactive  ->  rest    "Rest today. No training, no targets."
+   *     underPolicy      ->  hold    "Nothing new today. Do exactly what you did yesterday."
+   *
+   * Telling a sick person to repeat yesterday is the wrong instruction, and it re-broke a finding
+   * one-action.ts already carried: illness is directly observed durable state, sufficient by
+   * construction (2026-08-18). decideProactive knew it; the gate took a bare boolean and could not.
+   *
+   * Graded on the ACTIONS BOTH PATHS PRODUCE from one state, not on the predicate that chooses
+   * them — the two must agree, and the sparse-evidence protection must survive.
+   */
+  {
+    const { chooseAction, underPolicy, decideProactive, dayStateFrom } = await import("../server/one-action");
+    const profile: any = {
+      dreamGoal: null, biggestStruggle: null, doNotMention: null, lifeContext: null,
+      weeksOnProgramme: 5, sessionsTarget: 3, calorieTarget: 2700, proteinTarget: 180, stepsTarget: 10000,
+    };
+    const stateOf = (over: any) => ({
+      name: "Kam", goalType: "fat_loss",
+      health: { sick: false },
+      food: { loggedDays7d: 2, daysSinceAnyLog: 0 },
+      workout: { sessionsLast7d: 1, sessionsThisWeek: 1 },
+      steps: { avg7d: 3000 },
+      weight: { daysSinceWeighIn: 4, trendUsable: false },
+      today: { kcal: 1200, protein: 70, steps: 2000, logged: true, hour: 9 },
+      evidence: { foodSufficient: false, weightSufficient: false },
+      ...over,
+    }) as any;
+    // Both paths, from one state, with the evidence each genuinely holds.
+    const bothPaths = (s: any) => {
+      const proactive = decideProactive(s, profile, { hour: 9 });
+      const reactive = underPolicy(chooseAction(dayStateFrom(s, profile, { hour: 9 })), {
+        foodSufficient: s.evidence.foodSufficient,
+        weightSufficient: s.evidence.weightSufficient,
+        dreamGoal: null,
+      });
+      return { proactive: proactive.action, reactive };
+    };
+
+    // THE DEFECT: illness is its own evidence, and both paths must know it.
+    {
+      const { proactive, reactive } = bothPaths(stateOf({ health: { sick: true } }));
+      if (proactive.kind !== reactive.kind) {
+        failures.push(`Two proactive constitutions disagree on one client: decideProactive says "${proactive.todo}" and underPolicy says "${reactive.todo}"`);
+      }
+      if (reactive.kind !== "rest") {
+        failures.push(`A sick client did not get rest from the reactive gate — it said "${reactive.todo}"`);
+      }
+    }
+
+    // CONTROL — SPARSE EVIDENCE STILL PROTECTS. A thin ledger must not buy a prescription just
+    // because the paths now agree. Agreement is worthless if both agree to over-reach.
+    {
+      const { reactive } = bothPaths(stateOf({}));
+      if (["protein", "walk", "train", "eat_more"].includes(reactive.kind)) {
+        failures.push(`A client with two logged days and no weight trend was prescribed "${reactive.todo}" — sparse evidence stopped protecting`);
+      }
+    }
+
+    // CONTROL — REAL EVIDENCE STILL EARNS AN ANSWER. A gate that holds everything would satisfy
+    // the control above and make the coach mute.
+    {
+      const { reactive } = bothPaths(stateOf({ evidence: { foodSufficient: true, weightSufficient: false } }));
+      if (reactive.kind === "hold") {
+        failures.push(`A well-evidenced client was held silent by the gate — it now refuses to coach at all`);
+      }
+    }
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -685,7 +685,7 @@ export async function handleMiscCommands(ctx: {
         // The CARD is a weekly recap; the ACTION is what to do next, which is a daily question and
         // the only one chooseAction was built to answer. So the numbers stay weekly and the
         // decision context becomes today's — identical semantics to computeNextMove and morning.
-        const { chooseAction, underPolicy } = await import("../one-action");
+        const { chooseAction, underPolicy, PROACTIVE_LOG_FLOOR } = await import("../one-action");
         const { sastHour } = await import("../sast");
         const act = underPolicy(chooseAction({
           goal: (user.goalType as any) || "general", weeksOnProgramme: Math.max(0, (user.programmeWeek || 1) - 1),
@@ -698,7 +698,12 @@ export async function handleMiscCommands(ctx: {
           sessionsThisWeek: truth.sessions, sessionsTarget: Number(user.trainingDaysPerWeek) || 3,
           stepsToday: truth.today.steps, stepsTarget: Number(user.stepsTarget) || 0,
           hour: sastHour(), atKeyboard: true,
-        } as any), { evidenced: truth.window.daysLogged >= 3, dreamGoal: user.dreamGoal });
+        } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
+         // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a
+         // decision: the proactive side reads a stall verdict this path never computes, so
+         // passing anything but false would be inventing evidence. It means a client with a
+         // usable weight trend and a thin food log is still held on this path.
+         weightSufficient: false, dreamGoal: user.dreamGoal });
         return `*${name} — last 7 days*\n\n💪 Sessions: *${truth.sessions}*\n📋 Days logged: *${truth.window.daysLogged}/7*\n🔥 Avg: *${truth.window.avgKcal} kcal* · *${truth.window.avgProtein}g* protein\n👟 Avg steps: *${truth.avgSteps.toLocaleString()}*${weightLine}\n\n*${act.todo}*`;
       }
       const todayLine = truth.today.kcal > 0

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -649,6 +649,13 @@ export interface ProactiveDecision {
  * ask for the measurement that would let us decide, which is precisely INVESTIGATE. Everything
  * else alters what the client does today, and may only be said on sufficient evidence.
  */
+/**
+ * DISTINCT DAYS OF FOOD LOGGING BEFORE THE LEDGER CAN CARRY A PRESCRIPTION. Lives here, with the
+ * policy that applies it, because it was previously defined in the scheduler and hand-copied as a
+ * literal by every reactive caller — at a different number.
+ */
+export const PROACTIVE_LOG_FLOOR = 4;
+
 const INVESTIGATIVE: ReadonlySet<ActionKind> = new Set<ActionKind>(["come_back", "log", "weigh"]);
 const PRESCRIPTIVE: ReadonlySet<ActionKind> = new Set<ActionKind>(["protein", "walk", "train", "eat_more", "rest"]);
 
@@ -695,8 +702,34 @@ export function composeDecisionTurn(situationFrame: string, actionLine: string):
   return `${ctx}\n\n${action}`;
 }
 
-export function underPolicy(action: OneAction, opts: { evidenced: boolean; dreamGoal?: string | null }): OneAction {
-  if (!PRESCRIPTIVE.has(action.kind) || opts.evidenced) return action;
+/**
+ * TWO CONSTITUTIONS, ONE CLIENT (2026-08-28, traced on one state through both paths).
+ *
+ * This gate and decideProactive both answer "may we prescribe?", and they answered it differently.
+ * Measured on one client — sick, two of seven days logged, 09:00:
+ *
+ *     decideProactive  ->  rest    "Rest today. No training, no targets."
+ *     underPolicy      ->  hold    "Nothing new today. Do exactly what you did yesterday."
+ *
+ * Telling a sick person to repeat yesterday is the wrong instruction, and it re-broke a finding
+ * this file already carries: illness is DIRECTLY OBSERVED durable state, sufficient by
+ * construction (2026-08-18). decideProactive knew that through evidenceFor; this gate took a bare
+ * boolean from its caller and could not.
+ *
+ * The second disagreement was the threshold itself. Callers here asked `daysLogged >= 3` while the
+ * proactive side used PROACTIVE_LOG_FLOOR — so a client with exactly three logged days was
+ * evidenced on one path and not the other. One floor now, the named one.
+ *
+ * So the gate stops taking a verdict and takes the EVIDENCE, then reaches the verdict through the
+ * same two functions decideProactive uses. Neither path can hold an opinion the other does not.
+ */
+export function underPolicy(
+  action: OneAction,
+  opts: { foodSufficient: boolean; weightSufficient: boolean; dreamGoal?: string | null },
+): OneAction {
+  const verdict = evidenceFromKind(action.kind)
+    ?? evidenceFromLedger(opts.foodSufficient, opts.weightSufficient);
+  if (!PRESCRIPTIVE.has(action.kind) || verdict === "sufficient") return action;
   return holdAction(opts.dreamGoal);
 }
 
@@ -712,10 +745,20 @@ export function underPolicy(action: OneAction, opts: { evidenced: boolean; dream
  *
  * Silence is the same kind of fact: `come_back` follows from an observed absence, not a guess.
  */
-function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEvidence {
+function evidenceFromKind(kind: ActionKind): DecisionEvidence | null {
   if (kind === "rest") return "sufficient";
   if (INVESTIGATIVE.has(kind)) return "insufficient";
-  return s.evidence.foodSufficient || s.evidence.weightSufficient ? "sufficient" : "insufficient";
+  return null;   // nothing follows from the kind alone — ask the ledger
+}
+
+/** The ledger half. Either source on its own is enough; that is one rule, stated once. */
+function evidenceFromLedger(foodSufficient: boolean, weightSufficient: boolean): DecisionEvidence {
+  return foodSufficient || weightSufficient ? "sufficient" : "insufficient";
+}
+
+function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEvidence {
+  return evidenceFromKind(kind)
+    ?? evidenceFromLedger(s.evidence.foodSufficient, s.evidence.weightSufficient);
 }
 
 export function decideProactive(

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -722,6 +722,24 @@ export function composeDecisionTurn(situationFrame: string, actionLine: string):
  *
  * So the gate stops taking a verdict and takes the EVIDENCE, then reaches the verdict through the
  * same two functions decideProactive uses. Neither path can hold an opinion the other does not.
+ *
+ * FOUND, NOT FIXED — SPARSE EVIDENCE ACTION DIVERGENCE (parked 2026-08-28 by CTO decision).
+ *
+ * One evidence -> one policy is what this cut establishes. One policy -> one ACTION is NOT
+ * established, and on the insufficient branch the two paths still differ:
+ *
+ *     sparse but healthy   decideProactive -> weigh  "Stand on a scale this morning."
+ *                          underPolicy     -> hold   "Nothing new today."
+ *
+ * decideProactive downgrades to the measurement that would justify a prescription; this gate
+ * holds. There is a plausible product reason — proactively the ask IS the whole message, so
+ * silence wastes the contact, while reactively the client has already been answered and this line
+ * is supplementary — but that reason is UNPROVEN. No client has been traced to establish it.
+ *
+ * It is therefore a product-policy question, not a defect to patch: decide the desired reactive
+ * behaviour from production evidence BEFORE changing it. Closing it would mean this gate also
+ * performing the askToLog/askToWeigh downgrade, which needs today.logged, daysSinceWeighIn and
+ * doNotMention at the reactive call sites.
  */
 export function underPolicy(
   action: OneAction,

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -68,7 +68,7 @@ async function silenceAsk(client: any, daysSilent: number): Promise<string> {
       daysSinceAnyLog: daysSilent, daysSinceWeighIn: 0, loggedToday: false,
       proteinPct: 1, caloriePct: 1, sessionsThisWeek: 0, sessionsTarget: 0,
       stepsToday: 0, stepsTarget: 0, hour: 7,
-    }), { evidenced: false, dreamGoal: client.dreamGoal }), firstName);
+    }), { foodSufficient: false, weightSufficient: false, dreamGoal: client.dreamGoal }), firstName);
   }
 }
 

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -114,7 +114,7 @@ export async function canonicalNextMove(
       hour: opts?.hour ?? 12,
       foodDayClosed: held.foodDayClosed,
       trainingDeclined: held.trainingDeclined,
-    }), { evidenced: false, dreamGoal: client.dreamGoal });
+    }), { foodSufficient: false, weightSufficient: false, dreamGoal: client.dreamGoal });
     return {
       line: action.kind === "hold" ? "" : formatOneAction(action, firstName),
       action,

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -909,7 +909,9 @@ export interface ProactiveState {
 /** Below this many logged days in seven, intake averages are not evidence. Same floor as the
  *  hunger and deficit contracts — one client must not be "well logged" for one subsystem and
  *  "thinly logged" for another on the same morning. */
-export const PROACTIVE_LOG_FLOOR = 4;
+// ONE FLOOR, OWNED BY THE POLICY. Re-exported so existing importers are undisturbed.
+import { PROACTIVE_LOG_FLOOR } from "../one-action";
+export { PROACTIVE_LOG_FLOOR };
 
 /** Weeks of no meaningful weight movement (<0.3kg swing) from a series, newest first.
  *  Moved here from adaptive.ts so the stall a message TALKS about and the stall the engine ACTS

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -74,7 +74,7 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
     //
     // It now asks the decision owner, on canonical state, under the same policy contract every
     // other caller uses. theNextMove is deleted.
-    const { chooseAction, underPolicy, foodDayIsClosed, trainingDayIsDeclined } = await import("../one-action");
+    const { chooseAction, underPolicy, foodDayIsClosed, trainingDayIsDeclined, PROACTIVE_LOG_FLOOR } = await import("../one-action");
     const { readHeldConstraints } = await import("../held-constraints");
     const { getProgressTruth, sessionsThisCalendarWeek } = await import("../day-ledger");
     const { sastHour } = await import("../sast");
@@ -115,7 +115,12 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
       // it had no field at all: routes.ts computed it into `_isWorkoutRefusal` and dropped it.
       foodDayClosed: held.foodDayClosed || foodDayIsClosed(message || ""),
       trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
-    } as any), { evidenced: truth.window.daysLogged >= 3, dreamGoal: user.dreamGoal });
+    } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
+         // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a
+         // decision: the proactive side reads a stall verdict this path never computes, so
+         // passing anything but false would be inventing evidence. It means a client with a
+         // usable weight trend and a thin food log is still held on this path.
+         weightSufficient: false, dreamGoal: user.dreamGoal });
 
     // RECORD THE PROVENANCE. The verifier needs to know what this turn's canonical decision was,
     // so it can tell a model reply that CARRIES the decision from one that invented its own.


### PR DESCRIPTION
## The customer failure

Traced through both policy paths on **one** client state — sick, two of seven days logged, 09:00:

```
decideProactive  ->  rest    "Rest today. No training, no targets."
underPolicy      ->  hold    "Nothing new today. Do exactly what you did yesterday."
```

Telling a sick person to repeat yesterday is the wrong instruction, and it re-broke a finding `one-action.ts` already carried: **illness is directly observed durable state, sufficient by construction** (2026-08-18). `decideProactive` knew that through `evidenceFor`; the gate took a bare boolean from its caller and structurally could not.

## Three disagreements found, two closed

| # | disagreement | status |
|---|---|---|
| 1 | `rest` self-evidencing proactively, not reactively | **closed** — one definition, both paths |
| 2 | food floor `>= 3` reactive vs `PROACTIVE_LOG_FLOOR` (4) proactive | **closed** — floor moved to the policy owner |
| 3 | weight evidence counted proactively, ignored reactively | **found, not fixed** — see below |

## The correction

The gate stopped taking a **verdict** and now takes the **evidence**, reaching its answer through the same two functions `decideProactive` uses:

```ts
evidenceFromKind(kind)                                  // rest -> sufficient; investigative -> insufficient
  ?? evidenceFromLedger(foodSufficient, weightSufficient)
```

No third policy, no new authority. `PROACTIVE_LOG_FLOOR` moved to `one-action.ts` — the policy that applies it — and the scheduler imports it rather than defining a second copy. The compiler enumerated all four call sites when the signature changed.

## The four proof obligations

| # | obligation | result |
|---|---|---|
| 1 | sick + thin evidence | ✅ both paths → `rest`; neither says "do yesterday" |
| 2 | sparse but healthy | ✅ no prescription; a fresh event still answered, same on both |
| 3 | sufficient evidence | ✅ both → `protein`; the coach is not mute |
| 4 | illness constrains the **ladder** | ✅ ladder refuses; gate passes the ladder's object through |

**Obligation 4 is the one the cut rests on.** If `chooseAction` could still pick `train` for a sick client and a wrapper rewrote the sentence afterwards, we would have replaced one contradiction with a politer one — the decision still wrong, only the words agreeing. Illness is **rung 2 of the ladder**, ahead of every prescriptive rung.

Graded from three states that **do** reach a prescription when healthy — would-train, would-walk, would-protein — and the fixtures are themselves asserted to still do so, otherwise the test would pass because nothing was going to be prescribed anyway. The gate check is **object identity**, not string equality: a gate that rebuilt an equivalent action would be a second author of the same decision.

## Controls — six, each failing independently

| control | result |
|---|---|
| gate takes a bare verdict again | **RED** — reproduces the trace verbatim |
| `rest` stops being self-evidencing | **RED** — the sick client loses rest |
| gate opens for everyone | **RED** — sparse evidence stops protecting |
| gate holds everyone | **RED** — the coach goes mute |
| illness stops constraining the ladder | **RED** — the paths disagree again |
| gate returns `{ ...action }` | **RED** — re-authoring, not applying |

Both failure directions are covered: a gate that agrees by holding everything is as wrong as one that agrees by prescribing everything.

Law 26 is untouched — insufficient evidence still yields the downgrade to a real question or an honest hold, never an invented explanation.

## Found, not fixed — recorded at the gate, not on a board

**One evidence → one policy** is what this cut establishes. **One policy → one action** is *not*, and on the insufficient branch the paths still differ:

```
sparse but healthy   decideProactive -> weigh  "Stand on a scale this morning."
                     underPolicy     -> hold   "Nothing new today."
```

There is a plausible product reason — proactively the ask *is* the whole message, so silence wastes the contact; reactively the client has already been answered — **but that reason is unproven.** No client has been traced to establish it. It is a product-policy question to settle from production evidence before changing, and the note at the gate names what closing it would cost.

The weight-evidence gap (#3) is recorded the same way, at the reactive call site: the proactive side reads a stall verdict this path never computes, so passing anything but `false` would be inventing evidence.

## A gap-test that broke on wording, not behaviour

The full suite caught `gap-tests` going RED — 31/35 against main's 32/35 — where the guards were byte-identical and would have passed it through. The assertion greps `morning.ts` for the literal `evidenced: false`, which the signature change renamed. The property it guards is intact and now stated twice over.

**Control:** make the degraded fallback claim `foodSufficient: true, weightSufficient: true` and the assertion fails. It still guards what it was written to guard.

## Verification

```
suites: 32/35 green, 1 covered nothing — main's exact baseline
contract suite ✓   gap-tests ✓ 335/335

guards, 9d76633 vs 15dd88c:
  ARCHITECTURE: IDENTICAL (every counter, named or not)
  FILE SIZES:   IDENTICAL
```

The guards were re-run on `15dd88c` rather than carried forward from `6cbcbe7`: `authorshipPoints` counts client-facing strings and the parked-item note quotes two coach lines verbatim, so a comment-only commit could in principle have breached a governor.

## Commits

| SHA | scope |
|---|---|
| `e6bbe78` | the policy consolidation |
| `e32bee6` | test-only: gap-test follows the new shape |
| `6cbcbe7` | obligation 4's proof — ladder + object identity |
| `15dd88c` | the parked divergence, recorded at the gate |

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_