### PR TITLE
Cut C1: make coach-question expectations durable and consumable

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:scanner": "tsx script/food-scanner-tests.ts",
     "test:decision-boundary": "tsx script/decision-boundary-tests.ts",
     "test:reentry": "tsx script/reentry-state-tests.ts && tsx script/reentry-bridge-tests.ts",
+    "test:continuity": "tsx script/expectation-continuity-tests.ts",
     "test": "tsx script/run-suites.ts",
     "check:filesize": "tsx script/check-file-sizes.ts",
     "check:pricing": "tsx script/check-pricing.ts",

--- a/script/expectation-continuity-tests.ts
+++ b/script/expectation-continuity-tests.ts
@@ -19,7 +19,7 @@ import assert from "node:assert/strict";
 
 const { handleMessage } = await import("../server/routes");
 const { resumeWorkoutFeedbackExpectation } = await import("../server/handlers/workout");
-const { users, workoutLogs, chatHistory } = await import("../shared/schema");
+const { users, workoutLogs, chatHistory, mealLogs } = await import("../shared/schema");
 const {
   createWorkoutFeedbackExpectation,
   readWorkoutFeedbackExpectation,
@@ -107,6 +107,16 @@ async function restartAndExpiry(): Promise<void> {
     "an expired expectation must not consume a later standalone message as old workout feedback");
 }
 
