### PR TITLE
CUT A: converge authoritative activity writes

### DIFF
--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -173,8 +173,11 @@ const BUDGET = {
  *               backlog, and it is named rather than counted so nobody has to rediscover it.
  */
 const ACTION_FILES: Record<string, "guarded" | "must-act" | "bookkeeping" | "AT RISK"> = {
-  "server/handlers/meal-repeat.ts": "guarded",
-  "server/handlers/food-commands.ts": "guarded",
+  // meal-repeat.ts and food-commands.ts were here until Cut A. Both held their own meal INSERT —
+  // the repeat door copied a previous row, the alcohol door wrote its own — so both were
+  // independent authorities on "a new eating event happened". Both now hand rows to
+  // commitFoodLog and write nothing themselves, which is the whole point of the cut: this list
+  // shrinking is what convergence looks like from the governor's side.
   // food-context.ts was here until commitFoodLog — the write door — moved to server/day-ledger.ts.
   // It now parses and decides and hands rows to that one owner; it writes nothing itself.
   "server/handlers/food-log-mgmt.ts": "guarded",

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -848,6 +848,45 @@ for (const rule of ONE_OWNER) {
   }
 }
 
+// ── CUT A: ONE AUTHORITATIVE ACTIVITY-WRITE DOOR PER FACT ────────────────────────────────────
+// New events may have many callers, but only these two owners may materialise them. Corrections
+// remain updates/deletes in their existing APIs; this guard only forbids second INSERT authorities.
+{
+  const live = (src: string) => src.replace(/\/\*[\s\S]*?\*\//g, " ")
+    .split("\n").filter(line => !/^\s*\/\//.test(line)).join("\n");
+  const canonicalPath = (f: string) => f.replace(/\\/g, "/");
+  const serverFiles = files.filter(f => canonicalPath(f).startsWith("server/"));
+  const mealBypasses = serverFiles.filter(f => canonicalPath(f) !== "server/day-ledger.ts"
+    && /db\s*\.\s*insert\s*\(\s*mealLogs\s*\)/.test(live(read(f))));
+  for (const f of mealBypasses) problems.push(`  ✗ [OWNERSHIP] ${f} inserts a new meal outside server/day-ledger.ts commitFoodLog.`);
+
+  const permittedWeightMutators = new Set(["server/handlers/weight.ts", "server/handlers/safety.ts"]);
+  const weightBypasses = serverFiles.filter(f => !permittedWeightMutators.has(canonicalPath(f)) && (
+    /\.set\s*\(\s*\{[\s\S]{0,600}?\bcurrentWeight\s*:/.test(live(read(f)))
+    || /\bset\s*\.\s*currentWeight\s*=/.test(live(read(f)))
+  ));
+  for (const f of weightBypasses) problems.push(`  ✗ [OWNERSHIP] ${f} mutates currentWeight outside handleWeightLog (safety reset is the only exception).`);
+
+  const cutAContracts: Array<[string, string, RegExp]> = [
+    ["GOAL_CHANGE supplementary weight", "server/routes.ts", /handleWeightLog\(phone, user, wt\)/],
+    ["onboarding reported weight", "server/onboarding.ts", /handleWeightLog\(phone,[\s\S]{0,160}suppressCustomerLifecycle/],
+    ["scale-photo weight", "server/handlers/media.ts", /scaleReply\s*=\s*await handleWeightLog/],
+    ["text food lineage", "server/handlers/food-context.ts", /eventGroupId\s*=\s*ctx\.sourceMessageId\s*\|\|\s*randomUUID/],
+    ["normal photo lineage", "server/handlers/media.ts", /sourceMessageId:\s*mediaSourceId/],
+    ["collage canonical write", "server/handlers/media.ts", /collageCommit\s*=\s*await commitFoodLog/],
+    ["album canonical write", "server/handlers/media.ts", /albumCommit\s*=\s*await commitFoodLog/],
+    ["meal-repeat canonical write", "server/handlers/meal-repeat.ts", /committed\s*=\s*await commitFoodLog/],
+    ["alcohol canonical write", "server/handlers/food-commands.ts", /alcoholCommit\s*=\s*await commitFoodLog/],
+    ["permanent source replay key", "server/day-ledger.ts", /eq\(mealLogs\.sourceMessageId, params\.sourceMessageId\)/],
+    ["same-message correction API", "server/day-ledger.ts", /planCorrection[\s\S]*applyCorrection/],
+    ["held-meal and amendment APIs", "server/day-ledger.ts", /replaceHeldMeal[\s\S]*amendRecentMeal/],
+    ["meal relabel API", "server/handlers/food-context.ts", /update\(mealLogs\)\.set\(\{ mealLabel: relabelTo, corrected: true \}\)/],
+  ];
+  for (const [contract, file, pattern] of cutAContracts) {
+    if (!pattern.test(read(file))) problems.push(`  ✗ [OWNERSHIP] CUT A contract missing: ${contract} in ${file}.`);
+  }
+}
+
 // ── GUARD #10: A SUITE THAT STOPS RUNNING MUST FAIL FROM OUTSIDE ITSELF (2026-08-19) ─────────
 //
 // script/gap-tests.ts has been broken three times in two days by the same mechanism: an inserted

--- a/script/cut-a-regression-tests.ts
+++ b/script/cut-a-regression-tests.ts
@@ -1,0 +1,118 @@
+/** CUT A — canonical activity-write regressions. Offline and deterministic. */
+process.env.KAMLIFE_DB_STUB = "1";
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "sk-test-offline";
+process.env.NORMALIZER = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID || "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN || "test";
+process.env.TWILIO_WHATSAPP_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER || "+27000000000";
+
+import assert from "node:assert/strict";
+
+const { handleWeightLog } = await import("../server/handlers/weight");
+const { handleMealRepeat } = await import("../server/handlers/meal-repeat");
+const { commitFoodLog } = await import("../server/day-ledger");
+const { mealLogs, weightLogs } = await import("../shared/schema");
+const g = globalThis as any;
+
+const user = () => ({
+  id: "cut-a-user", phoneNumber: "whatsapp:+27000000991", name: "Cut A",
+  onboardingState: "COMPLETE", goalType: "fat_loss", currentWeight: "84",
+  calorieTarget: 2200, proteinTarget: 160, heightCm: 178, age: 35, gender: "male",
+  trainingDaysPerWeek: 3, trainingExperience: "beginner", targetWeightKg: null,
+});
+
+// Scale-photo and text weigh-ins share this owner. A second same-day report updates the event;
+// it never creates a second row, and the caller's turn-local profile follows durable truth.
+{
+  const u = user();
+  g.__KAMLIFE_STUB_USER = u;
+  g.__KAMLIFE_STUB_ROWS = new Map([[weightLogs, []]]);
+  g.__KAMLIFE_STUB_WRITES = [];
+  g.__KAMLIFE_STUB_UPDATES = [];
+  g.__KAMLIFE_STUB_REFLECT_WRITES = true;
+  await handleWeightLog(u.phoneNumber, u, 83);
+  await handleWeightLog(u.phoneNumber, u, 82);
+  const inserts = g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === weightLogs);
+  const updates = g.__KAMLIFE_STUB_UPDATES.filter((w: any) => w.table === weightLogs);
+  assert.equal(inserts.length, 1, "same-day weight writes must upsert one event");
+  assert.ok(updates.some((w: any) => w.set?.weight === "82"), "second scale value must update today's event");
+  assert.equal(u.currentWeight, "82", "turn-local profile must hold canonical current weight");
+  console.log("✓ weight owner — same-day upsert, one event, coherent current truth");
+}
+
+function meal(rawMessage: string, sourceMessageId: string, allowIntentionalRepeat = false) {
+  return commitFoodLog({
+    userId: "cut-a-user", phone: "whatsapp:+27000000991", rawMessage, source: "photo",
+    kcalInt: 420, proteinInt: 32, carbsInt: 0, fatInt: 0,
+    items: [{ name: "Chicken and rice", grams: 350, kcal: 420, protein: 32, category: "meal" }],
+    mealLabel: "lunch", loggedAt: new Date(), sourceMessageId, allowIntentionalRepeat,
+  });
+}
+
+// Stable inbound lineage, not a four-minute clock, is the replay authority.
+{
+  g.__KAMLIFE_STUB_USER = user();
+  g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, []]]);
+  g.__KAMLIFE_STUB_WRITES = [];
+  g.__KAMLIFE_STUB_REFLECT_WRITES = true;
+  const first = await meal("I had chicken and rice", "SM-TEXT-1");
+  const replay = await meal("I had chicken and rice", "SM-TEXT-1");
+  assert.equal(first.wasDup, false);
+  assert.equal(replay.wasDup, true);
+  assert.equal(g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === mealLogs).length, 1,
+    "replaying one inbound message must not insert a second meal");
+  console.log("✓ food owner — stable lineage suppresses webhook replay");
+}
+
+// Exercise the production repeat caller, not just the owner: copied macros/items survive, the
+// inbound id becomes lineage, and replay does not create another eating event.
+{
+  const u = user();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  yesterday.setHours(12, 0, 0, 0);
+  g.__KAMLIFE_STUB_USER = u;
+  g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [{
+    id: "source-lunch", userId: u.id, rawMessage: "Chicken and rice", source: "text",
+    sourceMessageId: "SM-SOURCE", kcalInt: 420, proteinInt: 32, carbsInt: 48, fatInt: 10,
+    items: [{ name: "Chicken and rice", grams: 350, kcal: 420, protein: 32, category: "meal" }],
+    mealLabel: "lunch", loggedAt: yesterday,
+  }]]);
+  g.__KAMLIFE_STUB_WRITES = [];
+  g.__KAMLIFE_STUB_REFLECT_WRITES = true;
+  const message = "same as yesterday's lunch";
+  const first = await handleMealRepeat({ phone: u.phoneNumber, message, m: message, user: u, sourceMessageId: "SM-REPEAT-1" });
+  const replay = await handleMealRepeat({ phone: u.phoneNumber, message, m: message, user: u, sourceMessageId: "SM-REPEAT-1" });
+  const rows = g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === mealLogs).map((w: any) => w.values);
+  assert.match(String(first), /logged/i);
+  assert.match(String(replay), /already logged/i);
+  assert.equal(rows.length, 1, "meal-repeat caller must materialise one canonical event");
+  assert.equal(rows[0].sourceMessageId, "SM-REPEAT-1");
+  assert.equal(rows[0].items[0].name, "Chicken and rice");
+  console.log("✓ meal-repeat caller — copied provenance, canonical write, replay-safe");
+}
+
+// An album is one inbound message but multiple eating-event rows. Per-image raw references keep
+// the shared lineage unambiguous; replaying the whole album inserts none of them twice.
+{
+  g.__KAMLIFE_STUB_USER = user();
+  g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, []]]);
+  g.__KAMLIFE_STUB_WRITES = [];
+  g.__KAMLIFE_STUB_REFLECT_WRITES = true;
+  for (let i = 1; i <= 3; i++) await meal(`[Album photo ${i}]`, "SM-ALBUM-1", true);
+  for (let i = 1; i <= 3; i++) await meal(`[Album photo ${i}]`, "SM-ALBUM-1", true);
+  const rows = g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === mealLogs).map((w: any) => w.values);
+  assert.equal(rows.length, 3, "album must create one row per food image, once");
+  assert.deepEqual(new Set(rows.map((r: any) => r.sourceMessageId)), new Set(["SM-ALBUM-1"]));
+  assert.deepEqual(rows.map((r: any) => r.rawMessage), ["[Album photo 1]", "[Album photo 2]", "[Album photo 3]"]);
+  console.log("✓ food owner — album rows share lineage and remain replay-idempotent");
+}
+
+delete g.__KAMLIFE_STUB_USER;
+delete g.__KAMLIFE_STUB_ROWS;
+delete g.__KAMLIFE_STUB_WRITES;
+delete g.__KAMLIFE_STUB_UPDATES;
+delete g.__KAMLIFE_STUB_REFLECT_WRITES;
+console.log("\nCUT A REGRESSION TESTS PASSED");
+process.exit(0);

