### PR TITLE
#131: one commercial contract — R149, paid upfront, 14-day guarantee, no free trial

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -661,6 +661,70 @@ const MUST_WRITE: [string, string][] = [
   }
 
   /**
+   * #131 — ONE COMMERCIAL CONTRACT: R149, PAID UPFRONT, 14-DAY MONEY-BACK, NO FREE TRIAL.
+   *
+   * The website was corrected to the locked offer while product truth still said R199 and a
+   * 7-day guarantee, so a customer could arrive from a truthful page and be quoted different
+   * terms by the coach — or, worse, be CHARGED different terms. The billing control below is the
+   * one that matters: display copy can be wrong and embarrassing, but the PayFast amount is
+   * money, and it was 199.
+   */
+  {
+    const { PRICING, GUARANTEE_PHRASE } = await import("../shared/pricing");
+
+    // 4. THE BILLING OWNER. routes/payments.ts sends this to PayFast as `amount` and
+    // `recurring_amount`, and verifies the ITN against it. This is the control that goes RED if
+    // the price is reverted.
+    if (PRICING.monthlyPriceZAR !== 149) {
+      failures.push(`The billing amount owner is ${PRICING.monthlyPriceZAR}, not 149 — PayFast would charge that, whatever the website says`);
+    }
+    if (!/^R149\b/.test(PRICING.monthlyDisplay)) {
+      failures.push(`The price display says "${PRICING.monthlyDisplay}" while the charge is R${PRICING.monthlyPriceZAR}`);
+    }
+    // The daily figure is a claim about the monthly price and has to follow it.
+    const dailyStated = Number(String(PRICING.dailyDisplay).replace(/[^0-9.]/g, ""));
+    if (Math.abs(dailyStated - PRICING.monthlyPriceZAR / 30) > 0.05) {
+      failures.push(`"${PRICING.dailyDisplay}" does not follow from R${PRICING.monthlyPriceZAR}/month — one of the two numbers is lying`);
+    }
+    if (PRICING.guaranteeDays !== 14 || !/14-day money-back guarantee/.test(GUARANTEE_PHRASE)) {
+      failures.push(`The guarantee owner says "${GUARANTEE_PHRASE}" — the locked offer is 14 days`);
+    }
+    // 5. TRIAL LENGTH HAS ONE OWNER, and it is not this file. shared/pricing.ts used to declare
+    // trialDays: 7 beside a server default of 0.
+    if ("trialDays" in (PRICING as any)) {
+      failures.push(`shared/pricing.ts declares trialDays again — server/pricing-config.ts owns it, and two owners of one fact is how this drifted`);
+    }
+    const { TRIAL_DAYS, TRIALS_ENABLED } = await import("../server/pricing-config");
+    // 3. Default config grants no trial to a NEW customer...
+    if (TRIAL_DAYS !== 0 || TRIALS_ENABLED) {
+      failures.push(`Default config grants a ${TRIAL_DAYS}-day trial — the locked offer has none for new customers`);
+    }
+
+    // 1 & 2 & 6. WHAT A PROSPECT IS ACTUALLY TOLD, through the real conversion handler.
+    const { handleConversionObjection } = await import("../server/handlers/conversion");
+    const say = (m: string) => handleConversionObjection({ m, payLink: "https://pay.test/x", name: "Kam" })?.reply || "";
+    const price = say("how much is it");
+    const stall = say("let me think about it");
+    const money = say("i can't afford it");
+    for (const [label, r] of [["price question", price], ["stall", stall], ["money objection", money]] as const) {
+      if (!r) { failures.push(`The conversion handler no longer answers a ${label} — the rest of this block grades nothing`); continue; }
+      if (/R199|R6\.63/.test(r)) {
+        failures.push(`A prospect asking about ${label} is still quoted the old offer: "${r.replace(/\n/g, " ⏎ ").slice(0, 160)}"`);
+      }
+    }
+    if (!/R149/.test(price)) {
+      failures.push(`A prospect asking the price is not told R149: "${price.replace(/\n/g, " ⏎ ").slice(0, 160)}"`);
+    }
+    // 2. Risk reversal is the guarantee, not a free week.
+    if (!/14-day money-back/.test(stall)) {
+      failures.push(`Hesitation is answered without the 14-day money-back guarantee: "${stall.replace(/\n/g, " ⏎ ").slice(0, 200)}"`);
+    }
+    if (/free (?:week|trial)|week one we make it right/i.test(stall)) {
+      failures.push(`Hesitation is still de-risked with a free-week promise the offer does not make: "${stall.replace(/\n/g, " ⏎ ").slice(0, 200)}"`);
+    }
+  }
+
+  /**
    * COACH HEALTH MUST DETECT THE FAILURES IT CLAIMS TO WATCH (2026-08-27).
    *
    * The dashboard's rules are the only thing standing between "we measure our adjudicated failures

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -2765,9 +2765,18 @@ test("plain goal message returns null (no objection)", async () => {
   const r = handleConversionObjection(convCtx("I want to lose weight"));
   assert.ok(r === null, "non-objection message should return null");
 });
-test("money objection reply contains R6.63", async () => {
-  const r = handleConversionObjection(convCtx("No money right now"));
-  assert.ok(r !== null && r.reply.includes("R6.63"), "money reply should frame the daily cost");
+test("money objection frames the daily cost, from the price owner", async () => {
+  // WAS `includes("R6.63")` — the daily figure frozen as a literal, so it asserted the old offer
+  // and went red the moment the price moved. The property is that the reply frames the monthly
+  // price as a daily one; the number comes from shared/pricing.ts, which is the thing allowed to
+  // change. Written this way it survives the next price change and still fails if the framing is
+  // dropped.
+  const { PRICING } = await import("../shared/pricing");
+  const r = handleConversionObjection(convCtx("I can't afford it"));
+  assert.ok(r !== null, "money objection should be answered");
+  const daily = PRICING.dailyDisplay.replace("/day", "");
+  assert.ok(r!.reply.includes(daily), `money reply should frame the daily cost (${daily}): ${r!.reply.slice(0, 120)}`);
+  assert.ok(!/R199|R6\.63/.test(r!.reply), "money reply still quotes the retired offer");
 });
 
 // ============================================================

--- a/server/handlers/conversion.ts
+++ b/server/handlers/conversion.ts
@@ -12,13 +12,15 @@
  */
 
 // Money / affordability objection — "no money", "too expensive", "after payday"
