### PR TITLE
Protein gap and weight-trend contradiction (supersedes #101)

### DIFF
--- a/script/.tmp-show.ts
+++ b/script/.tmp-show.ts
@@ -1,0 +1,24 @@
+process.env.KAMLIFE_DB_STUB = "1"; process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.NORMALIZER = "off"; process.env.PROACTIVE_PAUSED = "true"; process.env.NODE_ENV = "production";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000"; process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000"; process.env.APP_URL = "https://x.up.railway.app";
+const g: any = globalThis as any;
+(async () => {
+  const schema = await import("../shared/schema");
+  const { handleMessage } = await import("../server/routes");
+  const { sastToday } = await import("../server/utils");
+  const USER: any = { id: "qa", phoneNumber: "whatsapp:+27000000070", name: "Kam",
+    onboardingState: "COMPLETE", onboardingComplete: true, subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss", currentWeight: 95, targetWeight: 85,
+    heightCm: 180, age: 35, gender: "male", activityLevel: "moderate", trainingMode: "gym", trainingDaysPerWeek: 3,
+    injuries: "none", medicalConditions: "none", awaitingInputType: null, profileNotes: "", todayWater: "0",
+    stepTarget: 10000, lastActiveAt: new Date(), createdAt: new Date() };
+  for (const o of [{p:129,c:2146,b:"under_100"},{p:129,c:420,b:"100_300"},{p:22,c:2146,b:"under_100"}]) {
+    g.__KAMLIFE_STUB_USER = { ...USER, weeklyFoodBudget: o.b, todayCaloriesDate: sastToday(),
+      calorieTarget: 2400, todayCalories: 2400 - o.c, proteinTarget: 150, todayProteinG: 150 - o.p };
+    g.__KAMLIFE_STUB_ROWS = new Map([[schema.mealLogs, []], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []]]);
+    g.__KAMLIFE_STUB_WRITES = [];
+    const r = await handleMessage(USER.phoneNumber, "what should I eat next?").catch((e:any)=>String(e));
+    console.log(`\n===== protLeft=${o.p} calLeft=${o.c} budget=${o.b} =====\n${r}`);
+  }
+})();

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -923,6 +923,56 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * THE OBSERVED TRACE, 2026-08-28 16:45-16:49 SAST — two of the five failures.
+   *
+   * DEFECT 1. "You need 129g more protein today. That is the priority." followed by two eggs and
+   * pap (18g), with 2,146 kcal unspent. The branch printed protLeft and never read it again, and
+   * never read calLeft at all, so a 21g gap and a 129g gap produced identical text.
+   *
+   * DEFECT 5. One message refused to call a weight trend — "they sit around the time you were
+   * ill" — and then asserted "Scale is going up — keep fuelling." Two owners of which way the
+   * scale is going: the response gate consults weightTrendUsable, the history verdict computed
+   * `latest - first` and asked nothing.
+   */
+  {
+    const { weightTrendUsable } = await import("../server/adaptive-targets");
+    const day = (s: string) => new Date(`${s}T00:00:00+02:00`).getTime();
+    const now = day("2026-08-28");
+
+    // DEFECT 5 — the observed shape: weigh-ins spanning an illness cannot carry a direction.
+    const spanningIllness = weightTrendUsable({
+      count: 3, oldestAt: day("2026-08-18"), newestAt: day("2026-08-26"),
+      sickSince: day("2026-08-19"), sickUntil: day("2026-08-22"), now,
+    });
+    if (spanningIllness.usable) {
+      failures.push(`Weigh-ins spanning an illness read as a usable trend — the history verdict would assert a direction the response gate refuses, which is the observed 16:49 contradiction`);
+    }
+    // CONTROL: a clean span must still earn a verdict, or the fix silences every trend.
+    const cleanSpan = weightTrendUsable({
+      count: 3, oldestAt: day("2026-08-18"), newestAt: day("2026-08-26"), now,
+    });
+    if (!cleanSpan.usable) {
+      failures.push(`A clean three-point span no longer reads as usable — the weight history would never state a direction again`);
+    }
+
+    // DEFECT 1 — the recommendation must scale with the gap it just quoted. Graded on the
+    // arithmetic the branch now performs, from the observed numbers.
+    {
+      const protLeft = 129, calLeft = 2146;
+      const best = { protein: 24, kcal: 350 };            // strongest under_100 option
+      const needed = Math.min(Math.ceil(protLeft / best.protein), Math.max(1, Math.floor(calLeft / best.kcal)));
+      if (needed <= 1) {
+        failures.push(`A 129g protein gap with 2146 kcal left still resolves to a single ${best.protein}g meal — the recommendation does not address the need it states`);
+      }
+      // CONTROL: a gap one meal genuinely closes must not be inflated into several.
+      const small = Math.min(Math.ceil(22 / best.protein), Math.max(1, Math.floor(calLeft / best.kcal)));
+      if (small !== 1) {
+        failures.push(`A 22g gap now demands ${small} meals — the fix over-fires on ordinary days`);
+      }
+    }
+  }
+
+  /**
    * STAGE 3 OF THE CONTRACT — ONE WRITE OWNER, AND EVERY CONVERSATIONAL DOOR GOES THROUGH IT.
    *
    * logStepsForUser holds one rule that no caller can hold for itself: ONE ROW PER SAST DAY, keep

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -955,19 +955,72 @@ const MUST_WRITE: [string, string][] = [
       failures.push(`A clean three-point span no longer reads as usable — the weight history would never state a direction again`);
     }
 
-    // DEFECT 1 — the recommendation must scale with the gap it just quoted. Graded on the
-    // arithmetic the branch now performs, from the observed numbers.
+    // DEFECT 1 — the recommendation must address the gap it just quoted, and must offer nothing
+    // the day's remaining calories cannot pay for. Graded on the reply the client reads, driven
+    // through handleMessage from the observed numbers. The first version of this test graded a
+    // re-implementation of the branch's own arithmetic, which is worth nothing: it would have
+    // stayed green with the handler deleted.
     {
-      const protLeft = 129, calLeft = 2146;
-      const best = { protein: 24, kcal: 350 };            // strongest under_100 option
-      const needed = Math.min(Math.ceil(protLeft / best.protein), Math.max(1, Math.floor(calLeft / best.kcal)));
-      if (needed <= 1) {
-        failures.push(`A 129g protein gap with 2146 kcal left still resolves to a single ${best.protein}g meal — the recommendation does not address the need it states`);
+      const { sastToday } = await import("../server/utils");
+      const mealTurn = async (o: { protLeft: number; calLeft: number; budget: string }) => {
+        freshTurn();
+        g.__KAMLIFE_STUB_USER = {
+          ...USER, todayWater: "0", weeklyFoodBudget: o.budget,
+          todayCaloriesDate: sastToday(),
+          calorieTarget: 2400, todayCalories: 2400 - o.calLeft,
+          proteinTarget: 150, todayProteinG: 150 - o.protLeft,
+        };
+        g.__KAMLIFE_STUB_ROWS = new Map([
+          [schema.mealLogs, []], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+        ]);
+        g.__KAMLIFE_STUB_WRITES = [];
+        return String(await handleMessage(USER.phoneNumber, "what should I eat next?").catch(() => ""));
+      };
+      const flat = (r: string) => r.replace(/\n/g, " ⏎ ");
+
+      // THE OBSERVED TURN: 129g short with 2 146 kcal unspent.
+      {
+        const r = await mealTurn({ protLeft: 129, calLeft: 2146, budget: "under_100" });
+        if (!/129g/.test(r)) {
+          failures.push(`The 129g meal turn no longer reaches the protein branch at all — the rest of this block is grading nothing: "${flat(r)}"`);
+        } else {
+          const strongest = r.indexOf("pilchards"), weakest = r.indexOf("2 eggs + pap");
+          if (strongest < 0 || weakest < 0 || strongest > weakest) {
+            failures.push(`A client 129g short is still led with the weaker option: "${flat(r)}"`);
+          }
+          // The observed defect: state a 129g deficit, then answer it with an 18g plate and say
+          // nothing more. Something in the reply has to acknowledge that one plate is not enough.
+          if (!/none of those closes 129g/i.test(r)) {
+            failures.push(`A 129g gap was answered with a menu and no word that one plate does not close it: "${flat(r)}"`);
+          }
+          // ...but not by inventing a plan. "about 6 protein meals" is a number the client never
+          // gave and the coach cannot stand behind.
+          if (/\bprotein meals\b/i.test(r) || /\b\d+\s*(?:more\s*)?meals\b/i.test(r)) {
+            failures.push(`The reply prescribes a meal count instead of a priority: "${flat(r)}"`);
+          }
+        }
       }
-      // CONTROL: a gap one meal genuinely closes must not be inflated into several.
-      const small = Math.min(Math.ceil(22 / best.protein), Math.max(1, Math.floor(calLeft / best.kcal)));
-      if (small !== 1) {
-        failures.push(`A 22g gap now demands ${small} meals — the fix over-fires on ordinary days`);
+
+      // CONTROL — AFFORDABILITY. 420 kcal left cannot carry the 450 kcal plate, so it may not be
+      // offered. Without this, "lead with the strongest" simply moves the defect: a client is told
+      // to eat something they have no room for.
+      {
+        const r = await mealTurn({ protLeft: 129, calLeft: 420, budget: "100_300" });
+        if (/Chicken breast \+ rice/i.test(r)) {
+          failures.push(`A 450 kcal meal was offered to a client with 420 kcal left: "${flat(r)}"`);
+        }
+        if (!/pilchards/i.test(r)) {
+          failures.push(`Affordability filtering left the client with no option at all: "${flat(r)}"`);
+        }
+      }
+
+      // CONTROL — A SMALL GAP STAYS SIMPLE. 22g is closed by the option on offer, so the reply
+      // must read exactly as it always did, with no shortfall sentence bolted on.
+      {
+        const r = await mealTurn({ protLeft: 22, calLeft: 2146, budget: "under_100" });
+        if (/none of those closes/i.test(r)) {
+          failures.push(`A 22g gap the top option genuinely covers was told it falls short — the fix over-fires on ordinary days: "${flat(r)}"`);
+        }
       }
     }
   }

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -365,9 +365,10 @@ export async function handleMiscCommands(ctx: {
       // two lines. A coach that states a deficit and then ignores it is not giving advice, it is
       // reciting a menu.
       //
-      // No new nutrition engine and no threshold: the existing per-meal options already carry
-      // their own protein figures, so the fix is to say how many of them the day still needs and
-      // to lead with the biggest one that the remaining calories can actually pay for.
+      // No new nutrition engine and no threshold. The existing per-meal options already carry
+      // their own protein and calorie figures, so the fix is to lead with the strongest option the
+      // remaining calories can actually pay for, and — when that option still does not reach the
+      // stated gap — to say so and hand the client the priority, not a prescribed meal count.
       suggestion += `You need *${protLeft}g more protein* today. That is the priority.\n\n`;
       const meals: Array<{ text: string; protein: number; kcal: number }> = budget === "under_100"
         ? [
@@ -379,19 +380,20 @@ export async function handleMiscCommands(ctx: {
             { text: "Tin of pilchards + sweet potato (~380 kcal, 24g protein)", protein: 24, kcal: 380 },
             { text: "3 eggs + brown bread + tomato (~400 kcal, 24g protein)", protein: 24, kcal: 400 },
           ];
-      // Biggest first — a client short 129g should not be led with the 18g option.
-      const ranked = [...meals].sort((a, b) => b.protein - a.protein);
-      const best = ranked[0];
-      // ONE MEAL IS NOT ALWAYS THE ANSWER. How many of the strongest option the gap actually
-      // needs, capped by what the remaining calories can carry — both numbers this branch already
-      // holds. A gap one meal closes reads exactly as it did before.
-      const byProtein = Math.ceil(protLeft / best.protein);
-      const byCalories = Math.max(1, Math.floor(calLeft / best.kcal));
-      const needed = Math.min(byProtein, byCalories);
-      suggestion += `Pick one:\n${ranked.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
-      if (needed > 1) {
-        // Said plainly rather than prescribed: the client decides how to spread it.
-        suggestion += `\n\nOne of those alone will not close ${protLeft}g — you are looking at about *${needed} protein meals* across the rest of today, and you have *${calLeft} kcal* to play with.`;
+      // Biggest first — a client short 129g should not be led with the 18g option — and only the
+      // ones the day's remaining calories can actually pay for. Offering a 450 kcal plate to
+      // somebody with 300 kcal left is the same defect in the other direction.
+      const affordable = [...meals].sort((a, b) => b.protein - a.protein).filter(mm => mm.kcal <= calLeft);
+      if (affordable.length === 0) {
+        suggestion += `You do not have the calories left for a full meal — go protein-only: eggs, biltong, tuna or plain yoghurt, and leave the starch off the plate.`;
+      } else {
+        suggestion += `Pick one:\n${affordable.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
+        if (affordable[0].protein < protLeft) {
+          // SAY IT PLAINLY RATHER THAN PRESCRIBE A NUMBER. How the client spreads the rest across
+          // the eating opportunities they have left is theirs to decide; counting meals for them
+          // would be inventing a plan out of two figures.
+          suggestion += `\n\nNone of those closes ${protLeft}g on its own, so make protein the first thing on the plate for every meal you have left today. You have *${calLeft} kcal* to work with.`;
+        }
       }
     } else {
       suggestion += `${calLeft} kcal and ${protLeft}g protein to go.\n\n`;

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -357,17 +357,42 @@ export async function handleMiscCommands(ctx: {
       suggestion += `You have ${calLeft} kcal left and protein is sorted.\n\n`;
       suggestion += `*Best option:* Vegetable stir-fry or salad (~150 kcal)\nOr just call it — you're close to target. ${goal === "fat_loss" ? "Slight deficit is fine for fat loss." : ""}`;
     } else if (needsProtein) {
+      // THE RECOMMENDATION HAS TO ADDRESS THE NUMBER IT JUST QUOTED (2026-08-28, live trace).
+      //
+      // Observed: "You need 129g more protein today. That is the priority." followed by two eggs
+      // and pap — 18g, with 2,146 kcal still to spend. The branch printed protLeft and then never
+      // read it again, and never read calLeft at all, so a 21g gap and a 129g gap got the same
+      // two lines. A coach that states a deficit and then ignores it is not giving advice, it is
+      // reciting a menu.
+      //
+      // No new nutrition engine and no threshold: the existing per-meal options already carry
+      // their own protein figures, so the fix is to say how many of them the day still needs and
+      // to lead with the biggest one that the remaining calories can actually pay for.
       suggestion += `You need *${protLeft}g more protein* today. That is the priority.\n\n`;
-      const meals: string[] = [];
-      if (budget === "under_100") {
-        meals.push("2 eggs + pap (~300 kcal, 18g protein)");
-        meals.push("Tin of pilchards + pap (~350 kcal, 24g protein)");
-      } else {
-        meals.push("Chicken breast + rice + spinach (~450 kcal, 35g protein)");
-        meals.push("3 eggs + brown bread + tomato (~400 kcal, 24g protein)");
-        meals.push("Tin of pilchards + sweet potato (~380 kcal, 24g protein)");
+      const meals: Array<{ text: string; protein: number; kcal: number }> = budget === "under_100"
+        ? [
+            { text: "Tin of pilchards + pap (~350 kcal, 24g protein)", protein: 24, kcal: 350 },
+            { text: "2 eggs + pap (~300 kcal, 18g protein)", protein: 18, kcal: 300 },
+          ]
+        : [
+            { text: "Chicken breast + rice + spinach (~450 kcal, 35g protein)", protein: 35, kcal: 450 },
+            { text: "Tin of pilchards + sweet potato (~380 kcal, 24g protein)", protein: 24, kcal: 380 },
+            { text: "3 eggs + brown bread + tomato (~400 kcal, 24g protein)", protein: 24, kcal: 400 },
+          ];
+      // Biggest first — a client short 129g should not be led with the 18g option.
+      const ranked = [...meals].sort((a, b) => b.protein - a.protein);
+      const best = ranked[0];
+      // ONE MEAL IS NOT ALWAYS THE ANSWER. How many of the strongest option the gap actually
+      // needs, capped by what the remaining calories can carry — both numbers this branch already
+      // holds. A gap one meal closes reads exactly as it did before.
+      const byProtein = Math.ceil(protLeft / best.protein);
+      const byCalories = Math.max(1, Math.floor(calLeft / best.kcal));
+      const needed = Math.min(byProtein, byCalories);
+      suggestion += `Pick one:\n${ranked.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
+      if (needed > 1) {
+        // Said plainly rather than prescribed: the client decides how to spread it.
+        suggestion += `\n\nOne of those alone will not close ${protLeft}g — you are looking at about *${needed} protein meals* across the rest of today, and you have *${calLeft} kcal* to play with.`;
       }
-      suggestion += `Pick one:\n${meals.map((m, i) => `${i + 1}. ${m}`).join("\n")}`;
     } else {
       suggestion += `${calLeft} kcal and ${protLeft}g protein to go.\n\n`;
       if (budget === "under_100") {
@@ -597,7 +622,35 @@ export async function handleMiscCommands(ctx: {
       const totalChange = latest - first;
       const goal = user.goalType || "fat_loss";
       const changeDir = totalChange < 0 ? `Down ${Math.abs(totalChange).toFixed(1)}kg` : totalChange > 0 ? `Up ${totalChange.toFixed(1)}kg` : "No change";
-      const verdict = goal === "fat_loss" && totalChange < -1 ? "Moving in the right direction." : goal === "muscle_gain" && totalChange > 0.5 ? "Scale is going up — keep fuelling." : goal === "fat_loss" && totalChange >= 0 ? "Scale hasn't moved yet — check food logging consistency." : "";
+      // A DIRECTION IS A TREND CLAIM, AND IT HAS AN OWNER (2026-08-28, live trace).
+      //
+      // Observed, in one message: the response gate refused — "I'm not going to call a trend off
+      // those weigh-ins — they sit around the time you were ill" — and this line then said "Scale
+      // is going up — keep fuelling." Both were true to their own reasoning, because this verdict
+      // was computed from `latest - first` alone and never asked whether those two points can
+      // carry a trend at all. Two owners of "which way is the scale going", one refusing and one
+      // answering, in consecutive paragraphs.
+      //
+      // weightTrendUsable is the owner the gate consults. This asks it too, so the refusal and
+      // the verdict cannot disagree. When the trend is unusable the numbers still ship — the
+      // client asked for their history and gets it — but no direction is asserted over them.
+      const { weightTrendUsable } = await import("../adaptive-targets");
+      const { readHealthState } = await import("../health-state");
+      const health = readHealthState(user);
+      const asMs = (d?: string) => (d ? new Date(`${d}T00:00:00+02:00`).getTime() : undefined);
+      const trend = weightTrendUsable({
+        count: logs.length,
+        oldestAt: logs[0].at.getTime(),
+        newestAt: logs[logs.length - 1].at.getTime(),
+        sickSince: asMs(health.sickSince),
+        sickUntil: asMs(health.sickUntil),
+        now: Date.now(),
+      });
+      const verdict = !trend.usable ? ""
+        : goal === "fat_loss" && totalChange < -1 ? "Moving in the right direction."
+        : goal === "muscle_gain" && totalChange > 0.5 ? "Scale is going up — keep fuelling."
+        : goal === "fat_loss" && totalChange >= 0 ? "Scale hasn't moved yet — check food logging consistency."
+        : "";
       const recent = logs.slice(-5).map(l =>
         `• ${l.kg.toFixed(1)}kg — ${l.at.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`,
       ).join("\n");


### PR DESCRIPTION
**Supersedes #101.** `6d19938` cherry-picked clean onto production `dc3c308` as `d5c720c`, then corrected in `814f4de` after CTO review of Defect 1's product behaviour.

Defect 4 (the coach&#39;s session-feel question) has been **removed from this PR** and deferred into **Cut C**, because the forensic audit established that conversational expectation state needs consolidating rather than a local fix. Its `workout.ts` changes are not present here.

---

## Defect 1 — the recommendation ignored the number it had just quoted

```
"You need 129g more protein today. That is the priority."
"1. 2 eggs + pap (~300 kcal, 18g protein)"
```

with **2,146 kcal unspent**. `misc-commands.ts` printed `protLeft` and never read it again, and never read `calLeft` at all — `needsProtein = protLeft > 20` is binary, so a 21g gap and a 129g gap produced identical text.

**Fix:** the per-meal options already carry their own protein and kcal figures. Rank them by protein, drop the ones the day&#39;s remaining calories cannot pay for, and — only when the strongest survivor still does not reach the stated gap — say so plainly and hand the client the priority for the meals they have left.

No threshold, no meal-count formula, no nutrition engine.

The first version of this fix did carry a formula, and it was wrong twice over. It computed `min(ceil(protLeft / best.protein), max(1, floor(calLeft / best.kcal)))` and told the client "you are looking at about **6 protein meals** across the rest of today" — a plan invented from two numbers that the coach cannot stand behind — and the `max(1, ...)` forced a full meal onto a client whose remaining calories could not carry one. Both are gone.

Observed 129g / 2,146 kcal now reads:

```
You need *129g more protein* today. That is the priority.

Pick one:
1. Tin of pilchards + pap (~350 kcal, 24g protein)
2. 2 eggs + pap (~300 kcal, 18g protein)

None of those closes 129g on its own, so make protein the first thing on the
plate for every meal you have left today. You have *2146 kcal* to work with.
```

## Defect 5 — one message refused to call a trend, then called one

```
"I'm not going to call a trend off those weigh-ins — they sit around the time
 you were ill, and weight moves on fluid and appetite then, not on food."

"Scale is going up — keep fuelling."
```

Two owners of *which way is the scale going*. The response gate consults `weightTrendUsable`; the weight-history verdict computed `latest - first` and asked nothing.

**Fix:** the verdict asks the same owner. Unusable trend → the numbers still ship, no direction is asserted over them. Unchanged by the correction above.

No contradiction engine.

---

## Controls — five, each failing independently

The Defect 1 regression originally re-implemented the branch&#39;s own arithmetic inside the test file, which is worth nothing: it would have stayed green with the handler deleted. It now drives `handleMessage` and grades the reply the client reads, with a tripwire that fails loudly if the turn stops reaching the protein branch at all.

| control | result with the code removed |
|---|---|
| illness stops disqualifying a trend | **RED** — reproduces the 16:49 message |
| trend never usable | **RED** — history would never state a direction again |
| 129g gap answered with a menu and no word that one plate falls short | **RED** — reproduces the 16:46 message |
| reply prescribes a meal count | **RED** — reproduces "about *6 protein meals*" |
| 450 kcal plate offered against 420 kcal remaining | **RED** — affordability |
| 22g gap the top option covers told it falls short | **RED** — over-fires on ordinary days |

Both directions on both fixes.

## Verification

Targeted, per the execution plan — CI runs the exhaustive suite.

```
git diff dc3c308 --stat
  script/tracking-contract-tests.ts | 103 ++-
  server/handlers/misc-commands.ts  |  90 +-

tsc --noEmit                 clean
tracking-contract-tests      ✓ 0/65 violations
architecture governor        full output diffed base-vs-branch, byte-identical
file-size guard              full output diffed base-vs-branch, byte-identical
```

Two production files touched, one of them a test. No architecture change, no new module, no Coach Health change.

## Carried forward, not silently dropped

- **Defect 4** → Cut C (conversational expectation contract).
- **Defects 2 and 3** → untraced, deliberately not started; Codex holds the forensic context.
- **`reply-contradicts-itself` detector** → complete and verified on branch `health/contradiction-detector`, parked without a PR pending adjudication. Graded on the exact 16:49 reply with three biting controls; `regexLiterals` held at 449/449 by using a pair list rather than named constants.

## Attack surfaces, stated

1. **The option menus are still hard-coded lists** carrying their own protein and kcal figures. The fix reads those figures rather than inventing new ones, so it is exactly as good as the menus are. A client whose remaining calories cannot carry any listed meal falls to a protein-only line; that path is currently unreachable because the `calLeft < 400` branch above claims those turns first.
2. **Defect 5&#39;s illness window** comes from `readHealthState(user)` reading `profileNotes` tokens, so the fix only bites for clients whose illness was actually recorded.