### PR TITLE
CI: prove unit failures against PR merge base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  unit-baseline:
+    # This is deliberately PR-only: only a pull request has an authoritative base SHA.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # compare-unit-baseline verifies this is the exact head, then asks git for its merge base.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - name: Baseline comparator positive control
+        run: npm run test:unit:baseline:control
+      - name: Unit failures compared to exact merge base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npm run test:unit:baseline
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ hunger-gauntlet-*.json
 # The anchor store (docs/p2/anchors.json) IS tracked — it is the rubric, and an untracked
 # rubric is folklore. That file holds only the excerpts deliberately chosen as standards.
 p2-work/
+
+# Ephemeral exact-merge-base checkout made by script/compare-unit-baseline.ts.
+# It must stay under the repository so the base checkout can resolve this checkout's node_modules.
+.unit-baseline-worktree-*/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:golden": "tsx script/golden-regression.ts",
     "test:safety": "tsx script/safety-audit.ts",
     "test:unit": "tsx script/unit-tests.ts",
+    "test:unit:baseline": "tsx script/compare-unit-baseline.ts",
+    "test:unit:baseline:control": "tsx script/compare-unit-baseline-tests.ts",
     "test:scanner": "tsx script/food-scanner-tests.ts",
     "test:decision-boundary": "tsx script/decision-boundary-tests.ts",
     "test:reentry": "tsx script/reentry-state-tests.ts && tsx script/reentry-bridge-tests.ts",

--- a/script/compare-unit-baseline-tests.ts
+++ b/script/compare-unit-baseline-tests.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { classifyFailures, comparisonExitCode, parseUnitRun } from "./compare-unit-baseline";
+
+function transcript(passed: number, total: number, names: string[]): string {
+  return [
+    `unit-tests: ${passed}/${total} passed`,
+    ...(names.length ? ["", "Failures:", ...names.flatMap(name => [`  ✗ ${name}`, "    known control"])] : []),
+  ].join("\n");
+}
+
+// Positive control: the merge base already has one failure; the branch adds one assertion.
+// The classifier must preserve the former as BASELINE and make the latter NEW (therefore RED).
+const base = parseUnitRun(transcript(1, 2, ["merge-base failing assertion"]), "BASE");
+const head = parseUnitRun(transcript(1, 3, ["merge-base failing assertion", "branch-only failing assertion"]), "HEAD");
+const delta = classifyFailures(base, head);
+assert.deepEqual(delta.baseline, ["merge-base failing assertion"]);
+assert.deepEqual(delta.introduced, ["branch-only failing assertion"]);
+assert.deepEqual(delta.fixed, []);
+assert.equal(comparisonExitCode(delta), 1, "a NEW failure must block CI");
+
+// #130 shape: equal named failures are baseline even when both runs are red.
+const known130 = [
+  "every meal removal goes through ONE owner, and that owner writes an audit line",
+  "week card: full week shows all lines, first name only, brand footer",
+  "daily direction: covers today across all pillars + the weekly through-line",
+  "daily direction: rest day and walk-only are honoured, never insists on the gym",
+];
+const sameBase = parseUnitRun(transcript(1048, 1052, known130), "#130 BASE");
+const sameHead = parseUnitRun(transcript(1048, 1052, known130), "#130 HEAD");
+assert.deepEqual(classifyFailures(sameBase, sameHead), { baseline: known130, introduced: [], fixed: [] });
+assert.equal(comparisonExitCode(classifyFailures(sameBase, sameHead)), 0);
+
+assert.throws(() => parseUnitRun("unit-tests: 1/2 passed\n", "BROKEN"), /reported 1 failures but exposed 0/);
+console.log("unit-baseline controls: 3/3 passed");