+import { PRICING, GUARANTEE_PHRASE } from "../../shared/pricing";
+
 const MONEY_OBJECTION_RE = /\b(no money|don.?t have (?:the )?money|haven.?t got money|can.?t afford|cannot afford|too expensive|too pricey|so expensive|very expensive|bit expensive|quite expensive|expensive for me|too much money|no cash|i.?m broke|i am broke|broke right now|month.?end|end of month|after (?:i get )?payday|after payday|when i (?:get paid|have money|am paid|get money)|once i (?:get paid|have money)|next month|next pay|tight (?:on money|right now|financially)|money.?s tight|short on cash|not in my budget|out of my budget|can.?t pay|cannot pay)\b/i;
 
 // Stall / hesitation — "let me think", "maybe later", "not sure", "not ready"
 const STALL_RE = /\b(let me think|i.?ll think|think about it|thinking about it|need to think|have to think|not sure(?: yet| about this)?|maybe later|maybe next|maybe tomorrow|maybe soon|i.?ll get back|get back to you|give me (?:time|a (?:day|week|moment|minute|sec)|some time)|i.?ll decide|decide later|deciding|still deciding|not (?:right )?now|another time|i.?ll let you know|let you know|gonna think|going to think|considering it|i.?m not ready|not ready (?:yet|to|for)|hold off|hold on a|wait a bit|i.?ll see|we.?ll see)\b/i;
 
 // Plain price / cost question — pure information request, no objection
-const PRICE_RE = /\b(?:price|pricing|how expensive|monthly fee|subscription (?:cost|price|fee)|what.?s the (?:price|cost|fee|charge|damage)|how much (?:is|does|to|for|will|per|a month|it cost|this cost|the|your|do|i pay)|how much.{0,18}(?:cost|pay|month|rand|join|sign|subscri)|how many rands?|cost (?:per month|to join|to start|of this)|what (?:does it|do you|will it|do i) (?:cost|charge|pay)|is it free|free trial|r\s?199)\b/i;
+const PRICE_RE = /\b(?:price|pricing|how expensive|monthly fee|subscription (?:cost|price|fee)|what.?s the (?:price|cost|fee|charge|damage)|how much (?:is|does|to|for|will|per|a month|it cost|this cost|the|your|do|i pay)|how much.{0,18}(?:cost|pay|month|rand|join|sign|subscri)|how many rands?|cost (?:per month|to join|to start|of this)|what (?:does it|do you|will it|do i) (?:cost|charge|pay)|is it free|free trial|r\s?149|r\s?199)\b/i;
 
 export type ConversionResult = { reply: string; intent: string } | null;
 
