### PR TITLE
Coach Health A1: the quality loop runs with the dashboard closed

### DIFF
--- a/client/src/pages/coach-health.tsx
+++ b/client/src/pages/coach-health.tsx
@@ -178,6 +178,16 @@ interface BriefPayload {
   builds: Array<{ version: string; turns: number }>;
   buildWarning: string | null;
   disclaimer: string;
+  // THE LAST AUTOMATIC RUN (Coach Health A1). Everything above is recomputed when this page is
+  // opened; this is what the hourly sweep found while it was closed, read from scheduler_state.
+  // Null until the first sweep has run — a fresh deploy has not swept yet, and saying so is the
+  // point: an empty band would read as "nothing wrong" rather than "nothing has looked".
+  lastSweep: {
+    at: string; windowDays: number; turns: number; clients: number;
+    knownRegressions: number; buildWarning: string | null;
+    candidates: Array<{ id: string; label: string; priority: string; turns: number; clients: number }>;
+    fresh: string[];
+  } | null;
 }
 
 const PRIORITY_CHIP: Record<string, string> = {
@@ -210,6 +220,52 @@ function MorningBrief({ days }: { days: number }) {
           {data.knownRegressions} known regression{data.knownRegressions === 1 ? "" : "s"} ·{" "}
           {data.candidates.length} candidate pattern{data.candidates.length === 1 ? "" : "s"}
         </p>
+        <p className="text-xs text-muted-foreground mt-1">Recomputed now, for the last {data.windowDays} day{data.windowDays === 1 ? "" : "s"}.</p>
+      </div>
+
+      {/* THE AUTOMATIC RUN, kept visibly separate from the live window above. Without this the
+          background loop is invisible to the operator and A1's whole claim is unverifiable from
+          the page — which is what a reviewer caught on the first version of this cut. */}
+      <div className="mb-5 p-3 rounded-md border bg-muted/30">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <span className="text-sm font-semibold">🤖 Last automatic run</span>
+          {data.lastSweep ? (
+            <span className="text-xs text-muted-foreground font-mono">{new Date(data.lastSweep.at).toLocaleString()}</span>
+          ) : null}
+        </div>
+        {data.lastSweep ? (
+          <>
+            <p className="text-sm text-muted-foreground mt-1">
+              {data.lastSweep.turns.toLocaleString()} turns · {data.lastSweep.clients} client{data.lastSweep.clients === 1 ? "" : "s"} ·{" "}
+              {data.lastSweep.knownRegressions} known regression{data.lastSweep.knownRegressions === 1 ? "" : "s"} ·{" "}
+              {data.lastSweep.candidates.length} candidate pattern{data.lastSweep.candidates.length === 1 ? "" : "s"}
+              {" "}· window {data.lastSweep.windowDays}d
+            </p>
+            {data.lastSweep.fresh.length > 0 ? (
+              <p className="text-sm mt-2">
+                <span className="text-xs px-2 py-0.5 rounded border bg-rose-100 text-rose-700 border-rose-200">
+                  {data.lastSweep.fresh.length} new
+                </span>{" "}
+                <span className="font-mono text-xs text-muted-foreground">{data.lastSweep.fresh.join(" · ")}</span>
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground mt-2 italic">Nothing new since the run before it.</p>
+            )}
+            {data.lastSweep.candidates.length > 0 && (
+              <div className="text-xs text-muted-foreground mt-2 space-y-0.5">
+                {data.lastSweep.candidates.slice(0, 5).map(c => (
+                  <div key={c.id} className="truncate">
+                    <span className="font-mono">{c.id}</span> · {c.label} · {c.clients} client{c.clients === 1 ? "" : "s"}, {c.turns} turn{c.turns === 1 ? "" : "s"}
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground mt-1 italic">
+            The background sweep has not run yet — nothing here has been evaluated automatically.
+          </p>
+        )}
       </div>
 
       {data.buildWarning && (

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -765,6 +765,19 @@ const MUST_WRITE: [string, string][] = [
         ["empty-reply",
           { input: "hello", reply: "" },
           { input: "hello", reply: "Howzit Kam." }],
+        // THE OBSERVED 16:49 REPLY, verbatim from the live trace — a refusal to call a trend and a
+        // trend, in consecutive paragraphs of one message. The healthy case is the same refusal
+        // WITHOUT the assertion, which is what the fix in #102 makes the coach say: this must stay
+        // readable as correct behaviour, or the detector punishes the repair.
+        ["reply-contradicts-itself",
+          { input: "how is my weight going?",
+            reply: "I'm not going to call a trend off those weigh-ins — they sit around the time you "
+              + "were ill, and weight moves on fluid and appetite then, not on food.\n\n"
+              + "Scale is going up — keep fuelling." },
+          { input: "how is my weight going?",
+            reply: "I'm not going to call a trend off those weigh-ins — they sit around the time you "
+              + "were ill, and weight moves on fluid and appetite then, not on food.\n\n"
+              + "Weigh in three mornings this week and I'll read it properly." }],
       ];
       for (const [id, broken, healthy] of BREAKS) {
         if (check(id, broken) === true) {
@@ -799,6 +812,75 @@ const MUST_WRITE: [string, string][] = [
       // The handle must be stable, or a candidate cannot be named in a brief and found again.
       if (candidateRef("a", "b") !== candidateRef("a", "b") || candidateRef("a", "b") === candidateRef("a", "c")) {
         failures.push(`Coach Health V2 candidate references are not stable-and-distinct — "CH-xxxx" would not survive being written down`);
+      }
+
+      /**
+       * A1 — THE LOOP RUNS WITH THE DASHBOARD CLOSED (2026-09-01).
+       *
+       * The whole feature previously existed only while somebody had the page open: the rules ran
+       * inside the GET handler and nothing durable came out. Graded on the two things that makes
+       * true — a sweep with no HTTP request in sight produces a candidate, and the result is still
+       * there afterwards for the dashboard to read — plus the property that stops it becoming
+       * noise: running it twice over the same evidence announces nothing the second time.
+       */
+      {
+        const { runCoachHealthSweep, COACH_HEALTH_STATE_KEY } = await import("../server/routes/admin-turns");
+        const { loadState } = await import("../server/scheduler/shared");
+        const observed = "I'm not going to call a trend off those weigh-ins — they sit around the time you "
+          + "were ill, and weight moves on fluid and appetite then, not on food.\n\n"
+          + "Scale is going up — keep fuelling.";
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.turnLedger, [{
+          id: "tl-observed", userId: USER.id, createdAt: new Date(),
+          inputText: "how is my weight going?", reply: observed,
+          mutations: [], stateRead: {}, version: "25b2232",
+          lifecycleStatus: null, failureCategory: null, fixRef: null,
+        }]]]);
+
+        const first = await runCoachHealthSweep(1);
+        if (first.candidates === 0) {
+          failures.push(`The automatic sweep found nothing on the exact observed 16:49 reply — Coach Health still only works when the dashboard is open`);
+        }
+        if (first.fresh.length === 0) {
+          failures.push(`The automatic sweep surfaced no NEW candidate on first run — nothing would ever reach a human`);
+        }
+
+        // DURABLE: the dashboard must be able to read this without recomputing.
+        let stored: any = null;
+        try { stored = JSON.parse(loadState()[COACH_HEALTH_STATE_KEY] || "null"); } catch { /* below */ }
+        if (!stored || !Array.isArray(stored.candidates) || stored.candidates.length === 0) {
+          failures.push(`The automatic sweep left nothing durable behind — reopening the dashboard would show no automatic result`);
+        } else {
+          // PROVENANCE: a candidate has to identify the turn, the client and the build, from
+          // fields the ledger already records.
+          const ex = stored.candidates[0]?.examples?.[0];
+          if (!ex?.turnId || !ex?.version) {
+            failures.push(`A stored candidate carries no turn/build provenance — it cannot be traced back to the turn it came from`);
+          }
+        }
+
+        // NO DUPLICATE SPAM: the same evidence, swept again, announces nothing new.
+        const second = await runCoachHealthSweep(1);
+        if (second.fresh.length !== 0) {
+          failures.push(`Re-running the sweep re-announced ${second.fresh.length} candidate(s) it had already reported — the queue fills with duplicates every hour`);
+        }
+        if (second.candidates === 0) {
+          failures.push(`The second sweep lost the candidate entirely — dedup must suppress the ANNOUNCEMENT, not the evidence`);
+        }
+
+        // CONTROL: a clean window must not manufacture a candidate. Without this, "always report
+        // something" passes both assertions above.
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.turnLedger, [{
+          id: "tl-clean", userId: USER.id, createdAt: new Date(),
+          inputText: "how is my weight going?",
+          reply: "Down 1.2kg over three weeks. Keep the weigh-ins to one morning a week.",
+          mutations: [], stateRead: {}, version: "25b2232",
+          lifecycleStatus: null, failureCategory: null, fixRef: null,
+        }]]]);
+        const clean = await runCoachHealthSweep(1);
+        if (clean.fresh.length !== 0) {
+          failures.push(`A healthy weight reply produced a NEW candidate — the automatic queue would fill with turns that are fine: ${clean.fresh.join(", ")}`);
+        }
+        delete g.__KAMLIFE_STUB_ROWS;
       }
     }
     const check = (id: string, input: string, reply: string, mutations: string[] = []) => {

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -9202,7 +9202,7 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
     }
   });
 
-  test("coach health: what the automatic sweep stores, the page actually shows", async () => {
+  test("coach health: what the automatic sweep stores, the page actually shows", () => {
     // A CONTRACT ASSERTION, and source-shaped ON PURPOSE. The first version of A1 added lastSweep
     // to the brief endpoint and never rendered it, so the background loop ran, persisted, and was
     // invisible to the only person who would act on it — the feature's whole claim, unverifiable
@@ -9210,8 +9210,14 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
     // ignores" without driving a browser, so this counts instead, the same way check-reach counts
     // senders. Narrow by design: it asserts the operator-facing signals are consumed, not how they
     // are laid out.
-    const { runCoachHealthSweep } = await import("../server/routes/admin-turns");
-    assert.equal(typeof runCoachHealthSweep, "function", "the automatic sweep is gone");
+    // READ, DO NOT IMPORT. The first version of this case did `await import("admin-turns")` just
+    // to assert the export exists. Importing that module pulls in the route layer and leaves
+    // runtime handles open, so the suite reported 1050/1050 and then never exited — it sat until
+    // CI's 600s timeout. The whole check is already a source-shape assertion, so reading the file
+    // is the consistent instrument as well as the safe one: this suite must not need a live server
+    // to answer "is the export still there".
+    const turns = readFileSync("server/routes/admin-turns.ts", "utf-8");
+    assert.match(turns, /export async function runCoachHealthSweep/, "the automatic sweep is gone");
     const page = readFileSync("client/src/pages/coach-health.tsx", "utf-8");
     assert.match(page, /lastSweep/, "the Coach Health page does not read the automatic run at all");
     // The three things that prove the loop ran while the page was closed: WHEN it ran, what it

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -9202,6 +9202,30 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
     }
   });
 
+  test("coach health: what the automatic sweep stores, the page actually shows", async () => {
+    // A CONTRACT ASSERTION, and source-shaped ON PURPOSE. The first version of A1 added lastSweep
+    // to the brief endpoint and never rendered it, so the background loop ran, persisted, and was
+    // invisible to the only person who would act on it — the feature's whole claim, unverifiable
+    // from the page. No runtime trace in this repo can catch "the server sends a field the client
+    // ignores" without driving a browser, so this counts instead, the same way check-reach counts
+    // senders. Narrow by design: it asserts the operator-facing signals are consumed, not how they
+    // are laid out.
+    const { runCoachHealthSweep } = await import("../server/routes/admin-turns");
+    assert.equal(typeof runCoachHealthSweep, "function", "the automatic sweep is gone");
+    const page = readFileSync("client/src/pages/coach-health.tsx", "utf-8");
+    assert.match(page, /lastSweep/, "the Coach Health page does not read the automatic run at all");
+    // The three things that prove the loop ran while the page was closed: WHEN it ran, what it
+    // COVERED, and whether anything is NEW. A band missing any of them cannot make that case.
+    for (const signal of ["lastSweep.at", "lastSweep.turns", "lastSweep.fresh"]) {
+      assert.ok(page.includes(signal),
+        `the page never shows ${signal} — the operator cannot tell the automatic run from the live window`);
+    }
+    // ...and it must say so when nothing has swept yet, rather than rendering an empty band that
+    // reads as "all clear".
+    assert.match(page, /has not run yet/i,
+      "a page with no sweep yet shows nothing, which reads as health rather than as absence");
+  });
+
   test("reactive: BOTH gates run on the whole reply before it is split into bubbles", async () => {
     // Was a source-shape assertion over sendFinal's body. Cut B moved both gates into
     // prepareOutbound, so the old test broke on WORDING while the contract held — the failure

--- a/server/routes/admin-turns.ts
+++ b/server/routes/admin-turns.ts
@@ -313,7 +313,52 @@ type Invariant = {
 
 const FALLBACK_REPLY = /didn'?t (?:quite )?catch that|say it another way|had a moment|try that again|i'?m not sure what you mean/i;
 
+/**
+ * ONE REPLY, TWO POSITIONS — restored 2026-08-31, this time with a production instance.
+ *
+ * I removed a contradiction invariant on 2026-08-28 (a3519ed) because it had been reasoned about
+ * rather than observed, and an invariant with no observed instance is speculation that costs a
+ * budget. Seven hours later the live trace produced one:
+ *
+ *     "I'm not going to call a trend off those weigh-ins — they sit around the time you were
+ *      ill, and weight moves on fluid and appetite then, not on food."
+ *     "Scale is going up — keep fuelling."
+ *
+ * Consecutive paragraphs of one message: a refusal to state a direction, and a direction.
+ *
+ * WHAT I GOT WRONG, so the next person does not repeat it: the absence of a trace was treated as
+ * evidence the failure did not happen, when the real reason we had no trace was that nobody had
+ * looked at production. The detector was live and blind at the moment the failure shipped.
+ *
+ * RESTORING THE OLD ONE VERBATIM WOULD NOT HAVE CAUGHT THIS. The deleted version paired
+ * "the day is closed" against "eat now" — a food contradiction. The observed instance is a WEIGHT
+ * contradiction. So this is the same invariant with the pair the evidence actually gives us, and
+ * the shape is a LIST of pairs rather than named constants: a detector that grows adds a pair,
+ * not a new global. (It also does not add a named regex literal, which matters — that counter
+ * sits at exactly 449/449 on this baseline, so a constant here would breach the governor for a
+ * detector that has a perfectly good structural home.)
+ *
+ * A PAIR IS A CANDIDATE, NEVER A VERDICT. Both halves in one reply is suspicious, not proven
+ * wrong: a coach may legitimately refuse a trend and then discuss weight for another reason. The
+ * queue exists so a human reads the turn.
+ */
+const CONTRADICTION_PAIRS: Array<{ what: string; refuses: RegExp; asserts: RegExp }> = [
+  {
+    what: "weight trend",
+    // The response gate's honest refusals, and the directional claims that must not follow them.
+    refuses: new RegExp("not going to (?:call|put a number)|don'?t have enough weigh-?ins|too far back for me to read", "i"),
+    asserts: new RegExp("scale is going (?:up|down)|you'?re (?:gaining|losing)|moving in the right direction|trending (?:up|down)", "i"),
+  },
+];
+
 export const COACH_HEALTH_INVARIANTS: Invariant[] = [
+  {
+    id: "reply-contradicts-itself",
+    label: "One reply refused a claim and then made it",
+    layer: "Response",
+    expected: "one decision, one voice",
+    holds: t => !CONTRADICTION_PAIRS.some(p => p.refuses.test(t.reply) && p.asserts.test(t.reply)),
+  },
   {
     id: "unowned-message",
     label: "The coach did not understand a message",
@@ -402,6 +447,214 @@ export function candidateSignature(input: string): string {
   return carrying.join(" ") || "(no words)";
 }
 
+/**
+ * THE BRIEF, COMPUTED ONCE (Coach Health A1, 2026-09-01).
+ *
+ * This was the body of GET /coach-health/brief and nothing else could reach it, which is exactly
+ * why the feature only existed while somebody had the page open. The background sweep needs the
+ * same evaluation over the same evidence, and the one thing it must not be is a second copy of
+ * it — this repository has paid for "mirrors X exactly" twice already (logStepsForUser, and the
+ * template sender in Cut B2). So the endpoint and the job call this, and there is one definition
+ * of what a candidate is.
+ *
+ * Still no second store and no new judging: it reads the turns the ledger already holds and runs
+ * the rules and invariants already declared above.
+ */
+export async function buildCoachHealthBrief(days: number): Promise<any> {
+    const since = new Date(Date.now() - days * 86_400_000);
+    const rows = await db.select({
+      id: turnLedger.id, userId: turnLedger.userId, createdAt: turnLedger.createdAt,
+      inputText: turnLedger.inputText, reply: turnLedger.reply,
+      mutations: turnLedger.mutations, stateRead: turnLedger.stateRead,
+      version: turnLedger.version, lifecycleStatus: turnLedger.lifecycleStatus,
+      failureCategory: turnLedger.failureCategory,
+      fixRef: turnLedger.fixRef,
+    })
+      .from(turnLedger)
+      .where(gte(turnLedger.createdAt, since))
+      .orderBy(desc(turnLedger.createdAt))
+      .limit(5000);
+
+    const shaped = rows.map(r => ({
+      row: r,
+      input: String(r.inputText || ""),
+      reply: String(r.reply || ""),
+      mutations: Array.isArray(r.mutations) ? (r.mutations as string[]).map(String) : [],
+      state: r.stateRead,
+    }));
+
+    // ── KNOWN REGRESSIONS: the V1 rules, post-fix only, so this half of the brief means what
+    // it says. Reusing the same rules rather than restating them keeps one definition.
+    const known = COACH_HEALTH_RULES.map(rule => {
+      const hits = shaped.filter(t =>
+        rule.asks(t.input) && rule.failed({ reply: t.reply, mutations: t.mutations }));
+      const since_ = hits.filter(t => isRegression(rule, t.row.createdAt as any));
+      const exercised = shaped.filter(t =>
+        (rule.trigger === "request" ? rule.asks(t.input) : true) && isRegression(rule, t.row.createdAt as any)).length;
+      return { id: rule.id, label: rule.label, fixRef: rule.fixRef, regressions: since_.length, exercised };
+    });
+
+    // ── CANDIDATES: an invariant that did not hold, clustered by the shape of the message.
+    // NEVER called a defect. The queue is evidence, and adjudication stays with a person.
+    const clusters = new Map<string, { invariant: Invariant; signature: string; turns: typeof shaped }>();
+    for (const t of shaped) {
+      for (const inv of COACH_HEALTH_INVARIANTS) {
+        if (inv.holds({ input: t.input, reply: t.reply, mutations: t.mutations, state: t.state })) continue;
+        const signature = candidateSignature(t.input);
+        const key = `${inv.id}::${signature}`;
+        const bucket = clusters.get(key) || { invariant: inv, signature, turns: [] };
+        bucket.turns.push(t);
+        clusters.set(key, bucket);
+      }
+    }
+
+    const candidates = [...clusters.values()]
+      .map(c => {
+        const clients = new Set(c.turns.map(t => t.row.userId)).size;
+        const triaged = c.turns.filter(t => !!t.row.failureCategory);
+        const withFix = c.turns.filter(t => !!t.row.fixRef);
+        const lifecycles = new Set(c.turns.map(t => String(t.row.lifecycleStatus || "")).filter(Boolean));
+        return {
+        // A STABLE HANDLE, so a candidate can be referred to in a brief, a commit message or a
+        // conversation and still be the same thing tomorrow. Derived from what defines the
+        // cluster rather than stored, so it survives without a table and cannot drift from its
+        // own contents.
+        id: `CH-${candidateRef(c.invariant.id, c.signature)}`,
+        invariant: c.invariant.id,
+        label: c.invariant.label,
+        layer: c.invariant.layer,
+        expected: c.invariant.expected,
+        pattern: c.signature,
+        turns: c.turns.length,
+        clients,
+        firstSeen: c.turns[c.turns.length - 1]?.row.createdAt,
+        lastSeen: c.turns[0]?.row.createdAt,
+        triaged: triaged.length,
+        // THE STATUS IS DERIVED, NOT DECLARED. The per-turn lifecycle already exists and is
+        // already editable through PATCH /api/admin/turns/:id — the verdict machinery this file
+        // has had since 2026-08-25. A candidate's status is what its turns say, so triaging a
+        // turn moves the candidate and there is no second source of truth to fall out of step.
+        //
+        //   candidate    nobody has ruled on any of these turns yet
+        //   adjudicated  a human recorded a failure category
+        //   engineering  a fix is claimed against them (fix_ref)
+        //   deployed     a build carrying the fix has been recorded
+        //   resolved     replayed against that build and behaved
+        status: lifecycles.has("revalidated") ? "resolved"
+          : lifecycles.has("deployed") ? "deployed"
+          : withFix.length ? "engineering"
+          : triaged.length ? "adjudicated"
+          : "candidate",
+        // RANK, SAID OUT LOUD. Breadth beats frequency: nine clients hitting something once is
+        // the product misbehaving; one client hitting it nine times is one conversation.
+        priority: clients >= 5 ? "high" : clients >= 2 ? "medium" : "low",
+        // THE EVIDENCE PACKET — the message and the reply, not a summary of them. Whoever picks
+        // this up traces from the client's own words; a paraphrase would be the screenshot
+        // problem again, one layer further in.
+        examples: c.turns.slice(0, 5).map(t => ({
+          turnId: t.row.id, at: t.row.createdAt, version: t.row.version,
+          input: t.input.slice(0, 300),
+          reply: t.reply.replace(/\n/g, " ").slice(0, 300),
+          status: t.row.lifecycleStatus,
+        })),
+      }; })
+      // RANKED BY HOW MANY PEOPLE IT HAPPENED TO, then by how often. One client hitting the same
+      // thing nine times is a story about one client; nine clients hitting it once is the product.
+      .sort((a, b) => (b.clients - a.clients) || (b.turns - a.turns))
+      .slice(0, 40);
+
+    // ── BUILDS: attribution here is merge-time, so a window served by more than one build is
+    // the case where a "regression" may just be a turn that ran the old code. Surfaced rather
+    // than assumed away.
+    const byVersion = new Map<string, number>();
+    for (const t of shaped) byVersion.set(String(t.row.version || "?"), (byVersion.get(String(t.row.version || "?")) || 0) + 1);
+    const builds = [...byVersion.entries()].map(([version, turns]) => ({ version, turns }))
+      .sort((a, b) => b.turns - a.turns);
+
+    return {
+      windowDays: days,
+      turns: rows.length,
+      clients: new Set(shaped.map(t => t.row.userId)).size,
+      known,
+      knownRegressions: known.reduce((s, k) => s + k.regressions, 0),
+      unexercised: known.filter(k => k.exercised === 0).map(k => k.fixRef),
+      candidates,
+      candidateTurns: candidates.reduce((s, c) => s + c.turns, 0),
+      builds,
+      buildWarning: builds.length > 1
+        ? `${builds.length} builds served turns in this window — a regression may be a turn that ran the old code`
+        : null,
+      // The queue is evidence. It is not a defect list, and the page must not render it as one.
+      disclaimer: "Candidates are unadjudicated: a property did not hold on these turns. Confirm before treating any of them as a defect.",
+  };
+}
+
+/**
+ * THE AUTOMATIC LOOP (Coach Health A1).
+ *
+ *     real turn -> turn_ledger -> these same rules -> scheduler_state -> the same dashboard
+ *
+ * WHAT THIS DOES NOT DO, because the issue is explicit and the discipline above is the reason the
+ * queue is worth reading: it does not adjudicate, it does not write a verdict, it does not touch
+ * code and it does not message anybody. A candidate is evidence to inspect.
+ *
+ * WHY scheduler_state AND NOT A NEW TABLE. The durable per-turn fields — failureCategory,
+ * lifecycleStatus, fixRef — belong to HUMAN adjudication through PATCH /api/admin/turns/:id. A job
+ * writing them would put a second author on the verdict, which is the defect this whole project
+ * has spent the week removing. scheduler_state is the existing durable key/value store, already
+ * upserted by saveState and already read by every job, and one snapshot under one key expresses
+ * "the latest automatic evaluation" without inventing an authority or a table.
+ *
+ * DEDUP IS THE SNAPSHOT'S JOB. The previous snapshot carries the candidate refs it already knew,
+ * so a re-run announces only what is new. Refs are derived from the cluster's own identity, so
+ * they are stable across runs by construction — the same property that lets a brief name CH-3F2A
+ * today and mean the same thing tomorrow.
+ */
+export const COACH_HEALTH_STATE_KEY = "coach_health_sweep";
+
+export async function runCoachHealthSweep(days = 1): Promise<{ known: number; candidates: number; fresh: string[] }> {
+  const { loadState, saveState } = await import("../scheduler/shared");
+  const brief = await buildCoachHealthBrief(days);
+  const refs: string[] = (brief.candidates || []).map((c: any) => String(c.id));
+
+  let seen: string[] = [];
+  try {
+    const prev = JSON.parse(loadState()[COACH_HEALTH_STATE_KEY] || "{}");
+    if (Array.isArray(prev.seenRefs)) seen = prev.seenRefs.map(String);
+  } catch { /* a corrupt snapshot must not stop the sweep — it is rewritten below */ }
+  const fresh = refs.filter(r => !seen.includes(r));
+
+  const snapshot = {
+    at: new Date().toISOString(),
+    windowDays: days,
+    turns: brief.turns,
+    clients: brief.clients,
+    knownRegressions: brief.knownRegressions,
+    unexercised: brief.unexercised,
+    buildWarning: brief.buildWarning,
+    // The ranked head, with the provenance the ledger already records: turn id, build and time.
+    // Not the whole queue — the dashboard recomputes that on demand and this is the standing
+    // answer to "what did the last automatic run find".
+    candidates: (brief.candidates || []).slice(0, 20).map((c: any) => ({
+      id: c.id, invariant: c.invariant, label: c.label, layer: c.layer,
+      pattern: c.pattern, turns: c.turns, clients: c.clients,
+      priority: c.priority, status: c.status,
+      firstSeen: c.firstSeen, lastSeen: c.lastSeen,
+      examples: (c.examples || []).slice(0, 2),
+    })),
+    // Everything ever announced, so a second run of the same evidence announces nothing.
+    seenRefs: [...new Set([...seen, ...refs])].slice(-500),
+    fresh,
+  };
+  saveState(COACH_HEALTH_STATE_KEY, JSON.stringify(snapshot));
+  if (fresh.length > 0) {
+    console.log(`[COACH_HEALTH] sweep: ${brief.turns} turns, ${refs.length} candidate(s), ${fresh.length} new — ${fresh.join(", ")}`);
+  } else {
+    console.log(`[COACH_HEALTH] sweep: ${brief.turns} turns, ${refs.length} candidate(s), none new`);
+  }
+  return { known: brief.knownRegressions, candidates: refs.length, fresh };
+}
+
 export function registerAdminTurns(app: Express) {
   // ── COACH HEALTH ────────────────────────────────────────────────────────────────────────────
   // Rule-based, no model, no new telemetry: it reads the turns the ledger already holds.
@@ -413,133 +666,18 @@ export function registerAdminTurns(app: Express) {
   app.get("/api/admin/coach-health/brief", requireAdminKey, async (req: any, res) => {
     try {
       const days = Math.min(30, Math.max(1, parseInt(String(req.query.days || "1"))));
-      const since = new Date(Date.now() - days * 86_400_000);
-      const rows = await db.select({
-        id: turnLedger.id, userId: turnLedger.userId, createdAt: turnLedger.createdAt,
-        inputText: turnLedger.inputText, reply: turnLedger.reply,
-        mutations: turnLedger.mutations, stateRead: turnLedger.stateRead,
-        version: turnLedger.version, lifecycleStatus: turnLedger.lifecycleStatus,
-        failureCategory: turnLedger.failureCategory,
-        fixRef: turnLedger.fixRef,
-      })
-        .from(turnLedger)
-        .where(gte(turnLedger.createdAt, since))
-        .orderBy(desc(turnLedger.createdAt))
-        .limit(5000);
-
-      const shaped = rows.map(r => ({
-        row: r,
-        input: String(r.inputText || ""),
-        reply: String(r.reply || ""),
-        mutations: Array.isArray(r.mutations) ? (r.mutations as string[]).map(String) : [],
-        state: r.stateRead,
-      }));
-
-      // ── KNOWN REGRESSIONS: the V1 rules, post-fix only, so this half of the brief means what
-      // it says. Reusing the same rules rather than restating them keeps one definition.
-      const known = COACH_HEALTH_RULES.map(rule => {
-        const hits = shaped.filter(t =>
-          rule.asks(t.input) && rule.failed({ reply: t.reply, mutations: t.mutations }));
-        const since_ = hits.filter(t => isRegression(rule, t.row.createdAt as any));
-        const exercised = shaped.filter(t =>
-          (rule.trigger === "request" ? rule.asks(t.input) : true) && isRegression(rule, t.row.createdAt as any)).length;
-        return { id: rule.id, label: rule.label, fixRef: rule.fixRef, regressions: since_.length, exercised };
-      });
-
-      // ── CANDIDATES: an invariant that did not hold, clustered by the shape of the message.
-      // NEVER called a defect. The queue is evidence, and adjudication stays with a person.
-      const clusters = new Map<string, { invariant: Invariant; signature: string; turns: typeof shaped }>();
-      for (const t of shaped) {
-        for (const inv of COACH_HEALTH_INVARIANTS) {
-          if (inv.holds({ input: t.input, reply: t.reply, mutations: t.mutations, state: t.state })) continue;
-          const signature = candidateSignature(t.input);
-          const key = `${inv.id}::${signature}`;
-          const bucket = clusters.get(key) || { invariant: inv, signature, turns: [] };
-          bucket.turns.push(t);
-          clusters.set(key, bucket);
-        }
-      }
-
-      const candidates = [...clusters.values()]
-        .map(c => {
-          const clients = new Set(c.turns.map(t => t.row.userId)).size;
-          const triaged = c.turns.filter(t => !!t.row.failureCategory);
-          const withFix = c.turns.filter(t => !!t.row.fixRef);
-          const lifecycles = new Set(c.turns.map(t => String(t.row.lifecycleStatus || "")).filter(Boolean));
-          return {
-          // A STABLE HANDLE, so a candidate can be referred to in a brief, a commit message or a
-          // conversation and still be the same thing tomorrow. Derived from what defines the
-          // cluster rather than stored, so it survives without a table and cannot drift from its
-          // own contents.
-          id: `CH-${candidateRef(c.invariant.id, c.signature)}`,
-          invariant: c.invariant.id,
-          label: c.invariant.label,
-          layer: c.invariant.layer,
-          expected: c.invariant.expected,
-          pattern: c.signature,
-          turns: c.turns.length,
-          clients,
-          firstSeen: c.turns[c.turns.length - 1]?.row.createdAt,
-          lastSeen: c.turns[0]?.row.createdAt,
-          triaged: triaged.length,
-          // THE STATUS IS DERIVED, NOT DECLARED. The per-turn lifecycle already exists and is
-          // already editable through PATCH /api/admin/turns/:id — the verdict machinery this file
-          // has had since 2026-08-25. A candidate's status is what its turns say, so triaging a
-          // turn moves the candidate and there is no second source of truth to fall out of step.
-          //
-          //   candidate    nobody has ruled on any of these turns yet
-          //   adjudicated  a human recorded a failure category
-          //   engineering  a fix is claimed against them (fix_ref)
-          //   deployed     a build carrying the fix has been recorded
-          //   resolved     replayed against that build and behaved
-          status: lifecycles.has("revalidated") ? "resolved"
-            : lifecycles.has("deployed") ? "deployed"
-            : withFix.length ? "engineering"
-            : triaged.length ? "adjudicated"
-            : "candidate",
-          // RANK, SAID OUT LOUD. Breadth beats frequency: nine clients hitting something once is
-          // the product misbehaving; one client hitting it nine times is one conversation.
-          priority: clients >= 5 ? "high" : clients >= 2 ? "medium" : "low",
-          // THE EVIDENCE PACKET — the message and the reply, not a summary of them. Whoever picks
-          // this up traces from the client's own words; a paraphrase would be the screenshot
-          // problem again, one layer further in.
-          examples: c.turns.slice(0, 5).map(t => ({
-            turnId: t.row.id, at: t.row.createdAt, version: t.row.version,
-            input: t.input.slice(0, 300),
-            reply: t.reply.replace(/\n/g, " ").slice(0, 300),
-            status: t.row.lifecycleStatus,
-          })),
-        }; })
-        // RANKED BY HOW MANY PEOPLE IT HAPPENED TO, then by how often. One client hitting the same
-        // thing nine times is a story about one client; nine clients hitting it once is the product.
-        .sort((a, b) => (b.clients - a.clients) || (b.turns - a.turns))
-        .slice(0, 40);
-
-      // ── BUILDS: attribution here is merge-time, so a window served by more than one build is
-      // the case where a "regression" may just be a turn that ran the old code. Surfaced rather
-      // than assumed away.
-      const byVersion = new Map<string, number>();
-      for (const t of shaped) byVersion.set(String(t.row.version || "?"), (byVersion.get(String(t.row.version || "?")) || 0) + 1);
-      const builds = [...byVersion.entries()].map(([version, turns]) => ({ version, turns }))
-        .sort((a, b) => b.turns - a.turns);
-
-      await auditRead("coach_health_brief", { days, turns: rows.length });
-      res.json({
-        windowDays: days,
-        turns: rows.length,
-        clients: new Set(shaped.map(t => t.row.userId)).size,
-        known,
-        knownRegressions: known.reduce((s, k) => s + k.regressions, 0),
-        unexercised: known.filter(k => k.exercised === 0).map(k => k.fixRef),
-        candidates,
-        candidateTurns: candidates.reduce((s, c) => s + c.turns, 0),
-        builds,
-        buildWarning: builds.length > 1
-          ? `${builds.length} builds served turns in this window — a regression may be a turn that ran the old code`
-          : null,
-        // The queue is evidence. It is not a defect list, and the page must not render it as one.
-        disclaimer: "Candidates are unadjudicated: a property did not hold on these turns. Confirm before treating any of them as a defect.",
-      });
+      // MANUAL BEHAVIOUR IS UNCHANGED: opening the page still evaluates the live window. The
+      // automatic run is added ALONGSIDE it, so the dashboard shows what the loop found while
+      // nobody was looking without losing the ability to ask a fresh question.
+      const brief = await buildCoachHealthBrief(days);
+      const { loadState } = await import("../scheduler/shared");
+      let lastSweep: any = null;
+      try {
+        const raw = loadState()[COACH_HEALTH_STATE_KEY];
+        if (raw) lastSweep = JSON.parse(raw);
+      } catch { /* a corrupt snapshot must not take the dashboard down */ }
+      await auditRead("coach_health_brief", { days, turns: brief.turns });
+      res.json({ ...brief, lastSweep });
     } catch (e: any) {
       console.error("[COACH_HEALTH] brief failed:", e?.message);
       res.status(500).json({ message: "Failed to build the brief" });

--- a/server/scheduler.ts
+++ b/server/scheduler.ts
@@ -25,6 +25,7 @@ import { runTrialCountdown } from "./scheduler/jobs/trial";
 import { runBalanceCheck } from "./scheduler/jobs/balance-check";
 import { runDueReminders } from "./scheduler/jobs/reminders";
 import { runMediaJobRecovery } from "./scheduler/jobs/media-recovery";
+import { runCoachHealthSweep } from "./routes/admin-turns";
 
 // Re-export for routes.ts + index.ts consumers
 export { sendWhatsApp, sendWhatsAppTemplate, deliveryStats };
@@ -285,6 +286,16 @@ export async function initScheduler(): Promise<void> {
   // of a soft daily budget. Catches the account-wide runaway ("$20→$200 overnight")
   // that per-user caps never see. Alert only — never stops coaching.
   cron.schedule("0 * * * *",     () => safe("runSpendWatchdog",       runSpendWatchdog, { cron: "0 * * * *" }),       { timezone: "UTC" }); // top of every hour
+  // ── COACH HEALTH A1 (2026-09-01) — the quality loop runs whether or not anybody is looking.
+  //
+  // The brief was computed only when the dashboard was opened, so a weekend of real turns
+  // accumulated as evidence nobody had evaluated. This evaluates it on a schedule, writes one
+  // snapshot to scheduler_state, and announces only refs it has not announced before.
+  //
+  // It reads the ledger and runs pure rules — no model, no sends, no writes to the per-turn
+  // verdict fields, which stay with human adjudication. Half past the hour so it does not sit on
+  // top of the spend watchdog. The leader lock above already stops a second replica repeating it.
+  cron.schedule("30 * * * *",    () => safe("runCoachHealthSweep",    () => runCoachHealthSweep().then(() => undefined), { cron: "30 * * * *" }), { timezone: "UTC" });
 
   // ── Daily setup-checklist reminder ────────────────────────────────────────
   // Fires once/day at 9am SAST (7am UTC). Builds a WhatsApp message listing


### PR DESCRIPTION
Closes #106. Base `25b2232`.

```
real turn → turn_ledger → the same rules → scheduler_state → the same dashboard
```

## First divergence

The rules were not the problem and neither was the evidence — `turn_ledger` already persists everything the invariants read. What happened **only on read** was the *evaluation*: clustering, candidate refs and coverage counts were computed inside the request handler and thrown away with the response.

The file said so itself, as a deliberate design note: *"There is no second store and no background job."* That is exactly what made a weekend of real turns accumulate as evidence nobody had evaluated.

## Existing primitives reused — no new table, no new authority

| primitive | use |
|---|---|
| `turn_ledger` | unchanged; still the only evidence |
| `COACH_HEALTH_RULES` / `COACH_HEALTH_INVARIANTS` | unchanged; the same rule engine |
| `candidateSignature` / `candidateRef` | unchanged; clustering and stable `CH-xxxx` handles |
| `scheduler_state` (`text` key/value) | one snapshot via `saveState`/`loadState` |
| scheduler `safe()` + `cron` + leader lock | the run path, and what stops a second replica repeating it |

**The issue's STOP condition did not trigger:** durable candidates and coverage are expressible with what exists.

### What was deliberately *not* reused

`turn_ledger.failureCategory`, `lifecycleStatus` and `fixRef` are durable per-turn fields and would have been the obvious place to mark a candidate. **They belong to human adjudication** through `PATCH /api/admin/turns/:id`. A job writing them puts a second author on the verdict — the defect this project has spent the week removing. The sweep writes one snapshot and nothing else. No auto-fix, no auto-message, no model.

## Files changed

- `server/routes/admin-turns.ts` — brief body extracted to `buildCoachHealthBrief()`, now called by both the endpoint and the job; `runCoachHealthSweep()`; `reply-contradicts-itself` restored.
- `server/scheduler.ts` — hourly registration at `:30`.
- `script/tracking-contract-tests.ts` — detector pair + loop tests.

Copying the brief into the job would have been the third *"mirrors X exactly"* in this codebase, after `logStepsForUser` and the template sender in Cut B2. One definition of what a candidate is.

## Automatic-run contract

`cron.schedule("30 * * * *")` → `safe("runCoachHealthSweep", …)`. Reads the ledger, runs pure rules, writes one `scheduler_state` snapshot: `at`, coverage, the ranked head with turn/build provenance, and `seenRefs`. **Dedup lives in the snapshot** — a re-run announces only refs it has not announced before, and refs are derived from cluster identity so they are stable across runs by construction.

Manual behaviour untouched: opening the page still evaluates the live window; the stored sweep is added alongside as `lastSweep`.

## Detector regression + controls

Restored from the parked branch with the production instance that justified it — one reply refusing to call a weight trend and then asserting one. Its **healthy control is the same refusal *without* the assertion** — the shape #102 makes the coach produce — so the detector cannot punish the repair.

| control | result |
|---|---|
| detector removed | **RED** — observed reply never reaches the queue; sweep finds nothing |
| dedup removed | **RED** — `re-announced 1 candidate(s) it had already reported` |
| persistence removed | **RED** — `left nothing durable behind` |
| healthy weight reply | must produce **no** new candidate — guards against "always report something" |

Observed run: `1 turns, 1 candidate(s), 1 new — CH-E17F` → re-run `none new` → clean window `0 candidate(s)`.

## Focused verification

```
tsc --noEmit         clean
tracking-contract    green
unit-tests           1049/1049
production-parity    142/142
reach guard          green
cut-a-regression     pass

architecture guard   BYTE-IDENTICAL to main
file-size guard      BYTE-IDENTICAL to main
```

No new module (the sweep lives with the rules it runs), no new regex literal — both counters sit at zero headroom and neither moved. No budget raised.

## Remaining coverage debt — recorded, not hidden

- **Proactive/async sends are not in `turn_ledger`**, so the sweep sees replies and not the 06:00 fan-out. Not widened here.
- **The claimant is still not stamped on a turn** — Coach Health's own header already records this; a claim defect whose reply looks plausible stays invisible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_