### PR TITLE
Coach Health A2: audit the scheduled read, and let a real recurrence come back

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -880,6 +880,77 @@ const MUST_WRITE: [string, string][] = [
         if (clean.fresh.length !== 0) {
           failures.push(`A healthy weight reply produced a NEW candidate — the automatic queue would fill with turns that are fine: ${clean.fresh.join(", ")}`);
         }
+
+        /**
+         * A2 — A GENUINE RECURRENCE MUST COME BACK (2026-09-01).
+         *
+         * A1 filtered against a flat "already announced" list forever, so a candidate that aged
+         * out of the window and happened again a week later produced the same stable ref and was
+         * reported as "none new". The suppression that is right for the next hour is wrong for
+         * the next month.
+         *
+         * The window above has just gone clean, so the candidate is absent. What follows is the
+         * same failure recurring with a turn the sweep has never counted — and then the same
+         * evidence re-swept, which must NOT be announced again, or "recurrence" would just mean
+         * "we ran it twice".
+         */
+        const recur = (id: string, at: Date) => new Map<any, any[]>([[schema.turnLedger, [{
+          id, userId: USER.id, createdAt: at,
+          inputText: "how is my weight going?", reply: observed,
+          mutations: [], stateRead: {}, version: "25b2232",
+          lifecycleStatus: null, failureCategory: null, fixRef: null,
+        }]]]);
+
+        g.__KAMLIFE_STUB_ROWS = recur("tl-recurrence", new Date(Date.now() + 60_000));
+        const back = await runCoachHealthSweep(1);
+        if (back.fresh.length === 0) {
+          failures.push(`The same failure recurred after the candidate had gone quiet and was reported as "none new" — a real recurrence is silently suppressed and never reaches a human again`);
+        }
+
+        // ...and it cannot be manufactured by re-running what is already stored.
+        const rerun = await runCoachHealthSweep(1);
+        if (rerun.fresh.length !== 0) {
+          failures.push(`Re-running the sweep over the SAME evidence announced ${rerun.fresh.length} candidate(s) as a recurrence — "new" would mean "we ran again", not "it happened again"`);
+        }
+        if (rerun.candidates === 0) {
+          failures.push(`The re-run lost the candidate — recurrence handling must change what is ANNOUNCED, not what is held`);
+        }
+
+        // ABSENCE IS NOT ENOUGH ON ITS OWN, and this is the case that proves the second half of
+        // the rule carries weight. A candidate can leave the active set and come back with no new
+        // turn behind it — a shorter window, a boundary wobble, a sweep run at a different size.
+        // Announcing that would make "recurrence" mean "the window moved". Here the candidate goes
+        // absent and then the ORIGINAL rows return, older than the evidence already counted.
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.turnLedger, []]]);
+        await runCoachHealthSweep(1);
+        g.__KAMLIFE_STUB_ROWS = recur("tl-observed", new Date(Date.now() - 3 * 3_600_000));
+        const wobble = await runCoachHealthSweep(1);
+        if (wobble.fresh.length !== 0) {
+          failures.push(`A candidate that went absent and came back with NO new evidence was announced as a recurrence — the window moving would read as the failure happening again`);
+        }
+        delete g.__KAMLIFE_STUB_ROWS;
+      }
+
+      /**
+       * A2 — THE SCHEDULED READ IS AUDITED LIKE EVERY OTHER READ.
+       *
+       * buildCoachHealthBrief reads inbound text, replies, mutations and state. The audit call sat
+       * in the route handler, so a person opening the page was recorded and the hourly job reading
+       * the same rows was not. Graded on the row the read actually writes, and on it naming the
+       * scheduler rather than a person — a record that cannot tell them apart is not an audit.
+       */
+      {
+        const { runCoachHealthSweep } = await import("../server/routes/admin-turns");
+        freshTurn();
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.turnLedger, []]]);
+        g.__KAMLIFE_STUB_WRITES = [];
+        await runCoachHealthSweep(1);
+        const audits = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === schema.adminEvents);
+        if (audits.length === 0) {
+          failures.push(`The scheduled Coach Health read wrote no audit record — the background reader bypasses the control every guarded endpoint obeys`);
+        } else if (!audits.some((w: any) => String(w.values?.action || "").includes("sweep") || w.values?.meta?.scheduled === true)) {
+          failures.push(`The scheduled read was audited as though a person had made it: ${JSON.stringify(audits[0]?.values?.action)} — the trail cannot distinguish the job from an operator`);
+        }
         delete g.__KAMLIFE_STUB_ROWS;
       }
     }

