### PR TITLE
#126: one owner decides whether a weight direction may be spoken

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1149,6 +1149,91 @@ const MUST_WRITE: [string, string][] = [
     const day = (s: string) => new Date(`${s}T00:00:00+02:00`).getTime();
     const now = day("2026-08-28");
 
+    /**
+     * #126 — WEIGHT SPEECH HAS ONE OWNER, AND IT DECIDES BEFORE THE REPLY IS COMPOSED.
+     *
+     * Defect 5 fixed the weight HISTORY command. The weight CHART was never fixed and never asked:
+     * traced on current main with weigh-ins spanning a recorded illness it rendered an arrow, a
+     * pace and a coaching line straight off `last - first`, while the canonical evidence refused
+     * to call any direction at all.
+     *
+     * Graded on what the handler hands over, because that is the owner this cut changes. The
+     * outbound gate is deliberately NOT the instrument here: it classifies one sentence at a time,
+     * and the same trace showed it catching the header, deleting the client's weigh-ins with it,
+     * and leaving "this is muscle. Keep training hard." standing — the direction surviving in a
+     * sentence with no direction words. A boundary that loses the data and keeps the claim cannot
+     * be what this property rests on.
+     */
+    {
+      const day = (d: number) => new Date(Date.now() - d * 86_400_000);
+      const rows = (kgs: number[], days: number[]) => kgs.map((w, i) => ({
+        id: `wq${i}`, userId: USER.id, weight: w, weightKg: w,
+        // BOTH keys on purpose: getWeightTruth selects { at: loggedAt } and the stub returns raw
+        // rows without applying the alias, so a fixture with only loggedAt reads as Invalid Date
+        // and every assertion below would grade a NaN.
+        loggedAt: day(days[i]), at: day(days[i]),
+      }));
+      const iso = (d: number) => new Date(Date.now() - d * 86_400_000).toISOString().slice(0, 10);
+      const weightTurn = async (ask: string, o: { kgs: number[]; days: number[]; sick: boolean; goal: string }) => {
+        freshTurn();
+        g.__KAMLIFE_STUB_USER = {
+          ...USER, goalType: o.goal, currentWeight: o.kgs[o.kgs.length - 1], todayWater: "0",
+          profileNotes: o.sick ? `sick_since:${iso(14)} sick_until:${iso(6)}` : "",
+        };
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([
+          [schema.weightLogs, rows(o.kgs, o.days)], [schema.mealLogs, []],
+          [schema.stepLogs, []], [schema.workoutLogs, []],
+        ]);
+        g.__KAMLIFE_STUB_WRITES = [];
+        return String(await handleMessage(USER.phoneNumber, ask).catch(() => ""));
+      };
+      const flat2 = (r: string) => r.replace(/\n/g, " ⏎ ");
+      const SPANS_ILLNESS = { kgs: [95.0, 96.2, 97.4], days: [20, 12, 4], sick: true, goal: "muscle_gain" };
+      const CLEAN = { kgs: [98.0, 95.5, 92.0], days: [28, 14, 2], sick: false, goal: "fat_loss" };
+
+      // THE OBSERVED CONTRADICTION, on both weight surfaces.
+      for (const ask of ["weight chart", "weight history"]) {
+        const r = await weightTurn(ask, SPANS_ILLNESS);
+        if (!/95\.0|97\.4/.test(r)) {
+          failures.push(`"${ask}" stopped returning the client's own weigh-ins — the rest of this block grades nothing: "${flat2(r)}"`);
+          continue;
+        }
+        if (/⬆️|⬇️|\bUp \d|\bDown \d|going up|going down|keep fuelling/i.test(r)) {
+          failures.push(`"${ask}" asserted a weight direction over weigh-ins that span an illness — the same contradiction the response gate refuses: "${flat2(r)}"`);
+        }
+        if (/pace [+-]?\d/i.test(r)) {
+          failures.push(`"${ask}" stated a weekly PACE off a trend the evidence refuses — a rate is a direction with a number on it: "${flat2(r)}"`);
+        }
+        if (/Keep training hard|deficit is working|Gaining as planned/i.test(r)) {
+          failures.push(`"${ask}" drew a coaching conclusion from a direction it may not call: "${flat2(r)}"`);
+        }
+        // ...AND THE FACTS THEY ASKED FOR SURVIVE. Refusing to call a trend must not cost the
+        // client their own history.
+        if (!/95\.0/.test(r) || !/97\.4/.test(r)) {
+          failures.push(`"${ask}" dropped the weigh-ins while refusing the trend — they asked for their numbers: "${flat2(r)}"`);
+        }
+      }
+
+      // POSITIVE CONTROL — a clean, usable trend must still be spoken, on both surfaces. Without
+      // this, "never say a direction" passes every assertion above and the product goes mute.
+      {
+        const chart = await weightTurn("weight chart", CLEAN);
+        if (!/⬇️|Down 6\.0kg/.test(chart)) {
+          failures.push(`A clean four-week 6kg loss was no longer called on the chart — the fix went mute instead of honest: "${flat2(chart)}"`);
+        }
+        if (!/pace -/.test(chart)) {
+          failures.push(`A usable trend lost its pace line — legitimate output must be preserved: "${flat2(chart)}"`);
+        }
+        const hist = await weightTurn("weight history", CLEAN);
+        if (!/Down 6\.0kg since you started/.test(hist)) {
+          failures.push(`A clean usable trend lost its direction on the history surface: "${flat2(hist)}"`);
+        }
+        if (!/Moving in the right direction/.test(hist)) {
+          failures.push(`A usable fat-loss trend lost its coaching verdict: "${flat2(hist)}"`);
+        }
+      }
+    }
+
     // DEFECT 5 — the observed shape: weigh-ins spanning an illness cannot carry a direction.
     const spanningIllness = weightTrendUsable({
       count: 3, oldestAt: day("2026-08-18"), newestAt: day("2026-08-26"),

--- a/server/adaptive-targets.ts
+++ b/server/adaptive-targets.ts
@@ -328,6 +328,52 @@ export const MAX_TREND_AGE_DAYS = 10;
 // disagreeing interpretations of one stored fact; leaving them here as a second entry point to
 // the same answer is how the next caller ends up asking the wrong one.
 
+/**
+ * MAY THE COACH SAY WHICH WAY THE SCALE IS GOING? (#126, 2026-09-02)
+ *
+ * weightTrendUsable is the owner of that question and has been since the 16:49 contradiction.
+ * What it did not have was a caller-facing shape: every surface that wanted an answer had to
+ * assemble the window itself — count, oldest, newest, now, and the two illness edges read out of
+ * profileNotes. The weight-history command does exactly that in eight lines; the weight CHART did
+ * not do it at all, and simply computed `last - first` and spoke.
+ *
+ * So this is the same owner with the plumbing attached once. It is not a second authority and
+ * makes no judgement of its own: it reads the illness window, builds the window object, and
+ * returns what weightTrendUsable said. A surface that wants to state a direction asks this; a
+ * surface that only wants to print numbers does not have to.
+ *
+ * TAKES THE POINTS IT WILL BE SPEAKING ABOUT, deliberately. The response gate asks the same
+ * question against its own 28-day read, and the two can legitimately differ — this answers "may I
+ * call a direction over THESE weigh-ins", which is the only question a rendering surface has.
+ */
+export interface WeightSpeechVerdict {
+  /** May a direction, a pace, or a conclusion drawn from either appear in this reply? */
+  speakable: boolean;
+  /** weightTrendUsable's reason when it refused. Empty when speakable. */
+  why: "too_few" | "too_short" | "stale" | "illness" | "";
+}
+
+export async function weightDirectionSpeakable(
+  points: Array<{ at: Date }>,
+  user: { profileNotes?: string | null } | null | undefined,
+): Promise<WeightSpeechVerdict> {
+  if (!points || points.length < 2) return { speakable: false, why: "too_few" };
+  const { readHealthState } = await import("./health-state");
+  const health = readHealthState(user || {});
+  // profileNotes stores sick_since / sick_until as ISO dates; SAST midnight is the same boundary
+  // the history command already used, kept identical so the two cannot disagree on an edge day.
+  const asMs = (d?: string) => (d ? new Date(`${d}T00:00:00+02:00`).getTime() : undefined);
+  const verdict = weightTrendUsable({
+    count: points.length,
+    oldestAt: points[0].at.getTime(),
+    newestAt: points[points.length - 1].at.getTime(),
+    sickSince: asMs(health.sickSince),
+    sickUntil: asMs(health.sickUntil),
+    now: Date.now(),
+  });
+  return verdict.usable ? { speakable: true, why: "" } : { speakable: false, why: verdict.why };
+}
+
 export function weightTrendUsable(w: TrendWindow): TrendVerdict {
   if (w.count < 2) return { usable: false, why: "too_few" };
   if ((w.newestAt - w.oldestAt) / 86_400_000 < MIN_TREND_SPAN_DAYS) return { usable: false, why: "too_short" };

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -648,7 +648,8 @@ export async function handleMiscCommands(ctx: {
       const latest = logs[logs.length - 1].kg;
       const totalChange = latest - first;
       const goal = user.goalType || "fat_loss";
-      const changeDir = totalChange < 0 ? `Down ${Math.abs(totalChange).toFixed(1)}kg` : totalChange > 0 ? `Up ${totalChange.toFixed(1)}kg` : "No change";
+      // Computed below once the owner has answered — see the note at the return.
+      let changeDir = "";
       // A DIRECTION IS A TREND CLAIM, AND IT HAS AN OWNER (2026-08-28, live trace).
       //
       // Observed, in one message: the response gate refused — "I'm not going to call a trend off
@@ -661,19 +662,12 @@ export async function handleMiscCommands(ctx: {
       // weightTrendUsable is the owner the gate consults. This asks it too, so the refusal and
       // the verdict cannot disagree. When the trend is unusable the numbers still ship — the
       // client asked for their history and gets it — but no direction is asserted over them.
-      const { weightTrendUsable } = await import("../adaptive-targets");
-      const { readHealthState } = await import("../health-state");
-      const health = readHealthState(user);
-      const asMs = (d?: string) => (d ? new Date(`${d}T00:00:00+02:00`).getTime() : undefined);
-      const trend = weightTrendUsable({
-        count: logs.length,
-        oldestAt: logs[0].at.getTime(),
-        newestAt: logs[logs.length - 1].at.getTime(),
-        sickSince: asMs(health.sickSince),
-        sickUntil: asMs(health.sickUntil),
-        now: Date.now(),
-      });
-      const verdict = !trend.usable ? ""
+      // ONE OWNER, ONE CALLER-FACING SHAPE (#126). This assembled the window inline — count,
+      // oldest, newest, the two illness edges — and the chart below did not assemble it at all.
+      // Same owner, same answer, plumbing written once so a second surface cannot forget it.
+      const { weightDirectionSpeakable } = await import("../adaptive-targets");
+      const trend = await weightDirectionSpeakable(logs, user);
+      const verdict = !trend.speakable ? ""
         : goal === "fat_loss" && totalChange < -1 ? "Moving in the right direction."
         : goal === "muscle_gain" && totalChange > 0.5 ? "Scale is going up — keep fuelling."
         : goal === "fat_loss" && totalChange >= 0 ? "Scale hasn't moved yet — check food logging consistency."
@@ -681,8 +675,19 @@ export async function handleMiscCommands(ctx: {
       const recent = logs.slice(-5).map(l =>
         `• ${l.kg.toFixed(1)}kg — ${l.at.toLocaleDateString("en-ZA", { day: "numeric", month: "short" })}`,
       ).join("\n");
+      // "Up 2.4kg since you started" IS A DIRECTION CLAIM, and the outbound gate reads it as one.
+      // Traced on current main against an illness-spanning window: the gate correctly refused it
+      // and rewrote the WHOLE reply, so the three weigh-ins the client had just asked for were
+      // deleted along with it. Refusing to call a trend must not cost them their own history.
+      //
+      // So when the direction cannot be spoken the same numbers ship as data — start and now,
+      // no up/down word — which is honest and is also what the gate leaves intact.
+      changeDir = trend.speakable
+        ? (totalChange < 0 ? `Down ${Math.abs(totalChange).toFixed(1)}kg` : totalChange > 0 ? `Up ${totalChange.toFixed(1)}kg` : "No change")
+        : `Started ${first.toFixed(1)}kg · now ${latest.toFixed(1)}kg`;
       const name2 = user.name?.split(" ")[0] || "";
-      return `*${name2 ? name2 + "'s " : ""}Weight History*\n\n${recent}\n\n${changeDir} since you started. ${verdict}`.trim();
+      const tail = trend.speakable ? `${changeDir} since you started. ${verdict}` : changeDir;
+      return `*${name2 ? name2 + "'s " : ""}Weight History*\n\n${recent}\n\n${tail}`.trim();
     } catch { /* fall through */ }
   }
   if (["protein", "my protein", "protein target", "daily protein", "protein daily", "how much protein", "my protein target"].includes(m)) {
@@ -1543,12 +1548,41 @@ export async function handleMiscCommands(ctx: {
       const first = vals[0];
       const last = vals[vals.length - 1];
       const diff = last - first;
-      const trend = diff < -0.5 ? `⬇️ Down ${Math.abs(diff).toFixed(1)}kg` : diff > 0.5 ? `⬆️ Up ${diff.toFixed(1)}kg` : `➡️ Stable`;
-      const paceWk = spanDays >= 7 ? ` · pace ${(diff / (spanDays / 7)) >= 0 ? "+" : ""}${(diff / (spanDays / 7)).toFixed(2)}kg/week` : "";
+      // A DIRECTION IS A TREND CLAIM HERE TOO (#126, 2026-09-02).
+      //
+      // The history command asked weightTrendUsable after the 16:49 contradiction. This one never
+      // did: it computed `last - first` and rendered an arrow, a pace, and a coaching line off it.
+      // Traced on current main with weigh-ins spanning a recorded illness, that produced
+      //
+      //   Start: 95.0kg → Now: 97.4kg (⬆️ Up 2.4kg)
+      //   3 weigh-ins over 2 weeks · pace +1.05kg/week
+      //   Gaining as planned. If lifts are going up, this is muscle. Keep training hard.
+      //
+      // while the canonical evidence refuses to call any direction at all.
+      //
+      // THE OUTBOUND GATE IS NOT A SUBSTITUTE, and the same trace shows why: it classifies claims
+      // one SENTENCE at a time, so it caught the header, deleted the weigh-ins with it, and left
+      // "this is muscle. Keep training hard." standing — a conclusion carrying the direction with
+      // no direction words in it. Deferring the decision to the boundary loses the client's data
+      // and keeps the claim. It has to be made here, before the reply is composed.
+      const { weightDirectionSpeakable } = await import("../adaptive-targets");
+      const speech = await weightDirectionSpeakable(
+        (await getWeightTruth(user, { clientMessage: m })).points, user);
+      const trend = !speech.speakable ? "" : diff < -0.5 ? `⬇️ Down ${Math.abs(diff).toFixed(1)}kg` : diff > 0.5 ? `⬆️ Up ${diff.toFixed(1)}kg` : `➡️ Stable`;
+      // Pace is a direction with a rate attached — strictly more than the arrow, so it is gated by
+      // the same answer rather than by its own rule.
+      const paceWk = speech.speakable && spanDays >= 7 ? ` · pace ${(diff / (spanDays / 7)) >= 0 ? "+" : ""}${(diff / (spanDays / 7)).toFixed(2)}kg/week` : "";
+      // THE NUMBERS ARE NOT THE CLAIM. They asked for their chart, so start, now, the count and the
+      // span all still ship when the direction cannot — stated as data, with no word that reads as
+      // a direction, which is also what keeps the outbound gate from deleting them.
       const reply = `*⚖️ Weight — ${name}*\n\n` +
-        `Start: *${first.toFixed(1)}kg* → Now: *${last.toFixed(1)}kg* (${trend})\n` +
+        `Start: *${first.toFixed(1)}kg* → Now: *${last.toFixed(1)}kg*${trend ? ` (${trend})` : ""}\n` +
         `${weights.length} weigh-ins over ${spanDays >= 7 ? Math.round(spanDays / 7) + " weeks" : spanDays + " days"}${paceWk}\n\n` +
-        (diff < -2 ? `Consistent progress. The deficit is working — stay patient and stay on plan.` :
+        (!speech.speakable
+          ? (speech.why === "illness"
+            ? `I'm not calling a direction off these — they sit around the time you were ill, and weight moves on fluid and appetite then. Weigh in a few clear mornings and I'll read it properly.`
+            : `I'm not calling a direction off these yet. Weigh in a few more mornings and I'll give you a straight read.`)
+         : diff < -2 ? `Consistent progress. The deficit is working — stay patient and stay on plan.` :
          diff > 2 && user.goalType === "muscle_gain" ? `Gaining as planned. If lifts are going up, this is muscle. Keep training hard.` :
          Math.abs(diff) < 1 ? `Weight holding. Check measurements — you could be recomping (losing fat, gaining muscle). The tape does not lie.` :
          `Keep logging. Trends become clear after 4+ weeks of consistent data.`);


### PR DESCRIPTION
Closes #126. Base **current main `30f703c`** (after #117/#118). Re-derived from scratch — **stale PR #97 is not merged, revived, or touched**; its branch `fix/weight-speech-authority` still points at `cdb4d60` on the old `dc3c308` base and I pushed under a different name so the two cannot be confused.

## Exact current-main mechanism

Two weight surfaces in `misc-commands.ts`:

| surface | asks `weightTrendUsable`? |
|---|---|
| **WEIGHT HISTORY** (line ~637) | **yes** — added by Defect 5 after the 16:49 contradiction |
| **WEIGHT TREND CHART** (line ~1519) | **no** — computes `diff = last - first` and speaks |

Both return through `routes.ts:1349` — `if (miscResult !== null) return miscResult;` — which is the **only** deterministic owner that returns raw. Every other one returns through `closeCoachingTurn(...)`.

## First divergence

Driven through `handleMessage` on `30f703c`, weigh-ins spanning a recorded illness (95.0 → 96.2 → 97.4kg, `sick_since`/`sick_until` covering the middle):

```
*⚖️ Weight — Kam*

Start: *95.0kg* → Now: *97.4kg* (⬆️ Up 2.4kg)
3 weigh-ins over 2 weeks · pace +1.05kg/week

Gaining as planned. If lifts are going up, this is muscle. Keep training hard.
```

**The divergence is not only the missing call.** The outbound provenance gate classifies claims **one sentence at a time**. Measured on that exact reply:

```
"Start: *95.0kg* → Now: *97.4kg* (⬆️ Up 2.4kg)"          -> weight-trend
"3 weigh-ins over 2 weeks · pace +1.05kg/week"           -> null
"Gaining as planned. ... Keep training hard."            -> null
```

So the gate caught the header, **rewrote the whole reply and deleted the three weigh-ins the client had just asked for**, while the coaching sentence survived — a conclusion carrying the direction with no direction words in it:

> I don't have enough weigh-ins yet to call which way you're going… **If lifts are going up, this is muscle. Keep training hard.**

**Deferring the decision to the boundary loses the client's data and keeps the claim.** That is why an outbound floor cannot be what this rests on, and why the decision has to be made before the reply is composed.

**The history surface had the same shape one step along.** Its verdict was correctly gated, but `"Up 2.4kg since you started"` is itself read as a trend claim, so the gate deleted that reply too — all three weigh-ins gone. Refusing to call a trend was costing the client their own history.

## Owner changed

`weightDirectionSpeakable` in `server/adaptive-targets.ts`, **beside `weightTrendUsable`** — the same owner with the plumbing attached once. It adds **no judgement**: reads the illness window, builds the window object the history command was assembling inline, returns what `weightTrendUsable` said.

No new module (`modules` is at budget), no orchestrator, no new authority, no bulk misc rewrite.

Both surfaces now ask **before composing**:

- **unusable** → no arrow, no pace, no direction-derived coaching; the numbers still ship **as data, not as a claim**, which is also what stops the gate deleting them;
- **usable** → unchanged.

Pace is gated by the same answer rather than a rule of its own — **a rate is a direction with a number on it**.

## Regression output

**Illness-spanning, after the fix** — HOLD is terminal, facts preserved, and the gate now leaves it untouched (`changed=false`):

```
*⚖️ Weight — Kam*

Start: *95.0kg* → Now: *97.4kg*
3 weigh-ins over 2 weeks

I'm not calling a direction off these — they sit around the time you were ill,
and weight moves on fluid and appetite then. Weigh in a few clear mornings and
I'll read it properly.
```

```
*Kam's Weight History*

• 95.0kg — 13 Aug
• 96.2kg — 21 Aug
• 97.4kg — 29 Aug

Started 95.0kg · now 97.4kg
```

**Clean usable trend — legitimate output preserved:**

```
Start: *98.0kg* → Now: *92.0kg* (⬇️ Down 6.0kg)
3 weigh-ins over 4 weeks · pace -1.62kg/week
Consistent progress. The deficit is working — stay patient and stay on plan.
```

## Controls

| control | result |
|---|---|
| chart stops asking the owner | **RED** — reproduces the observed reply verbatim, all three assertions (direction, pace, coaching) |
| history stops asking the owner | **RED** — reproduces `Scale is going up — keep fuelling` |
| direction suppressed unconditionally | **RED** — `the fix went mute instead of honest` |

The third exists because "never say a direction" would pass every other assertion.

## Verification

```
tsc --noEmit         clean
tracking-contract    green, exit 0
unit-tests           1052/1052, exit 0
production-parity    142/142

architecture guard   IDENTICAL to current main 30f703c
file-size guard      IDENTICAL to current main 30f703c
name guard           IDENTICAL to current main 30f703c
reach guard          IDENTICAL to current main 30f703c
```

Compared against **current main**, not `dc3c308`, as instructed. No budget raised.

## Remaining debt — named, not done

1. **`miscResult` still returns raw at `routes.ts:1349`.** This cut makes the weight surfaces decide correctly at the owner, so nothing weight-related bypasses it any more — but misc is still the one deterministic owner that does not return through `closeCoachingTurn`, and I did not change that. Routing all of misc through the closer touches every misc branch (protein, programme, portions, holiday guide…) and is a wider behavioural change than this assignment allows. **It should be its own bounded cut**, and until then the structural guarantee here is per-surface, not per-router.
2. **The provenance gate is sentence-scoped.** A conclusion drawn from a claim is invisible to it. That is now worked around at the two weight surfaces; it remains true everywhere else.
3. **A harness limitation I could not measure through:** the DB stub ignores `orderBy`, so the gate's own 28-day weigh-in read comes back ASC where production gets DESC, computing a negative span. The clean-trend case therefore cannot be graded end-to-end through the gate offline. Regressions grade the **handler output**, which is the owner this cut changes; the gate's behaviour on usable trends is unverified offline and is stated rather than claimed.
4. **`getWeightTruth`'s alias is invisible to the stub** (`{ at: loggedAt }`), so weight fixtures must carry both keys or every assertion grades a `NaN`. Noted in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_