### PR TITLE
Re-entry uses the canonical contact-state owner

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -923,6 +923,37 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * "HAS THIS CLIENT BEEN AWAY?" HAS ONE OWNER (2026-08-28, traced on two client states).
+   *
+   * The milestone voice decided `lapsed` — which selects the "comeback" register, the firm
+   * welcome-back tone — by regexing `(\d+ days silent)` out of the pattern summary it had just
+   * written. A number round-tripped through English. And it was never absence: that figure is
+   * `7 - daysWithLogs`, days in the week with no inbound message. The two facts disagree in both
+   * directions, and the first is the one a client feels:
+   *
+   *   spoke TODAY, logged 3 of 7 days     contactState: present    voice: "comeback"
+   *   away 5 days, logged 6 of 7 before   contactState: returning  voice: warm
+   *
+   * Graded on the OWNER's answer for both shapes, and on the absence of the round-trip.
+   */
+  {
+    const { contactState, RETURNING_DAYS } = await import("../server/understanding/reentry");
+    const now = Date.now();
+    const present = contactState(new Date(now).toISOString(), now);
+    const away = contactState(new Date(now - 5 * 86_400_000).toISOString(), now);
+    if (present.isReturning) {
+      failures.push(`A client who messaged today reads as returning — the coach would greet a present client as though they had vanished`);
+    }
+    if (!away.isReturning) {
+      failures.push(`A client absent 5 days does not read as returning (RETURNING_DAYS=${RETURNING_DAYS}) — re-entry would never fire`);
+    }
+    // NOT ASSERTED HERE: that gpt.ts calls this owner. Proving it behaviourally needs
+    // generateMilestoneVoiceScript, which calls OpenAI and cannot run offline, and a source-string
+    // check would break on wording rather than behaviour — the failure mode gap-tests hit today.
+    // The runtime trace on this cut showed both shapes agreeing; that is the evidence, not this.
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -1281,14 +1281,14 @@ export async function generateMilestoneVoiceScript(
     workout_sessions: `Completed ${data.sessions} total workout sessions with Coach K`,
   };
 
-  // Pick the emotional register from the REAL pattern data, then let it drive both
-  // the words (prompt below) and the voice delivery (returned to the caller).
-  // buildPatternSummary already computed these signals — read them back out.
-  const silentMatch = patternSummary.match(/\((\d+)\s+days?\s+silent\)/i);
-  const daysSilent = silentMatch ? parseInt(silentMatch[1], 10) : 0;
+  // The emotional register, driving both the words below and the voice delivery. ABSENCE HAS AN
+  // OWNER (2026-08-28): this regexed `(N days silent)` back out of the summary it had just
+  // written, and that figure is `7 - daysWithLogs` — days not LOGGED, never days away.
+  const { contactState } = await import("./understanding/reentry");
+  const { isReturning } = contactState(user?.lastActiveAt);
   const lastTrainMatch = patternSummary.match(/Last training was (\d+) days ago/i);
   const daysSinceTraining = lastTrainMatch ? parseInt(lastTrainMatch[1], 10) : 0;
-  const lapsed = daysSilent >= 4 || daysSinceTraining >= 5
+  const lapsed = isReturning || daysSinceTraining >= 5
     || /No training sessions logged this week/i.test(patternSummary);
   const struggling = /too hard or wanting to quit|needs direct accountability|consistently under/i.test(patternSummary);
   const thriving = /solid habit|at or above target|Food logging is consistent/i.test(patternSummary);


### PR DESCRIPTION
Fixes the re-entry/comeback divergence by having the milestone voice read the existing `contactState` owner instead of inferring absence from `7 - daysWithLogs` and round-tripping it through generated prose.

Verified on both directions:
- spoke today, 3/7 logged → present
- away 5 days, 6/7 logged previously → returning

Two behavioural controls bite. No new module or predicate. The offline suite deliberately does not source-check `gpt.ts` because that would be wording-sensitive and the live voice path requires OpenAI.

Baseline: `a633c7c`. Head: `ca7a9a8`.