--- a/script/cut-a-regression-tests.ts
+++ b/script/cut-a-regression-tests.ts
@@ -78,7 +78,7 @@ function meal(rawMessage: string, sourceMessageId: string, allowIntentionalRepea
     sourceMessageId: "SM-SOURCE", kcalInt: 420, proteinInt: 32, carbsInt: 48, fatInt: 10,
     items: [{ name: "Chicken and rice", grams: 350, kcal: 420, protein: 32, category: "meal" }],
     mealLabel: "lunch", loggedAt: yesterday,
-  }]]);
+  }]]]);
   g.__KAMLIFE_STUB_WRITES = [];
   g.__KAMLIFE_STUB_REFLECT_WRITES = true;
   const message = "same as yesterday's lunch";

--- a/script/onboarding-e2e.ts
+++ b/script/onboarding-e2e.ts
@@ -33,6 +33,8 @@ process.env.TWILIO_WHATSAPP_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER || "+270
 
 const { handleMessage } = await import("../server/routes");
 const { calculateTargets, calculateStepsTarget } = await import("../server/targets");
+const { getWeightTruth } = await import("../server/day-ledger");
+const { weightLogs } = await import("../shared/schema");
 
 type Turn = {
   send: string;
@@ -165,6 +167,7 @@ function fail(flow: string, what: string): void {
 
 async function runFlow(flow: Flow): Promise<void> {
   (globalThis as any).__KAMLIFE_STUB_USER = freshUser(flow.phone);
+  (globalThis as any).__KAMLIFE_STUB_WRITES = [];
   const stub = () => (globalThis as any).__KAMLIFE_STUB_USER;
 
   for (const [i, t] of flow.turns.entries()) {
@@ -194,6 +197,15 @@ async function runFlow(flow: Flow): Promise<void> {
   for (const [k, want] of Object.entries(flow.final)) {
     const got = u[k];
     if (got !== want) fail(flow.name, `field ${k}: got ${JSON.stringify(got)}, expected ${JSON.stringify(want)}`);
+  }
+  const weightWrites = ((globalThis as any).__KAMLIFE_STUB_WRITES as any[])
+    .filter(w => w.table === weightLogs);
+  if (weightWrites.length !== 1) fail(flow.name, `reported weight must create exactly one weight event, got ${weightWrites.length}`);
+  if (weightWrites[0]) {
+    (globalThis as any).__KAMLIFE_STUB_ROWS = new Map([[weightLogs, [{ ...weightWrites[0].values, at: new Date() }]]]);
+    const truth = await getWeightTruth(u);
+    if (truth.currentKg !== flow.targetInputs.weight) fail(flow.name, `getWeightTruth current ${truth.currentKg}, expected ${flow.targetInputs.weight}`);
+    delete (globalThis as any).__KAMLIFE_STUB_ROWS;
   }
   // Free-text intake must have landed as non-empty strings
   if (flow === FLOW_A) {
@@ -226,6 +238,22 @@ async function runFlow(flow: Flow): Promise<void> {
 await runFlow(FLOW_A);
 await runFlow(FLOW_B);
 await runFlow(FLOW_C);
+
+// An unreported default may support provisional targets, but it is not a scale reading and must
+// never become either current truth or a weight event.
+{
+  const phone = "whatsapp:+27000000104";
+  const u = freshUser(phone);
+  Object.assign(u, { onboardingState: "ASK_WEIGHT_HEIGHT_FAST", gender: "female", age: 31, goalType: "fat_loss" });
+  (globalThis as any).__KAMLIFE_STUB_USER = u;
+  (globalThis as any).__KAMLIFE_STUB_WRITES = [];
+  const reply = await handleMessage(phone, "skip", undefined, undefined, undefined, "SM-ONBOARD-SKIP");
+  const weightWrites = ((globalThis as any).__KAMLIFE_STUB_WRITES as any[]).filter(w => w.table === weightLogs);
+  if (!/baseline targets/i.test(reply)) fail("Onboarding skip", `unexpected reply: ${JSON.stringify(reply)}`);
+  if (u.currentWeight != null) fail("Onboarding skip", `fabricated durable currentWeight ${u.currentWeight}`);
+  if (weightWrites.length !== 0) fail("Onboarding skip", `fabricated ${weightWrites.length} weight event(s)`);
+  console.log("✓ Onboarding skip — no fabricated current weight and no weight event");
+}
 
 // ── DAY ONE — what happens AFTER signup ───────────────────────────────────────────────────────
 // (2026-07-28, from the review: "every flow is tested up to the moment the client is onboarded,

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2376,6 +2376,39 @@ async function main() {
     }
   });
 
+  check("CUT A . GOAL_CHANGE supplementary weight crosses the canonical weight owner", async () => {
+    const g = globalThis as any;
+    const msg = "My current weight is 82kg and I joined a gym";
+    const { weightLogs } = await import("../shared/schema");
+    const { getWeightTruth } = await import("../server/day-ledger");
+    const result = await serialise(async () => {
+      const prevNorm = process.env.NORMALIZER;
+      delete process.env.NORMALIZER;
+      g.__KAMLIFE_INTENT_FIXTURES = {
+        [msg.toLowerCase()]: { intent: "GOAL_CHANGE", confidence: 0.95, canonical: "change my goal to muscle gain" },
+      };
+      g.__KAMLIFE_STUB_USER = { ...USER, trainingMode: "home", currentWeight: "84.5" };
+      g.__KAMLIFE_STUB_ROWS = new Map([[weightLogs, []]]);
+      g.__KAMLIFE_STUB_WRITES = [];
+      g.__KAMLIFE_STUB_REFLECT_WRITES = true;
+      try {
+        await handleMessage(USER.phoneNumber, msg, undefined, undefined, undefined, "SM-CUT-A-WEIGHT");
+        const events = g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === weightLogs);
+        assert.equal(events.length, 1, "the turn must create one weight event, even if another weight route sees it later");
+        g.__KAMLIFE_STUB_ROWS = new Map([[weightLogs, [{ ...events[0].values, at: new Date() }]]]);
+        return { currentWeight: g.__KAMLIFE_STUB_USER.currentWeight, truth: await getWeightTruth(g.__KAMLIFE_STUB_USER) };
+      } finally {
+        delete g.__KAMLIFE_INTENT_FIXTURES;
+        delete g.__KAMLIFE_STUB_ROWS;
+        delete g.__KAMLIFE_STUB_WRITES;
+        delete g.__KAMLIFE_STUB_REFLECT_WRITES;
+        if (prevNorm === undefined) delete process.env.NORMALIZER; else process.env.NORMALIZER = prevNorm;
+      }
+    });
+    assert.equal(result.currentWeight, "82", "users.currentWeight must be the canonical value");
+    assert.equal(result.truth.currentKg, 82, "getWeightTruth must read the same event as current truth");
+  });
+
   check("P0-3 . a historical write does not move today's programme", async () => {
     // The retro path advanced programmeDayInWeek and programmeWeek, so "I trained on Monday"
     // silently consumed TODAY's session slot. A backfill is a statement about that day only.

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2035,6 +2035,7 @@ async function main() {
 
   check("2c . the client is told which day was changed", async () => {
     const { mealLogs } = await import("../shared/schema");
+    const { sastDayStart } = await import("../server/utils");
     const g = globalThis as any;
     const replies = await serialise(async () => {
       // One row per day the check corrects — see 2b. A single yesterday row made the today case
@@ -2069,11 +2070,19 @@ async function main() {
     // …AND THE MEAL THEY NAMED. With dinner logged after breakfast, "at breakfast" must not
     // attach to dinner — the date defect one axis over, found reviewing this cut.
     const slotted = await serialise(async () => {
+      // ANCHORED TO THE SAST DAY, NOT TO "NOW MINUS SEVEN HOURS" (2026-09-01).
+      //
+      // Breakfast was seeded at NOW − 7h, which is the previous SAST day on any run before 07:00.
+      // The amend window is correctly bounded to one day, so before 07:00 the named breakfast row
+      // was not in it, the lookup fell through to dinner, and this check went red on the clock
+      // rather than on the code — it failed identically on dc3c308 and on main at 06:47 SAST.
+      // Both rows now sit inside the day the correction resolves to, at every hour.
+      const dayStart = sastDayStart().getTime();
       g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [
         { id: "p-dinner", mealLabel: "dinner", kcalInt: 800, proteinInt: 50, carbsInt: 70,
-          fatInt: 30, items: [{ name: "Steak" }], loggedAt: new Date(NOW - 3600_000) },
+          fatInt: 30, items: [{ name: "Steak" }], loggedAt: new Date(dayStart + 19 * 3600_000) },
         { id: "p-bfast", mealLabel: "breakfast", kcalInt: 669, proteinInt: 63, carbsInt: 60,
-          fatInt: 25, items: [{ name: "Bread" }], loggedAt: new Date(NOW - 7 * 3600_000) },
+          fatInt: 25, items: [{ name: "Bread" }], loggedAt: new Date(dayStart + 7 * 3600_000) },
       ]]]);
       const out = {
         named: await say("You missed the black coffee at breakfast"),
@@ -2082,10 +2091,27 @@ async function main() {
       delete g.__KAMLIFE_STUB_ROWS;
       return out;
     });
+    // AND THE CONTROL FOR THAT PREFERENCE: a named meal the day does not hold must not be
+    // silently redirected to the meal that happens to be newest. Seeded with dinner only, so the
+    // `find` fails and the old `|| rows[0]` fallback would attach the coffee to dinner.
+    const absentSlot = await serialise(async () => {
+      const dayStart = sastDayStart().getTime();
+      g.__KAMLIFE_STUB_ROWS = new Map([[mealLogs, [
+        { id: "p-dinner-only", mealLabel: "dinner", kcalInt: 800, proteinInt: 50, carbsInt: 70,
+          fatInt: 30, items: [{ name: "Steak" }], loggedAt: new Date(dayStart + 19 * 3600_000) },
+      ]]]);
+      const out = await say("You missed the black coffee at breakfast");
+      delete g.__KAMLIFE_STUB_ROWS;
+      return out;
+    });
     assert.match(slotted.named, /to your breakfast/i,
       `the client named the meal and it went elsewhere: ${slotted.named}`);
     assert.match(slotted.unnamed, /to your dinner/i,
       `with no meal named, the most recent must stand: ${slotted.unnamed}`);
+    assert.ok(!/to your dinner/i.test(absentSlot),
+      `the client named a meal the day does not hold and it was written to another: ${absentSlot}`);
+    assert.match(absentSlot, /which meal did i miss/i,
+      `a named meal that is absent must be asked about, not guessed: ${absentSlot}`);
     assert.match(replies.span, /which meal did i miss/i,
       `an unpinnable day was written instead of clarified: ${replies.span}`);
   });

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -49,7 +49,7 @@ export const SUITES = [
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
   "turn-triage-tests", "normalizer-replay-tests", "tracking-contract-tests",
-  "production-parity", "check-architecture",
+  "production-parity", "cut-a-regression-tests", "check-architecture",
 ];
 
 const PER_SUITE_TIMEOUT_MS = 10 * 60_000;

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -205,6 +205,27 @@ const MUST_WRITE: [string, string][] = [
   async function wroteFor(message: string): Promise<Set<string>> {
     freshTurn();
     g.__KAMLIFE_STUB_USER = { ...USER, todayWater: "0" };
+    // THE LEDGER IS PROCESS STATE TOO (2026-09-01, found integrating Cut A).
+    //
+    // freshTurn() resets the caches and limiters above for exactly the reason stated there — a
+    // graded turn must not inherit the previous one. __KAMLIFE_STUB_ROWS was never in that reset,
+    // so every turn here ran against whatever meal/step/weight rows earlier BLOCKS of this file
+    // had left in the Map, and those rows carry only the columns their own block cared about.
+    //
+    // That was invisible while every dedup query happened to carry a leaf the stub could judge
+    // against the residue: commitFoodLog filtered on `loggedAt >= now-4min`, the stale rows are
+    // older, so they were dropped and the count came out right by accident. Cut A's replay
+    // suppression keys on sourceMessageId + rawMessage with NO time bound — correct, because a
+    // Twilio retry can arrive at any distance — and the residue seeds NEITHER column, so the stub
+    // could not judge either leaf, kept all five rows, and "I had eggs. what should I eat?"
+    // reported itself a duplicate and wrote nothing.
+    //
+    // The product is right: in Postgres those rows have sourceMessageId NULL and never match a
+    // real id. The fixture was wrong, and it was wrong before Cut A — Cut A is only what made it
+    // visible. Reset the ledger with the rest of the turn state.
+    g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([
+      [schema.mealLogs, []], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+    ]);
     g.__KAMLIFE_STUB_WRITES = [];
     await handleMessage(USER.phoneNumber, message).catch(() => "");
     const wrote = new Set<string>(

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -180,7 +180,19 @@ export async function appendItemsToRecentMeal(
     .where(and(eq(mealLogs.userId, userId), gte(mealLogs.loggedAt, dayStart), lt(mealLogs.loggedAt, dayEnd)))
     .orderBy(desc(mealLogs.loggedAt)).limit(8);
   const slot = String(namedSlot || "").toLowerCase();
-  const target = (slot ? rows.find(r => String(r.mealLabel || "").toLowerCase() === slot) : null) || rows[0];
+  // A NAMED SLOT THAT IS NOT THERE IS NOT A LICENCE TO PICK ANOTHER MEAL (2026-09-01).
+  //
+  // `find(...) || rows[0]` read as "prefer the named meal", but the `||` also fires when the named
+  // meal simply is not in that day — so a client saying "you missed the black coffee at breakfast"
+  // before their breakfast was logged had the coffee silently attached to whatever they ate last.
+  // That is the same defect the day bound above fixed, one axis over and one step later: we knew
+  // which meal they meant, could not find it, and wrote somewhere else anyway.
+  //
+  // Naming no slot is unchanged — most-recent still stands, which is what "you missed the black
+  // coffee" has always meant. Returning null hands the turn to the clarification the caller
+  // already owns ("Which meal did I miss?"), the same answer an unpinnable DAY gets. Asking is
+  // cheap; a correction on a meal the client did not name is not visible to them.
+  const target = slot ? rows.find(r => String(r.mealLabel || "").toLowerCase() === slot) : rows[0];
   if (!target?.id) return null;
 
   const existing = Array.isArray(target.items) ? target.items as any[] : [];

--- a/server/day-ledger.ts
+++ b/server/day-ledger.ts
@@ -91,6 +91,8 @@ interface CommitFoodLogParams {
   /** EVENT LINEAGE (0004). Rows sharing this came from ONE client message. Omitted → NULL, which
    *  is a group of one and exactly how every row behaved before events existed. */
   sourceMessageId?: string | null;
+  /** Explicit copies and separate photos are distinct eating events even when their foods match. */
+  allowIntentionalRepeat?: boolean;
 }
 
 interface CommitFoodLogResult {
@@ -250,7 +252,17 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
   const dedupWindow = new Date(Date.now() - 4 * 60 * 1000);
   const rawSlice = params.rawMessage.slice(0, 1000);
   const effLoggedAt = effectiveMealLoggedAt(params.loggedAt, params.rawMessage, params.mealLabel);
-  let recentDup = await db.select({ id: mealLogs.id })
+  // Twilio retries keep the inbound message id. Raw event text disambiguates multi-event text
+  // and album images that deliberately share one lineage id.
+  let recentDup = params.sourceMessageId ? await db.select({ id: mealLogs.id })
+    .from(mealLogs)
+    .where(and(
+      eq(mealLogs.userId, params.userId),
+      eq(mealLogs.sourceMessageId, params.sourceMessageId),
+      eq(mealLogs.rawMessage, rawSlice),
+    ))
+    .limit(1) : [];
+  if (recentDup.length === 0) recentDup = await db.select({ id: mealLogs.id })
     .from(mealLogs)
     .where(and(
       eq(mealLogs.userId, params.userId),
@@ -262,7 +274,7 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
   // Voice retries of the same takeaway (McDonald's breakfast x3) have different raw text
   // so exact-match never fires — 127g protein from one breakfast. Treat same-chain items
   // in the last 2 hours as one meal.
-  if (recentDup.length === 0) {
+  if (recentDup.length === 0 && !params.allowIntentionalRepeat) {
     const retryWindow = new Date(Date.now() - 2 * 60 * 60 * 1000);
     const recentRows = await db.select({ id: mealLogs.id, items: mealLogs.items })
       .from(mealLogs)
@@ -283,8 +295,8 @@ export async function commitFoodLog(params: CommitFoodLogParams): Promise<Commit
   }
   // A held row's REPLACEMENT and an AMENDMENT both rewrite an existing row and suppress the
   // insert below. Neither ever creates a second row.
-  const heldId = await replaceHeldMeal(params.userId, `${rawSlice} ${itemNames.join(" ")}`, patch);
-  const amendedId = heldId || await amendRecentMeal(params.userId, itemNames, patch);
+  const heldId = params.allowIntentionalRepeat ? null : await replaceHeldMeal(params.userId, `${rawSlice} ${itemNames.join(" ")}`, patch);
+  const amendedId = heldId || (params.allowIntentionalRepeat ? null : await amendRecentMeal(params.userId, itemNames, patch));
   if (amendedId) { invalidatePatternCache(params.userId); invalidateFoodTotalsCache(params.userId); }
   let insertOk = true;
   const wasDup = recentDup.length > 0 || !!amendedId;

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -50,6 +50,7 @@ export async function handleEarlyCommands(ctx: {
   message: string;
   m: string;
   user: any;
+  sourceMessageId?: string;
   hasMedia?: boolean;
   /** SYSTEMIC GATE: classifier says this is a QUESTION (conf >= 0.8). Handlers with
    *  SIDE EFFECTS (log, flip mode, dump content) must not fire — questions go to the
@@ -833,7 +834,7 @@ export async function handleEarlyCommands(ctx: {
   // as dinner" — the media pipeline owns it. Firing here copied yesterday's dinner
   // instead and the photo was never analysed (production cascade, 2026-07-02).
   if (!ctx.hasMedia && !ctx.isQuestion) {
-    const sameAsReply = await handleMealRepeat({ phone, message, m, user });
+    const sameAsReply = await handleMealRepeat({ phone, message, m, user, sourceMessageId: ctx.sourceMessageId });
     if (sameAsReply) return sameAsReply;
   }
 
@@ -900,7 +901,7 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
 
   // ---- FOOD COMMANDS (server/handlers/food-commands.ts) — restaurant / street food / swaps /
   // meal prep / grocery / supplements; extracted for isolation, identical behaviour + order. ----
-  const foodCmdReply = await handleFoodCommands({ phone, message, m, user });
+  const foodCmdReply = await handleFoodCommands({ phone, message, m, user, sourceMessageId: ctx.sourceMessageId });
   if (foodCmdReply !== null) return foodCmdReply;
 
   // ---- WHY command ----

--- a/server/handlers/food-commands.ts
+++ b/server/handlers/food-commands.ts
@@ -7,15 +7,14 @@
  */
 
 import { db } from "../db";
-import { turnMutation } from "./chat-log";
-import { users, mealLogs, chatHistory } from "../../shared/schema";
+import { users, chatHistory } from "../../shared/schema";
 import { eq, and, gte, desc, sql } from "drizzle-orm";
 import { SA_FOODS_SEED } from "../foods";
 import { isAskingNotReporting } from "../utils";
 import { askCoachK } from "../gpt";
 import { getShoppingList, formatShoppingList } from "../shopping-lists";
 import { getGroceryPersonalization } from "../grocery-personalize";
-import { scanForSAFoods, invalidateFoodTotalsCache } from "./food-scanner";
+import { scanForSAFoods } from "./food-scanner";
 import { logChat, withTimeout } from "./chat-log";
 import { tryLogWater } from "./water";
 import { generateMealPlan } from "../meal-plan";
@@ -24,8 +23,9 @@ import { matchRestaurant, formatRestaurantGuide, listRestaurantNames } from "../
 import { matchStreetDish, isStreetContext, formatStreetDish, streetGuide } from "../street-food";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
 import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel , commaName} from "../utils";
+import { commitFoodLog } from "../day-ledger";
 
-export async function handleFoodCommands(ctx: { phone: string; message: string; m: string; user: any }): Promise<string | null> {
+export async function handleFoodCommands(ctx: { phone: string; message: string; m: string; user: any; sourceMessageId?: string }): Promise<string | null> {
   const { phone, message, m, user } = ctx;
   const firstName = user.name?.split(" ")[0] || "";
   const capName = user.name?.split(" ")[0] || "there";
@@ -104,21 +104,21 @@ export async function handleFoodCommands(ctx: { phone: string; message: string; 
     const alcoholLoggedAt = parseMealDate(m);
     const alcoholDateLabel = mealDateLabel(alcoholLoggedAt);
 
-    // Always insert into mealLogs — alcohol calories must actually be tracked
-    await db.insert(mealLogs).values({
+    const alcoholCommit = await commitFoodLog({
       userId: user.id,
+      phone,
       rawMessage: message.slice(0, 1000),
       source: "alcohol_log",
       kcalInt: totalCal,
       proteinInt: 0,
       carbsInt: Math.round(totalCal * 0.85 / 4),
       fatInt: 0,
-      items: [{ name: `${drinkName} ×${qty}`, kcal: totalCal, protein: 0 }],
+      items: [{ name: `${drinkName} ×${qty}`, grams: 0, kcal: totalCal, protein: 0, category: "alcohol" }],
       mealLabel: "alcohol",
       loggedAt: alcoholLoggedAt,
-    }).catch(e => console.warn("[alcohol mealLog insert]", e));
-    turnMutation("INSERT meal", "[WRITE]");
-    invalidateFoodTotalsCache(user.id);
+      sourceMessageId: ctx.sourceMessageId,
+    });
+    if (!alcoholCommit.ok) return `I worked out the drinks (~${totalCal} kcal) but couldn't save them just now. Send that again in a moment.`;
 
     let alcoholReply: string;
     if (isRetroAlcohol) {

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -259,10 +259,13 @@ export async function handleFoodContext(ctx: {
   classifierQuestion?: boolean;
   /** EXECUTOR resolved an explicit LOG_MEAL: skip advisory branches (2026-07-27: the ordering guide answered a log 3x). */
   forceLog?: boolean;
+  /** Stable inbound id used by the canonical writer to make webhook replays idempotent. */
+  sourceMessageId?: string;
 }): Promise<string | null> {
   const { phone, message, m, user, handleMessage } = ctx;
   const classifierQuestion = !!ctx.classifierQuestion;
   const forceLog = !!ctx.forceLog;
+  const eventGroupId = ctx.sourceMessageId || randomUUID();
 
   // ---- SUPPORT BEFORE LOGGING (2026-07-14) — a deep emotional share ("I ate a whole
   // cake, I've tried everything, I want to quit") must reach emotional support, NOT get
@@ -497,7 +500,7 @@ export async function handleFoodContext(ctx: {
             userId: user.id, phone, rawMessage: "[Photo — checked first, then eaten]", source: "photo",
             kcalInt: vKcal, proteinInt: vProt, carbsInt: 0, fatInt: 0, items: [],
             mealLabel: extractMealLabel(message, undefined, { kcal: vKcal, protein: vProt }, user, await getSlotContext(user.id)),
-            loggedAt: new Date(),
+            loggedAt: new Date(), sourceMessageId: eventGroupId,
           });
           const vReply = `Logged ✅ ~${vKcal} kcal | ${vProt}g protein.\n\n_Today: ${cv.runningCals} kcal | ${cv.runningProtein}g protein_`;
           await logChat(user.id, message, vReply, "FOOD_LOG");
@@ -524,7 +527,7 @@ export async function handleFoodContext(ctx: {
             userId: user.id, phone, rawMessage: lastUnloggedFood.messageIn || "", source: "text",
             kcalInt: totalCals, proteinInt: totalProt2, carbsInt: 0, fatInt: 0, items: [],
             mealLabel: extractMealLabel(lastUnloggedFood.messageIn || "", undefined, { kcal: totalCals, protein: totalProt2 }, user, await getSlotContext(user.id)),
-            loggedAt: new Date(),
+            loggedAt: new Date(), sourceMessageId: eventGroupId,
           });
           return `Logged! ✅\n${parts.join("\n")}\n\n_Today: ${cs.runningCals} kcal | ${cs.runningProtein}g protein_`;
         }
@@ -888,7 +891,7 @@ export async function handleFoodContext(ctx: {
           userId: user.id, phone, rawMessage: p.raw, source: "text",
           kcalInt: p.kcal, proteinInt: p.prot, carbsInt: 0, fatInt: 0, items: [],
           mealLabel: extractMealLabel(p.raw, p.date, { kcal: p.kcal, protein: p.prot }, user, slotCtxMulti),
-          loggedAt: p.date,
+          loggedAt: p.date, sourceMessageId: eventGroupId,
         });
         recomp = { calories: c.runningCals, protein: c.runningProtein };
       }
@@ -1186,7 +1189,6 @@ export async function handleFoodContext(ctx: {
       // utterance stays undoable as one thing. Single-event messages are untouched — one row, as
       // before, and that is the common case. rawMessage carries the EVENT's words: commitFoodLog
       // dedups on it, so four rows sharing the full text would drop three as duplicates.
-      const eventGroupId = randomUUID();
       const eventBuckets = segmentBuckets.filter(b => b.foods.length > 0);
       const splitIntoEvents = eventBuckets.length >= 2;
       let committed!: Awaited<ReturnType<typeof commitFoodLog>>;
@@ -1333,7 +1335,7 @@ export async function handleFoodContext(ctx: {
             origin: "ai",
           })),
           mealLabel: extractMealLabel(message, undefined, { kcal: gptFallbackResult.totalKcal, protein: gptFallbackResult.totalProtein }, user, await getSlotContext(user.id)),
-          loggedAt: gptLoggedAt,
+          loggedAt: gptLoggedAt, sourceMessageId: eventGroupId,
         });
         const { prevCals: fbPrevCals, runningCals, runningProtein } = committed;
         const fallbackReply = await buildFoodLogReply({
@@ -1421,7 +1423,7 @@ export async function handleFoodContext(ctx: {
           name: f.name, grams: 0, kcal: f.kcal, protein: f.protein_g, category: f.category,
         })),
         mealLabel: extractMealLabel(message, undefined, { kcal: gptFallbackResult.totalKcal, protein: gptFallbackResult.totalProtein }, user, await getSlotContext(user.id)),
-        loggedAt: fb2LoggedAt,
+        loggedAt: fb2LoggedAt, sourceMessageId: eventGroupId,
       });
       const { prevCals: fb2PrevCals, runningCals, runningProtein } = committed2;
       const fallbackReply = await buildFoodLogReply({

--- a/server/handlers/meal-repeat.ts
+++ b/server/handlers/meal-repeat.ts
@@ -12,21 +12,21 @@
  *    webhook retry must not double-log the meal and inflate the day's calories.
  */
 import { db } from "../db";
-import { turnMutation } from "./chat-log";
-import { users, mealLogs } from "../../shared/schema";
+import { mealLogs } from "../../shared/schema";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { sastDayStart, slotFromSastHour } from "../utils";
 import { selectMealToCopy, parseMealRepeatTarget, type CopyableMeal } from "../meal-select";
-import { recomputeTodayFoodTotals, invalidateFoodTotalsCache } from "./food-scanner";
 import { logChat } from "./chat-log";
 import { isAskingNotReporting } from "../utils";
 import { dailyMacroCardMarker } from "../macro-card-attach";
+import { commitFoodLog } from "../day-ledger";
 
 export async function handleMealRepeat(ctx: {
   phone: string;
   message: string;
   m: string;
   user: any;
+  sourceMessageId?: string;
 }): Promise<string | null> {
   const { phone, message, m, user } = ctx;
 
@@ -170,24 +170,31 @@ export async function handleMealRepeat(ctx: {
       return dupReply;
     }
 
-    await db.insert(mealLogs).values({
+    const repeatedItems = Array.isArray(match.items) ? (match.items as any[]).map(item => ({
+      ...item,
+      name: String(item?.name || item?.foodName || "Repeated item"),
+      grams: Number(item?.grams) || 0,
+      kcal: Number(item?.kcal) || 0,
+      protein: Number(item?.protein) || 0,
+      category: String(item?.category || "other"),
+    })) : [];
+    const committed = await commitFoodLog({
       userId: user.id,
-      rawMessage: match.rawMessage || "[Repeat meal]",
+      phone,
+      rawMessage: message.slice(0, 1000),
       source: "retro",
-      kcalInt: match.kcalInt,
-      proteinInt: match.proteinInt,
+      kcalInt: match.kcalInt || 0,
+      proteinInt: match.proteinInt || 0,
       carbsInt: match.carbsInt || 0,
       fatInt: match.fatInt || 0,
       mealLabel: targetLabel || sourceHint || match.mealLabel || null,
-      items: match.items,
+      items: repeatedItems,
+      loggedAt: new Date(),
+      sourceMessageId: ctx.sourceMessageId,
+      allowIntentionalRepeat: true,
     });
-    turnMutation("INSERT meal", "[WRITE]");
-    invalidateFoodTotalsCache(user.id);
-    const recomputed = await recomputeTodayFoodTotals(user.id);
-    await db.update(users).set({
-      todayCalories: recomputed.calories,
-      todayProteinG: recomputed.protein,
-    }).where(eq(users.phoneNumber, phone));
+    if (!committed.ok) return `I found that meal but couldn't save the copy just now. Send that again in a moment.`;
+    if (committed.wasDup) return `Already logged ✅ — that meal is counted in today's total.`;
 
     const labelDisplay = (targetLabel || sourceHint || match.mealLabel || "Meal").replace(/\b\w/g, c => c.toUpperCase());
     const mealWasToday = match.loggedAt && new Date(match.loggedAt) >= todayStart;
@@ -195,8 +202,8 @@ export async function handleMealRepeat(ctx: {
     const fromNote = crossish && sourceHint && sourceHint !== targetLabel ? `copied from ${sourceHint}`
       : daysBack > 0 ? `from ${daysBack === 1 ? "yesterday" : `${daysBack} days ago`}`
       : mealWasToday ? "from earlier today" : "from yesterday";
-    const remaining = (user.calorieTarget || 1800) - recomputed.calories;
-    const protGap = (user.proteinTarget || 120) - recomputed.protein;
+    const remaining = (user.calorieTarget || 1800) - committed.runningCals;
+    const protGap = (user.proteinTarget || 120) - committed.runningProtein;
     // Echo parsed food names ("Apple, Pear"), never the client's raw sentence verbatim.
     const itemNames = Array.isArray(match.items) ? (match.items as Array<{ name?: string }>).map(i => i?.name).filter(Boolean).join(", ") : "";
     const rawLabel = itemNames ? `_${itemNames}_\n` : match.rawMessage ? `_${match.rawMessage.slice(0, 80)}_\n` : "";

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -12,7 +12,7 @@ import type OpenAI from "openai";
 import type { ChatCompletionContentPart } from "openai/resources/chat/completions";
 import { db } from "../db";
 import {
-  users, chatHistory, stepLogs, mealLogs, progressPhotos,
+  users, chatHistory, stepLogs, progressPhotos,
 } from "../../shared/schema";
 import { eq, and, gte, lt, asc, desc, sql } from "drizzle-orm";
 import {
@@ -26,7 +26,7 @@ import { getStepResponse, getStepStreak } from "./steps";
 import { checkPerfectDay, checkFoodPatterns } from "./checks";
 import { handleWeightLog } from "./weight";
 import { handleWater } from "./water";
-import { recomputeTodayFoodTotals, invalidateFoodTotalsCache, scanForSAFoods, findDuplicateMealToday, parseFoodLogTotalsFromMessageOut } from "./food-scanner";
+import { recomputeTodayFoodTotals, scanForSAFoods, findDuplicateMealToday, parseFoodLogTotalsFromMessageOut } from "./food-scanner";
 import { buildFoodVisionSystemPrompt, buildFoodVisionUserPrompt, buildMenuPickPrompt } from "./food-vision-prompt";
 import { selectVisionModel, estimateVisionCostUSD } from "../gpt";
 import { calculateTargets, getDailyStepContext, waterTargetLitres } from "../targets";
@@ -170,12 +170,14 @@ export async function handleMediaMessage(ctx: {
   mediaUrl: string;
   mediaContentType: string | undefined;
   allMediaUrls: string[] | undefined;
+  sourceMessageId?: string;
   user: any;
   isCoach: boolean;
   openai: OpenAI;
-  handleMessage: (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[]) => Promise<string>;
+  handleMessage: (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string) => Promise<string>;
 }): Promise<string> {
-  const { phone, message, mediaUrl, allMediaUrls, user, isCoach, openai, handleMessage } = ctx;
+  const { phone, message, mediaUrl, allMediaUrls, user, isCoach, openai, handleMessage, sourceMessageId } = ctx;
+  const mediaSourceId = sourceMessageId || crypto.randomUUID();
   const ctype = ctx.mediaContentType || "";
   const mediaTrace = buildMediaTrace(phone, ctype);
   const mediaFlowStart = Date.now();
@@ -461,15 +463,14 @@ export async function handleMediaMessage(ctx: {
                   const kcal = tl ? parseInt(tl[1].replace(/,/g, ""), 10) : 0;
                   const prot = tl ? parseInt(tl[2], 10) : 0;
                   if (kcal <= 0 && prot <= 0) return;
-                  await db.insert(mealLogs).values({
-                    userId: user.id, source: "photo", kcalInt: kcal, proteinInt: prot,
-                    loggedAt: new Date(), rawMessage: "[Collage food]", mealLabel: "Collage meal",
-                  }).catch((e) => console.error("[COLLAGE_FOOD] mealLogs insert failed:", e));
-                  turnMutation("INSERT meal", "[WRITE]");
+                  const collageCommit = await commitFoodLog({
+                    userId: user.id, phone, source: "photo", kcalInt: kcal, proteinInt: prot,
+                    carbsInt: 0, fatInt: 0, items: itemsFromVisionText(txt), loggedAt: new Date(),
+                    rawMessage: "[Collage food]", mealLabel: "Collage meal", sourceMessageId: mediaSourceId,
+                  });
+                  if (!collageCommit.ok || collageCommit.wasDup) return;
                   await logChat(user.id, "[Photo - collage meal]", txt, "FOOD_LOG");
-                  invalidateFoodTotalsCache(user.id);
-                  const totals = await recomputeTodayFoodTotals(user.id).catch(() => null);
-                  const totalNote = totals?.calories ? `\n\n_Today so far: ~${totals.calories} kcal | ${totals.protein}g protein._` : "";
+                  const totalNote = collageCommit.runningCals ? `\n\n_Today so far: ~${collageCommit.runningCals} kcal | ${collageCommit.runningProtein}g protein._` : "";
                   const displayTxt = txt.replace(/\nTOTAL:.*$/im, "").trim();
                   await sendWhatsApp(phone, `Also logged your meal from the photo:\n\n${displayTxt}\n\n*~${kcal} kcal | ~${prot}g protein*${totalNote}`);
                   console.log(`[COLLAGE_FOOD] food logged and sent kcal=${kcal} prot=${prot}`);
@@ -486,7 +487,7 @@ export async function handleMediaMessage(ctx: {
                 try {
                   let albumKcal = 0, albumProt = 0;
                   const albumParts: string[] = [];
-                  for (const extraUrl of albumExtras.slice(0, 3)) {
+                  for (const [albumIndex, extraUrl] of albumExtras.slice(0, 3).entries()) {
                     try {
                       await assertSafeMediaUrl(extraUrl);
                     } catch (e) {
@@ -522,17 +523,18 @@ export async function handleMediaMessage(ctx: {
                     const prot = Number.isFinite(protRaw) ? Math.min(200, Math.max(0, protRaw)) : 0;
                     console.log(`[ALBUM_FOOD] extracted kcal=${kcal} prot=${prot}`);
                     if (kcal <= 0 && prot <= 0) continue; // non-food image — skip
+                    const albumCommit = await commitFoodLog({
+                      userId: user.id, phone, source: "photo", kcalInt: kcal, proteinInt: prot,
+                      carbsInt: 0, fatInt: 0, items: itemsFromVisionText(text), loggedAt: new Date(),
+                      rawMessage: `[Album photo ${albumIndex + 1}]`, mealLabel: "Album meal",
+                      sourceMessageId: mediaSourceId, allowIntentionalRepeat: true,
+                    });
+                    if (!albumCommit.ok || albumCommit.wasDup) continue;
                     albumKcal += kcal; albumProt += prot;
                     albumParts.push(text.replace(/\nTOTAL:.*$/i, "").trim());
-                    await db.insert(mealLogs).values({
-                      userId: user.id, source: "photo", kcalInt: kcal, proteinInt: prot,
-                      loggedAt: new Date(), rawMessage: "[Album photo]", mealLabel: "Album meal",
-                    }).catch((e) => console.error("[ALBUM_FOOD] mealLogs insert failed:", e));
-                    turnMutation("INSERT meal", "[WRITE]");
                     await logChat(user.id, "[Photo - album meal]", text, "FOOD_LOG");
                   }
                   if (albumKcal > 0) {
-                    invalidateFoodTotalsCache(user.id);
                     const suffix = albumParts.length > 1 ? "s" : "";
                     const totals = await recomputeTodayFoodTotals(user.id).catch(() => null);
                     const totalNote = totals && totals.calories > 0
@@ -866,7 +868,7 @@ export async function handleMediaMessage(ctx: {
       if (!visionReply || visionReply.length < 10) {
         if (captionHasFood) {
           console.log(`[FOOD_VISION] unreadable photo — logging from caption user=${user.id.slice(-6)}`);
-          return handleMessage(phone, message);
+          return handleMessage(phone, message, undefined, undefined, undefined, mediaSourceId);
         }
         return mealAsk;
       }
@@ -880,7 +882,7 @@ export async function handleMediaMessage(ctx: {
         // Photo isn't food, but the caption names real food — log from the caption.
         if (captionHasFood) {
           console.log(`[FOOD_VISION] not_food photo but caption has food — logging from caption user=${user.id.slice(-6)}`);
-          return handleMessage(phone, message);
+          return handleMessage(phone, message, undefined, undefined, undefined, mediaSourceId);
         }
         if (noCaption) {
           await logChat(user.id, "[Equipment Photo]", "", "EQUIPMENT_ID");
@@ -991,8 +993,10 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
         return vals.length > 0 ? vals.reduce((a, b) => a + b, 0) : 0;
       };
 
-      let totalPhotoKcal = extractKcal(visionReply);
-      let totalPhotoProt = extractProt(visionReply);
+      const primaryPhotoKcal = extractKcal(visionReply);
+      const primaryPhotoProt = extractProt(visionReply);
+      let totalPhotoKcal = primaryPhotoKcal;
+      let totalPhotoProt = primaryPhotoProt;
       // Strip internal TOTAL/ITEMS/LABEL lines; unwrap a scare-quoted food name (reads as
       // sarcasm). "Black coffee logged ☕" (2026-08-05) — scrubbed at source now.
       const visionDisplay = stripFoodLoggedClaim(visionReply
@@ -1049,9 +1053,12 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       // ── MULTI-PHOTO: process any extra images sent in the same message ──
       const extraImageUrls = (allMediaUrls || []).filter(u => u !== mediaUrl);
       const extraReplies: string[] = [];
+      const photoLoggedAt = parseMealDate(message || "");
+      const photoIsRetro = isRetroactiveMeal(message || "");
+      let photoCommit: Awaited<ReturnType<typeof commitFoodLog>> | null = null;
       if (extraImageUrls.length > 0) {
         const imgAuthHeaderExtra = "Basic " + Buffer.from(`${process.env.TWILIO_ACCOUNT_SID || ""}:${process.env.TWILIO_AUTH_TOKEN || ""}`).toString("base64");
-        for (const extraUrl of extraImageUrls.slice(0, 3)) {
+        for (const [extraIndex, extraUrl] of extraImageUrls.slice(0, 3).entries()) {
           try {
             try {
               await assertSafeMediaUrl(extraUrl);
@@ -1081,6 +1088,14 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
             const extraKcal = extractKcal(extraText);
             const extraProt = extractProt(extraText);
             if (!(/^NOT_FOOD\b/i.test(extraText)) && (extraKcal > 0 || extraProt > 0)) {
+              const extraLabel = extractMealLabel(message || "", photoLoggedAt, { kcal: extraKcal, protein: extraProt }, user, await (await import("../portion-memory")).getSlotContext(user.id)) || slotFromSastHour(photoLoggedAt);
+              const extraCommit = await commitFoodLog({
+                userId: user.id, phone, rawMessage: `[Album photo ${extraIndex + 2}]`, source: "photo",
+                kcalInt: extraKcal, proteinInt: extraProt, carbsInt: 0, fatInt: 0,
+                items: itemsFromVisionText(extraText), mealLabel: extraLabel, loggedAt: photoLoggedAt,
+                sourceMessageId: mediaSourceId, allowIntentionalRepeat: true,
+              });
+              if (!extraCommit.ok || extraCommit.wasDup) continue;
               extraReplies.push(extraText.replace(/\nTOTAL:.*$/i, "").trim());
               totalPhotoKcal += extraKcal;
               totalPhotoProt += extraProt;
@@ -1123,16 +1138,13 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
         }
       }
 
-      const photoLoggedAt = parseMealDate(message || "");
-      const photoIsRetro = isRetroactiveMeal(message || "");
-      let photoCommit: Awaited<ReturnType<typeof commitFoodLog>> | null = null;
-      if (totalPhotoKcal > 0 || totalPhotoProt > 0) {
+      if (primaryPhotoKcal > 0 || primaryPhotoProt > 0) {
         // Readable description: caption wins, else vision's first real line. (kcal dedup banned.)
         const photoDesc = (message && message.trim().length > 2 ? message.trim().slice(0, 110) : "")
           || (visionDisplay.split("\n").find(l => l.trim().length > 5) || "").replace(/[*_•]/g, " ").replace(/\s+/g, " ").trim().slice(0, 110)
           || "[Photo]";
         // NAME-overlap dupe guard: a photo of a meal ALREADY logged today must not double-log.
-        const dupe = await findDuplicateMealToday(user.id, photoDesc);
+        const dupe = extraImageUrls.length === 0 ? await findDuplicateMealToday(user.id, photoDesc) : null;
         if (dupe) {
           const dupeReply = `📸 That looks like the *${dupe.desc}* you already logged today — I have NOT logged it again, your totals are safe.\n\nIf this is a second helping, say *"same as ${dupe.slot}"* and I'll log it properly.`;
           await logChat(user.id, "[Food Photo — duplicate held]", dupeReply, "FOOD_PHOTO_DUPE");
@@ -1140,12 +1152,13 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
         }
         // ONE WRITE DOOR (Box 2): commitFoodLog dedups + guarantees complete macros;
         // caption wins over the clock for the slot.
-        const photoLabel = extractMealLabel(message || "", photoLoggedAt, { kcal: totalPhotoKcal, protein: totalPhotoProt }, user, await (await import("../portion-memory")).getSlotContext(user.id)) || slotFromSastHour(photoLoggedAt);
+        const photoLabel = extractMealLabel(message || "", photoLoggedAt, { kcal: primaryPhotoKcal, protein: primaryPhotoProt }, user, await (await import("../portion-memory")).getSlotContext(user.id)) || slotFromSastHour(photoLoggedAt);
         // Structured items from the vision reply — names in "my meals", scalable corrections.
         photoCommit = await commitFoodLog({
-          userId: user.id, phone, rawMessage: photoDesc, source: "photo",
-          kcalInt: totalPhotoKcal, proteinInt: totalPhotoProt, carbsInt: 0, fatInt: 0,
+          userId: user.id, phone, rawMessage: extraImageUrls.length > 0 ? `[Album photo 1] ${photoDesc}` : photoDesc, source: "photo",
+          kcalInt: primaryPhotoKcal, proteinInt: primaryPhotoProt, carbsInt: 0, fatInt: 0,
           items: itemsFromVisionText(visionDisplay), mealLabel: photoLabel, loggedAt: photoLoggedAt,
+          sourceMessageId: mediaSourceId, allowIntentionalRepeat: extraImageUrls.length > 0,
         });
       }
 
@@ -1430,7 +1443,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       voiceStage = "coach_reply";
       voiceStageStart = Date.now();
       const voiceReply = await withTimeout("voice_coach_reply", 20000, () =>
-        handleMessage(phone, forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""))
+        handleMessage(phone, forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""), undefined, undefined, undefined, mediaSourceId)
       );
       const coachReplyMs = Date.now() - voiceStageStart;
       const voiceTotalMs = Date.now() - voiceFlowStart;

--- a/server/handlers/weight.ts
+++ b/server/handlers/weight.ts
@@ -114,6 +114,7 @@ export async function handleWeightLog(
   phone: string,
   user: any,
   newKg: number,
+  options: { suppressCustomerLifecycle?: boolean } = {},
 ): Promise<string> {
   if (!Number.isFinite(newKg) || newKg < 30 || newKg > 250) {
     return `That weight reads as *${newKg}kg* — that doesn't look right. Send your weight again as just a number followed by kg, like "82kg" or "76.5kg".`;
@@ -167,6 +168,12 @@ export async function handleWeightLog(
       turnMutation(`INSERT weight=${newKg}kg`, "[WEIGHT_LOG]");
     }
   });
+  // Keep the caller's turn-local profile coherent with the durable truth this owner just wrote.
+  // The normalizer can capture weight before later goal handling in the same turn; leaving this
+  // object stale would make that downstream calculation use yesterday's weight.
+  user.currentWeight = newKg.toString();
+  user.calorieTarget = newCals;
+  user.proteinTarget = newProtein;
   // The cached pattern summary feeds every GPT reply for up to an hour — without this,
   // the coach can contradict the weigh-in the client JUST sent ("no weight data this week").
   invalidatePatternCache(user.id);
@@ -193,7 +200,7 @@ export async function handleWeightLog(
       20: `\n\n🏆 *${firstName}, 20 kilograms.* I have coached a lot of people. 20kg is real transformation. This is the version of you that does not go back.`,
     };
     for (const milestone of [2, 5, 10, 15, 20]) {
-      if (totalLoss >= milestone && totalLoss < milestone + 0.6) {
+      if (!options.suppressCustomerLifecycle && totalLoss >= milestone && totalLoss < milestone + 0.6) {
         await storeMemory(phone, `Weight loss milestone: lost ${milestone}kg total — started at ${startKg}kg, now at ${newKg}kg`, "milestone");
         milestoneCelebration = MILESTONE_MESSAGES[milestone] || "";
         generateMilestoneVoiceScript(user, "weight_loss", { kgLost: milestone, currentKg: newKg, startKg })
@@ -235,7 +242,7 @@ export async function handleWeightLog(
 
   const targetKg = parseFloat(user.targetWeightKg || "0");
   const goal = user.goalType || "fat_loss";
-  if (targetKg > 0) {
+  if (!options.suppressCustomerLifecycle && targetKg > 0) {
     const hitGoal = (goal === "fat_loss" && newKg <= targetKg)
       || (goal === "muscle_gain" && newKg >= targetKg);
     if (hitGoal) {

--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -1,5 +1,5 @@
 import { db } from "./db";
-import { users, weightLogs, chatHistory, stepLogs, escalations } from "../shared/schema";
+import { users, chatHistory, stepLogs, escalations } from "../shared/schema";
 import { escalationSLA } from "./safety-detection";
 import { generateReferralCode } from "./onboarding-referral";
 import { parseFoodPreferences, parseVisionAnswer, looksLikeBulkIntake, applyIntakeBrake, describeIntake, type BulkIntake } from "./onboarding-intake";
@@ -16,6 +16,7 @@ import { getDisplayName, sastDayStart, timeGreeting } from "./utils";
 import { getTodayWorkoutState } from "./workout-state";
 import { parseFirstName } from "./onboarding-name";
 import { MEDICAL_QUESTION, bodyPhotoAsk } from "./onboarding-physique";
+import { handleWeightLog } from "./handlers/weight";
 
 /**
  * "No thanks" to an OPTIONAL onboarding step — one owner, two callers (2026-08-06).
@@ -465,7 +466,6 @@ async function commitBulkIntake(user: any, bulk: BulkIntake, source: string, pho
   if (bulk.name) set.name = bulk.name;
   if (bulk.gender) set.gender = bulk.gender;
   if (bulk.age) set.age = bulk.age;
-  if (bulk.weightKg) set.currentWeight = String(bulk.weightKg);
   if (bulk.heightCm) set.heightCm = bulk.heightCm;
   if (bulk.goalType) set.goalType = bulk.goalType;
   if (bulk.targetWeightKg) set.targetWeightKg = String(bulk.targetWeightKg);
@@ -475,15 +475,25 @@ async function commitBulkIntake(user: any, bulk: BulkIntake, source: string, pho
   if (bulk.homeEquipment) set.homeEquipment = bulk.homeEquipment;
   if (bulk.trainingExperience) set.trainingExperience = bulk.trainingExperience;
   if (bulk.foodDislikes) set.foodDislikes = bulk.foodDislikes;
-  if (bulk.weightKg && bulk.heightCm) {
+  const reportedWeight = bulk.weightKg && bulk.weightKg >= 30 && bulk.weightKg <= 250
+    ? bulk.weightKg : null;
+  if (reportedWeight && bulk.heightCm) {
     const hM = bulk.heightCm / 100;
-    set.bmi = String(Math.round((bulk.weightKg / (hM * hM)) * 10) / 10);
+    set.bmi = String(Math.round((reportedWeight / (hM * hM)) * 10) / 10);
   }
 
-  const merged = { ...user, ...set, currentWeight: set.currentWeight ?? user.currentWeight };
+  const merged = { ...user, ...set, currentWeight: reportedWeight ? String(reportedWeight) : user.currentWeight };
   const next = BULK_RESUME.find(r => r.missing(merged));
-  set.onboardingState = next ? next.state : "ASK_MEDICAL";
-  await db.update(users).set(set).where(eq(users.phoneNumber, phone));
+  // Height, goal and the rest of the profile must be durable before the weight owner calculates
+  // BMI gates and targets. Weight itself is never staged here: handleWeightLog owns that truth.
+  if (Object.keys(set).length > 0) {
+    await db.update(users).set(set).where(eq(users.phoneNumber, phone));
+  }
+  if (reportedWeight) {
+    await handleWeightLog(phone, merged, reportedWeight, { suppressCustomerLifecycle: true });
+  }
+  const nextState = next ? next.state : "ASK_MEDICAL";
+  await db.update(users).set({ onboardingState: nextState }).where(eq(users.phoneNumber, phone));
 
   // A dislike is a preference that has to outlive onboarding — every meal suggestion
   // from here on must respect it, so it goes to durable memory, not just a column.
@@ -497,7 +507,7 @@ async function commitBulkIntake(user: any, bulk: BulkIntake, source: string, pho
   const who = bulk.name ? ` ${bulk.name}` : "";
   const captured = describeIntake(bulk);
   const question = next ? next.ask(merged) : MEDICAL_QUESTION;
-  console.log(`[BULK_INTAKE] ${phone.slice(-4)} — ${Object.keys(set).length - 1} fields from one message, resuming at ${set.onboardingState}`);
+  console.log(`[BULK_INTAKE] ${phone.slice(-4)} — ${Object.keys(set).length + (reportedWeight ? 1 : 0)} fields from one message, resuming at ${nextState}`);
   return `Sharp${who} 👌 I got all of that — you don't have to type it again.\n\n${captured}\n\nAnything wrong there, just tell me and I'll fix it.\n\n---\n\n${question}`;
 }
 
@@ -729,7 +739,6 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
       const fallbackWeight = user.gender === "female" ? 65 : 75;
       const { proteinTarget: skipProt } = calculateTargets(fallbackWeight, user.goalType || "fat_loss", user.lifeSituation || "office", user.trainingDaysPerWeek || 3, user.gender || "male", user.age || 30, 170, user.trainingExperience || "beginner");
       await db.update(users).set({
-        currentWeight: fallbackWeight.toString(),
         heightCm: null,
         bmi: null,
         proteinTarget: skipProt,
@@ -744,7 +753,7 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
     }
 
     const weight = parseFloat(weightMatch[1]);
-    if (weight < 30 || weight > 350) {
+    if (weight < 30 || weight > 250) {
       return `That weight looks off. Please send it like: *78kg, 1.72m*`;
     }
 
@@ -771,12 +780,12 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
       bmiVal = bmi.toString();
     }
 
-    const { proteinTarget: weightProt } = calculateTargets(weight, user.goalType || "fat_loss", user.lifeSituation || "office", user.trainingDaysPerWeek || 3, user.gender || "male", user.age || 30, heightCmVal || 170, user.trainingExperience || "beginner");
     await db.update(users).set({
-      currentWeight: weight.toString(),
       heightCm: heightCmVal,
       bmi: bmiVal,
-      proteinTarget: weightProt,
+    }).where(eq(users.phoneNumber, phone));
+    await handleWeightLog(phone, { ...user, heightCm: heightCmVal, bmi: bmiVal }, weight, { suppressCustomerLifecycle: true });
+    await db.update(users).set({
       // THE STEP THAT WAS NEVER REACHABLE (2026-08-06). onboarding-physique.ts — the day-zero
       // read that catches a client picking a deficit when their body needs a surplus — has
       // existed since July and NOTHING ever set this state, so the module has never run for a
@@ -987,7 +996,7 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
     }
 
     const weight = weightMatch ? parseFloat(weightMatch[1]) : parseFloat(user.currentWeight || "70");
-    if (weight < 30 || weight > 300) return `That doesn't look right. Example: *78kg, 1.72m*`;
+    if (weight < 30 || weight > 250) return `That doesn't look right. Example: *78kg, 1.72m*`;
 
     // Parse height — multiple formats: 1.72m, 172cm, 5'8 — from the message WITHOUT
     // the weight portion. CAPTURE BUG (caught by onboarding-e2e, 2026-07-14): the old
@@ -1015,7 +1024,9 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
 
     // No height provided OR "don't know" — save weight and offer estimate options
     if (heightCmVal < 100 || heightCmVal > 230) {
-      await db.update(users).set({ currentWeight: weight.toString() }).where(eq(users.phoneNumber, phone));
+      if (weightMatch) {
+        await handleWeightLog(phone, user, weight, { suppressCustomerLifecycle: true });
+      }
       const shortLabel = isFemale ? "Short (under 160cm)" : "Short (under 165cm)";
       const avgLabel   = isFemale ? "Average (163cm)"     : "Average (172cm)";
       const tallLabel  = isFemale ? "Tall (172cm+)"       : "Tall (181cm+)";
@@ -1024,11 +1035,13 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
 
     const bmi = Math.round((weight / (heightM * heightM)) * 10) / 10;
     await db.update(users).set({
-      currentWeight: weight.toString(),
       heightCm: heightCmVal,
       bmi: bmi.toString(),
-      onboardingState: "ASK_GOAL",
     }).where(eq(users.phoneNumber, phone));
+    if (weightMatch) {
+      await handleWeightLog(phone, { ...user, heightCm: heightCmVal, bmi: bmi.toString() }, weight, { suppressCustomerLifecycle: true });
+    }
+    await db.update(users).set({ onboardingState: "ASK_GOAL" }).where(eq(users.phoneNumber, phone));
     return `${weight}kg, ${heightCmVal}cm — got it. Main goal?\n\n1️⃣ Lose fat\n2️⃣ Build muscle\n3️⃣ Both`;
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -33,6 +33,7 @@ import { verifyBrainReply } from "./brain/reply-verifier";
 import { cardFontLoaded } from "./macro-card";
 import { handleWater, tryLogWater } from "./handlers/water";
 import { handleFoodContext } from "./handlers/food-context";
+import { handleWeightLog } from "./handlers/weight";
 import { stripSignupSource } from "./signup-source";
 import { captureSignupSource } from "./signup-capture";
 import { JUNK_WORDS as _JUNK_WORDS, checkFoodPatterns, getDamageControlNote, checkPerfectDay } from "./handlers/checks";
@@ -840,13 +841,12 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
           user.trainingMode = "gym";
           console.log("[NORMALIZER] supplementary: training mode → gym from GOAL_CHANGE original");
         }
-        const wtMatch = originalMBeforeNorm.match(/\bmy\s+(?:current\s+)?weight\s+(?:is\s+)?(\d{2,3}(?:\.\d+)?)\b/i)
+        const wtMatch = originalMBeforeNorm.match(/\bmy\s+(?:current\s+)?weight\s+(?:is\s+)?(\d{2,3}(?:\.\d+)?)\s*(?:kg|kgs)?\b/i)
           || originalMBeforeNorm.match(/\bi\s+(?:currently\s+)?weigh\s+(\d{2,3}(?:\.\d+)?)\s*kg/i);
         if (wtMatch) {
           const wt = parseFloat(wtMatch[1]);
-          if (wt >= 30 && wt <= 300) {
-            await db.update(users).set({ currentWeight: wt.toString() }).where(eq(users.phoneNumber, phone));
-            user.currentWeight = wt.toString();
+          if (wt >= 30 && wt <= 250) {
+            await handleWeightLog(phone, user, wt);
             console.log(`[NORMALIZER] supplementary: weight → ${wt}kg from GOAL_CHANGE original`);
           }
         }
@@ -1151,7 +1151,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // COMMITS, DOES NOT CLAIM THE TURN (Cut 2/3). On "2 litres of water and took my creatine" the
   // supplement handler inside it used to end the turn and the water was never logged. Standing
   // down loses the supplement instead — it must run, and commit.
-  const earlyResult = await handleEarlyCommands({ phone, message, m, user, hasMedia: !!mediaUrl, isQuestion: normalizedQuestion });
+  const earlyResult = await handleEarlyCommands({ phone, message, m, user, sourceMessageId, hasMedia: !!mediaUrl, isQuestion: normalizedQuestion });
   if (earlyResult !== null) {
     if (mayEndTurn("early-commands")) return closeCoachingTurn(earlyResult);
     commitFact(turn, "other", earlyResult);
@@ -1159,7 +1159,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
 
   // ---- MEDIA: IMAGE or AUDIO — exclusive branches, always return ----
   if (mediaUrl) {
-    return handleMediaMessage({ phone, message, mediaUrl, mediaContentType, allMediaUrls, user, isCoach, openai, handleMessage });
+    return handleMediaMessage({ phone, message, mediaUrl, mediaContentType, allMediaUrls, sourceMessageId, user, isCoach, openai, handleMessage });
   }
 
 
@@ -1294,7 +1294,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // ---- FOOD CONTEXT (corrections, braai, eating out, relog, scanner, GPT fallback) ----
   // Messy-life intake: stated meal (incl. branded takeaway voice notes) forces food path.
   const foodCtxResult = await handleFoodContext({
-    phone, message, m, user, handleMessage,
+    phone, message, m, user, handleMessage, sourceMessageId,
     classifierQuestion: normalizedQuestion,
     forceLog: turnFacts.mustForceFoodLog,
   });

--- a/server/understanding/executor.ts
+++ b/server/understanding/executor.ts
@@ -229,7 +229,7 @@ async function mealTool(action: Extract<CoachAction, { type: "LOG_MEAL" }>, ctx:
   // a [MEDIA:…] marker, so the gate flip silently took the card with it. A client logging a meal
   // got no card at all, which is a regression, not a simplification. The PROSE is still binned;
   // only the picture is kept.
-  const discarded = await handleFoodContext({ phone: ctx.phone, message: text, m: text.toLowerCase(), user: ctx.user, handleMessage: async () => "", forceLog: true });
+  const discarded = await handleFoodContext({ phone: ctx.phone, message: text, m: text.toLowerCase(), user: ctx.user, handleMessage: async () => "", forceLog: true, sourceMessageId: ctx.sourceMessageId });
   lastCardMarker = (String(discarded || "").match(/\[MEDIA:[^\]]+\]/) || [""])[0];
   const refs: Record<string, string> = { mealName: String(action.foodText || "").slice(0, 60) };
   if (slot) refs.slot = String(slot).slice(0, 20);


### PR DESCRIPTION
## Baseline

Implemented from exact production baseline `dc3c308c7fcdaf0bc62f207622c4ed738765f3d6`.

## CUT A

- Preserves `server/handlers/weight.ts -> handleWeightLog` as the sole body-weight writer.
- Routes GOAL_CHANGE supplementary extraction and all onboarding reported-weight paths through that owner.
- Removes fabricated current weight and weight events from onboarding skip.
- Preserves `server/day-ledger.ts -> commitFoodLog` as the sole new-meal writer.
- Routes collage, album, meal repeat, and alcohol logging through the canonical writer.
- Threads inbound `sourceMessageId` through text, media, executor, repeat, and alcohol paths.
- Stores album food as one row per image under one shared lineage and makes webhook replay idempotent.
- Preserves correction, amendment, held-meal replacement, and relabel APIs.
- Adds architecture guards forbidding new meal inserts and ordinary current-weight mutations outside their owners.

## Regressions

- Exact phrase: `My current weight is 82kg and I joined a gym` -> one event and `getWeightTruth().currentKg === 82`.
- Onboarding reported weight -> one event and canonical truth; skip -> no fabricated event/current truth.
- Same-day weight update -> one event (upsert).
- Text replay -> no duplicate.
- Meal repeat -> copied metadata, canonical write, replay safe.
- Album -> one row per image, shared lineage, replay safe.

## Verification

- TypeScript check: passed.
- CUT A regression suite: passed.
- Onboarding E2E: passed.
- Production-parity CUT A assertion: passed.
- All CUT A architecture ownership assertions: passed; no budget raised.
- Broad deterministic run was completed before handoff. Remaining failures are pre-existing/independent (weekly-owner vacuity, multi-day reply omission, existing unit/tracking assertions, existing architecture/file-size/SAST budgets, Windows path/spawn harness noise).

No CUT B, CUT C, Coach Health, or PR #101 work is included.