--- a/script/compare-unit-baseline.ts
+++ b/script/compare-unit-baseline.ts
@@ -1,0 +1,173 @@
+/**
+ * PR UNIT FAILURE DELTA
+ *
+ * A red deterministic suite does not say whether a pull request caused the red.
+ * This script runs the existing unit entrypoint at the checked-out PR head and at
+ * git's exact merge base, then compares the harness's stable test names. A base
+ * checkout that cannot be resolved or run is an error, never a convenient
+ * "everything was already failing" classification.
+ *
+ * CI supplies the two immutable pull-request SHAs. Local use is explicit:
+ *   npm run test:unit:baseline -- --base <base-sha>
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { resolve, relative, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface UnitRun {
+  passed: number;
+  total: number;
+  failures: string[];
+}
+
+export interface FailureDelta {
+  baseline: string[];
+  introduced: string[];
+  fixed: string[];
+}
+
+function command(command: string, args: string[], cwd: string): string {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 });
+  if (result.error || result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed: ${(result.stderr || result.error?.message || "no diagnostic").trim()}`);
+  }
+  return (result.stdout || "").trim();
+}
+
+function requiredBase(): string {
+  const arg = process.argv.find(value => value.startsWith("--base="));
+  const value = process.env.PR_BASE_SHA || process.env.UNIT_BASELINE_BASE_SHA || arg?.slice("--base=".length);
+  if (!value) {
+    throw new Error("Missing PR_BASE_SHA (CI) or --base=<commit> (local); refusing to guess a baseline.");
+  }
+  return value;
+}
+
+/** Parse only the final harness report, so incidental diagnostic glyphs are not test IDs. */
+export function parseUnitRun(output: string, label: string): UnitRun {
+  const summaries = [...output.matchAll(/unit-tests:\s*(\d+)\/(\d+)\s+passed/g)];
+  const summary = summaries.at(-1);
+  if (!summary) throw new Error(`${label} unit suite did not print its pass/total summary.`);
+
+  const passed = Number(summary[1]);
+  const total = Number(summary[2]);
+  if (!Number.isSafeInteger(passed) || !Number.isSafeInteger(total) || passed > total) {
+    throw new Error(`${label} unit suite printed an invalid summary: ${summary[0]}`);
+  }
+
+  const failed = total - passed;
+  const finalReport = output.slice(output.lastIndexOf(summary[0]) + summary[0].length);
+  const failureSection = finalReport.match(/\nFailures:\s*\n([\s\S]*)$/);
+  const failures = failureSection
+    ? [...failureSection[1].matchAll(/^\s*(?:✗|âœ—)\s+(.+?)\s*$/gm)].map(match => match[1])
+    : [];
+
+  if (failures.length !== failed) {
+    throw new Error(`${label} unit suite reported ${failed} failures but exposed ${failures.length} stable failure name(s).`);
+  }
+  if (new Set(failures).size !== failures.length) {
+    throw new Error(`${label} unit suite repeated a failure name; identifiers are not stable enough to compare.`);
+  }
+  return { passed, total, failures };
+}
+
+export function classifyFailures(base: UnitRun, head: UnitRun): FailureDelta {
+  const baseSet = new Set(base.failures);
+  const headSet = new Set(head.failures);
+  return {
+    baseline: base.failures.filter(name => headSet.has(name)),
+    introduced: head.failures.filter(name => !baseSet.has(name)),
+    fixed: base.failures.filter(name => !headSet.has(name)),
+  };
+}
+
+/** Kept pure so the positive control proves that NEW is a blocking outcome. */
+export function comparisonExitCode(delta: FailureDelta): number {
+  return delta.introduced.length > 0 ? 1 : 0;
+}
+
+function runUnit(cwd: string, tsxCli: string, label: string): UnitRun {
+  // Invoke the JS CLI through this Node process instead of a platform-specific .bin shim.
+  const result = spawnSync(process.execPath, [tsxCli, "script/unit-tests.ts"], {
+    cwd,
+    encoding: "utf8",
+    timeout: 10 * 60_000,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error || result.status === null || ![0, 1].includes(result.status)) {
+    const reason = result.error?.message || result.stderr || "timed out or returned no status";
+    throw new Error(`${label} unit suite could not run: ${reason.trim()}`);
+  }
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const parsed = parseUnitRun(output, label);
+  if ((result.status === 0) !== (parsed.failures.length === 0)) {
+    throw new Error(`${label} unit suite exit status disagrees with its failure report.`);
+  }
+  return parsed;
+}
+
+function list(title: string, names: string[]): string[] {
+  return [`${title} (${names.length})`, ...names.map(name => `  - ${name}`)];
+}
+
+async function main() {
+  const root = command("git", ["rev-parse", "--show-toplevel"], process.cwd());
+  const baseTip = requiredBase();
+  const head = command("git", ["rev-parse", "HEAD"], root);
+  const expectedHead = process.env.PR_HEAD_SHA;
+  if (expectedHead && head !== expectedHead) {
+    throw new Error(`Checked-out HEAD ${head} is not PR_HEAD_SHA ${expectedHead}; refusing an inexact comparison.`);
+  }
+  command("git", ["cat-file", "-e", `${baseTip}^{commit}`], root);
+  const mergeBase = command("git", ["merge-base", head, baseTip], root);
+
+  const tsxCli = resolve(root, "node_modules/tsx/dist/cli.mjs");
+  if (!existsSync(tsxCli)) throw new Error(`Missing ${tsxCli}; run npm ci before comparing.`);
+
+  // Keep the temporary worktree below root: Node can then resolve this checkout's node_modules.
+  const worktree = mkdtempSync(join(root, ".unit-baseline-worktree-"));
+  rmSync(worktree, { recursive: true, force: true });
+  const safeRelative = relative(root, worktree);
+  if (isAbsolute(safeRelative) || safeRelative.startsWith("..")) {
+    throw new Error("Refusing to remove a worktree path outside the repository.");
+  }
+
+  try {
+    command("git", ["worktree", "add", "--detach", worktree, mergeBase], root);
+    // Capture head first, then prove whether each named failure existed at its merge base.
+    const headRun = runUnit(root, tsxCli, "HEAD");
+    const baseRun = runUnit(worktree, tsxCli, "MERGE BASE");
+    const delta = classifyFailures(baseRun, headRun);
+    const report = [
+      "PR UNIT FAILURE COMPARISON",
+      `HEAD: ${head}`,
+      `MERGE BASE: ${mergeBase} (resolved from ${baseTip})`,
+      `BASE: ${baseRun.passed}/${baseRun.total} passed (${baseRun.failures.length} failures)`,
+      `HEAD: ${headRun.passed}/${headRun.total} passed (${headRun.failures.length} failures)`,
+      ...list("BASELINE", delta.baseline),
+      ...list("NEW", delta.introduced),
+      ...list("FIXED", delta.fixed),
+    ];
+    console.log(report.join("\n"));
+    if (comparisonExitCode(delta) !== 0) {
+      console.error("CI VERDICT: RED — branch-introduced unit failure(s) detected.");
+      process.exitCode = 1;
+    } else {
+      console.log("CI VERDICT: PASS — no branch-introduced unit failures.");
+    }
+  } finally {
+    // This path is freshly generated under root and verified above; never leave a test checkout behind.
+    spawnSync("git", ["worktree", "remove", "--force", worktree], { cwd: root, encoding: "utf8" });
+    rmSync(worktree, { recursive: true, force: true });
+  }
+}
+
+const invoked = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invoked) {
+  main().catch(error => {
+    console.error(`CI VERDICT: RED — baseline comparison could not complete: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #132.

## Mechanism
Adds a PR-only `unit-baseline` CI job while preserving the existing full-suite job. Actions checks out the immutable PR head SHA with full history, passes `pull_request.base.sha` and `pull_request.head.sha` to `script/compare-unit-baseline.ts`, and the script:

1. refuses to run if either the required base or checked-out expected head cannot be resolved;
2. calculates `git merge-base HEAD PR_BASE_SHA`;
3. creates an isolated temporary worktree at that exact merge-base commit;
4. runs the existing `script/unit-tests.ts` entrypoint at head and base;
5. parses the harness's final named failures and pass/total counts; and
6. emits BASELINE / NEW / FIXED sets.

A missing base, failed worktree, malformed harness report, timeout, or exit/report disagreement exits RED. Any NEW named failure exits RED. Equal base/head failures remain visible but do not get misclassified as branch-introduced.

## Output
```
PR UNIT FAILURE COMPARISON
HEAD: <sha>
MERGE BASE: <sha> (resolved from <PR base sha>)
BASE: <passed>/<total> passed (<n> failures)
HEAD: <passed>/<total> passed (<n> failures)
BASELINE (<n>)
NEW (<n>)
FIXED (<n>)
CI VERDICT: PASS|RED
```

## Controls
`npm run test:unit:baseline:control` is a CI step. It proves a known merge-base assertion is BASELINE, an injected branch-only assertion is NEW, and NEW produces blocking exit code 1. It also records the real #130 four-name shape as four BASELINE failures.

Real committed-head evidence:
- head `39954851bebcd005af75b2bd53852d17e28f11cd`
- merge base `d35cb78eb1329844536ef7b51fe4f3190386824a`
- base and head: `1048/1052`; four BASELINE, zero NEW, zero FIXED; PASS.

## Verification
- `npm run check` - passed
- `npm run test:unit:baseline:control` - 3/3 passed
- `npm run test:unit:baseline -- --base=d35cb78eb1329844536ef7b51fe4f3190386824a` - passed with the report above
- `git diff --check` - passed
- names guard - passed at 97/97
- no budgets raised; existing file-size and architecture red baselines are unchanged.

## Deliberate boundary
This first cut covers only the existing deterministic unit suite. The remaining deterministic suites and live-model suites are not yet compared; no product tests, #131 pricing/billing/copy files, or test-framework rewrite were changed.