### PR TITLE
Test: accept rendered separator in multi-day reply

### DIFF
--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2296,7 +2296,8 @@ async function main() {
     assert.match(r.out, new RegExp(d1, "i"), `the reply lost a day: ${r.out.slice(0, 120)}`);
     assert.match(r.out, new RegExp(d3, "i"), `the backfilled day was written but never acknowledged: ${r.out.slice(0, 120)}`);
     assert.match(r.out, /session/i, "the reply does not mention the session it wrote");
-    assert.match(r.out, /8,000 steps/i, "the reply does not mention the steps it wrote");
+    // renderers use a non-breaking space for thousands; this is still the same client-reported 8,000.
+    assert.match(r.out, /8[\s,]?000 steps/i, `the reply does not mention the steps it wrote: ${r.out.slice(0, 400)}`);
     assert.match(r.out, /kcal/i, "food lost its quantity-aware owner");
     assert.ok(r.backfillWorkoutDays.length === 1, `expected one backfilled session, got ${JSON.stringify(r.backfillWorkoutDays)}`);
     assert.ok(r.backfillStepDays.length === 1, `expected one backfilled step row, got ${JSON.stringify(r.backfillStepDays)}`);


### PR DESCRIPTION
Closes #135.

Trace: the exact real-handler parity input writes food rows on the first two named SAST days and the workout plus 8,000 steps on the third. The existing route appends that backfill acknowledgement to the existing food-owner reply before the final compose/verifier. The client receives one coherent reply with the two dated food lines and the dated session plus step line.

The first divergence was the assertion, not production behavior. It required `8,000 steps`, while the renderer intentionally emits `8 000 steps` with a non-breaking space. This PR accepts either comma or whitespace as the thousands separator, preserving the same real-handler checks for every dated write, one reply, named-day acknowledgement, session, exact step amount, kcal, and no duplicates/today leakage.

The existing control goes red if the backfill acknowledgement is removed because the final reply then loses the session and steps it wrote.

Verification: TypeScript passed; production parity is 141/142 with P0-2 passing (the sole remaining failure is the unrelated weekly-owner assertion); tracking contract passed; multi-day attribution passed; diff check passed.

No temporal owner, parser, event model, product behavior, pricing/billing/copy file, or budget changed.