### PR TITLE
Fix SMART NEXT MEAL day-ledger ownership

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1257,21 +1257,109 @@ const MUST_WRITE: [string, string][] = [
     // stayed green with the handler deleted.
     {
       const { sastToday } = await import("../server/utils");
-      const mealTurn = async (o: { protLeft: number; calLeft: number; budget: string }) => {
+      type MealPart = { kcal: number; protein: number; source?: string; label?: string };
+      const mealRows = (parts: MealPart[]) => parts.map((part, i) => ({
+        id: `meal-${i}`, userId: USER.id,
+        mealLabel: part.label || "meal", source: part.source || "sa_scanner",
+        loggedAt: new Date(dayStart.getTime() + (i + 1) * 3_600_000), corrected: false,
+        kcalInt: part.kcal, proteinInt: part.protein,
+        kcal: part.kcal, protein: part.protein, carbs: 0, fat: 0,
+      }));
+      const mealTurn = async (o: {
+        protLeft: number; calLeft: number; budget: string;
+        ledger?: MealPart[];
+        overlay?: { calories: number; protein: number };
+      }) => {
         freshTurn();
+        const ledger = o.ledger || [{ kcal: 2400 - o.calLeft, protein: 150 - o.protLeft }];
+        const overlay = o.overlay || { calories: 2400 - o.calLeft, protein: 150 - o.protLeft };
         g.__KAMLIFE_STUB_USER = {
           ...USER, todayWater: "0", weeklyFoodBudget: o.budget,
-          todayCaloriesDate: sastToday(),
-          calorieTarget: 2400, todayCalories: 2400 - o.calLeft,
-          proteinTarget: 150, todayProteinG: 150 - o.protLeft,
+          todayCaloriesDate: sastToday(), calorieTarget: 2400, proteinTarget: 150,
+          todayCalories: overlay.calories, todayProteinG: overlay.protein,
         };
         g.__KAMLIFE_STUB_ROWS = new Map([
-          [schema.mealLogs, []], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+          [schema.mealLogs, mealRows(ledger)], [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
         ]);
         g.__KAMLIFE_STUB_WRITES = [];
         return String(await handleMessage(USER.phoneNumber, "what should I eat next?").catch(() => ""));
       };
       const flat = (r: string) => r.replace(/\n/g, " ⏎ ");
+
+      /**
+       * #127 — SMART NEXT MEAL MUST DECIDE FROM THE DAY LEDGER.
+       *
+       * Each control drives the actual route handler with deliberately disagreeing meal rows and
+       * users overlay. Reverting the owner to todayCalories/todayProteinG makes controls 1–4 read
+       * the stale overlay and fail; the matching control keeps today's rendered recommendation.
+       */
+      {
+        // 1. Protein is met and 700 kcal remain. A stale overlay must not manufacture a gap.
+        const met = await mealTurn({
+          protLeft: 0, calLeft: 700, budget: "100_300",
+          ledger: [{ kcal: 1700, protein: 150 }],
+          overlay: { calories: 400, protein: 20 },
+        });
+        if (!/700 kcal and 0g protein to go/i.test(met) || /130g more protein/i.test(met)) {
+          failures.push(`Ledger protein completion with 700 kcal left was replaced by the stale overlay: "${flat(met)}"`);
+        }
+
+        // 2. Only 200 kcal remain and protein is genuinely short: the ledger must choose a plate
+        // that fits, even when the overlay claims ample calories and protein completion.
+        const tightProtein = await mealTurn({
+          protLeft: 130, calLeft: 200, budget: "100_300",
+          ledger: [{ kcal: 2200, protein: 20 }],
+          overlay: { calories: 1700, protein: 150 },
+        });
+        if (!/200 kcal and 130g protein left/i.test(tightProtein)
+          || !/Tuna salad, no dressing/i.test(tightProtein)
+          || /\(~(?:[3-9]\d\d|[1-9]\d{3,}) kcal/i.test(tightProtein)) {
+          failures.push(`Ledger's tight protein gap did not produce an affordable protein-first plate: "${flat(tightProtein)}"`);
+        }
+
+        // 3. A photo plus another logged row folds before the decision; its stale overlay loses.
+        const photoMultiRow = await mealTurn({
+          protLeft: 0, calLeft: 700, budget: "100_300",
+          ledger: [
+            { kcal: 900, protein: 80, source: "photo", label: "lunch" },
+            { kcal: 800, protein: 70, label: "dinner" },
+          ],
+          overlay: { calories: 300, protein: 10 },
+        });
+        if (!/700 kcal and 0g protein to go/i.test(photoMultiRow) || /140g more protein/i.test(photoMultiRow)) {
+          failures.push(`Photo/multi-row ledger total lost to the stale overlay: "${flat(photoMultiRow)}"`);
+        }
+
+        // 4. Post-removal rows immediately change the same ask while the mirror still holds the
+        // old total. This is the state the correction/removal writer leaves for the next turn.
+        const beforeRemoval = await mealTurn({
+          protLeft: 130, calLeft: 200, budget: "100_300",
+          ledger: [{ kcal: 2200, protein: 20 }],
+          overlay: { calories: 2200, protein: 20 },
+        });
+        const afterRemoval = await mealTurn({
+          protLeft: 0, calLeft: 700, budget: "100_300",
+          ledger: [{ kcal: 1700, protein: 150 }],
+          overlay: { calories: 2200, protein: 20 },
+        });
+        if (!/200 kcal and 130g protein left/i.test(beforeRemoval)
+          || !/700 kcal and 0g protein to go/i.test(afterRemoval)
+          || beforeRemoval === afterRemoval) {
+          failures.push(`Post-correction/removal ledger rows did not immediately change SMART NEXT MEAL: before="${flat(beforeRemoval)}" after="${flat(afterRemoval)}"`);
+        }
+
+        // 5. The ordinary, healthy state is a control: matching mirror and ledger keep the
+        // existing rendered suggestion rather than changing policy or wording.
+        const matching = await mealTurn({
+          protLeft: 1, calLeft: 700, budget: "100_300",
+          ledger: [{ kcal: 1700, protein: 149 }],
+          overlay: { calories: 1700, protein: 149 },
+        });
+        if (!/700 kcal and 1g protein to go/i.test(matching)
+          || !/Chicken \+ sweet potato \+ vegetables/i.test(matching)) {
+          failures.push(`Matching ledger and overlay changed today's SMART NEXT MEAL policy: "${flat(matching)}"`);
+        }
+      }
 
       // THE OBSERVED TURN: 129g short with 2 146 kcal unspent.
       {

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -33,11 +33,11 @@ import { getStepStreak } from "./steps";
 import { scanForSAFoods } from "./food-scanner";
 import { storeMemory, addFact } from "../memory";
 import { sendWhatsApp } from "../scheduler";
-import { sastToday, sastDayStart, looksLikeDirectionRequest, classifyPainReport , getDisplayName} from "../utils";
+import { sastDayStart, looksLikeDirectionRequest, classifyPainReport , getDisplayName} from "../utils";
 import { isDespairNotAQuestion } from "../despair";
 import { SA_FOODS_SEED } from "../foods";
 import { turnEvidence } from "./chat-log";
-import { getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
+import { getDayLedger, getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
 
@@ -303,9 +303,9 @@ export async function handleMiscCommands(ctx: {
   // which this door already owns. Requiring the suffix is what sent it to the meal-plan door
   // instead (2026-08-27). Dropping one word covers both, and adds no new vocabulary.
   if (/\b(what should i eat|next meal|(?:suggest|give|send|show|recommend)(?:\s+me)?\s*a?n?\s*meal|what.?s? next|what to eat now|what can i eat|what must i eat|hungry|starving|i.?m hungry|what now)\b/i.test(m) && !/\b(breakfast|lunch|dinner|supper|braai|social)\b/i.test(m)) {
-    const todayStr = sastToday();
-    const todayCals = user.todayCaloriesDate === todayStr ? (user.todayCalories || 0) : 0;
-    const todayProt = user.todayCaloriesDate === todayStr ? (user.todayProteinG || 0) : 0;
+    const ledger = await getDayLedger(user.id, { user });
+    const todayCals = ledger.kcal;
+    const todayProt = ledger.protein;
     const calTarget = user.calorieTarget || 1800;
     const protTarget = user.proteinTarget || 120;
     const calLeftRaw = calTarget - todayCals;


### PR DESCRIPTION
Closes #127.

## Scope
SMART NEXT MEAL only. It now reads the existing authoritative SAST day ledger with `getDayLedger(user.id, { user })`, then derives its remaining kcal/protein from `ledger.kcal` and `ledger.protein`. It no longer makes a coaching decision from the denormalised `todayCalories` / `todayProteinG` overlay.

No lifecycle, client snapshot, GPT fallback, schema, nutrition, weight, or framework work.

## Five live handler disagreement controls
`script/tracking-contract-tests.ts` exercises `handleMessage` with real dated meal rows and deliberately contradictory overlays:
1. met protein despite a stale low overlay;
2. energy nearly met while protein is low despite a stale high-protein overlay;
3. multi-row / photo-style day;
4. correction/removal changing the ledger while the overlay stays stale;
5. matching overlay / ledger control.

Controls 1-4 assert the ledger-derived remaining values and would go red if SMART NEXT MEAL were restored to the overlay. The tests do not mock `getDayLedger`.

## CTO cleanup / current-main comparison
Base remains `origin/main@d13d20b6971b2c87e50c5be3637f1e1e266e395d`; the PR has one commit, `b3a5508d`.

The exact `npm run test:unit` result is **1048/1052** on both the PR head and a detached checkout of that exact base. The same four static checks fail in both places:
- `every meal removal goes through ONE owner, and that owner writes an audit line` - `MEAL_DROP` check in `server/handlers/food-scanner.ts`;
- `week card: full week shows all lines, first name only, brand footer` - steps tick expectation;
- `daily direction: covers today across all pillars + the weekly through-line` - food/steps/water expectation;
- `daily direction: rest day and walk-only are honoured, never insists on the gym` - walk-only expectation.

They are not an overlay/ledger harness assumption and are outside this PR's two-file diff. Repairing them here would widen #127; no fixture was changed and `getDayLedger` remains the real production read.

`npx tsx script/production-parity.ts` likewise returns **140/142** on both head and that exact base, with the same pre-existing failures: `the weekly owner does not list a door the report card wins` and `P0-2 . a multi-day report writes each day, in one reply`.

## Verification
- `npx tsx script/tracking-contract-tests.ts` - passed
- `npm run check` - passed
- `git diff --check origin/main...HEAD` - passed
- `npm run test:unit` - 1048/1052 on both head and exact base (same four pre-existing failures above)
- `npx tsx script/production-parity.ts` - 140/142 on both head and exact base (same two pre-existing failures above)
- `npm run check:names` - passed, 97/97
- reach, architecture, and file-size guards remain no worse than exact base; their existing red baselines include the 8 reach declarations, architecture governor findings, and `misc-commands.ts` at 1603 lines on both revisions. No budget was raised.