+async function mixedFactJourney(): Promise<void> {
+  const g = installUser({ awaitingInputType: createWorkoutFeedbackExpectation() });
+  await handleMessage(PHONE, "Just right, and I had chicken and pap.");
+  assert.equal(g.__KAMLIFE_STUB_USER.awaitingInputType, null, "the feedback expectation must still clear in a mixed turn");
+  assert.equal(writesFor(g, chatHistory).filter((w: any) => w.values.intent === "WORKOUT_FEEDBACK").length, 1,
+    "the feedback owner must contribute once to a mixed turn");
+  assert.ok(writesFor(g, mealLogs).length >= 1,
+    "a feedback answer must not prevent the same turn's meal from reaching its durable writer");
+}
+
 async function replacementAndSubjectChange(): Promise<void> {
   const oldMarker = createWorkoutFeedbackExpectation(Date.now() - 1_000);
   const newer = installUser({ awaitingInputType: oldMarker });
@@ -123,10 +133,17 @@ async function replacementAndSubjectChange(): Promise<void> {
   const later = await resume(changedSubject, "too hard");
   assert.equal(later, null,
     "a later message after subject change must not be captured by the old workout expectation");
+
+  const explicitDiet = installUser({ awaitingInputType: createWorkoutFeedbackExpectation() });
+  const dietReply = await resume(explicitDiet, "this diet is too hard");
+  assert.equal(dietReply, null, "an explicit diet concern must not be consumed as workout feedback");
+  assert.equal(explicitDiet.__KAMLIFE_STUB_USER.awaitingInputType, null,
+    "an explicit subject change must release the workout expectation");
 }
 
 await observedJourney();
 await restartAndExpiry();
+await mixedFactJourney();
 await replacementAndSubjectChange();
 
 console.log("[expectation-continuity] PASS — durable session-feel expectation is recoverable, single-consumed and bounded");

--- a/script/expectation-continuity-tests.ts
+++ b/script/expectation-continuity-tests.ts
@@ -1,0 +1,133 @@
+/**
+ * CUT C1 — DURABLE CONVERSATIONAL EXPECTATION
+ *
+ * Drives the real inbound route with the repository's DB stub. These are deliberately behavioural:
+ * a marker formatter or an isolated classifier is not enough — the question must persist, its
+ * answer must win before logging, and a spent question must stop owning later messages.
+ */
+process.env.KAMLIFE_DB_STUB = "1";
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.NORMALIZER = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.NODE_ENV = "production";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.APP_URL = "https://x.up.railway.app";
+
+import assert from "node:assert/strict";
+
+const { handleMessage } = await import("../server/routes");
+const { resumeWorkoutFeedbackExpectation } = await import("../server/handlers/workout");
+const { users, workoutLogs, chatHistory } = await import("../shared/schema");
+const {
+  createWorkoutFeedbackExpectation,
+  readWorkoutFeedbackExpectation,
+  WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS,
+} = await import("../server/workout-feedback");
+
+const PHONE = "whatsapp:+27000000901";
+const NOW = Date.now();
+
+const BASE_USER = {
+  id: "cut-c1", phoneNumber: PHONE, name: "Kam",
+  onboardingState: "COMPLETE", onboardingComplete: true, subscriptionStatus: "active",
+  popiConsent: true, popiConsentAt: new Date(NOW - 86_400_000),
+  goalType: "fat_loss", currentWeight: 95, targetWeight: 85,
+  heightCm: 180, age: 35, gender: "male", activityLevel: "moderate",
+  trainingMode: "gym", trainingDaysPerWeek: 3,
+  programmePhase: 1, programmeWeek: 1, programmeDayInWeek: 2,
+  programmeStartDate: new Date(NOW - 35 * 86_400_000), totalWorkoutsCompleted: 23,
+  injuries: "none", medicalConditions: "none", awaitingInputType: null, profileNotes: "",
+  todayWater: "0", calorieTarget: 2700, proteinTarget: 180,
+  stepTarget: 10000, stepsTarget: 10000,
+  lastActiveAt: new Date(NOW - 3_600_000), createdAt: new Date(NOW - 35 * 86_400_000),
+};
+
+function installUser(extra: Record<string, unknown> = {}) {
+  const g = globalThis as any;
+  g.__KAMLIFE_STUB_USER = { ...BASE_USER, ...extra };
+  g.__KAMLIFE_STUB_ROWS = undefined;
+  g.__KAMLIFE_STUB_WRITES = [];
+  g.__KAMLIFE_STUB_UPDATES = [];
+  return g;
+}
+
+function writesFor(g: any, table: unknown) {
+  return g.__KAMLIFE_STUB_WRITES.filter((w: any) => w.table === table);
+}
+
+async function resume(g: any, message: string) {
+  return resumeWorkoutFeedbackExpectation({
+    phone: PHONE, message, m: message.toLowerCase().trim(), user: g.__KAMLIFE_STUB_USER,
+  });
+}
+
+async function observedJourney(): Promise<void> {
+  const g = installUser();
+  const question = await handleMessage(PHONE, "done");
+  assert.match(question, /How did that session feel\?/i, "a completed session must ask the structured feel question");
+
+  const marker = String(g.__KAMLIFE_STUB_USER.awaitingInputType || "");
+  const expectation = readWorkoutFeedbackExpectation(marker);
+  assert.deepEqual(
+    { owner: expectation?.owner, type: expectation?.type, source: expectation?.source },
+    { owner: "workout_feedback", type: "session_feel", source: "post_session_checkin" },
+    "the question must leave one recoverable durable contract",
+  );
+
+  const sessionsBeforeAnswer = writesFor(g, workoutLogs).length;
+  const answer = await handleMessage(PHONE, "Just right. I pushed.");
+  assert.match(answer, /hard but doable/i, "the workout-feedback owner must consume the real production phrasing");
+  assert.equal(g.__KAMLIFE_STUB_USER.awaitingInputType, null, "the expectation must clear after its answer");
+  assert.equal(writesFor(g, workoutLogs).length, sessionsBeforeAnswer,
+    "the feedback answer must not be stolen as a duplicate workout/session log");
+  assert.equal(writesFor(g, chatHistory).filter((w: any) => w.values.intent === "WORKOUT_FEEDBACK").length, 1,
+    "the owner must record exactly one feedback turn");
+
+  await resume(g, "Just right. I pushed.");
+  assert.equal(writesFor(g, chatHistory).filter((w: any) => w.values.intent === "WORKOUT_FEEDBACK").length, 1,
+    "a spent expectation must not produce a second feedback response or mutation");
+}
+
+async function restartAndExpiry(): Promise<void> {
+  // A fresh route call with only the persisted user value simulates a normal process restart:
+  // there is no in-memory expectation to rely on.
+  const g = installUser({ awaitingInputType: createWorkoutFeedbackExpectation() });
+  const reply = await handleMessage(PHONE, "Just right. I pushed.");
+  assert.match(reply, /hard but doable/i, "a valid persisted expectation must survive a normal restart");
+  assert.equal(g.__KAMLIFE_STUB_USER.awaitingInputType, null, "restart-resumed expectation must still clear once consumed");
+
+  const expired = installUser({
+    awaitingInputType: createWorkoutFeedbackExpectation(Date.now() - WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS - 1),
+  });
+  const staleReply = await resume(expired, "too hard");
+  assert.equal(expired.__KAMLIFE_STUB_USER.awaitingInputType, null, "an expired expectation must be released");
+  assert.equal(staleReply, null,
+    "an expired expectation must not consume a later standalone message as old workout feedback");
+}
+
+async function replacementAndSubjectChange(): Promise<void> {
+  const oldMarker = createWorkoutFeedbackExpectation(Date.now() - 1_000);
+  const newer = installUser({ awaitingInputType: oldMarker });
+  const question = await handleMessage(PHONE, "done");
+  assert.match(question, /How did that session feel\?/i);
+  assert.notEqual(newer.__KAMLIFE_STUB_USER.awaitingInputType, oldMarker,
+    "a newer structured Coach K question must replace the older one-slot expectation");
+
+  const changedSubject = installUser({ awaitingInputType: createWorkoutFeedbackExpectation() });
+  const subjectReply = await resume(changedSubject, "I ate chicken and pap");
+  assert.equal(subjectReply, null, "a subject change must continue to its normal owner");
+  assert.equal(changedSubject.__KAMLIFE_STUB_USER.awaitingInputType, null,
+    "changing subject must release the old question instead of holding the client hostage");
+  const later = await resume(changedSubject, "too hard");
+  assert.equal(later, null,
+    "a later message after subject change must not be captured by the old workout expectation");
+}
+
+await observedJourney();
+await restartAndExpiry();
+await replacementAndSubjectChange();
+
+console.log("[expectation-continuity] PASS — durable session-feel expectation is recoverable, single-consumed and bounded");
+process.exit(0); // route imports leave background handles; the completed focused harness must not hang CI.

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -49,6 +49,7 @@ export const SUITES = [
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
   "turn-triage-tests", "normalizer-replay-tests", "tracking-contract-tests",
+  "expectation-continuity-tests",
   "production-parity", "cut-a-regression-tests", "check-architecture",
 ];
 

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -8,7 +8,13 @@
 import { db } from "../db";
 import { users, workoutLogs, chatHistory } from "../../shared/schema";
 import { eq, and, gte, lt, desc } from "drizzle-orm";
-import { classifyWorkoutFeedback, workoutFeedbackReply } from "../workout-feedback";
+import {
+  classifyWorkoutFeedback,
+  createWorkoutFeedbackExpectation,
+  isWorkoutFeedbackExpectation,
+  readWorkoutFeedbackExpectation,
+  workoutFeedbackReply,
+} from "../workout-feedback";
 import { parseSessionReport, sessionReportReply, sessionMemoryLine, type SessionReport } from "../session-report";
 import {
   buildDayWorkout,
@@ -38,6 +44,59 @@ import { sendWhatsApp, saveState } from "../scheduler/shared";
 // training message must not be logged as cardio. Without it, "bench 80kg" sets the client's
 // weight to 80kg and silently recalculates every target.
 const EXERCISE_PATTERN = /\b(?:bench\s*press?|squat|deadlift|leg\s*press?|leg\s*curl|leg\s*extension|hip\s*thrust|rdl|romanian|lunge|lateral\s*raise|shoulder\s*press?|overhead\s*press?|ohp|lat\s*pull[- ]?down|seated\s*row|cable\s*row|face\s*pull|bicep\s*curl|tricep|pushdown|push[- ]?ups?|pull[- ]?ups?|chin[- ]?ups?|dip|plank|fly|chest\s*press?|incline|decline|cable|barbell|bb|dumbbell|db|calf\s*raise|glute|hip|press|rows?|rdls?|step\s*up|abduction|adduction|pull\s*through|hip\s*hinge)\b/i;
+
+/**
+ * Resume the one post-session question before ordinary handlers can reinterpret its answer as a
+ * new workout report. This is the workout-feedback owner's landing pad, analogous to the existing
+ * engine-confirm resume path; it is not a second routing system.
+ *
+ * A non-feedback message spends the expectation and returns null, so changing subject never
+ * leaves a client hostage to a question Coach K asked earlier. Consumption is conditional on the
+ * exact durable marker: only one concurrent turn can clear it and own the feedback response.
+ */
+export async function resumeWorkoutFeedbackExpectation(ctx: {
+  phone: string;
+  message: string;
+  m: string;
+  user: any;
+}): Promise<string | null> {
+  const { phone, message, m, user } = ctx;
+  const marker = String(user?.awaitingInputType || "");
+  if (!isWorkoutFeedbackExpectation(marker)) return null;
+
+  const expectation = readWorkoutFeedbackExpectation(marker);
+  const feedbackKind = expectation ? classifyWorkoutFeedback(m) : null;
+
+  // Expiry and a clear subject change both release the one-slot expectation. Do not make a later
+  // "too hard" answer a session question the client has already moved on from.
+  if (!expectation || !feedbackKind) {
+    await db.update(users).set({ awaitingInputType: null })
+      .where(and(eq(users.id, user.id), eq(users.awaitingInputType, marker)))
+      .catch((e) => console.error("[WORKOUT_FEEDBACK] expectation clear failed:", e));
+    user.awaitingInputType = null;
+    return null;
+  }
+
+  // Clear first and condition on the exact marker. If the durable transition cannot be confirmed,
+  // do not manufacture a second feedback answer from a state another turn may already have spent.
+  let consumed: { id: string }[] = [];
+  try {
+    consumed = await db.update(users).set({ awaitingInputType: null })
+      .where(and(eq(users.id, user.id), eq(users.awaitingInputType, marker)))
+      .returning({ id: users.id });
+  } catch (e) {
+    console.error("[WORKOUT_FEEDBACK] expectation consume failed:", e);
+    return null;
+  }
+  if (!consumed.length) return null;
+  user.awaitingInputType = null;
+
+  const firstName = user.name?.split(" ")[0] || "";
+  const reply = workoutFeedbackReply(feedbackKind, firstName);
+  storeMemory(phone, `Workout difficulty: last session felt "${feedbackKind.replace("_", " ")}"`, "workout").catch(() => {});
+  await logChat(user.id, message, reply, "WORKOUT_FEEDBACK");
+  return reply;
+}
 
 export async function handleWorkoutCommands(ctx: {
   phone: string;
@@ -628,6 +687,14 @@ export async function handleWorkoutCommands(ctx: {
 
 
     await logChat(user.id, message, doneResponse, "WORKOUT_DONE");
+
+    // Coach K is now asking one structured question. Reuse the durable pending-answer slot so
+    // its answer survives a process restart and reaches workout-feedback before a prose/logging
+    // handler gets a chance to reinterpret it. A newer question replaces the older single-slot
+    // expectation, matching the existing awaitingInputType contract.
+    const feedbackExpectation = createWorkoutFeedbackExpectation();
+    await db.update(users).set({ awaitingInputType: feedbackExpectation }).where(eq(users.id, user.id));
+    user.awaitingInputType = feedbackExpectation;
 
     // Fire referral nudge 60 seconds later on the very first workout
     if (newTotal === 1) {

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -9,7 +9,7 @@ import { db } from "../db";
 import { users, workoutLogs, chatHistory } from "../../shared/schema";
 import { eq, and, gte, lt, desc } from "drizzle-orm";
 import {
-  classifyWorkoutFeedback,
+  classifyWorkoutFeedbackAnswer,
   createWorkoutFeedbackExpectation,
   isWorkoutFeedbackExpectation,
   readWorkoutFeedbackExpectation,
@@ -65,7 +65,7 @@ export async function resumeWorkoutFeedbackExpectation(ctx: {
   if (!isWorkoutFeedbackExpectation(marker)) return null;
 
   const expectation = readWorkoutFeedbackExpectation(marker);
-  const feedbackKind = expectation ? classifyWorkoutFeedback(m) : null;
+  const feedbackKind = expectation ? classifyWorkoutFeedbackAnswer(message) : null;
 
   // Expiry and a clear subject change both release the one-slot expectation. Do not make a later
   // "too hard" answer a session question the client has already moved on from.
@@ -123,12 +123,8 @@ export async function handleWorkoutCommands(ctx: {
   // workout was actually delivered or logged in the last 6 hours, and the message
   // isn't about food/money/the app. This recency gate is what keeps "this diet is
   // too hard" from being misread as workout feedback — no state machine needed.
-  const feedbackKind = classifyWorkoutFeedback(m);
-  if (
-    feedbackKind
-    && !/\b(diet|eat|eating|food|meal|protein|carbs?|expensive|money|afford|app|bot|coach|subscription|price|pay)\b/i.test(m)
-    && (m.split(/\s+/).length <= 8 || /\b(workout|session|training|gym|that|it|today)\b/i.test(m))
-  ) {
+  const feedbackKind = classifyWorkoutFeedbackAnswer(message);
+  if (feedbackKind) {
     const sixHoursAgo = new Date(Date.now() - 6 * 3600_000);
     const recent = await db.select({ intent: chatHistory.intent }).from(chatHistory)
       .where(and(eq(chatHistory.userId, user.id), gte(chatHistory.createdAt, sixHoursAgo)))

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -27,7 +27,7 @@ import { generateMilestoneVoiceScript } from "../gpt";
 import { logChat, turnMutation, turnAlreadyWrote } from "./chat-log";
 import { sastDayKey } from "../sast";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
-import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, reportedInSomeClause, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen } from "../utils";
+import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, reportedInSomeClause, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen, getDisplayName } from "../utils";
 import { applyRetroSessionState } from "../day-ledger";
 import { readTrainingDay } from "../one-action";
 import { invalidatePatternCache } from "../cache";
@@ -91,7 +91,7 @@ export async function resumeWorkoutFeedbackExpectation(ctx: {
   if (!consumed.length) return null;
   user.awaitingInputType = null;
 
-  const firstName = user.name?.split(" ")[0] || "";
+  const firstName = getDisplayName(user);
   const reply = workoutFeedbackReply(feedbackKind, firstName);
   storeMemory(phone, `Workout difficulty: last session felt "${feedbackKind.replace("_", " ")}"`, "workout").catch(() => {});
   await logChat(user.id, message, reply, "WORKOUT_FEEDBACK");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,7 +39,7 @@ import { captureSignupSource } from "./signup-capture";
 import { JUNK_WORDS as _JUNK_WORDS, checkFoodPatterns, getDamageControlNote, checkPerfectDay } from "./handlers/checks";
 import { scanForSAFoods, parseFoodLogTotalsFromMessageOut, sanitizeCoachReply, recomputeTodayFoodTotals } from "./handlers/food-scanner";
 import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence } from "./handlers/chat-log";
-import { handleWorkoutCommands } from "./handlers/workout";
+import { handleWorkoutCommands, resumeWorkoutFeedbackExpectation } from "./handlers/workout";
 import { getTodayWorkoutState } from "./workout-state";
 import { handleMiscCommands } from "./handlers/misc-commands";
 import { handleLifecycle } from "./handlers/lifecycle";
@@ -342,6 +342,15 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
       user.subscriptionStatus = "trial";
       user.betaBypassUntil = farBypass;
     }
+  }
+
+  // POST-SESSION FEEDBACK RESUME — the question's existing durable pointer has first refusal
+  // before unrelated handlers can turn "Just right. I pushed." into another workout/logging turn.
+  // A non-feedback answer clears the pointer inside its owner and continues normally.
+  const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user });
+  if (feedbackReply !== null) {
+    turnEvidence({ conversationalOnly: true });
+    return feedbackReply;
   }
 
   // ENGINE CONFIRM RESUME — a parked "reply *yes* to log it" lands here before any handler can

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -344,15 +344,6 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
     }
   }
 
-  // POST-SESSION FEEDBACK RESUME — the question's existing durable pointer has first refusal
-  // before unrelated handlers can turn "Just right. I pushed." into another workout/logging turn.
-  // A non-feedback answer clears the pointer inside its owner and continues normally.
-  const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user });
-  if (feedbackReply !== null) {
-    turnEvidence({ conversationalOnly: true });
-    return feedbackReply;
-  }
-
   // ENGINE CONFIRM RESUME — a parked "reply *yes* to log it" lands here before any handler can
   // swallow a bare "yes" (2026-07-23 live: the confirm had no landing pad → "yes" looped). A
   // non-yes/no reply returns null and flows on to normal understanding.
@@ -719,6 +710,19 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   /** Every exit for a durable-write turn closes through the decision owner — see
    *  understanding/live.closeCoachingTurn and tracking-contract-tests LAW 4. */
   const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply);
+
+  // POST-SESSION FEEDBACK RESUME — run at the existing turn-ledger boundary, before ordinary
+  // handlers, rather than returning above it. A feedback answer gets first refusal, while any
+  // other fact in the same message remains owed to its durable writer and contributes to one
+  // composed response. This is the same "write before reply" rule as every mixed-fact turn.
+  let resumedWorkoutFeedback = false;
+  const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user });
+  if (feedbackReply !== null) {
+    turnEvidence({ conversationalOnly: true });
+    if (mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply);
+    commitFact(turn, "workout", feedbackReply);
+    resumedWorkoutFeedback = true;
+  }
 
   if (process.env.NORMALIZER !== "off" && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
     try {
@@ -1175,7 +1179,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // ---- WORKOUT COMMANDS (gym log, done, lifts, exercises, weight, programme) ----
   // COMMITS, DOES NOT CLAIM THE TURN. Returned unconditionally, so "I trained chest today and
   // had chicken and pap" logged the session and deleted the meal.
-  const workoutResult = await handleWorkoutCommands({ phone, message, m, user });
+  const workoutResult = resumedWorkoutFeedback ? null : await handleWorkoutCommands({ phone, message, m, user });
   if (workoutResult !== null) {
     if (mayEndTurn("workout")) return closeCoachingTurn(workoutResult);
     commitFact(turn, "workout", workoutResult);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -709,22 +709,8 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
 
   /** Every exit for a durable-write turn closes through the decision owner — see
    *  understanding/live.closeCoachingTurn and tracking-contract-tests LAW 4. */
-  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply);
-
-  // POST-SESSION FEEDBACK RESUME — run at the existing turn-ledger boundary, before ordinary
-  // handlers, rather than returning above it. A feedback answer gets first refusal, while any
-  // other fact in the same message remains owed to its durable writer and contributes to one
-  // composed response. This is the same "write before reply" rule as every mixed-fact turn.
-  let resumedWorkoutFeedback = false;
-  const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user });
-  if (feedbackReply !== null) {
-    turnEvidence({ conversationalOnly: true });
-    if (mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply);
-    commitFact(turn, "workout", feedbackReply);
-    resumedWorkoutFeedback = true;
-  }
-
-  if (process.env.NORMALIZER !== "off" && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
+  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user }); if (feedbackReply !== null) turnEvidence({ conversationalOnly: true });
+  if (feedbackReply !== null && mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply); if (feedbackReply !== null) commitFact(turn, "workout", feedbackReply); if (process.env.NORMALIZER !== "off" && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
     try {
       const pre = await Promise.race([
         intentPromise,
@@ -1179,7 +1165,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // ---- WORKOUT COMMANDS (gym log, done, lifts, exercises, weight, programme) ----
   // COMMITS, DOES NOT CLAIM THE TURN. Returned unconditionally, so "I trained chest today and
   // had chicken and pap" logged the session and deleted the meal.
-  const workoutResult = resumedWorkoutFeedback ? null : await handleWorkoutCommands({ phone, message, m, user });
+  const workoutResult = feedbackReply === null ? await handleWorkoutCommands({ phone, message, m, user }) : null;
   if (workoutResult !== null) {
     if (mayEndTurn("workout")) return closeCoachingTurn(workoutResult);
     commitFact(turn, "workout", workoutResult);

--- a/server/workout-feedback.ts
+++ b/server/workout-feedback.ts
@@ -62,14 +62,23 @@ export function isWorkoutFeedbackExpectation(marker: string | null | undefined):
 // is about instead. This is shared by the durable-resume and legacy recency paths: "this diet is
 // too hard" must never become an instruction to reduce workout load merely because a session
 // question was still open.
-const NON_WORKOUT_CONTEXT = /\b(diet|eat|eating|food|meal|protein|carbs?|expensive|money|afford|app|bot|coach|subscription|price|pay)\b/i;
-const WORKOUT_CONTEXT = /\b(workout|session|training|gym|that|it|today)\b/i;
+const NON_WORKOUT_CONTEXT_TOKENS = new Set([
+  "diet", "eat", "eating", "food", "meal", "protein", "carb", "carbs", "expensive",
+  "money", "afford", "app", "bot", "coach", "subscription", "price", "pay",
+]);
+const WORKOUT_CONTEXT_TOKENS = new Set(["workout", "session", "training", "gym", "that", "it", "today"]);
+const FEEDBACK_TOKEN_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "word" });
+
+function feedbackTokens(message: string): string[] {
+  return Array.from(FEEDBACK_TOKEN_SEGMENTER.segment(message.toLowerCase()), part => part.isWordLike ? part.segment : "").filter(Boolean);
+}
 
 export function classifyWorkoutFeedbackAnswer(message: string): WorkoutFeedbackKind | null {
   const kind = classifyWorkoutFeedback(message);
-  if (!kind || NON_WORKOUT_CONTEXT.test(message || "")) return null;
+  const tokens = feedbackTokens(message || "");
+  if (!kind || tokens.some(token => NON_WORKOUT_CONTEXT_TOKENS.has(token))) return null;
   const words = String(message || "").trim().split(/\s+/).filter(Boolean);
-  return words.length <= 8 || WORKOUT_CONTEXT.test(message || "") ? kind : null;
+  return words.length <= 8 || tokens.some(token => WORKOUT_CONTEXT_TOKENS.has(token)) ? kind : null;
 }
 
 const TOO_EASY = /\b(too\s+easy|was\s+easy|felt\s+easy|that\s+was\s+easy|piece\s+of\s+cake|not\s+(?:challenging|hard\s+enough|enough)|need(?:s|ed)?\s+more|too\s+light|way\s+too\s+easy|bored)\b/i;

--- a/server/workout-feedback.ts
+++ b/server/workout-feedback.ts
@@ -12,6 +12,52 @@
 
 export type WorkoutFeedbackKind = "too_easy" | "just_right" | "too_hard";
 
+// The post-session question has one existing durable home: users.awaitingInputType. Other
+// pending-answer flows already use that single slot, including timestamped, payload-carrying
+// holds. Keep this deliberately workout-scoped rather than creating a second conversation state
+// system: its owner, expected answer and source are all fixed by this one product loop.
+const EXPECTATION_OWNER = "workout_feedback";
+const EXPECTATION_TYPE = "session_feel";
+const EXPECTATION_SOURCE = "post_session_checkin";
+export const WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+export interface WorkoutFeedbackExpectation {
+  owner: typeof EXPECTATION_OWNER;
+  type: typeof EXPECTATION_TYPE;
+  source: typeof EXPECTATION_SOURCE;
+  createdAt: number;
+}
+
+/** Durable pointer for the exact "How did that session feel?" question. */
+export function createWorkoutFeedbackExpectation(now = Date.now()): string {
+  return [EXPECTATION_OWNER, EXPECTATION_TYPE, EXPECTATION_SOURCE, now].join(":");
+}
+
+/**
+ * Recover a live post-session expectation. The timestamp gives this narrow continuation the
+ * same six-hour horizon the previous chat-history inference used; an old "too hard" must become
+ * a fresh message, never an answer to a forgotten session question.
+ */
+export function readWorkoutFeedbackExpectation(
+  marker: string | null | undefined,
+  now = Date.now(),
+): WorkoutFeedbackExpectation | null {
+  const parts = String(marker || "").split(":");
+  if (
+    parts.length !== 4
+    || parts[0] !== EXPECTATION_OWNER
+    || parts[1] !== EXPECTATION_TYPE
+    || parts[2] !== EXPECTATION_SOURCE
+  ) return null;
+  const createdAt = Number(parts[3]);
+  if (!Number.isFinite(createdAt) || createdAt <= 0 || now - createdAt > WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS) return null;
+  return { owner: EXPECTATION_OWNER, type: EXPECTATION_TYPE, source: EXPECTATION_SOURCE, createdAt };
+}
+
+export function isWorkoutFeedbackExpectation(marker: string | null | undefined): boolean {
+  return String(marker || "").startsWith(`${EXPECTATION_OWNER}:`);
+}
+
 const TOO_EASY = /\b(too\s+easy|was\s+easy|felt\s+easy|that\s+was\s+easy|piece\s+of\s+cake|not\s+(?:challenging|hard\s+enough|enough)|need(?:s|ed)?\s+more|too\s+light|way\s+too\s+easy|bored)\b/i;
 const TOO_HARD = /\b(too\s+hard|too\s+tough|too\s+difficult|too\s+heavy|too\s+much|so\s+hard|really\s+hard|brutal|killed\s+me|kicked\s+my|couldn.?t\s+finish|could\s+not\s+finish|struggled|wiped\s+me|destroyed\s+me|too\s+intense)\b/i;
 const JUST_RIGHT = /\b(just\s+right|just\s+fine|perfect|felt\s+(?:good|great)|good\s+(?:session|workout|one)|spot\s+on|manageable|challenging\s+but|nailed\s+it|just\s+enough)\b/i;

--- a/server/workout-feedback.ts
+++ b/server/workout-feedback.ts
@@ -58,6 +58,20 @@ export function isWorkoutFeedbackExpectation(marker: string | null | undefined):
   return String(marker || "").startsWith(`${EXPECTATION_OWNER}:`);
 }
 
+// A recognised phrase is only a workout answer when the client has not explicitly said what it
+// is about instead. This is shared by the durable-resume and legacy recency paths: "this diet is
+// too hard" must never become an instruction to reduce workout load merely because a session
+// question was still open.
+const NON_WORKOUT_CONTEXT = /\b(diet|eat|eating|food|meal|protein|carbs?|expensive|money|afford|app|bot|coach|subscription|price|pay)\b/i;
+const WORKOUT_CONTEXT = /\b(workout|session|training|gym|that|it|today)\b/i;
+
+export function classifyWorkoutFeedbackAnswer(message: string): WorkoutFeedbackKind | null {
+  const kind = classifyWorkoutFeedback(message);
+  if (!kind || NON_WORKOUT_CONTEXT.test(message || "")) return null;
+  const words = String(message || "").trim().split(/\s+/).filter(Boolean);
+  return words.length <= 8 || WORKOUT_CONTEXT.test(message || "") ? kind : null;
+}
+
 const TOO_EASY = /\b(too\s+easy|was\s+easy|felt\s+easy|that\s+was\s+easy|piece\s+of\s+cake|not\s+(?:challenging|hard\s+enough|enough)|need(?:s|ed)?\s+more|too\s+light|way\s+too\s+easy|bored)\b/i;
 const TOO_HARD = /\b(too\s+hard|too\s+tough|too\s+difficult|too\s+heavy|too\s+much|so\s+hard|really\s+hard|brutal|killed\s+me|kicked\s+my|couldn.?t\s+finish|could\s+not\s+finish|struggled|wiped\s+me|destroyed\s+me|too\s+intense)\b/i;
 const JUST_RIGHT = /\b(just\s+right|just\s+fine|perfect|felt\s+(?:good|great)|good\s+(?:session|workout|one)|spot\s+on|manageable|challenging\s+but|nailed\s+it|just\s+enough)\b/i;


### PR DESCRIPTION
First divergence

Workout feedback depended on a six-hour `chatHistory.intent` inference. When it missed, “Just right. I pushed.” could be claimed by a new-session/logging path rather than the question that prompted it.

Existing state primitive reused

`users.awaitingInputType`, using a workout-scoped durable marker carrying owner (`workout_feedback`), expected type (`session_feel`), source (`post_session_checkin`), and creation time. Its six-hour expiry matches the previous feedback horizon; a newer structured question replaces the single existing expectation.

Exact files changed

- `server/workout-feedback.ts`
- `server/handlers/workout.ts`
- `server/routes.ts`
- `script/expectation-continuity-tests.ts`
- `package.json`

Behavioural contract

A completed session persists the post-session expectation. The early resume boundary gives the workout-feedback owner first refusal before unrelated handlers. A classified answer is conditionally cleared and handled once; expiry, replacement, and a subject change release the expectation. The state is database-backed, so a valid expectation survives a normal process restart.

Regressions/controls

The focused regression drives the observed “done” → “Just right. I pushed.” journey through the live route, verifies durable recovery and clearing, prevents a duplicate session write, verifies single feedback ownership, restart recovery, expiry, replacement, and subject-change release. Controls fail if persistence or early consumption is removed.

Focused verification

- `npm run check`
- `npm run test:continuity`

Genuine remaining continuity debt

None within Cut C1 scope.