--- a/server/routes/admin-turns.ts
+++ b/server/routes/admin-turns.ts
@@ -460,7 +460,7 @@ export function candidateSignature(input: string): string {
  * Still no second store and no new judging: it reads the turns the ledger already holds and runs
  * the rules and invariants already declared above.
  */
-export async function buildCoachHealthBrief(days: number): Promise<any> {
+export async function buildCoachHealthBrief(days: number, readBy = "coach_health_brief"): Promise<any> {
     const since = new Date(Date.now() - days * 86_400_000);
     const rows = await db.select({
       id: turnLedger.id, userId: turnLedger.userId, createdAt: turnLedger.createdAt,
@@ -566,7 +566,18 @@ export async function buildCoachHealthBrief(days: number): Promise<any> {
     // ── BUILDS: attribution here is merge-time, so a window served by more than one build is
     // the case where a "regression" may just be a turn that ran the old code. Surfaced rather
     // than assumed away.
-    const byVersion = new Map<string, number>();
+    // EVERY READ OF THIS IS AUDITED, INCLUDING THE ONE NOBODY ASKED FOR (A2, 2026-09-01).
+  //
+  // The audit call used to sit in the route handler, so it recorded the reads a person made and
+  // not the hourly one A1 added — a background job reading the same inbound text, replies and
+  // state under no audit record at all. Naming the caller and leaving the call outside would have
+  // fixed today's gap and left the next caller free to repeat it, which is the shape of defect
+  // this project keeps paying for. The function that performs the read now records it, so a
+  // reader cannot exist without an audit trail. `readBy` is what distinguishes a person opening
+  // the page from the scheduler, and the endpoint's own record is unchanged.
+  await auditRead(readBy, { days, turns: rows.length, scheduled: readBy !== "coach_health_brief" });
+
+  const byVersion = new Map<string, number>();
     for (const t of shaped) byVersion.set(String(t.row.version || "?"), (byVersion.get(String(t.row.version || "?")) || 0) + 1);
     const builds = [...byVersion.entries()].map(([version, turns]) => ({ version, turns }))
       .sort((a, b) => b.turns - a.turns);
@@ -614,15 +625,65 @@ export const COACH_HEALTH_STATE_KEY = "coach_health_sweep";
 
 export async function runCoachHealthSweep(days = 1): Promise<{ known: number; candidates: number; fresh: string[] }> {
   const { loadState, saveState } = await import("../scheduler/shared");
-  const brief = await buildCoachHealthBrief(days);
-  const refs: string[] = (brief.candidates || []).map((c: any) => String(c.id));
+  const brief = await buildCoachHealthBrief(days, "coach_health_sweep");
+  const active: Array<{ ref: string; lastSeen: string }> = (brief.candidates || []).map((c: any) => ({
+    ref: String(c.id),
+    // The newest turn in the cluster. Already computed for the dashboard; it is what makes
+    // "there is new evidence" a fact about the ledger rather than a fact about when we ran.
+    lastSeen: String(c.lastSeen || ""),
+  }));
+  const refs = active.map(a => a.ref);
 
-  let seen: string[] = [];
+  /**
+   * THE RECURRENCE RULE (A2, 2026-09-01).
+   *
+   * A1 kept a flat seenRefs list and filtered against it forever. Refs are derived from the
+   * cluster's identity, which is the property that makes CH-E17F mean the same thing tomorrow —
+   * and it is also what made a real recurrence invisible: once a candidate aged out of the rolling
+   * window, the same failure a week later produced the same ref and was reported as "none new".
+   * Suppression is right for the hour after we announced it and wrong for the month after.
+   *
+   * A ref is announced when:
+   *   1. it has never been announced, or
+   *   2. it was ABSENT from the previous run's active set, AND its newest turn is newer than the
+   *      newest turn we had when we last saw it.
+   *
+   * Both halves of (2) are load-bearing. Absence alone would re-announce on any window wobble;
+   * newer evidence alone would re-announce while the candidate is still active and noisy. Together
+   * they mean "it went away, and it has come back with turns we have never counted" — which is
+   * exactly a recurrence and cannot be produced by re-running stored evidence, because re-running
+   * moves neither the active set nor the newest turn.
+   */
+  let seen: Record<string, string> = {};
+  let prevActive: string[] = [];
   try {
     const prev = JSON.parse(loadState()[COACH_HEALTH_STATE_KEY] || "{}");
-    if (Array.isArray(prev.seenRefs)) seen = prev.seenRefs.map(String);
+    if (prev.seen && typeof prev.seen === "object") {
+      for (const [k, v] of Object.entries(prev.seen)) seen[String(k)] = String(v ?? "");
+    }
+    if (Array.isArray(prev.activeRefs)) prevActive = prev.activeRefs.map(String);
+    // A snapshot written by A1 has seenRefs and neither of the above. Treat those refs as both
+    // known and active, so the first run after this deploys announces nothing it already had.
+    if (Array.isArray(prev.seenRefs)) {
+      for (const r of prev.seenRefs.map(String)) if (!(r in seen)) seen[r] = "";
+      if (!Array.isArray(prev.activeRefs)) prevActive = prev.seenRefs.map(String);
+    }
   } catch { /* a corrupt snapshot must not stop the sweep — it is rewritten below */ }
-  const fresh = refs.filter(r => !seen.includes(r));
+
+  const fresh = active
+    .filter(a => !(a.ref in seen) || (!prevActive.includes(a.ref) && a.lastSeen > (seen[a.ref] || "")))
+    .map(a => a.ref);
+
+  // What we have now counted for each ref. Never moves backwards: a shorter window must not make
+  // older evidence look new on the next run.
+  const nextSeen: Record<string, string> = { ...seen };
+  for (const a of active) {
+    if (!(a.ref in nextSeen) || a.lastSeen > nextSeen[a.ref]) nextSeen[a.ref] = a.lastSeen;
+  }
+  // Bounded, oldest evidence dropped first.
+  const trimmed = Object.entries(nextSeen)
+    .sort((x, y) => String(y[1]).localeCompare(String(x[1])))
+    .slice(0, 500);
 
   const snapshot = {
     at: new Date().toISOString(),
@@ -642,8 +703,11 @@ export async function runCoachHealthSweep(days = 1): Promise<{ known: number; ca
       firstSeen: c.firstSeen, lastSeen: c.lastSeen,
       examples: (c.examples || []).slice(0, 2),
     })),
-    // Everything ever announced, so a second run of the same evidence announces nothing.
-    seenRefs: [...new Set([...seen, ...refs])].slice(-500),
+    // ref -> the newest turn we have counted for it. Replaces A1's flat seenRefs, which could say
+    // "already announced" but never "already announced, and nothing has happened since".
+    seen: Object.fromEntries(trimmed),
+    // What was live THIS run, so the next one can tell "still here" from "came back".
+    activeRefs: refs,
     fresh,
   };
   saveState(COACH_HEALTH_STATE_KEY, JSON.stringify(snapshot));
@@ -676,7 +740,8 @@ export function registerAdminTurns(app: Express) {
         const raw = loadState()[COACH_HEALTH_STATE_KEY];
         if (raw) lastSweep = JSON.parse(raw);
       } catch { /* a corrupt snapshot must not take the dashboard down */ }
-      await auditRead("coach_health_brief", { days, turns: brief.turns });
+      // buildCoachHealthBrief records the read itself — see the note there. Auditing again here
+      // would put two records on one read.
       res.json({ ...brief, lastSweep });
     } catch (e: any) {
       console.error("[COACH_HEALTH] brief failed:", e?.message);


### PR DESCRIPTION
Closes #109. Base `99d2f41`.

## First divergence

**Audit.** `auditRead` was called in the *route handler*, not in the function that performs the read. `buildCoachHealthBrief` reads inbound text, replies, mutations and state — so a person opening the page produced an audit record and the hourly job reading the same rows produced none.

**Recurrence.** `seenRefs` was a flat "already announced" list. Refs are derived from cluster identity, which is exactly what makes `CH-E17F` mean the same thing tomorrow — and exactly what made a recurrence invisible: once a candidate aged out of the rolling window, the same failure a week later produced the same ref and was reported `none new`. The suppression that is right for the next hour is wrong for the next month.

## Existing primitives reused

`auditRead` → `admin_events` (unchanged) · `scheduler_state` via `saveState`/`loadState` · the existing `candidateRef`/`candidateSignature` clustering · each candidate's already-computed `lastSeen`. No new table, no new audit system, no model, no dashboard change.

## Audit behaviour

The reader records its own read, with `readBy` naming the caller:

| caller | action | meta |
|---|---|---|
| dashboard | `coach_health_brief` | `{ days, turns, scheduled: false }` |
| hourly sweep | `coach_health_sweep` | `{ days, turns, scheduled: true }` |

The endpoint no longer audits separately — two records for one read is not an audit either. **The fix is where the call moved, not that it was added.** A second call next to the job would have closed today's gap and left the next caller free to repeat it. `/api/admin/coach-health` does its own query and keeps its own `coach_health` record, untouched.

## Exact dedup / recurrence rule

Announce a ref when:

1. it has **never** been announced, **or**
2. it was **absent** from the previous run's active set **AND** its newest turn is **newer** than the newest turn counted when we last saw it.

Snapshot now carries `seen` (ref → newest turn counted, never moves backwards, bounded at 500 oldest-first) and `activeRefs`, replacing `seenRefs`. An A1 snapshot is migrated by treating its refs as both known and active, so the first run after deploy announces nothing it already had.

Observed sequence:

```
1 candidate, 1 new — CH-E17F     first sighting
1 candidate, none new            same active evidence, next hour
0 candidates                     aged out of the window
1 candidate, 1 new — CH-E17F     recurred, with a turn never counted
1 candidate, none new            same evidence re-swept — not a recurrence
```

## Controls — four, each failing on its own mechanism

| control | result |
|---|---|
| A1's flat forever-list restored | **RED** — recurrence reported as "none new" |
| absence without the newer-evidence clause | **RED** — window wobble announced as a recurrence |
| audit call removed | **RED** — scheduled read writes no audit record |
| scheduled read audited as `coach_health_brief` | **RED** — trail cannot distinguish job from operator |

**Control 2 initially did not fail.** My first sequence never exercised the newer-evidence clause — absence alone decided every case, so half the rule was unproven. I added the case that isolates it: the candidate goes absent, then the *original* rows return with no newer turn, and must not be announced. Both halves are proven now.

## Verification

```
tsc --noEmit         clean
tracking-contract    green, exit 0
unit-tests           1050/1050, exit 0
production-parity    142/142
reach guard          green
name guard           97, at budget

architecture guard   BYTE-IDENTICAL to main
file-size guard      BYTE-IDENTICAL to main
```

No budget raised. Untouched: PR #108 / Cut C1, workout/expectation state, Defects 2/3, the normalizer corpus, release-governor cleanup, proactive/async ledger coverage debt, claimant stamping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_