### PR TITLE
fix: weight trend speaks through one structured HOLD-terminal turn

### DIFF
--- a/script/check-names.ts
+++ b/script/check-names.ts
@@ -20,7 +20,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 // Frozen 2026-07-29 after removing every full-name-in-prose use. LOWER THIS, NEVER RAISE IT.
-const BUDGET = 97;   // 2026-08-23: gpt-block short/punct fallbacks moved to getDisplayName
+const BUDGET = 96;   // 2026-08-29: weight chart/history writers share one first-name fact
 
 /** Prose shapes that put a FULL name in front of a client. These may never come back at all. */
 const FORBIDDEN: Array<[RegExp, string]> = [

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -46,6 +46,7 @@ export const SUITES = [
   "check-file-sizes", "check-pricing", "check-schema-safety", "check-sast", "check-names",
   "check-reach", "check-prompt-integrity", "hunger-gauntlet", "decision-boundary-tests",
   "reentry-state-tests", "reentry-bridge-tests", "reaction-guard-tests", "current-date-tests", "day-relative-situation-tests", "coach-loop-foundation-tests", "multi-day-attribution-tests",
+  "weight-hold-seam-tests",
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
   "turn-triage-tests", "normalizer-replay-tests", "tracking-contract-tests",

--- a/script/weight-hold-seam-tests.ts
+++ b/script/weight-hold-seam-tests.ts
@@ -1,0 +1,168 @@
+/**
+ * 16:55 seam — HOLD is terminal. One structured turn. No second closer.
+ * Run: npx tsx script/weight-hold-seam-tests.ts
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { composeWeightTurn, isCoachingTurn, weightTrendUsable } from "../server/adaptive-targets";
+
+process.env.KAMLIFE_DB_STUB = "1";
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "unit-test-stub";
+
+const { applyProvenance, classifyClaim } = await import("../server/verifiers/response-gate");
+const { withNextMove, isHoldReply } = await import("../server/reply-hygiene");
+
+let failed = 0;
+function test(name: string, fn: () => void) {
+  try { fn(); console.log(`  ok  ${name}`); }
+  catch (e) { failed++; console.error(`  FAIL ${name}\n${(e as Error).stack}`); }
+}
+
+const holdFacts = {
+  currentKg: 85.75,
+  changeKg: 0.6,
+  trendUsable: false as const,
+  trendWhy: "illness" as const,
+  points: [
+    { kg: 85.15, at: new Date("2026-08-20T06:00:00+02:00") },
+    { kg: 85.75, at: new Date("2026-08-28T06:00:00+02:00") },
+  ],
+  goal: "muscle_gain",
+  name: "Kam",
+};
+
+const holdTurn = {
+  kind: "coach" as const,
+  domain: "weight" as const,
+  decision: "HOLD" as const,
+  facts: holdFacts,
+};
+
+test("16:55 T1: illness HOLD cannot contain a direction", () => {
+  const out = composeWeightTurn(holdTurn);
+  assert.match(out, /not going to call a trend/i);
+  assert.doesNotMatch(out, /going up|keep fuelling|keep fueling|eat more|continue fuelling/i);
+  assert.equal(isHoldReply(out), true);
+});
+
+test("16:55 T1: HOLD ignores a +2.4kg muscle-gain change — facts cannot smuggle a closer", () => {
+  const out = composeWeightTurn({ ...holdTurn, facts: { ...holdFacts, changeKg: 2.4 } });
+  assert.doesNotMatch(out, /going up|fuell|Up 2|eat more/i);
+});
+
+test("16:55 T4: HOLD never grows a next move through withNextMove", () => {
+  const hold = composeWeightTurn(holdTurn);
+  const appended = withNextMove(hold, "Scale is going up — keep fuelling");
+  assert.equal(appended, hold);
+  assert.doesNotMatch(appended, /keep fuelling/i);
+});
+
+test("16:55: the old misc closer is invisible to classifyClaim — that is why the gate failed", () => {
+  assert.equal(classifyClaim("Scale is going up — keep fuelling."), null);
+  assert.equal(classifyClaim("Up 0.3kg since you started."), "weight-trend");
+});
+
+test("16:55: provenance on the OLD draft still concatenates — the gate is not the composer", () => {
+  const draft = "*Kam's Weight History*\n\n• 85.8kg — 28 Aug\n\nUp 0.3kg since you started. Scale is going up — keep fuelling.";
+  const r = applyProvenance(draft, {
+    trend: { usable: false, why: "illness" }, mealsLoggedToday: 1, calorieTarget: 2200, weighedThisWeek: true,
+  });
+  assert.match(r.text, /not going to call a trend/i);
+  assert.match(r.text, /keep fuelling/i, "documenting the gate hole; composeWeightTurn is what must not emit this");
+});
+
+test("16:55: provenance on the NEW compose cannot resurrect fuelling", () => {
+  const composed = composeWeightTurn(holdTurn);
+  const r = applyProvenance(composed, {
+    trend: { usable: false, why: "illness" }, mealsLoggedToday: 1, calorieTarget: 2200, weighedThisWeek: true,
+  });
+  assert.doesNotMatch(r.text, /going up|keep fuelling/i);
+  assert.match(r.text, /not going to call a trend/i);
+});
+
+test("16:55 T8 anti-vacuity: usable=false forces HOLD even if the label says REPORT_TREND", () => {
+  const out = composeWeightTurn({
+    kind: "coach",
+    domain: "weight",
+    decision: "REPORT_TREND",
+    facts: holdFacts,
+  });
+  assert.match(out, /not going to call a trend/i);
+  assert.doesNotMatch(out, /going up|keep fuelling/i);
+});
+
+test("16:55 T8: weightTrendUsable illness window is false", () => {
+  const v = weightTrendUsable({
+    count: 2,
+    newestAt: Date.parse("2026-08-28T06:00:00+02:00"),
+    oldestAt: Date.parse("2026-08-20T06:00:00+02:00"),
+    now: Date.parse("2026-08-28T16:55:00+02:00"),
+    sickSince: Date.parse("2026-08-18T00:00:00+02:00"),
+    sickUntil: Date.parse("2026-08-27T00:00:00+02:00"),
+  });
+  assert.equal(v.usable, false);
+  assert.equal(v.usable === false && v.why, "illness");
+});
+
+test("structured turn has domain weight and no reply string", () => {
+  assert.equal(isCoachingTurn(holdTurn), true);
+  assert.equal(isCoachingTurn("Scale is going up — keep fuelling."), false);
+  assert.equal(isCoachingTurn({ kind: "coach", domain: "weight", decision: "HOLD", reply: "nope" }), false);
+});
+
+test("positive control: usable REPORT_TREND still speaks the classified change", () => {
+  const out = composeWeightTurn({
+    kind: "coach",
+    domain: "weight",
+    decision: "REPORT_TREND",
+    facts: { ...holdFacts, trendUsable: true, trendWhy: null },
+  });
+  assert.match(out, /Weight History/);
+  assert.match(out, /Up 0\.6kg since you started/);
+  assert.doesNotMatch(out, /keep fuelling|keep training hard|Moving in the right direction/i);
+});
+
+{
+  const miscSrc = readFileSync("server/handlers/misc-commands.ts", "utf8");
+  const routesSrc = readFileSync("server/routes.ts", "utf8");
+  const liveSrc = readFileSync("server/understanding/live.ts", "utf8");
+  const hygieneSrc = readFileSync("server/reply-hygiene.ts", "utf8");
+  const composeSrc = readFileSync("server/adaptive-targets.ts", "utf8");
+
+  test("16:55 source: misc no longer authors keep fuelling or keep training hard", () => {
+    assert.doesNotMatch(miscSrc, /Scale is going up — keep fuelling/);
+    assert.doesNotMatch(miscSrc, /Keep training hard/);
+    assert.doesNotMatch(miscSrc, /Moving in the right direction/);
+    assert.match(miscSrc, /weightTrendUsable\(/);
+    assert.match(miscSrc, /domain:\s*"weight"/);
+  });
+
+  test("16:55 source: routes finalizes a CoachingTurn through closeCoachingTurn", () => {
+    assert.match(routesSrc, /isCoachingTurn\(miscResult\)/);
+    assert.match(routesSrc, /finalizeCoachingTurn\(/);
+    const miscBlock = routesSrc.slice(routesSrc.indexOf("const miscResult"), routesSrc.indexOf("const lifecycleResult"));
+    assert.match(miscBlock, /closeCoachingTurn\(await finalizeCoachingTurn/);
+    assert.doesNotMatch(miscBlock, /if \(isCoachingTurn\(miscResult\)\) return finalizeCoachingTurn/);
+  });
+
+  test("16:55 source: composeWeightTurn has no withNextMove call", () => {
+    const i = composeSrc.indexOf("export function composeWeightTurn");
+    assert.doesNotMatch(composeSrc.slice(i, i + 900), /withNextMove\(/);
+    assert.match(composeSrc, /decision === "HOLD"/);
+  });
+
+  test("16:55 source: closeCoachingTurn bails on HOLD before canonicalDecision", () => {
+    const fn = liveSrc.slice(liveSrc.indexOf("export async function closeCoachingTurn"));
+    assert.match(fn.slice(0, 500), /isHoldReply/);
+  });
+
+  test("16:55 source: withNextMove refuses to tail a HOLD", () => {
+    assert.match(hygieneSrc, /if \(isHoldReply/);
+  });
+}
+
+if (failed) {
+  console.log(`weight-hold-seam-tests: ${failed} failed`);
+  process.exit(1);
+}
+console.log("weight-hold-seam-tests: all assertions passed");

--- a/server/adaptive-targets.ts
+++ b/server/adaptive-targets.ts
@@ -332,13 +332,67 @@ export function weightTrendUsable(w: TrendWindow): TrendVerdict {
   if (w.count < 2) return { usable: false, why: "too_few" };
   if ((w.newestAt - w.oldestAt) / 86_400_000 < MIN_TREND_SPAN_DAYS) return { usable: false, why: "too_short" };
   if ((w.now - w.newestAt) / 86_400_000 > MAX_TREND_AGE_DAYS) return { usable: false, why: "stale" };
-  // An illness overlaps the span if it began before the newest weigh-in and had not yet finished
-  // (plus its tail) by the oldest. An illness with no end date is still running.
   const illnessEnds = w.sickUntil !== undefined ? w.sickUntil + ILLNESS_TAIL_MS : w.now;
   if (w.sickSince !== undefined && w.sickSince <= w.newestAt && illnessEnds >= w.oldestAt) {
     return { usable: false, why: "illness" };
   }
   return { usable: true };
+}
+
+const TREND_HOLD: Record<string, string> = {
+  illness: "I'm not going to call a trend off those weigh-ins — they sit around the time you were ill, and weight moves on fluid and appetite then, not on food. Hop on the scale in the morning and I'll give you a straight read.",
+  stale: "Your last weigh-in is too far back for me to read anything into it. Jump on the scale in the morning and I'll tell you exactly where you're going.",
+  this_week: "You haven't weighed in this week, so I'm not going to put a number on it. Hop on the scale in the morning and I'll tell you exactly where you're going.",
+  too_few: "I don't have enough weigh-ins yet to call which way you're going. Get on the scale in the morning and again next week, and I'll give you a straight read.",
+  too_short: "I don't have enough weigh-ins yet to call which way you're going. Get on the scale in the morning and again next week, and I'll give you a straight read.",
+};
+
+export function trendHoldText(why?: string | null): string {
+  return TREND_HOLD[why || ""] || TREND_HOLD.too_few;
+}
+
+export type CoachingTurn = {
+  kind: "coach";
+  domain: "weight";
+  decision: "HOLD" | "REPORT_TREND";
+  facts: {
+    currentKg: number | null;
+    changeKg: number | null;
+    trendUsable: boolean;
+    trendWhy: "too_few" | "too_short" | "stale" | "illness" | null;
+    points: Array<{ kg: number; at: Date }>;
+    goal: string;
+    name: string;
+  };
+};
+
+export function isCoachingTurn(x: unknown): x is CoachingTurn {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return o.kind === "coach" && o.domain === "weight"
+    && (o.decision === "HOLD" || o.decision === "REPORT_TREND")
+    && !("reply" in o);
+}
+
+export function composeWeightTurn(turn: CoachingTurn): string {
+  if (turn.decision === "HOLD" || !turn.facts.trendUsable || turn.facts.points.length === 0) {
+    return trendHoldText(turn.facts.trendWhy || "too_few");
+  }
+  const points = turn.facts.points;
+  const first = points[0].kg;
+  const latest = points[points.length - 1].kg;
+  const totalChange = turn.facts.changeKg ?? (latest - first);
+  const changeDir = totalChange < 0
+    ? `Down ${Math.abs(totalChange).toFixed(1)}kg`
+    : totalChange > 0
+      ? `Up ${totalChange.toFixed(1)}kg`
+      : "No change";
+  const recent = points.slice(-5).map(l =>
+    `• ${l.kg.toFixed(1)}kg — ${l.at.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`,
+  ).join("\n");
+  const name2 = turn.facts.name;
+  const report = `*${name2 ? name2 + "'s " : ""}Weight History*\n\n${recent}\n\n${changeDir} since you started.`;
+  return report.trim();
 }
 
 

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -1,6 +1,6 @@
 /**
  * Miscellaneous command handlers — supplements, motivation, stats, progress, NPS, etc.
- * Returns string if handled, null to fall through.
+ * Returns string if handled, a structured CoachingTurn for weight/trend, or null to fall through.
  */
 
 import { db } from "../db";
@@ -40,6 +40,8 @@ import { turnEvidence } from "./chat-log";
 import { getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
+import { weightTrendUsable, type CoachingTurn, composeWeightTurn, isCoachingTurn } from "../adaptive-targets";
+import { readHealthState } from "../health-state";
 
 // Protein keywords built from SA food database (same logic as routes.ts)
 const PROTEIN_WORDS: string[] = Array.from(new Set([
@@ -54,6 +56,51 @@ const PROTEIN_WORDS: string[] = Array.from(new Set([
   "droëwors", "droewors", "cottage cheese", "greek yoghurt", "greek yogurt",
 ]));
 
+export { isCoachingTurn, composeWeightTurn };
+export type { CoachingTurn };
+
+export async function finalizeCoachingTurn(
+  user: { id: string },
+  message: string,
+  turn: CoachingTurn,
+): Promise<string> {
+  const text = composeWeightTurn(turn);
+  await logChat(user.id, message, text, turn.decision === "HOLD" ? "WEIGHT_TREND_HOLD" : "WEIGHT_TREND");
+  return text;
+}
+
+async function weightTrendTurn(user: any, m: string): Promise<CoachingTurn> {
+  const wt = await getWeightTruth(user, { clientMessage: m });
+  const logs = wt.points;
+  const health = readHealthState(user);
+  const newestAt = logs.length ? logs[logs.length - 1].at.getTime() : 0;
+  const oldestAt = logs.length ? logs[0].at.getTime() : 0;
+  const isoMs = (iso: string | null | undefined) =>
+    iso ? new Date(iso).getTime() : undefined;
+  const usable = weightTrendUsable({
+    count: logs.length,
+    newestAt,
+    oldestAt,
+    now: Date.now(),
+    sickSince: isoMs(health.sickSince),
+    sickUntil: isoMs(health.sickUntil),
+  });
+  return {
+    kind: "coach",
+    domain: "weight",
+    decision: usable.usable ? "REPORT_TREND" : "HOLD",
+    facts: {
+      currentKg: wt.currentKg,
+      changeKg: wt.changeKg,
+      trendUsable: usable.usable,
+      trendWhy: usable.usable ? null : usable.why,
+      points: logs,
+      goal: user.goalType || "fat_loss",
+      name: user.name?.split(" ")[0] || "",
+    },
+  };
+}
+
 export async function handleMiscCommands(ctx: {
   phone: string;
   message: string;
@@ -62,7 +109,7 @@ export async function handleMiscCommands(ctx: {
   isQuestion?: boolean; // systemic QUESTION gate — see early-commands.ts
   /** This turn already INSERT-ed a durable fact. Educational mouths must not consume a remaining ask. */
   wroteThisTurn?: boolean;
-}): Promise<string | null> {
+}): Promise<string | CoachingTurn | null> {
   const { phone, message, m, user, wroteThisTurn } = ctx;
 
   // Calendar facts are deterministic SAST state, not coaching.
@@ -585,24 +632,7 @@ export async function handleMiscCommands(ctx: {
   // ---- WEIGHT HISTORY — "weight history", "weight trend", "how much have I lost" ----
   if (/\b(weight history|weight trend|my weights|all my weights|weight progress|how much (weight )?(have i|did i) (lost?|gained?)|total (weight )?(lost?|gained?)|weight (since|over time))\b/i.test(m)) {
     try {
-      // THEY ASKED, SO THEY GET AN ANSWER (2026-08-25, P0-5 · weight). The owner applies the
-      // do-not-mention rule, and `clientMessage` is what tells it this client raised the scale
-      // themselves — "don't mention my weight" is not "refuse to tell me my weight when I ask".
-      // That exemption used to be accidental: this command simply never checked. Now it is stated.
-      const wt = await getWeightTruth(user, { clientMessage: m });
-      const logs = wt.points;
-      if (logs.length === 0) return `No weight history yet. Log your first weight — just send "84kg".`;
-      const first = logs[0].kg;
-      const latest = logs[logs.length - 1].kg;
-      const totalChange = latest - first;
-      const goal = user.goalType || "fat_loss";
-      const changeDir = totalChange < 0 ? `Down ${Math.abs(totalChange).toFixed(1)}kg` : totalChange > 0 ? `Up ${totalChange.toFixed(1)}kg` : "No change";
-      const verdict = goal === "fat_loss" && totalChange < -1 ? "Moving in the right direction." : goal === "muscle_gain" && totalChange > 0.5 ? "Scale is going up — keep fuelling." : goal === "fat_loss" && totalChange >= 0 ? "Scale hasn't moved yet — check food logging consistency." : "";
-      const recent = logs.slice(-5).map(l =>
-        `• ${l.kg.toFixed(1)}kg — ${l.at.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`,
-      ).join("\n");
-      const name2 = user.name?.split(" ")[0] || "";
-      return `*${name2 ? name2 + "'s " : ""}Weight History*\n\n${recent}\n\n${changeDir} since you started. ${verdict}`.trim();
+      return await weightTrendTurn(user, m);
     } catch { /* fall through */ }
   }
   if (["protein", "my protein", "protein target", "daily protein", "protein daily", "how much protein", "my protein target"].includes(m)) {
@@ -1443,42 +1473,8 @@ export async function handleMiscCommands(ctx: {
   const asksWeightProjection = /\b(should|target|goal|aim)\b.{0,40}\bweight\b|\bweight\b.{0,40}\b(in|by)\s+(\d+\s*(?:weeks?|months?)|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*|next year)\b/i.test(m);
   if (!asksWeightProjection && !ctx.isQuestion && (m === "weight chart" || m === "weight graph" || m === "weight trend" || m === "my weight" || /\b(weight\s*(?:chart|graph|trend|history|journey)|scale\s*trend)\b/i.test(m))) {
     try {
-      // "my weight" / "weight chart" — they raised it, so the owner answers rather than withholds.
-      const weights = (await getWeightTruth(user, { clientMessage: m })).points
-        .map(p => ({ weight: p.kg, date: p.at }));
-
-      if (weights.length < 2) {
-        return `Not enough weight logs for a trend. Log your weight regularly — "84.5kg" — and I will show you the full picture over time.`;
-      }
-
-      const name = user.name?.split(" ")[0] || "there";
-      const vals = weights.map(w => parseFloat(String(w.weight)));
-
-      // WhatsApp is not a terminal — the old ASCII dot-chart rendered as broken
-      // monospace soup on phones ("nobody's paying R199 for this", 2026-07-03).
-      // A clean start→now line + pace tells the same story properly.
-      const spanDays = weights.length >= 2 && weights[0].date && weights[weights.length - 1].date
-        ? Math.max(1, Math.round((new Date(weights[weights.length - 1].date as any).getTime() - new Date(weights[0].date as any).getTime()) / 86_400_000))
-        : 0;
-      const first = vals[0];
-      const last = vals[vals.length - 1];
-      const diff = last - first;
-      const trend = diff < -0.5 ? `⬇️ Down ${Math.abs(diff).toFixed(1)}kg` : diff > 0.5 ? `⬆️ Up ${diff.toFixed(1)}kg` : `➡️ Stable`;
-      const paceWk = spanDays >= 7 ? ` · pace ${(diff / (spanDays / 7)) >= 0 ? "+" : ""}${(diff / (spanDays / 7)).toFixed(2)}kg/week` : "";
-      const reply = `*⚖️ Weight — ${name}*\n\n` +
-        `Start: *${first.toFixed(1)}kg* → Now: *${last.toFixed(1)}kg* (${trend})\n` +
-        `${weights.length} weigh-ins over ${spanDays >= 7 ? Math.round(spanDays / 7) + " weeks" : spanDays + " days"}${paceWk}\n\n` +
-        (diff < -2 ? `Consistent progress. The deficit is working — stay patient and stay on plan.` :
-         diff > 2 && user.goalType === "muscle_gain" ? `Gaining as planned. If lifts are going up, this is muscle. Keep training hard.` :
-         Math.abs(diff) < 1 ? `Weight holding. Check measurements — you could be recomping (losing fat, gaining muscle). The tape does not lie.` :
-         `Keep logging. Trends become clear after 4+ weeks of consistent data.`);
-
-      await logChat(user.id, message, reply, "WEIGHT_TREND");
-      return reply;
-    } catch (err) {
-      console.error("[WEIGHT TREND]", err);
-      return `Could not generate weight chart. Try again later.`;
-    }
+      return await weightTrendTurn(user, m);
+    } catch { /* fall through */ }
   }
 
   // ---- SA HOLIDAY MEAL GUIDE — braai, Christmas, Easter, Heritage Day ----

--- a/server/reply-hygiene.ts
+++ b/server/reply-hygiene.ts
@@ -523,8 +523,13 @@ export function ownsNextAction(reply: string): boolean {
  * we cannot yet read. Never invents a move, never picks one, never rewrites the acknowledgement it
  * is given — it is the join, and the decision belongs to its owner.
  */
+export function isHoldReply(text: string): boolean {
+  return /not going to call a trend off those weigh-ins|not going to put a number on it|last weigh-in is too far back|don't have enough weigh-ins yet/i.test(text || "");
+}
+
 export function withNextMove(reply: string, todo: string): string {
   const t = (reply || "").trim();
+  if (isHoldReply(t)) return reply;
   const move = (todo || "").trim().replace(/[.\s]*$/, "");
   if (!move || ownsNextAction(t)) return reply;
   // Same separator composeMessyAck uses — a blank line, never `\n\n---\n\n`, which WhatsApp

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -40,7 +40,7 @@ import { scanForSAFoods, parseFoodLogTotalsFromMessageOut, sanitizeCoachReply, r
 import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence } from "./handlers/chat-log";
 import { handleWorkoutCommands } from "./handlers/workout";
 import { getTodayWorkoutState } from "./workout-state";
-import { handleMiscCommands } from "./handlers/misc-commands";
+import { handleMiscCommands, isCoachingTurn, finalizeCoachingTurn } from "./handlers/misc-commands";
 import { handleLifecycle } from "./handlers/lifecycle";
 import { handleEarlyCommands } from "./handlers/early-commands";
 import { handleReminderCommand } from "./handlers/reminders-handler";
@@ -1347,6 +1347,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   //   mustForceFoodLog  — adapter; already stood down after INSERT meal
   const wroteThisTurn = durableDomains(turnMutations()).length > 0;
   const miscResult = await handleMiscCommands({ phone, message, m, user, isQuestion: normalizedQuestion, wroteThisTurn });
+  if (isCoachingTurn(miscResult)) return closeCoachingTurn(await finalizeCoachingTurn(user, message, miscResult));
   if (miscResult !== null) return miscResult;
 
 

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -625,6 +625,8 @@ export async function runMeaningEngineLive(ctx: {
  */
 export async function closeCoachingTurn(user: any, message: string, reply: string | null): Promise<string> {
   const out = String(reply ?? "");
+  const { isHoldReply } = await import("../reply-hygiene");
+  if (isHoldReply(out)) return out;
   const { turnMutations } = await import("../handlers/chat-log");
   const { durableDomains } = await import("./messy-intake");
   const { withNextMove } = await import("../reply-hygiene");

--- a/server/verifiers/response-gate.ts
+++ b/server/verifiers/response-gate.ts
@@ -25,7 +25,7 @@ import OpenAI from "openai";
 import { extractBodyParts, checkExercisesAgainstInjuries } from "./injury-rules";
 import { splitSentences } from "../reply-hygiene";
 import { readHealthState } from "../health-state";
-import { weightTrendUsable, type TrendVerdict } from "../adaptive-targets";
+import { weightTrendUsable, trendHoldText, type TrendVerdict } from "../adaptive-targets";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { db } from "../db";
 import { users, weightLogs, mealLogs, shadowReplies } from "../../shared/schema";
@@ -301,17 +301,9 @@ function isBacked(kind: ClaimKind, sentence: string, ev: Evidence): boolean {
  */
 function askInstead(kind: ClaimKind, ev: Evidence): string {
   if (kind === "weight-trend") {
-    if (ev.trend.usable && !ev.weighedThisWeek) {
-      return "You haven't weighed in this week, so I'm not going to put a number on it. Hop on the scale in the morning and I'll tell you exactly where you're going.";
-    }
+    if (ev.trend.usable && !ev.weighedThisWeek) return trendHoldText("this_week");
     const why = ev.trend.usable ? "" : ev.trend.why;
-    if (why === "illness") {
-      return "I'm not going to call a trend off those weigh-ins — they sit around the time you were ill, and weight moves on fluid and appetite then, not on food. Hop on the scale in the morning and I'll give you a straight read.";
-    }
-    if (why === "stale") {
-      return "Your last weigh-in is too far back for me to read anything into it. Jump on the scale in the morning and I'll tell you exactly where you're going.";
-    }
-    return "I don't have enough weigh-ins yet to call which way you're going. Get on the scale in the morning and again next week, and I'll give you a straight read.";
+    return trendHoldText(why);
   }
   if (kind === "meal-eaten") {
     return "I don't have a meal logged for you today. What did you eat?";


### PR DESCRIPTION
## What this is

The 16:55 production defect: the weight handler still constructs a spoken verdict (`Scale is going up — keep fuelling.`) and `routes.ts` returns `miscResult` before the canonical coaching authority gets control.

This PR closes **only that mouth**.

```
weight evidence
    → structured CoachingTurn  (facts + HOLD | REPORT_TREND, no reply string)
    → finalizeCoachingTurn     (composeWeightTurn + logChat)
    → closeCoachingTurn        (HOLD is terminal; no second action)
    → customer
```

Base: `dc3c308` (`origin/main`).
Head: `cdb4d60` on `fix/weight-speech-authority`.
Does **not** resurrect #96. Does **not** use `pull_request_target`. Does **not** add a workflow.

## Files (9)

| File | Why |
|---|---|
| `server/handlers/misc-commands.ts` | Both weight-history and weight-chart return `weightTrendTurn` (structured). No `keep fuelling` / `Keep training hard`. |
| `server/adaptive-targets.ts` | `CoachingTurn`, `isCoachingTurn` (rejects `reply`), `composeWeightTurn`, `trendHoldText`. |
| `server/routes.ts` | `if (isCoachingTurn(miscResult)) return closeCoachingTurn(await finalizeCoachingTurn(...))` **before** `return miscResult`. |
| `server/understanding/live.ts` | `closeCoachingTurn` bails on `isHoldReply` before `canonicalDecision`. |
| `server/reply-hygiene.ts` | `isHoldReply`; `withNextMove` refuses to tail a HOLD. |
| `server/verifiers/response-gate.ts` | `askInstead` uses `trendHoldText` (one copy of HOLD language). |
| `script/weight-hold-seam-tests.ts` | 15 architectural 16:55 tests, wired into `npm test`. |
| `script/run-suites.ts` | Registers the seam suite. |
| `script/check-names.ts` | Budget 97 → 96 (writer consolidation). |

Remote blobs were verified against local. `misc-commands.ts` on this branch: **no** `keep fuelling`, **no** `Keep training hard`, **two** `return await weightTrendTurn` calls.

## Tests run on this commit (not “1061”)

| Suite | Result |
|---|---|
| `script/unit-tests.ts` | **1046/1046** |
| `script/gap-tests.ts` | **335/335** |
| `script/weight-hold-seam-tests.ts` | **15/15** |
| `tsc --noEmit` | **pass** |
| `script/check-names.ts` | **96 at budget 96** |

16:55 family covered:

- illness HOLD + historical +2.4kg muscle-gain change → no direction, no fuelling closer
- HOLD does not grow a next move through `withNextMove`
- `usable=false` forces HOLD even if the label says `REPORT_TREND`
- positive control: usable trend still speaks `*Weight History*` + `Up 0.6kg`

## What is PROVEN on this branch

- The two 16:55 writers (weight history / weight chart) no longer author customer-facing trend verdicts.
- `CoachingTurn` cannot carry a `reply` string (`isCoachingTurn` rejects it).
- HOLD copy is one owner (`trendHoldText`). Illness text: *I'm not going to call a trend off those weigh-ins…*
- HOLD is terminal in compose, in `closeCoachingTurn`, and in `withNextMove`.
- `routes.ts` cannot return a weight `CoachingTurn` as a finished string.

## What is NOT PROVEN / KNOWN DEBT (out of this shot)

- Exact-match snapshot `["weight","my weight","current weight"]` in `misc-commands.ts` still returns `Last logged: *84kg*` (not a trend verdict).
- Body-check / recomp mouth (`misc-commands.ts` ~1066) still renders its own weight up/down line. **Not this mouth.**
- `monday.ts` scheduler: `Moving in the right direction.` **Not this mouth.**
- GPT fallback still sees weight facts if misc returns `null`. **Not this mouth.**
- `applyProvenance` will still concatenate old `keep fuelling` **if a draft contains it**. `classifyClaim` is blind to that phrase. Compose never emits it. Pinned by a seam test.
- Non-weight misc still `return miscResult` immediately.
- `check-file-sizes` / `check-architecture` were already over budget on `main`. This PR does **not** raise budgets. Authorship 425→422. `routes.ts` 1501→1502 (the required intercept line).

## Explicitly not in this PR

Alcohol, workout, cards, voice, lifecycle, memory, scheduler, Coach Health, new architecture, new workflow, `cto/one-shot-*`.