@@ -32,19 +34,19 @@ export function handleConversionObjection(ctx: {
 
   // ── MONEY / AFFORDABILITY — reframe the cost, hold the door open ──
   if (MONEY_OBJECTION_RE.test(m)) {
-    const reply = `${name}, no pressure and no judgment — money is real. But look at it this way: *R199 is R6.63 a day.* That is less than a single cooldrink or your daily airtime. It is not a big expense, it is a small daily one.\n\nThe real cost is staying stuck — another year in the same body, the same energy, the same clothes that do not fit.\n\nYour programme is already built and saved right here. Nothing is lost. The day the money comes in, you tap this link and pick up exactly where you left off:\n${payLink}\n\nIn the meantime — what is the *one* thing you most want to change about your body? Tell me, and I will give you something free to start today.`;
+    const reply = `${name}, no pressure and no judgment — money is real. But look at it this way: *R${PRICING.monthlyPriceZAR} is ${PRICING.dailyDisplay.replace("/day", "")} a day.* That is less than a single cooldrink or your daily airtime. It is not a big expense, it is a small daily one.\n\nThe real cost is staying stuck — another year in the same body, the same energy, the same clothes that do not fit.\n\nYour programme is already built and saved right here. Nothing is lost. The day the money comes in, you tap this link and pick up exactly where you left off:\n${payLink}\n\nIn the meantime — what is the *one* thing you most want to change about your body? Tell me, and I will give you something free to start today.`;
     return { reply, intent: "CONVERSION_MONEY" };
   }
 
   // ── STALL / HESITATION — surface the real blocker, de-risk the decision ──
   if (STALL_RE.test(m)) {
-    const reply = `${name}, fair enough — no rush. But let me ask you straight: what is actually holding you back — the price, or whether it will really work for you?\n\nIf it is whether it works: your full programme is already built. R199/month, cancel anytime, and if you are not happy after week one we make it right. The risk is basically zero — the only thing you lose by waiting is time.\n\nWhen you are ready, tap here and you pick up right where you left off:\n${payLink}\n\nSo tell me — what is your main goal? Fat loss, or building muscle? Let me show you what week one looks like for you.`;
+    const reply = `${name}, fair enough — no rush. But let me ask you straight: what is actually holding you back — the price, or whether it will really work for you?\n\nIf it is whether it works: your full programme is already built. ${PRICING.monthlyDisplay}, cancel anytime, and a ${GUARANTEE_PHRASE} — if it is not for you, you get your money back. The risk is basically zero — the only thing you lose by waiting is time.\n\nWhen you are ready, tap here and you pick up right where you left off:\n${payLink}\n\nSo tell me — what is your main goal? Fat loss, or building muscle? Let me show you what week one looks like for you.`;
     return { reply, intent: "CONVERSION_STALL" };
   }
 
   // ── PLAIN PRICE QUESTION — answer crisply, frame the value, redirect to goal ──
   if (PRICE_RE.test(m)) {
-    const reply = `${name}, straight up: *R199 a month — that is R6.63 a day.* Less than a loaf of bread, cancel anytime, no contract.\n\nFor that you get everything: your full personalised programme, daily food and calorie coaching on real SA food, workout tracking, and me checking in on you every single day. All on WhatsApp — no app to download.\n\nA personal trainer charges R250+ for *one* session. This is all-in, every day, for the price of a chocolate.\n\nReady to start? Tap here:\n${payLink}\n\nOr tell me first — what is your main goal? Fat loss, muscle, or just getting healthy? Let me show you exactly how I would get you there.`;
+    const reply = `${name}, straight up: *R${PRICING.monthlyPriceZAR} a month — that is ${PRICING.dailyDisplay.replace("/day", "")} a day.* Less than a loaf of bread, cancel anytime, no contract.\n\nFor that you get everything: your full personalised programme, daily food and calorie coaching on real SA food, workout tracking, and me checking in on you every single day. All on WhatsApp — no app to download.\n\nA personal trainer charges R250+ for *one* session. This is all-in, every day, for the price of a chocolate.\n\nReady to start? Tap here:\n${payLink}\n\nOr tell me first — what is your main goal? Fat loss, muscle, or just getting healthy? Let me show you exactly how I would get you there.`;
     return { reply, intent: "CONVERSION_PRICE" };
   }
 

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -37,6 +37,7 @@ import { SA_FOODS_SEED } from "../foods";
 import { scanForSAFoods, weeklyNetLine } from "./food-scanner";
 import { getWeightTruth } from "../day-ledger";
 import { readTrainingDay } from "../one-action";
+import { PRICING } from "../../shared/pricing";
 
 export async function handleLifecycle(ctx: {
   phone: string;
@@ -533,7 +534,7 @@ export async function handleLifecycle(ctx: {
 
     // Option 4 or unrecognised — route to confirm flow
     await db.update(users).set({ awaitingInputType: "cancel_confirm" }).where(eq(users.phoneNumber, phone));
-    const confirmReply = `${name}, last check — reply *yes* to cancel completely, or anything else to keep your subscription.\n\n_Your R199/month coaching stops. Data saved 90 days._`;
+    const confirmReply = `${name}, last check — reply *yes* to cancel completely, or anything else to keep your subscription.\n\n_Your ${PRICING.monthlyDisplay} coaching stops. Data saved 90 days._`;
     await logChat(user.id, message, confirmReply, "CANCEL_SAVE_TO_CONFIRM");
     return confirmReply;
   }
@@ -612,11 +613,11 @@ export async function handleLifecycle(ctx: {
     if (merchantId && appUrl) {
       const cleanPhone = phone.replace(/^whatsapp:/, "");
       const payLink = `${appUrl}/api/payfast/link?phone=${encodeURIComponent(cleanPhone)}`;
-      const payReply = `Sharp${clientName}. Here is your payment link: ${payLink}\n\nR199/month — cancel anytime. Your profile and progress are saved and will be waiting when you activate.`;
+      const payReply = `Sharp${clientName}. Here is your payment link: ${payLink}\n\n${PRICING.monthlyDisplay} — cancel anytime. Your profile and progress are saved and will be waiting when you activate.`;
       await logChat(user.id, message, payReply, "PAYMENT_REQUEST");
       return payReply;
     } else {
-      const payReply = `Sharp${clientName}. To subscribe or renew, go to ${appUrl} or WhatsApp the team directly. R199/month — cancel anytime.`;
+      const payReply = `Sharp${clientName}. To subscribe or renew, go to ${appUrl} or WhatsApp the team directly. ${PRICING.monthlyDisplay} — cancel anytime.`;
       await logChat(user.id, message, payReply, "PAYMENT_REQUEST");
       return payReply;
     }

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -40,6 +40,7 @@ import { turnEvidence } from "./chat-log";
 import { getDayLedger, getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
+import { PRICING, GUARANTEE_PHRASE } from "../../shared/pricing";
 
 // Protein keywords built from SA food database (same logic as routes.ts)
 const PROTEIN_WORDS: string[] = Array.from(new Set([
@@ -896,8 +897,8 @@ export async function handleMiscCommands(ctx: {
     const waNum = (process.env.TWILIO_WHATSAPP_NUMBER || "").replace(/^whatsapp:/, "").replace(/\D/g, "");
     const waLink = waNum ? `https://wa.me/${waNum}?text=Hi%2C+I+was+referred+by+${code}` : null;
     const shareMsg = waLink
-      ? `_"I've been using a WhatsApp fitness coach — real SA food, full workouts, daily check-ins. R199/month, no app, and a 7-day money-back guarantee so there's no risk: ${waLink}"_`
-      : `_"I've been using KamLife Coach — WhatsApp fitness coaching, real SA food, R199/month. Use my code ${code} when you join — there's a 7-day money-back guarantee, so zero risk."_`;
+      ? `_"I've been using a WhatsApp fitness coach — real SA food, full workouts, daily check-ins. ${PRICING.monthlyDisplay}, no app, and a ${GUARANTEE_PHRASE} so there's no risk: ${waLink}"_`
+      : `_"I've been using KamLife Coach — WhatsApp fitness coaching, real SA food, ${PRICING.monthlyDisplay}. Use my code ${code} when you join — there's a ${GUARANTEE_PHRASE}, so zero risk."_`;
     const referralReply = `*Your referral code: ${code}* 🎯\n\nSend your friend this:\n\n${shareMsg}\n\nWhen they subscribe, *you get a free month.* No cap — every friend who joins earns you one.`;
     await logChat(user.id, message, referralReply, "REFERRAL");
     return referralReply;

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -37,6 +37,7 @@ import { logStepsForUser } from "./steps";
 import { calculateTargets } from "../targets";
 import { getPrimaryWorkoutGifUrl } from "../exercise-media";
 import { sendWhatsApp, saveState } from "../scheduler/shared";
+import { PRICING, GUARANTEE_PHRASE } from "../../shared/pricing";
 
 // Exercise-name vocabulary. parseLiftLog was deleted with lift logging on 2026-08-06, but
 // this pattern is NOT a parser input — it is a GUARD used twice below, and both uses are the
@@ -354,7 +355,7 @@ export async function handleWorkoutCommands(ctx: {
             referralCode = `KAM${rand}`;
             await db.update(users).set({ referralCode }).where(eq(users.phoneNumber, phone));
           }
-          const referralMsg = `One more thing — you just completed your first session. That already puts you ahead of most people who sign up and never start.\n\nIf you know someone who needs this, share your code: *${referralCode}*\n\nWhen they join, *you get a free month* — they come in at R199 with a 7-day money-back guarantee, no risk.`;
+          const referralMsg = `One more thing — you just completed your first session. That already puts you ahead of most people who sign up and never start.\n\nIf you know someone who needs this, share your code: *${referralCode}*\n\nWhen they join, *you get a free month* — they come in at R${PRICING.monthlyPriceZAR} with a ${GUARANTEE_PHRASE}, no risk.`;
           await sendWhatsApp(phone, referralMsg);
           await logChat(userId, "", referralMsg, "REFERRAL_NUDGE_POST_WORKOUT");
         } catch (err) { console.warn("[REFERRAL_NUDGE] Cardio first-workout:", err); }
@@ -715,7 +716,7 @@ export async function handleWorkoutCommands(ctx: {
             referralCode = `KAM${rand}`;
             await db.update(users).set({ referralCode }).where(eq(users.phoneNumber, phone));
           }
-          const referralMsg = `One more thing — you just completed your first session. That already puts you ahead of most people who sign up and never start.\n\nIf you know someone who needs this, share your code: *${referralCode}*\n\nWhen they join, *you get a free month* — they come in at R199 with a 7-day money-back guarantee, no risk. One message to one person is all it takes.`;
+          const referralMsg = `One more thing — you just completed your first session. That already puts you ahead of most people who sign up and never start.\n\nIf you know someone who needs this, share your code: *${referralCode}*\n\nWhen they join, *you get a free month* — they come in at R${PRICING.monthlyPriceZAR} with a ${GUARANTEE_PHRASE}, no risk. One message to one person is all it takes.`;
           await sendWhatsApp(phone, referralMsg);
           await logChat(userId, "", referralMsg, "REFERRAL_NUDGE_POST_WORKOUT");
         } catch (err) {

--- a/server/join-qr.ts
+++ b/server/join-qr.ts
@@ -16,7 +16,7 @@ import { existsSync } from "fs";
 import { join } from "path";
 import qrcode from "qrcode-generator";
 import { buildJoinLink, sanitiseSourceTag } from "./signup-source";
-import { PRICING } from "../shared/pricing";
+import { PRICING, GUARANTEE_PHRASE } from "../shared/pricing";
 
 const FONT = "KamLife Sans";
 let fontReady = false;
@@ -97,7 +97,7 @@ function roundRect(ctx: SKRSContext2D, x: number, y: number, w: number, h: numbe
 export interface JoinCardOpts {
   sourceTag?: string | null; // gym / flyer / ig — labelled small on the card, encoded in the QR
   link?: string;             // override the encoded link (defaults to the wa.me join link)
-  priceLabel?: string;       // e.g. "R199/month" — pulled from pricing by the caller
+  priceLabel?: string;       // e.g. PRICING.monthlyDisplay — pulled from pricing by the caller
 }
 
 // The standalone QR as a PNG (no card chrome) — for embedding elsewhere.
@@ -190,7 +190,7 @@ export function renderJoinCard(opts: JoinCardOpts = {}): Buffer {
   ctx.fillStyle = ORANGE;
   ctx.textAlign = "left";
   ctx.font = `bold 26px "${FONT}"`;
-  ctx.fillText("7-day money-back guarantee", 40, H - 34);
+  ctx.fillText(GUARANTEE_PHRASE, 40, H - 34);
   if (tag) {
     ctx.fillStyle = MUTED;
     ctx.textAlign = "right";

--- a/server/onboarding.ts
+++ b/server/onboarding.ts
@@ -33,6 +33,7 @@ function declinesOptionalStep(msg: string): boolean {
   return DECLINES.has((msg || "").toLowerCase().trim().replace(/[.!]+$/, ""));
 }
 import { welcomeAvatarMarker } from "./macro-card-attach";
+import { PRICING, GUARANTEE_PHRASE } from "../shared/pricing";
 
 // ============================================================
 // ONBOARDING STATE MACHINE — valid states (CTO audit #17/#41)
@@ -322,7 +323,7 @@ async function completeOnboarding(phone: string, u: any, budget: string, budgetL
   const heightDisplay = u.heightCm != null ? ` · ${heightCm}cm` : "";
   const bmiDisplay = u.bmi ? ` · BMI ${u.bmi}` : "";
 
-  const refCodeLine = referralCode ? `\n\n🎁 *Your referral code: ${referralCode}* — share it. When a friend joins with it, *you get a free month.* They join at the normal R199, with the same 7-day money-back guarantee — zero risk.` : "";
+  const refCodeLine = referralCode ? `\n\n🎁 *Your referral code: ${referralCode}* — share it. When a friend joins with it, *you get a free month.* They join at the normal R${PRICING.monthlyPriceZAR}, with the same ${GUARANTEE_PHRASE} — zero risk.` : "";
 
   // Goal-specific hook line — personal, not generic
   const goalHook: Record<string, string> = {
@@ -366,7 +367,7 @@ async function completeOnboarding(phone: string, u: any, budget: string, budgetL
   const msg1b = `${calExplainer}\n\nLog your first meal and I will show you exactly where it lands. Type what you ate — e.g. *2 eggs and pap* — and Coach K does the maths.`;
 
   const msg2 = `*Day 1 is ready.*\n\n${firstWorkout}`;
-  const msg3 = `Your personalised shopping list and weekly meal plan are ready.\n\nPay to unlock them — and Day 2 drops the moment you finish today's session.\n\n*R199/month — cancel anytime:*\n${payLinkOnb}\n\n_R6.63/day. Less than a coffee. *7-day money-back guarantee* — if you're not happy in your first week, full refund, no questions. POPIA protected._`;
+  const msg3 = `Your personalised shopping list and weekly meal plan are ready.\n\nPay to unlock them — and Day 2 drops the moment you finish today's session.\n\n*${PRICING.monthlyDisplay} — cancel anytime:*\n${payLinkOnb}\n\n_${PRICING.dailyDisplay}. Less than a coffee. *${GUARANTEE_PHRASE}* — if it is not for you, full refund, no questions. POPIA protected._`;
   // ACTIVATION MOMENT — the calm, clear expectation-setter (what's required, don't
   // panic, what to expect, at your own pace), then ONE tiny first action to hook the
   // habit in the first five minutes.
@@ -564,7 +565,7 @@ Then on a NEW LINE add: "Reply *yes* when you're ready and I'll build your perso
 Rules: Short sentences. No lists. No bullet points. SA voice — warm, direct, no corporate speak.
 DON'T MAKE THEM THINK: name the OUTCOME plainly (get fit eating the food they already eat, a coach in their pocket), never jargon like "programme" or "accountability".
 Banned words: "I understand", "I hear you", "journey", "wellness", "reach out", "feel free", "awesome", "amazing", "fantastic"
-Do NOT mention price. Do NOT mention R199. Just be a helpful coach.
+Do NOT mention price. Do NOT quote any rand amount. Just be a helpful coach.
 If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one word is enough.`;
       const intakeReply = await askCoachK(message, user, intakeCtx);
       return intakeReply;
@@ -576,7 +577,7 @@ If they mention a referral (e.g. "from Donda"), acknowledge it warmly — one wo
     // POPIA + data deletion, and Terms/Privacy links — mirrors the pattern the SA gov health bot
     // used to pass Meta. Tapping "Yes, I agree" (or typing yes/agree) consents; "No thanks" deletes.
     return replyWithButtons(
-      `I'm Coach K. I help you lose weight and get fit using the food you already eat — right here on WhatsApp. No gym. No app. No expensive diet.\n\nJust tell me what you ate — "pap and chicken" — and I'll log it. I check in every day so you actually stick to it.\n\nR199/month — R6.63 a day, less than a coffee. Cancel anytime.\n\n*Before we start:*\n✅ You're 18 or older.\n✅ I'm an AI coach, not a doctor — for any medical condition, follow your doctor.\n🤝 A real coach may check in on you if a message suggests you need extra support.\n🔒 Your info is stored under POPIA — only for your coaching, never sold. Reply *delete my data* anytime.\nTerms: kamlifecoach.co.za/terms · Privacy: kamlifecoach.co.za/privacy\n\nTap *Yes, I agree* and I'll build your plan.`,
+      `I'm Coach K. I help you lose weight and get fit using the food you already eat — right here on WhatsApp. No gym. No app. No expensive diet.\n\nJust tell me what you ate — "pap and chicken" — and I'll log it. I check in every day so you actually stick to it.\n\n${PRICING.monthlyDisplay} — ${PRICING.dailyDisplay}, less than a coffee. Cancel anytime, and a ${GUARANTEE_PHRASE}.\n\n*Before we start:*\n✅ You're 18 or older.\n✅ I'm an AI coach, not a doctor — for any medical condition, follow your doctor.\n🤝 A real coach may check in on you if a message suggests you need extra support.\n🔒 Your info is stored under POPIA — only for your coaching, never sold. Reply *delete my data* anytime.\nTerms: kamlifecoach.co.za/terms · Privacy: kamlifecoach.co.za/privacy\n\nTap *Yes, I agree* and I'll build your plan.`,
       ["Yes, I agree", "No thanks"],
     );
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,7 +61,7 @@ import { invalidatePatternCache } from "./cache";
 import { mentionsConditionOrMedication, conditionWelcome } from "./condition-welcome";
 import { captureSymptom } from "./quality-signals";
 import { reportsHunger } from "./unlogged-notice";
-
+import { PRICING, GUARANTEE_PHRASE } from "../shared/pricing";   // commercial terms have one owner
 const openaiKey = process.env.AI_INTEGRATIONS_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
 if (!openaiKey) {
   console.error("[FATAL] OPENAI_API_KEY is not set. Server cannot start without it.");
@@ -409,7 +409,7 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
         const planParts = glimpsePlan.split("\n\n---\n\n");
         const planHeader = planParts[0] || "";
         const day1 = planParts[1] || "";
-        const upsell = `That is Day 1.\n\nDays 2 and 3 rotate the meals so you are not eating the same thing every day. Your weekly shopping list with ZAR prices is in there too.\n\n*Full weekly plan + shopping list + daily coaching — R199/month:*\n${payLink}\n\n_R6.63/day. Not satisfied after week 1? Message us and we will make it right._`;
+        const upsell = `That is Day 1.\n\nDays 2 and 3 rotate the meals so you are not eating the same thing every day. Your weekly shopping list with ZAR prices is in there too.\n\n*Full weekly plan + shopping list + daily coaching — ${PRICING.monthlyDisplay}:*\n${payLink}\n\n_${PRICING.dailyDisplay}. Not satisfied? ${GUARANTEE_PHRASE} — Message us and we will make it right._`;
         const glimpseReply = `${planHeader}\n\n${day1}\n\n---\n\n${upsell}`;
         await logChat(user.id, message, glimpseReply, "MEAL_PLAN_GLIMPSE");
         return glimpseReply;
@@ -421,11 +421,11 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
         const cancelDate = new Date(user.cancelledAt!).toLocaleDateString("en-ZA", { day: "numeric", month: "short", year: "numeric" });
         const currentKg = user.currentWeight ? `${parseFloat(String(user.currentWeight)).toFixed(1)}kg` : null;
         const progressNote = workouts > 0 ? `${workouts} session${workouts !== 1 ? "s" : ""}${currentKg ? `, currently at ${currentKg}` : ""} — all saved.` : "";
-        gateReply = `${name}, your subscription ended ${cancelDate}. ${progressNote}\n\nReply *pay* to pick up exactly where you left off.\n\n*R199/month — cancel anytime:*\n${payLink}`;
+        gateReply = `${name}, your subscription ended ${cancelDate}. ${progressNote}\n\nReply *pay* to pick up exactly where you left off.\n\n*${PRICING.monthlyDisplay} — cancel anytime:*\n${payLink}`;
       } else if (workouts > 0) {
-        gateReply = `${name}, reactivate to get your workouts, food coaching, and full programme back.\n\n*R199/month — cancel anytime:*\n${payLink}\n\nYour ${workouts} session${workouts !== 1 ? "s" : ""} and all progress are saved.`;
+        gateReply = `${name}, reactivate to get your workouts, food coaching, and full programme back.\n\n*${PRICING.monthlyDisplay} — cancel anytime:*\n${payLink}\n\nYour ${workouts} session${workouts !== 1 ? "s" : ""} and all progress are saved.`;
       } else {
-        gateReply = `${name}, your programme is built and waiting.\n\n*Start today — R199/month (R6.63/day)*\n${payLink}\n\n_Not satisfied after your first week? Message us and we'll make it right._`;
+        gateReply = `${name}, your programme is built and waiting.\n\n*Start today — ${PRICING.monthlyDisplay} (${PRICING.dailyDisplay})*\n${payLink}\n\n_${GUARANTEE_PHRASE} — not for you, and we make it right._`;
       }
       await logChat(user.id, message, gateReply, "SUBSCRIPTION_GATE");
       return gateReply;

--- a/server/routes/admin-client.ts
+++ b/server/routes/admin-client.ts
@@ -156,7 +156,7 @@ export function registerAdminClient(app: Express) {
   <span style="flex:1"></span><button id="refresh">refresh</button></header>
 <div class="summary" id="summary"></div>
 <div id="content"><div class="empty">Loading…</div></div>
-<div class="note">Cost-to-serve = OpenAI + voice + WhatsApp, month-to-date, against the R199 fee. Rates are estimates until real invoices land. A 🐋 whale costs more than half their fee to serve — usually voice or vision. Killswitches: <b>TTS=off</b>, model routing.</div>
+<div class="note">Cost-to-serve = OpenAI + voice + WhatsApp, month-to-date, against the monthly fee. Rates are estimates until real invoices land. A 🐋 whale costs more than half their fee to serve — usually voice or vision. Killswitches: <b>TTS=off</b>, model routing.</div>
 <script>
 (function(){
   var KEY="kamlife-dashboard-key";

--- a/server/scaling-milestones.ts
+++ b/server/scaling-milestones.ts
@@ -19,7 +19,7 @@ export interface MilestoneAction {
 export interface Milestone {
   clients: number;
   title: string;
-  mrrZar: number; // clients × R199 — shown so every mark reads as money, not vanity
+  mrrZar: number; // clients × the monthly price — shown so every mark reads as money, not vanity
   why: string;
   actions: MilestoneAction[];
 }

--- a/server/scheduler/jobs/business.ts
+++ b/server/scheduler/jobs/business.ts
@@ -112,11 +112,11 @@ export async function runSignupNudge(): Promise<void> {
         const workouts = client.totalWorkoutsCompleted || 0;
         if (daysSince === 1 && client.subscriptionStatus === "inactive") {
           if (await claimCritical(client.id, "signup_nudge", todaySAST())) {
-            await sendCriticalAlert(client.phoneNumber, `${name}, your programme is built and ready.\n\n${workouts === 0 ? "Day 1 is waiting." : `${workouts} session${workouts > 1 ? "s" : ""} logged.`} Activate now and coaching starts immediately.\n\n*R199/month — cancel anytime:*\n${payLink}\n\nR6.63/day.`);
+            await sendCriticalAlert(client.phoneNumber, `${name}, your programme is built and ready.\n\n${workouts === 0 ? "Day 1 is waiting." : `${workouts} session${workouts > 1 ? "s" : ""} logged.`} Activate now and coaching starts immediately.\n\n*${PRICING.monthlyDisplay} — cancel anytime:*\n${payLink}\n\n${PRICING.dailyDisplay}.`);
           }
         } else if (daysSince === 3 && client.subscriptionStatus === "inactive") {
           if (await claimCritical(client.id, "signup_nudge", todaySAST())) {
-            await sendCriticalAlert(client.phoneNumber, `${name}, your programme is still here and ready to go.\n\nR199/month — activate when you're ready:\n${payLink}`);
+            await sendCriticalAlert(client.phoneNumber, `${name}, your programme is still here and ready to go.\n\n${PRICING.monthlyDisplay} — activate when you're ready:\n${payLink}`);
           }
         }
       } else if (!isNewSignup && cancelled) {
@@ -125,11 +125,11 @@ export async function runSignupNudge(): Promise<void> {
         if (daysSinceCancelled !== 3 && daysSinceCancelled !== 7 && daysSinceCancelled !== 30) continue;
         if (!(await claimCritical(client.id, "winback", todaySAST()))) continue;
         if (daysSinceCancelled === 3) {
-          await sendCriticalAlert(client.phoneNumber, `${name} — you've done ${workouts} sessions with Coach K. That doesn't disappear.\n\nYour programme, weight history, and streaks are all saved. Pick up exactly where you left off.\n\n*Reactivate for R199/month:*\n${payLink}`);
+          await sendCriticalAlert(client.phoneNumber, `${name} — you've done ${workouts} sessions with Coach K. That doesn't disappear.\n\nYour programme, weight history, and streaks are all saved. Pick up exactly where you left off.\n\n*Reactivate for ${PRICING.monthlyDisplay}:*\n${payLink}`);
         } else if (daysSinceCancelled === 7) {
-          await sendCriticalAlert(client.phoneNumber, `${name}, a week since you left.\n\nThe people who come back after a week are the ones who actually get results — they know what consistency feels like now.\n\nR199/month. Your data is here:\n${payLink}`);
+          await sendCriticalAlert(client.phoneNumber, `${name}, a week since you left.\n\nThe people who come back after a week are the ones who actually get results — they know what consistency feels like now.\n\n${PRICING.monthlyDisplay}. Your data is here:\n${payLink}`);
         } else if (daysSinceCancelled === 30) {
-          await sendCriticalAlert(client.phoneNumber, `${name} — 30 days. Coach K here.\n\nOne message to say your profile is still here if you want it. ${workouts} sessions logged. Progress saved.\n\nR199/month if you're ready:\n${payLink}\n\nIf not — no hard feelings. Reply STOP and I won't message again.`);
+          await sendCriticalAlert(client.phoneNumber, `${name} — 30 days. Coach K here.\n\nOne message to say your profile is still here if you want it. ${workouts} sessions logged. Progress saved.\n\n${PRICING.monthlyDisplay} if you're ready:\n${payLink}\n\nIf not — no hard feelings. Reply STOP and I won't message again.`);
         }
       }
     } catch (err) { console.error(`[SCHEDULER] Signup/win-back error — ${client.phoneNumber}:`, err); }
@@ -159,14 +159,14 @@ export async function runSignupNudge(): Promise<void> {
       let msg: string;
       if (daysSinceExpiry === 1) {
         msg = hasProgress
-          ? `${name}, your free trial ended yesterday.\n\n${workouts} session${workouts !== 1 ? "s" : ""} logged — all saved.\n\nActivate for R199/month to continue exactly where you left off:\n${payLink}\n\nR6.63/day. Cancel anytime.`
-          : `${name}, your free trial ended yesterday. Your personalised programme is ready and waiting.\n\nActivate for R199/month:\n${payLink}\n\nR6.63/day. Cancel anytime.`;
+          ? `${name}, your free trial ended yesterday.\n\n${workouts} session${workouts !== 1 ? "s" : ""} logged — all saved.\n\nActivate for ${PRICING.monthlyDisplay} to continue exactly where you left off:\n${payLink}\n\n${PRICING.dailyDisplay}. Cancel anytime.`
+          : `${name}, your free trial ended yesterday. Your personalised programme is ready and waiting.\n\nActivate for ${PRICING.monthlyDisplay}:\n${payLink}\n\n${PRICING.dailyDisplay}. Cancel anytime.`;
       } else if (daysSinceExpiry === 3) {
         msg = hasProgress
-          ? `${name} — ${workouts} session${workouts !== 1 ? "s" : ""} saved and waiting. 3 days since your trial ended.\n\nR199/month — your programme, food coaching, and progress all pick up immediately:\n${payLink}`
-          : `${name}, 3 days since your trial ended. Your programme is still here.\n\nR199/month — R6.63/day:\n${payLink}`;
+          ? `${name} — ${workouts} session${workouts !== 1 ? "s" : ""} saved and waiting. 3 days since your trial ended.\n\n${PRICING.monthlyDisplay} — your programme, food coaching, and progress all pick up immediately:\n${payLink}`
+          : `${name}, 3 days since your trial ended. Your programme is still here.\n\n${PRICING.monthlyDisplay} — ${PRICING.dailyDisplay}:\n${payLink}`;
       } else {
-        msg = `${name}, last nudge — your trial ended a week ago.\n\n${hasProgress ? `${workouts} sessions and all your data are saved.` : "Your programme is still ready."}\n\nWhen you are ready — R199/month:\n${payLink}\n\nIf you have decided not to continue, reply STOP.`;
+        msg = `${name}, last nudge — your trial ended a week ago.\n\n${hasProgress ? `${workouts} sessions and all your data are saved.` : "Your programme is still ready."}\n\nWhen you are ready — ${PRICING.monthlyDisplay}:\n${payLink}\n\nIf you have decided not to continue, reply STOP.`;
       }
       if (await claimCritical(client.id, "trial_expiry_nudge", todaySAST())) {
         await sendCriticalAlert(client.phoneNumber, msg);

--- a/server/scheduler/jobs/trial.ts
+++ b/server/scheduler/jobs/trial.ts
@@ -18,6 +18,7 @@ import {
   todaySAST, isProactivePaused,
 } from "../shared";
 import { TRIAL_DAYS, TRIALS_ENABLED } from "../../pricing-config";
+import { PRICING } from "../../../shared/pricing";
 
 function trialDaysIn(betaBypassUntil: Date | null | undefined): number | null {
   if (!betaBypassUntil) return null;
@@ -75,7 +76,7 @@ export async function runTrialCountdown(): Promise<void> {
         if (await claimProactive(user.id, "trial_day5", todaySAST())) {
           const msg = `${name}, *3 days left on your trial.*\n\n`
             + `You are ${workouts > 0 ? `${workouts} session${workouts === 1 ? "" : "s"} in` : "getting started"} — do not let the momentum stop here.\n\n`
-            + `R199/month. R6.63/day. Less than a cooldrink. Cancel anytime.\n\n`
+            + `${PRICING.monthlyDisplay}. ${PRICING.dailyDisplay}. Less than a cooldrink. Cancel anytime.\n\n`
             + `Tap to continue coaching:\n${payLink || "Reply *pay* for your link."}`;
           await sendWhatsApp(user.phoneNumber, msg);
         }
@@ -89,7 +90,7 @@ export async function runTrialCountdown(): Promise<void> {
           const msg = `${name}, your trial ends *today.*\n\n`
             + `Everything you have built — your programme, your logs, your ${workouts} session${workouts === 1 ? "" : "s"} — is saved. Nothing is lost.\n\n`
             + `To keep coaching going, tap here now:\n${payLink || "Reply *pay* for your link."}\n\n`
-            + `R199/month — cancel anytime. If you have questions about the price or are not sure, just reply and I will sort it out.`;
+            + `${PRICING.monthlyDisplay} — cancel anytime. If you have questions about the price or are not sure, just reply and I will sort it out.`;
           await sendWhatsApp(user.phoneNumber, msg);
         }
       }

--- a/shared/pricing.ts
+++ b/shared/pricing.ts
@@ -7,21 +7,42 @@
 // ============================================================
 
 export const PRICING = {
-  /** Monthly subscription price in ZAR */
-  monthlyPriceZAR: 199,
+  /**
+   * Monthly subscription price in ZAR. THIS IS THE BILLING AMOUNT, not a label:
+   * routes/payments.ts sends it to PayFast as both `amount` and `recurring_amount`, and
+   * verifies the ITN against it. Changing it changes what a customer is charged.
+   */
+  monthlyPriceZAR: 149,
 
   /** Display string for UI/messages */
-  monthlyDisplay: "R199/month",
+  monthlyDisplay: "R149/month",
 
-  /** Daily equivalent (for marketing) */
-  dailyDisplay: "R6.63/day",
+  /** Daily equivalent (for marketing) — 149 / 30, rounded to the cent. */
+  dailyDisplay: "R4.97/day",
 
   /** Currency code */
   currency: "ZAR",
 
-  /** Free trial duration in days */
-  trialDays: 7,
+  /**
+   * THE RISK REVERSAL, and it had no owner until now (2026-09-02).
+   *
+   * "7-day money-back" was hardcoded in five customer-facing places — onboarding's paywall,
+   * two referral messages, the first-session share prompt, and painted onto the join QR
+   * image — so the promise could drift per surface and did. The offer is 14 days; there is
+   * one number to change.
+   */
+  guaranteeDays: 14,
 } as const;
+
+/** "14-day money-back guarantee" — written once so five surfaces cannot disagree. */
+export const GUARANTEE_PHRASE = `${PRICING.guaranteeDays}-day money-back guarantee`;
+
+// TRIAL LENGTH IS NOT DECLARED HERE, deliberately (2026-09-02). This file used to carry
+// `trialDays: 7` while server/pricing-config.ts — the module every trial consumer actually
+// imports — defaulted TRIAL_DAYS to 0. Two owners of one fact, disagreeing, in the file that
+// calls itself the single source of truth. It had zero readers, so it was not a runtime bug;
+// it was a false statement about the product sitting where people go to check. The owner is
+// pricing-config.ts, which also holds the grandfathering rule. Do not add it back here.
 
 // ============================================================
 // METRIC FORMULAS — used by all dashboard/reporting endpoints


### PR DESCRIPTION
Closes #131. **Current main used: `d35cb78`** (after #130 and #126 merged, so both previously-locked files were free).

## First divergence is the money, not the copy

`server/routes/payments.ts:427,433`:

```ts
amount:           String(PRICING.monthlyPriceZAR) + ".00",
recurring_amount: String(PRICING.monthlyPriceZAR) + ".00",
```

`PRICING.monthlyPriceZAR` was **199**. A customer arriving from the corrected R149 website was **charged R199.00 upfront and R199.00 recurring**. The same constant guards the ITN verification, so one owner drives charge, recurrence and verification.

## Commercial truth owners — before / after

| fact | before | after |
|---|---|---|
| **billing amount** | `PRICING.monthlyPriceZAR` = **199** | **149** — one owner, no new config |
| price display | `"R199/month"` | `"R149/month"` |
| daily display | `"R6.63/day"` | `"R4.97/day"` (149 ÷ 30) |
| **trial length** | **two owners**: `PRICING.trialDays: 7` **and** `pricing-config.TRIAL_DAYS = 0` | one owner — `pricing-config.ts`, **untouched** |
| **guarantee length** | **no owner** — "7-day" hardcoded in 5 places | `PRICING.guaranteeDays` + `GUARANTEE_PHRASE` |

**`PRICING.trialDays` had ZERO readers.** Every trial consumer imports `TRIAL_DAYS` from `server/pricing-config.ts`. So it was never a runtime bug — it was a false statement about the product sitting in the file people go to check, in a module that calls itself the single source of truth. Removed, with a note saying where the owner is.

**The guarantee had no owner at all**, which is exactly why "7-day money-back" survived in five separate places.

## Every reachable stale surface fixed

| file | what a customer saw |
|---|---|
| `shared/pricing.ts` | price, display, daily, the false `trialDays` |
| `handlers/conversion.ts` | price / money / stall replies |
| `routes.ts` | paywall upsell + 3 reactivation gates |
| `onboarding.ts` | **the intro/consent message — the first thing a prospect reads** — plus paywall and referral |
| `handlers/lifecycle.ts` | cancel confirmation + both pay links |
| `handlers/workout.ts` | 2 first-session referral messages |
| `handlers/misc-commands.ts` | referral share copy |
| `scheduler/jobs/business.ts` | trial-ended and win-back messages (11 sites) |
| `scheduler/jobs/trial.ts` | trial countdown messages |
| `join-qr.ts` | guarantee **painted onto the join QR image** |

Three stale risk-reversal statements that were not price strings are also gone: *"if you are not happy after week one we make it right"*, *"Not satisfied after week 1"*, *"Not satisfied after your first week"*.

`onboarding.ts` also instructed the model **"Do NOT mention R199"** — a rule naming a price we no longer charge. It now forbids quoting any rand amount.

## Billing / payment amount proof

The control asserts the **owner the PayFast payload reads**, not display copy:

```
✗ The billing amount owner is 199, not 149 — PayFast would charge that,
  whatever the website says
```

That is the RED-on-revert control you required.

## Customer-visible controls

| # | control | instrument |
|---|---|---|
| 1 | prospect asks price → **R149** | real `handleConversionObjection` |
| 2 | hesitation → **14-day money-back**, no free-week promise | real handler |
| 3 | default config grants/advertises **no trial** | `TRIAL_DAYS`/`TRIALS_ENABLED` |
| 4 | **billing owner resolves to 149** | `PRICING.monthlyPriceZAR` |
| 5 | trial length has **one** owner | fails if `trialDays` returns |
| 6 | no reachable copy states R199 / R6.63 | all three conversion replies |

Plus a coherence check: the daily figure must follow from the monthly price, so the two numbers cannot drift apart again.

**Negative controls, all verified RED:** revert price to 199 · re-add `trialDays` · restore the free-week promise.

## Grandfathered trial behaviour

**`server/pricing-config.ts` is untouched — zero diff.** `TRIAL_DAYS` still defaults to 0, `betaBypassUntil` grandfathering is intact, the one-trial-per-number hash is intact, and `scheduler/jobs/trial.ts` still runs for existing trial members. The "your free trial ended" wording in `business.ts` is **kept**: it is true for exactly the grandfathered population that job targets. Only the price they were quoted was wrong.

## Deliberately not changed

Comments recording historical rationale — `cost-tracking.ts` ("whether R199 survives needs the number to be too high"), `engagement.ts`, `image-downscale.ts`, `surface.ts`, `macro-card-attach.ts`, `tts.ts`, `gpt.ts`, `media.ts`, `misc-commands.ts:1538`, `weekly.ts`, `scheduler/shared.ts`. These are the record of *why* decisions were made; rewriting them would falsify it. Three that stated a wrong number as present fact — an admin cost-to-serve note, a JSDoc example, a type comment — were corrected.

One existing unit test asserted `includes("R6.63")`, freezing the retired offer as a literal. Rewritten to assert the reply frames the daily cost **from the owner** — survives the next price change, still fails if the framing is dropped.

## Verification

```
tsc --noEmit          clean
tracking-contract     green, exit 0
unit-tests            1052/1052, exit 0
production-parity     142/142
routing-audit         green
onboarding-e2e        green
gap-tests             green

architecture guard    IDENTICAL to main d35cb78
file-size guard       IDENTICAL to main d35cb78
name guard            IDENTICAL to main d35cb78
reach guard           IDENTICAL to main d35cb78
```

`routes.ts` held at **exactly 1500** — my import initially pushed an already-over-budget file to 1501 and I reclaimed the line rather than let it drift. No budget raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_