### PR TITLE
Defect 2: the plate must be proportional to the day that is left

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1196,6 +1196,71 @@ const MUST_WRITE: [string, string][] = [
           failures.push(`A 22g gap the top option genuinely covers was told it falls short — the fix over-fires on ordinary days: "${flat(r)}"`);
         }
       }
+
+      /**
+       * DEFECT 2 — THE PLATE MUST BE PROPORTIONAL TO THE DAY THAT IS LEFT (2026-09-01).
+       *
+       * Traced before changing anything: protLeft and calLeft were both read and both printed, so
+       * this was never missing evidence or the wrong claimant. The owner simply had nothing in its
+       * option list big enough to answer with. A client holding 2 146 kcal of headroom and one
+       * holding 420 got plates from the same 380–450 kcal band, because that band WAS the menu —
+       * headroom could only ever remove an option, never size one up.
+       *
+       * Graded on the plates the client is actually offered, parsed out of the rendered reply. No
+       * threshold is asserted and none exists in the code: the property is that the two headrooms
+       * must not produce the same leading plate, which is the defect stated as a test.
+       */
+      {
+        const plates = (r: string) => [...r.matchAll(/\(~(\d+) kcal, (\d+)g protein\)/g)]
+          .map(m => ({ kcal: Number(m[1]), protein: Number(m[2]) }));
+
+        const roomy = await mealTurn({ protLeft: 129, calLeft: 2146, budget: "100_300" });
+        const tight = await mealTurn({ protLeft: 129, calLeft: 420, budget: "100_300" });
+        const roomyPlates = plates(roomy), tightPlates = plates(tight);
+        if (roomyPlates.length === 0 || tightPlates.length === 0) {
+          failures.push(`The plate-ask stopped offering plates at all — the rest of this block grades nothing: "${flat(roomy)}"`);
+        } else {
+          // THE DEFECT ITSELF: a whole day of headroom answered with the same plate as 420 kcal.
+          if (roomyPlates[0].kcal === tightPlates[0].kcal && roomyPlates[0].protein === tightPlates[0].protein) {
+            failures.push(`2 146 kcal of headroom and 420 kcal produced the same leading plate (${roomyPlates[0].kcal} kcal, ${roomyPlates[0].protein}g) — the owner still cannot answer in proportion to the evidence it holds: "${flat(roomy)}"`);
+          }
+          if (roomyPlates[0].protein <= tightPlates[0].protein) {
+            failures.push(`With most of the day's calories unspent the client was led to a plate no stronger than the one offered on 420 kcal: "${flat(roomy)}"`);
+          }
+          // AND THE MENU MUST CONTAIN A REAL MEAL, which the two comparisons above do NOT prove:
+          // the old 380–450 kcal menu satisfies both, because filtering alone already makes the
+          // two headrooms differ. 600 kcal is this suite's statement of what counts as a plate for
+          // somebody who has eaten almost nothing all day — an expectation of the product, not a
+          // rule in the code, and the number to revisit if the menu is ever re-authored. Without
+          // it, deleting every fuller plate leaves this block green, which is how the first
+          // version of this test would have shipped a defect it claimed to guard.
+          if (roomyPlates[0].kcal < 600) {
+            failures.push(`With 2 146 kcal unspent the biggest thing on offer was ${roomyPlates[0].kcal} kcal — the menu still has no plate you could call a meal: "${flat(roomy)}"`);
+          }
+          // HEADROOM STILL CONSTRAINS. A fuller plate must never be offered to somebody who has no
+          // room for it — the same defect in the other direction, and the reason the menu could
+          // not simply be made bigger.
+          const unaffordable = tightPlates.filter(p => p.kcal > 420);
+          if (unaffordable.length > 0) {
+            failures.push(`A plate of ${unaffordable[0].kcal} kcal was offered to a client with 420 kcal left: "${flat(tight)}"`);
+          }
+        }
+
+        // AND THE ORDINARY DAY IS NOT OVER-SERVED. 22g short with the same big headroom: the
+        // fuller plates exist and must not be what the client is led to. "Biggest protein first"
+        // was safe while every option was small and is exactly what goes wrong once one is not.
+        const ordinary = await mealTurn({ protLeft: 22, calLeft: 2146, budget: "100_300" });
+        const ordinaryPlates = plates(ordinary);
+        if (ordinaryPlates.length > 1) {
+          const largest = Math.max(...ordinaryPlates.map(p => p.kcal));
+          if (ordinaryPlates[0].kcal === largest) {
+            failures.push(`A client 22g short was led to the largest plate on the menu (${largest} kcal) — enough is enough, and over-serving is how a fat-loss client is talked out of their deficit: "${flat(ordinary)}"`);
+          }
+          if (ordinaryPlates[0].protein < 22) {
+            failures.push(`A client 22g short was led to a plate that does not even cover it: "${flat(ordinary)}"`);
+          }
+        }
+      }
     }
   }
 

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -370,25 +370,50 @@ export async function handleMiscCommands(ctx: {
       // remaining calories can actually pay for, and — when that option still does not reach the
       // stated gap — to say so and hand the client the priority, not a prescribed meal count.
       suggestion += `You need *${protLeft}g more protein* today. That is the priority.\n\n`;
+      // THE MENU HAD NO FULL PLATE IN IT (2026-09-01, Defect 2).
+      //
+      // Traced before changing anything: protLeft and calLeft are both read and both printed, so
+      // this is not missing evidence and not the wrong claimant. What the owner could not do was
+      // answer in proportion to the evidence it held. Driving the real path on main, a client with
+      // 2 146 kcal of headroom and one with 420 kcal were offered plates from the same 380–450
+      // kcal band, because that band was the entire menu. Headroom could only ever REMOVE an
+      // option; nothing in the list could express "you have most of a day left, eat properly".
+      //
+      // So the correction is to the option set and the ordering, not to the architecture: fuller
+      // plates in the same hand-authored style as the entries already here, and a choice rule that
+      // fits the plate to the need.
       const meals: Array<{ text: string; protein: number; kcal: number }> = budget === "under_100"
         ? [
+            { text: "Tin of pilchards + 2 eggs + pap (~600 kcal, 42g protein)", protein: 42, kcal: 600 },
+            { text: "Sugar beans + 2 eggs + pap + spinach (~620 kcal, 30g protein)", protein: 30, kcal: 620 },
             { text: "Tin of pilchards + pap (~350 kcal, 24g protein)", protein: 24, kcal: 350 },
             { text: "2 eggs + pap (~300 kcal, 18g protein)", protein: 18, kcal: 300 },
           ]
         : [
+            { text: "2 chicken thighs + rice + mixed veg (~680 kcal, 55g protein)", protein: 55, kcal: 680 },
+            { text: "Beef mince + pap + spinach (~640 kcal, 40g protein)", protein: 40, kcal: 640 },
             { text: "Chicken breast + rice + spinach (~450 kcal, 35g protein)", protein: 35, kcal: 450 },
             { text: "Tin of pilchards + sweet potato (~380 kcal, 24g protein)", protein: 24, kcal: 380 },
             { text: "3 eggs + brown bread + tomato (~400 kcal, 24g protein)", protein: 24, kcal: 400 },
           ];
-      // Biggest first — a client short 129g should not be led with the 18g option — and only the
-      // ones the day's remaining calories can actually pay for. Offering a 450 kcal plate to
-      // somebody with 300 kcal left is the same defect in the other direction.
-      const affordable = [...meals].sort((a, b) => b.protein - a.protein).filter(mm => mm.kcal <= calLeft);
-      if (affordable.length === 0) {
+      // FIT THE PLATE TO THE NEED, and it takes no arithmetic beyond a comparison.
+      //
+      // "Biggest protein first" was right while every option was small and becomes wrong the
+      // moment a 680 kcal plate exists: a client 22g short would be led to it. Ranking rule:
+      //   - the SMALLEST plate that actually covers the gap, if one does — enough is enough;
+      //   - otherwise the BIGGEST the day's calories can pay for, because nothing will finish it
+      //     and the largest dent is the most useful answer.
+      // No threshold, no percentage, no division, no meal count. The calorie filter is what stops
+      // the fuller plates being offered to somebody who has no room for them.
+      const affordable = meals.filter(mm => mm.kcal <= calLeft);
+      const covers = affordable.filter(mm => mm.protein >= protLeft).sort((a, b) => a.kcal - b.kcal);
+      const dents = affordable.filter(mm => mm.protein < protLeft).sort((a, b) => b.protein - a.protein);
+      const ordered = [...covers, ...dents];
+      if (ordered.length === 0) {
         suggestion += `You do not have the calories left for a full meal — go protein-only: eggs, biltong, tuna or plain yoghurt, and leave the starch off the plate.`;
       } else {
-        suggestion += `Pick one:\n${affordable.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
-        if (affordable[0].protein < protLeft) {
+        suggestion += `Pick one:\n${ordered.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
+        if (ordered[0].protein < protLeft) {
           // SAY IT PLAINLY RATHER THAN PRESCRIBE A NUMBER. How the client spreads the rest across
           // the eating opportunities they have left is theirs to decide; counting meals for them
           // would be inventing a plan out of two figures.


### PR DESCRIPTION
Closes #111. Base `d0d7e15`.

## First divergence

Not what the issue's candidate list led with. I drove the real plate-ask through `handleMessage` before changing anything:

```
2 146 kcal headroom  →  Chicken breast + rice + spinach (~450 kcal, 35g protein)
  420 kcal headroom  →  Tin of pilchards + sweet potato (~380 kcal, 24g protein)
```

**Evidence available to the owner:** `protLeft` **and** `calLeft` are both read and both printed. Not missing protein evidence, not missing calorie evidence, not missing context, not the wrong claimant.

**The divergence is the option set.** 380–450 kcal *was* the entire menu, so headroom could only ever *remove* an option — nothing in the list could express *"you have most of a day left, eat properly."*

## Why the observed plate was wrong

A client who had eaten ~250 kcal all day and needed 129g of protein was handed a plate using **a fifth of their remaining calories**, presented as the answer. The reply simultaneously knew the need was 129g and the headroom was 2 146 kcal — exactly the product-contract violation in the issue.

## Smallest correction — both inside the existing deterministic owner

1. **Fuller plates in both budget tiers**, hand-authored in the same style as the entries already there, so the option set can express a real meal.
2. **Fit the plate to the need** — no arithmetic beyond a comparison: the **smallest** plate that covers the gap if one does; otherwise the **biggest** the day's calories can pay for.

"Biggest protein first" was safe while every option was small and becomes wrong the moment a 680 kcal plate exists — a client 22g short would be led straight to it. That is why the ordering had to change in the same cut as the menu.

No threshold, no percentage, no division, no meal count, no nutrition engine, no routing change, no new owner. The `kcal <= calLeft` filter from #102 keeps fuller plates away from a client with no room.

**After:**

| case | leading plate |
|---|---|
| 129g need, 2 146 kcal | 2 chicken thighs + rice + mixed veg (~680 kcal, 55g) |
| 129g need, 420 kcal | Tin of pilchards + sweet potato (~380 kcal, 24g) |
| 22g need, 2 146 kcal | Tin of pilchards + sweet potato (~380 kcal, 24g) |

## On the strings quoted in the issue

`3 eggs + pap (450 kcal, 30g protein)` and `2 chicken thighs + mixed veggies (600 kcal, 50g protein)` **appear in no commit in this repository's history** (`git log --all -S`, checked against `server/` and `client/`). That reply was not deterministic output.

It does not change the fix — the contract violation described is real, reproducible in the deterministic owner, and is what is fixed here. It is recorded so nobody re-derives a false provenance later.

## Regressions and controls

All drive the real handler and grade the plates parsed from the rendered reply. No branch arithmetic is re-implemented in the test.

| control | result |
|---|---|
| fuller plates removed | **RED** — `the biggest thing on offer was 450 kcal — the menu still has no plate you could call a meal` |
| ordering reverted to biggest-protein-first | **RED** — `a client 22g short was led to the largest plate on the menu (680 kcal)` |
| calorie filter removed | **RED** — `a 450 kcal meal was offered to a client with 420 kcal left` |

**The first version of the roomy-vs-tight comparison did not fail when every fuller plate was deleted.** Filtering alone already makes two headrooms differ, so it proved nothing about the menu. The assertion that a roomy day's leading plate is *a real meal* was added for exactly that, and is the one that bites. The 600 kcal figure lives only in the test, as its statement of what counts as a plate for someone who has eaten almost nothing — it is not a rule in the code.

## Verification

```
tsc --noEmit         clean
tracking-contract    green, exit 0
unit-tests           1050/1050, exit 0
production-parity    142/142

architecture guard   BYTE-IDENTICAL to main
file-size guard      BYTE-IDENTICAL to main
name guard           BYTE-IDENTICAL to main
reach guard          BYTE-IDENTICAL to main
```

## Remaining plate-decision debt

- **The menu's figures are hand-authored and do not reconcile with `server/foods.ts`.** One chicken breast is 297 kcal / 56g protein there; the menu entry says 450 kcal / 35g for breast + rice + spinach. The new entries follow the menu's existing conservative convention rather than the food table, because reconciling the two is a nutrition-data change, not a plate-decision fix.
- **The menu is fixed and ignores stated preferences** (vegetarian, no fish, dislikes). Out of scope here; no evidence traced for it.

Untouched: PR #108 / Cut C1, training continuity, Coach Health, outbound delivery, release-governor cleanup, normalizer corpus, Defect 1 / protein-gap work from #102.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_