### PR TITLE
#116: make the normalizer corpus representative, and state what still blocks the replay

### DIFF
--- a/script/normalizer-replay-tests.ts
+++ b/script/normalizer-replay-tests.ts
@@ -32,7 +32,7 @@ process.env.NORMALIZER_FIXTURES_STRICT = "1";
 
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
-import { CORPUS, CORPUS_PATH, recordingFingerprint } from "./record-normalizer";
+import { CORPUS, CORPUS_PATH, REQUIRED_CATEGORIES, recordingFingerprint } from "./record-normalizer";
 
 let passed = 0;
 const failures: string[] = [];
@@ -41,6 +41,25 @@ async function check(name: string, fn: () => Promise<void> | void) {
 }
 
 async function main() {
+  // ── THE CORPUS IS CHECKABLE WITHOUT THE RECORDING (#116, 2026-09-02) ────────────────────────
+  //
+  // Everything below needs the model's recorded answers. The corpus itself does not: whether the
+  // front door has representative inputs to replay at all is a property of this repository, and it
+  // is the half that silently rots — a category can be dropped in a refactor and nothing notices
+  // while the suite is standing down for a missing recording anyway.
+  //
+  // So this runs FIRST and can genuinely fail. It is not a substitute for replaying production
+  // behaviour and does not pretend to be: it asserts the corpus is representative, never that the
+  // normalizer is correct.
+  const covered = new Set(CORPUS.map(c => c.category));
+  const uncovered = REQUIRED_CATEGORIES.filter(c => !covered.has(c));
+  if (uncovered.length > 0) {
+    console.log(`✗ the corpus no longer represents ${uncovered.length} required input class(es): ${uncovered.join(", ")}`);
+    console.log(`  A front door with no recorded example of a class is a front door nobody is watching there.`);
+    process.exit(1);
+  }
+  const byCategory = REQUIRED_CATEGORIES.map(c => `${c} ${CORPUS.filter(e => e.category === c).length}`).join(" · ");
+
   if (!existsSync(CORPUS_PATH)) {
     // THE MARKER MATTERS AS MUCH AS THE MESSAGE (2026-08-25). Exiting 0 with a printed notice made
     // run-suites report `✓ normalizer-replay-tests` — a green tick on a suite that asserted
@@ -49,7 +68,9 @@ async function main() {
     console.log(
       `SUITE_SKIPPED: no recording at ${CORPUS_PATH} — the production front door is NOT covered\n` +
       `  Record it once with a real key:  OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts\n` +
-      `  ${CORPUS.length} corpus inputs are waiting. This is a stated gap, not a pass.`);
+      `  ${CORPUS.length} corpus inputs are waiting, across ${REQUIRED_CATEGORIES.length} input classes: ${byCategory}.\n` +
+      `  The corpus is present and representative; what is missing is the RECORDING of production's\n` +
+      `  answers, which needs a real key. This is a stated gap, not a pass.`);
     process.exit(0);
   }
 

--- a/script/record-normalizer.ts
+++ b/script/record-normalizer.ts
@@ -41,27 +41,88 @@ export const CORPUS_PATH = "script/fixtures/normalizer-corpus.json";
  * Each entry says WHY it is here, because a corpus nobody can justify becomes a corpus nobody
  * dares change.
  */
-export const CORPUS: Array<{ input: string; why: string }> = [
+/**
+ * THE CATEGORIES A FRONT DOOR HAS TO SURVIVE (#116, 2026-09-02).
+ *
+ * Written down as data rather than as a claim in a pull request, because "which classes of messy
+ * input are covered" was previously answerable only by reading ten entries and judging. The replay
+ * suite asserts every one of these is present, and that assertion runs even when no recording
+ * exists — the corpus is checkable offline; only the model's answers are not.
+ */
+export const REQUIRED_CATEGORIES = [
+  "ordinary", "messy-punctuation", "sa-food", "correction-day",
+  "mixed-intent", "workout-feedback", "weight", "voice-transcript",
+] as const;
+export type CorpusCategory = typeof REQUIRED_CATEGORIES[number];
+
+export const CORPUS: Array<{ input: string; why: string; category: CorpusCategory }> = [
   { input: "No I moved yesterdays workout to today",
+    category: "workout-feedback",
     why: "#63: comprehension is correct (moved_to_today) and nothing consumes it — the reply is a food prompt" },
   { input: "My dinner is the same as the last meal",
+    category: "correction-day",
     why: "#63: reported as logged from yesterday; a back-reference whose day resolution is the risk" },
   { input: "No I'm just fine with this meal",
+    category: "ordinary",
     why: "#63: a plain decline answered with 'I didn't catch that one' — reproduces offline" },
   { input: "My steps are 10k today",
+    category: "ordinary",
     why: "#63: evidence stated, action contradicted it ('get a 20-minute walk in')" },
   { input: "Monday I had pap and chicken, eggs and bread for breakfast, and rice with beef stew for dinner. Tuesday was oats, a chicken salad, and pasta with mince. Wednesday I had eggs and bacon, a burger and chips, and lamb chops with rice.",
+    category: "sa-food",
     why: "#63 (Bonolo): three days in one batch. multiFact is false for a single-domain note, so the rewrite brake does not engage — this is the input that must not collapse into one day" },
   { input: "I had a burger and chips last night, I feel like I ruined everything",
+    category: "mixed-intent",
     why: "gauntlet: mouth-layer failure, 5 sentences where 3 are the rule" },
   { input: "Work is stressing me out and I ate takeaways again tonight",
+    category: "mixed-intent",
     why: "gauntlet: 6 sentences where 3 are the rule, and the stress is never acknowledged" },
   { input: "is today a rest day",
+    category: "ordinary",
     why: "gauntlet: 3 sentences where 2 are the rule" },
   { input: "I'm doing yesterday's session today",
+    category: "workout-feedback",
     why: "the adjacent shape of moved_to_today — a rewrite must not turn this into a refusal" },
   { input: "you missed the black coffee yesterday",
+    category: "correction-day",
     why: "a correction naming a past day; the day must survive the rewrite" },
+
+  // ── #116, 2026-09-02. Categories the corpus could not speak for, filled from evidence ALREADY
+  // in this repository — the Reality Test traces recorded in normalizer-fidelity.ts, the LAW 5
+  // mixed-turn table, the fragmentation finding, C1's continuity suite and the SA-transcript
+  // incident. No input here was imagined by a test author, and no expected output is stated
+  // anywhere in this file: what the model returns is recorded, never asserted by hand.
+
+  { input: "Actually no, that was yesterday. And it wasn't rice, it was pap. And I had spinach too.",
+    category: "correction-day",
+    why: "Reality Test J5, quoted verbatim in normalizer-fidelity.ts: the rewrite INVENTED tin fish and mixed veggies, destroyed the correction framing, and the turn logged as a fresh retro meal. The most damaging front-door failure this product has recorded" },
+  { input: "I'm feeling a bit useless honestly, and tonight there's a family thing with lots of food. What do I do about tonight?",
+    category: "mixed-intent",
+    why: "Reality Test J4, quoted verbatim in normalizer-fidelity.ts: rewritten to 'i had pap and beef stew for supper yesterday' — the question and the emotion discarded before routing, so nothing downstream could answer a question it never received" },
+  { input: "at nandos what should i order",
+    category: "messy-punctuation",
+    why: "tracking-contract fragmentation finding: three clients asked one question and a possessive plus a missing preposition split it into three candidates. Messy casing with no punctuation is the ordinary shape, not the exception" },
+  { input: "I had eggs. what should I eat?",
+    category: "mixed-intent",
+    why: "LAW 5 mixed turn: a report in one clause and a question in another. The rewrite must not drop either half — five of ten mixed turns lost the fact before that law existed" },
+  { input: "walked 8000 steps. what should I eat?",
+    category: "mixed-intent",
+    why: "LAW 5 on a second domain: steps were extracted and then thrown away because a whole-message question guard read the second clause" },
+  { input: "I'm trying to lose weight, weighed 84kg this morning",
+    category: "weight",
+    why: "tracking-contract: a weight REPORT carrying an intention word. utils.isFutureIntent excludes 'trying to' on purpose, and a rewrite that normalises this into a goal statement re-opens the false-write class #73 closed" },
+  { input: "Just right, and I had chicken and pap.",
+    category: "workout-feedback",
+    why: "C1 expectation-continuity: a workout-feedback answer and a meal in one message. Both must survive — the feedback is consumed once and the food still has to reach its writer" },
+  { input: "Lunch / Tin fish / Rice",
+    category: "messy-punctuation",
+    why: "normalizer-fidelity cites the bare slash-separated log list as the shape that DOES work today. A regression here is silent: it looks like ordinary logging until the day it stops" },
+  { input: "Yoh, I'm feeling mos kak today, neh?",
+    category: "voice-transcript",
+    why: "sa-transcript.ts: clients are voice-first and code-switch. This exact phrasing is the module's own worked example, and the transcript re-enters handleMessage as text, so the same normalizer consumes it" },
+  { input: "i had samp and chicken for lunch",
+    category: "voice-transcript",
+    why: "sa-transcript.ts records the live incident: a client said samp, STT heard 'stamp and chicken fingers', and the coach lectured her on food she never mentioned. The SA food word must survive the front door" },
 ];
 
 /** The prompt text and model this recording is only valid for. */


### PR DESCRIPTION
Addresses #116. Base `47f0789`.

> **This PR does not close the release blocker, and says so.** It closes the half that can be closed honestly from here. Read "Still open" before merging.

## First trace

**Production function exercised:** `classifyIntent` in `server/gpt.ts` (gpt-4o-mini), applied at the front door in `routes.ts` before any handler sees a message. `script/normalizer-replay-tests.ts` replays it from a recording; `script/record-normalizer.ts` owns the corpus and the recorder.

**Fixture schema:** `{ model, promptHash, entries: { <lowercased input>: { canonical, … } } }`, fingerprinted against the prompt and model so a stale recording announces itself.

**Existing recording mechanism / corpus source:** yes — `record-normalizer.ts`, run once with a real key.

## Why the blocker is not the corpus

| check | result |
|---|---|
| `script/fixtures/normalizer-corpus.json` in git history | **never existed** — no commit, no blob, across all refs |
| `OPENAI_API_KEY` in this environment | **not set** |
| egress to `api.openai.com` | **403 on CONNECT** (organisation policy) |

`record-normalizer.ts` refuses to run without a real key *by design*: *"a recording made against the offline shim would be a fixture full of OTHER/no-canonical, which is worse than none."*

So the recording cannot be produced here, and hand-writing it is precisely what that file forbids in its own header and what this issue forbids in its guardrails — a fixture that agrees with its author instead of with production is the vacuous pass this suite exists to prevent. **Nothing in this PR fabricates a model answer.**

## What is real work, and is done

The corpus holds **inputs and reasons, no expected outputs**, so it can be made representative offline. **10 → 20 entries.** Every addition is quoted from evidence already in this repository:

- **Reality Test J5** — `"Actually no, that was yesterday. And it wasn't rice, it was pap…"` — recorded verbatim in `normalizer-fidelity.ts`, where the rewrite *invented* tin fish and mixed veggies and destroyed the correction framing. The most damaging front-door failure on record.
- **Reality Test J4** — the emotion-plus-question message rewritten into a bare food log, so nothing downstream could answer a question it never received.
- **LAW 5 mixed turns** from the tracking-contract table.
- **The Nando's fragmentation finding** — messy casing, no punctuation.
- **C1's continuity suite** — workout feedback and a meal in one message.
- **`sa-transcript.ts`** — the live samp → "stamp and chicken fingers" incident, and the module's own code-switch example.

## Case count and categories — now data, not prose

`REQUIRED_CATEGORIES` names the eight classes a front door must survive, and every entry carries one:

```
ordinary 3 · messy-punctuation 2 · sa-food 1 · correction-day 3
mixed-intent 5 · workout-feedback 3 · weight 1 · voice-transcript 2
```

The replay suite checks that composition **first**, before the recording check, so it runs and can genuinely fail even while standing down for a missing recording — the half that silently rots, since a category can be dropped in a refactor while the suite is skipping anyway. It asserts the corpus is *representative*, never that the normalizer is *correct*. Those are different claims and only one is available without a key.

`voice-transcript` is included because the same normalizer consumes it: a transcript is cleaned by `sa-transcript.ts` and re-enters `handleMessage` as text.

## Controls

| control | result |
|---|---|
| drop the only `weight` case | **RED**, exit 1 — `the corpus no longer represents 1 required input class(es): weight` |
| corpus file absent | `SUITE_SKIPPED` → run-suites renders `⊘ covered nothing`, **not green** — verified unchanged |

Issue controls **1 and 2 cannot be demonstrated** — both need a recording. Stated, not worked around.

## Verification

```
tsc --noEmit         clean
production-parity    142/142
tracking-contract    green

architecture guard   BYTE-IDENTICAL to main
file-size guard      BYTE-IDENTICAL to main
name guard           BYTE-IDENTICAL to main
reach guard          BYTE-IDENTICAL to main
```

No normalizer change, no router, no budget raised. No PII: the corpus is message text only — no phone numbers, names or secrets — and the recording adds only model output for those inputs.

## Still open — the actual release blocker

**The replay of production behaviour.** One command, from a machine with a real key and egress:

```
OPENAI_API_KEY=sk-… npx tsx script/record-normalizer.ts
```

Then commit `script/fixtures/normalizer-corpus.json`. That flips `normalizer-replay-tests` from `⊘ covered nothing` to a real green over 20 replayed cases, and only then can control 2 (perturb a recorded result, prove failure) be shown.

## Remaining front-door coverage debt

- **`cleanSATranscript` is not replayed at all.** It is a second model call on the voice path, ahead of the normalizer, with its own prompt and its own failure mode — the samp incident happened *there*. This corpus covers what the normalizer does with transcript-shaped text, not what the cleaner does with audio.
- **`sa-food` has one entry.** The existing multi-day batch case carries SA food, but as a batch case; the class deserves more once someone is recording anyway.
- **The corpus grows by hand.** #64's turn-triage dashboard was meant to feed it from real inbound text; nothing wires that yet, so representativeness still depends on someone remembering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_