### PR TITLE
food-context.ts 1486 → 1371: portion quantity moves to its owner

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -32,8 +32,8 @@ process.env.TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN || "test";
 process.env.TWILIO_WHATSAPP_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER || "+27000000000";
 
 // Dynamic imports — execute after env vars above, unlike static imports which are hoisted.
-const { extractMealLabel, adjustFoodsForSegment } = await import("../server/handlers/food-context");
-const { scalePortionDescription } = await import("../server/portion-memory");
+const { extractMealLabel } = await import("../server/handlers/food-context");
+const { scalePortionDescription, adjustFoodsForSegment } = await import("../server/portion-memory");
 const { assessWeightRate, weeklyTrendSlopeKg } = await import("../server/handlers/weight");
 const { parseMealDate, isRetroactiveMeal, mealDateLabel } = await import("../server/utils");
 const { explicitMealSlot } = await import("../server/understanding/actions");
@@ -3207,7 +3207,7 @@ test("portion units: the FOOD decides — a handful of peanuts is one portion of
 });
 
 test("portion units: END TO END — the hard South African cases", async () => {
-  const { adjustFoodsForSegment } = await import("../server/handlers/food-context");
+  const { adjustFoodsForSegment } = await import("../server/portion-memory");
   const { scanForSAFoods } = await import("../server/handlers/food-scanner");
 // These were written as CommonJS require() inside an ESM module, so every test below
 // that used them threw "require is not defined" — they had never executed. Bound once here.
@@ -3233,7 +3233,7 @@ const VERIF = await import("../server/brain/reply-verifier");
 });
 
 test("portion units: an estimated quantity is tagged ai even when the FOOD is db", async () => {
-  const { adjustFoodsForSegment } = await import("../server/handlers/food-context");
+  const { adjustFoodsForSegment } = await import("../server/portion-memory");
   const { scanForSAFoods } = await import("../server/handlers/food-scanner");
 // These were written as CommonJS require() inside an ESM module, so every test below
 // that used them threw "require is not defined" — they had never executed. Bound once here.

--- a/script/trace-turn.ts
+++ b/script/trace-turn.ts
@@ -63,7 +63,8 @@ function agoMs(spec?: string): number | null {
 }
 
 const { scanForSAFoods } = await import("../server/handlers/food-scanner");
-const { adjustFoodsForSegment, extractMealLabel } = await import("../server/handlers/food-context");
+const { extractMealLabel } = await import("../server/handlers/food-context");
+const { adjustFoodsForSegment } = await import("../server/portion-memory");
 const { explicitMealSlot } = await import("../server/understanding/actions");
 const { parseMealDate, isRetroactiveMeal } = await import("../server/utils");
 const { classifyPortionUnit } = await import("../server/portion-memory");

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -463,7 +463,7 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
 // order). The client's own median portion beats the table default — but ONLY in
 // silence: explicit amounts and size words always win, and no history changes nothing.
 {
-  const { medianPortions, personalPortionFor, normalizeFoodKey } = await import("../server/portion-memory");
+  const { medianPortions, personalPortionFor, normalizeFoodKey, adjustFoodsForSegment } = await import("../server/portion-memory");
   const mkMem = (kcals: number[]) => medianPortions(kcals.map(k => [{ name: "Eggs", kcal: k, protein: Math.round(k / 10) }]));
   test("portion memory: median needs 3+ logs; keys normalise variants together", () => {
     assert.equal(mkMem([200, 220]).size, 0, "2 logs = no memory");
@@ -478,10 +478,31 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
   test("portion memory: personal median lands with macro shape preserved", () => {
     const r = personalPortionFor(mkMem([280, 280, 280]), "Eggs", 140, 12);
     assert.ok(r.personal && r.kcal === 280 && r.protein === 24, `2x kcal scales protein 2x: ${JSON.stringify(r)}`);
-    // The silence-only guard (explicit counts and size words beat memory) lives in
-    // adjustFoodsForSegment — source-guarded here, behaviour-verified in prod replies.
-    const src = readFileSync(join("server", "handlers", "food-context.ts"), "utf-8");
-    assert.ok(/!explicitQty && !vagueQty && sizeMultiplier === 1 && personal/.test(src), "memory must only fill silence — explicit, vague AND size words all beat it");
+  });
+  // MEMORY ONLY FILLS SILENCE. Was a regex over food-context.ts source — an assertion that
+  // passed on the presence of a line, not on what the line did, and it would have kept passing
+  // if the condition had been inverted. adjustFoodsForSegment now lives in this same module, so
+  // the rule is asserted where it is decided: three ways the client can SPEAK an amount, each of
+  // which must beat their history, against the one silent case where history is allowed to win.
+  test("portion memory: speech beats memory — explicit, vague and size words all win", () => {
+    const EGGS = {
+      name: "Eggs", aliases: ["eggs"], caloriesPer100g: 140, proteinPer100g: 12,
+      carbsPer100g: 1, fatPer100g: 10, typicalPortionDescription: "2 eggs",
+      typicalPortionGrams: 100, typicalPortionCalories: 140, typicalPortionProtein: 12,
+      category: "protein", budgetTier: 1, notes: "",
+    };
+    const mem = mkMem([280, 280, 280]);
+    const seg = (msg: string) => adjustFoodsForSegment([EGGS], msg, mem)[0] as any;
+
+    const silent = seg("eggs");
+    assert.equal(silent.portionSource, "personal", "silence: their own median is allowed to win");
+    assert.equal(silent.adjustedCalories, 280, "and it is the learned 280, not the table's 140");
+
+    for (const [msg, source] of [["3 eggs", "explicit"], ["some eggs", "vague"], ["big plate of eggs", "size"]] as const) {
+      const got = seg(msg);
+      assert.equal(got.portionSource, source, `"${msg}" is speech — provenance must be ${source}`);
+      assert.notEqual(got.adjustedCalories, 280, `"${msg}" must not be overridden by the 280 kcal memory`);
+    }
   });
 }
 

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -12,7 +12,6 @@ import { eq, and, gte, lt, desc } from "drizzle-orm";
 import { type SAFood } from "../foods";
 import {
   scanForSAFoods, recomputeTodayFoodTotals, buildFoodLogReply, escapeRegex,
-  portionDefaultCount,
   computeFoodLogStreak, getFoodStreakCelebration, shortStreakNote,
   invalidateFoodTotalsCache,
 } from "./food-scanner";
@@ -29,7 +28,7 @@ import { unloggedFoodNotice, carriesFeelingClause } from "../unlogged-notice";
 import { enforceReplyContract, clientAskedForDetail } from "../reply-contract";
 import { sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, SAYS_TODAY_RE, mealDateLabel, statedWhen, slotFromSastHour, slotFromCaptionTime, isNightWorker, looksLikeDeepEmotionalShare, effectiveMealLoggedAt, spaceName, isAskingNotReporting } from "../utils";
 import { explicitMealSlot } from "../understanding/actions";
-import { getPortionMemory, personalPortionFor, getSlotContext, resolveInferredSlot, classifyPortionUnit, scalePortionDescription, type PortionStat, type SlotContext } from "../portion-memory";
+import { getPortionMemory, getSlotContext, resolveInferredSlot, adjustFoodsForSegment, type SlotContext } from "../portion-memory";
 import { invalidatePatternCache } from "../cache";
 import { educationNote, remainingInMeals } from "../education";
 import { firstActionCelebration } from "../activation";
@@ -131,120 +130,6 @@ async function getStreakNote(userId: string, streak: number, name: string): Prom
 
 
 type HandleMessageFn = (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[]) => Promise<string>;
-
-// Quantity/portion scaling — shared by the scanner, smart-log and multi-day paths.
-function normaliseWordNumbers(text: string): string {
-  const map: Record<string, string> = {
-    "one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
-    "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10",
-    "half": "0.5", "a": "1", "an": "1",
-  };
-  // Phrase pass FIRST: "half a vienna" must become "0.5 vienna", not "0.5 1 vienna" —
-  // the a→1 word map was eating the half and logging a whole item (2026-07-23).
-  const phrased = text.replace(/\bhalf\s+(?:a|an|the)\s+/gi, "0.5 ");
-  return phrased.replace(/\b(one|two|three|four|five|six|seven|eight|nine|ten|half|a|an)\b/gi, w => map[w.toLowerCase()] ?? w);
-}
-
-export function adjustFoodsForSegment(foods: SAFood[], segText: string, personal?: Map<string, PortionStat>) {
-  const normText = normaliseWordNumbers(segText);
-
-  // Portion-size modifier — "big plate of pap" → 1.5×, "half a portion" → 0.5×
-  // Applied globally across all foods in the segment (whole meal was described as big/small)
-  let sizeMultiplier = 1;
-  if (/(big|large|huge|heaped|extra\s*large|xl|full\s*plate|loaded)\s+(?:plate|bowl|portion|serving|of\b)/i.test(normText)
-    || /\b(double|extra\s+helping|extra\s+large\b)/i.test(normText)) {
-    sizeMultiplier = 1.5;
-  } else if (/(small|tiny|little|mini|quarter)\s+(?:plate|bowl|portion|serving)/i.test(normText)
-    || /\ba\s+(?:small|tiny|little)\s+bit\s+of\b/i.test(normText)
-    || /\bsmall\s+amount\s+of\b/i.test(normText)) {
-    sizeMultiplier = 0.7;
-  } else if (/\b(?:half|halved)\s+(?:a\s+)?(?:plate|bowl|portion|serving|of\b)/i.test(normText)
-    || /\b(?:half\s+(?:the\s+)?(?:pap|rice|pasta|meal|food)\b)/i.test(normText)) {
-    sizeMultiplier = 0.5;
-  }
-
-  return foods.map(f => {
-    const allAliases = [f.name.toLowerCase(), ...f.aliases.map(a => a.toLowerCase())];
-    let quantity = 1;
-    let explicitQty = false; // the client SAID an amount — memory never overrides speech
-    let quantityEstimated = false; // WE interpreted the amount — identity can be db, quantity a guess
-    for (const alias of allAliases) {
-      const qtyDirect = normText.match(new RegExp(`(\\d+(?:\\.\\d+)?)\\s+(?:${escapeRegex(alias)})`, "i"));
-      // UNIT-AWARE (2026-08-13): capture the unit WORD and classify it — "2 plates", "2 tablespoons",
-      // "2 pieces" and "2 spoons" are four different claims, and the old catch-all made all four N
-      // whole portions, so "2 spoons of pap" logged 660 kcal. See portion-memory.classifyPortionUnit.
-      const qtyWithUnit = qtyDirect ? null : normText.match(new RegExp(`(\\d+(?:\\.\\d+)?)\\s+([a-z]+)\\s+(?:of\\s+)?(?:${escapeRegex(alias)})`, "i"));
-      const qtyBefore = qtyDirect || qtyWithUnit;
-      if (qtyBefore) {
-        explicitQty = true;
-        const userQty = parseFloat(qtyBefore[1]);
-        const unit = qtyWithUnit ? classifyPortionUnit(qtyWithUnit[2], f.typicalPortionDescription, f.typicalPortionGrams) : null;
-        if (unit && unit.fraction !== null) {
-          quantity = unit.cls === "unknown" ? 1 : userQty * unit.fraction;  // never N portions
-          if (unit.estimated) quantityEstimated = true;
-        } else {
-          const defaultQty = portionDefaultCount(f.typicalPortionDescription);
-          if (userQty > 0 && defaultQty > 0 && userQty !== defaultQty) quantity = userQty / defaultQty;
-        }
-        break;
-      }
-    }
-    // VAGUE PER-FOOD AMOUNT (2026-07-23 live: "half a Vienna" logged the 2-vienna default and
-    // the client argued the log DOWN — trust killer). "Half a <food>" = 0.5 of ONE item vs the
-    // portion's default count; "some/a few/a bit of <food>" = half the default. Lean LOW.
-    // Skipped when a global size phrase already scaled the segment (no double-halving).
-    let vagueQty = false;
-    if (!explicitQty && sizeMultiplier === 1) {
-      for (const alias of allAliases) {
-        const a = escapeRegex(alias);
-        // Match on the RAW text: normalisation rewrites "a"→"1", destroying "a bit of".
-        const halfM = segText.match(new RegExp(`\\bhalf\\s+(?:a\\s+|an\\s+|the\\s+|of\\s+(?:a\\s+|the\\s+)?)?(?:${a})`, "i"));
-        const vagueM = !halfM && segText.match(new RegExp(`\\b(?:some|a few|a couple(?:\\s+of)?|a bit of|a little(?:\\s+bit)?(?:\\s+of)?|a small piece of|a taste of)\\s+(?:${a})`, "i"));
-        if (halfM) {
-          quantity = 0.5 / Math.max(1, portionDefaultCount(f.typicalPortionDescription));
-          vagueQty = true;
-        } else if (vagueM) {
-          quantity = 0.5;
-          vagueQty = true;
-        }
-        if (vagueQty) break;
-      }
-    }
-    quantity = quantity * sizeMultiplier;
-    // ADAPTIVE PORTION (2026-07-17): when the client stated NO amount and NO size word,
-    // their own median portion of this food (portion-memory, >=3 logs, clamped) beats
-    // the table default. Memory fills silence; it never overrides what they said —
-    // and a vague amount ("some", "half a") IS speech, so memory stays out of its way.
-    if (!explicitQty && !vagueQty && sizeMultiplier === 1 && personal) {
-      const pp = personalPortionFor(personal, f.name, f.typicalPortionCalories, f.typicalPortionProtein);
-      if (pp.personal) {
-        return {
-          ...f,
-          adjustedCalories: pp.kcal,
-          adjustedProtein: pp.protein,
-          adjustedDescription: `${f.typicalPortionDescription} — your usual`,
-          quantity: 1,
-          portionSource: "personal" as const,
-        };
-      }
-    }
-    // PORTION PROVENANCE (2026-07-19): every inferred portion carries HOW it was decided —
-    // the audit-trail atom the reviews keep asking for, and the signal the confidence layer
-    // reads. "default" = a bare guess (no amount, no size word, no history) — the only case
-    // that's genuinely uncertain.
-    const portionSource = explicitQty ? "explicit" as const : vagueQty ? "vague" as const : sizeMultiplier !== 1 ? "size" as const : "default" as const;
-    return {
-      ...f,
-      adjustedCalories: Math.round(f.typicalPortionCalories * quantity),
-      adjustedProtein: Math.round(f.typicalPortionProtein * quantity),
-      adjustedDescription: scalePortionDescription(f.typicalPortionDescription, quantity),
-      quantity,
-      portionSource,
-      // Identity verified, quantity estimated — "2 spoons of pap" is db-true about pap, a guess about how much.
-      origin: quantityEstimated ? "ai" as const : undefined,
-    };
-  });
-}
 
 export async function handleFoodContext(ctx: {
   phone: string;

--- a/server/portion-memory.ts
+++ b/server/portion-memory.ts
@@ -15,6 +15,8 @@
 import { db } from "./db";
 import { mealLogs } from "../shared/schema";
 import { eq, and, gte, desc } from "drizzle-orm";
+import { type SAFood } from "./foods";
+import { escapeRegex, portionDefaultCount } from "./handlers/food-scanner";
 
 export type PortionStat = { kcal: number; protein: number; n: number };
 type ItemRow = Array<{ name?: string; foodName?: string; kcal?: number; protein?: number }> | null;
@@ -266,5 +268,129 @@ export function scalePortionDescription(desc: string, quantity: number): string 
       return `${num} ${word}s`;
     }
     return match;
+  });
+}
+
+/**
+ * HOW MUCH DID THEY EAT (moved here from handlers/food-context.ts, 2026-09-03 — unchanged).
+ *
+ * The scanner answers WHICH foods a message names; this answers HOW MUCH of each, and that is
+ * this file's subject. Everything it needs already lived here: classifyPortionUnit reads the unit
+ * word, personalPortionFor supplies the learned portion when the client said no amount, and
+ * scalePortionDescription writes the result back out. It sat in the food handler only because
+ * that is where it was first called from — the handler now imports it like any other caller.
+ */
+
+// Quantity/portion scaling — shared by the scanner, smart-log and multi-day paths.
+function normaliseWordNumbers(text: string): string {
+  const map: Record<string, string> = {
+    "one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
+    "six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10",
+    "half": "0.5", "a": "1", "an": "1",
+  };
+  // Phrase pass FIRST: "half a vienna" must become "0.5 vienna", not "0.5 1 vienna" —
+  // the a→1 word map was eating the half and logging a whole item (2026-07-23).
+  const phrased = text.replace(/\bhalf\s+(?:a|an|the)\s+/gi, "0.5 ");
+  return phrased.replace(/\b(one|two|three|four|five|six|seven|eight|nine|ten|half|a|an)\b/gi, w => map[w.toLowerCase()] ?? w);
+}
+
+export function adjustFoodsForSegment(foods: SAFood[], segText: string, personal?: Map<string, PortionStat>) {
+  const normText = normaliseWordNumbers(segText);
+
+  // Portion-size modifier — "big plate of pap" → 1.5×, "half a portion" → 0.5×
+  // Applied globally across all foods in the segment (whole meal was described as big/small)
+  let sizeMultiplier = 1;
+  if (/(big|large|huge|heaped|extra\s*large|xl|full\s*plate|loaded)\s+(?:plate|bowl|portion|serving|of\b)/i.test(normText)
+    || /\b(double|extra\s+helping|extra\s+large\b)/i.test(normText)) {
+    sizeMultiplier = 1.5;
+  } else if (/(small|tiny|little|mini|quarter)\s+(?:plate|bowl|portion|serving)/i.test(normText)
+    || /\ba\s+(?:small|tiny|little)\s+bit\s+of\b/i.test(normText)
+    || /\bsmall\s+amount\s+of\b/i.test(normText)) {
+    sizeMultiplier = 0.7;
+  } else if (/\b(?:half|halved)\s+(?:a\s+)?(?:plate|bowl|portion|serving|of\b)/i.test(normText)
+    || /\b(?:half\s+(?:the\s+)?(?:pap|rice|pasta|meal|food)\b)/i.test(normText)) {
+    sizeMultiplier = 0.5;
+  }
+
+  return foods.map(f => {
+    const allAliases = [f.name.toLowerCase(), ...f.aliases.map(a => a.toLowerCase())];
+    let quantity = 1;
+    let explicitQty = false; // the client SAID an amount — memory never overrides speech
+    let quantityEstimated = false; // WE interpreted the amount — identity can be db, quantity a guess
+    for (const alias of allAliases) {
+      const qtyDirect = normText.match(new RegExp(`(\\d+(?:\\.\\d+)?)\\s+(?:${escapeRegex(alias)})`, "i"));
+      // UNIT-AWARE (2026-08-13): capture the unit WORD and classify it — "2 plates", "2 tablespoons",
+      // "2 pieces" and "2 spoons" are four different claims, and the old catch-all made all four N
+      // whole portions, so "2 spoons of pap" logged 660 kcal. See classifyPortionUnit above.
+      const qtyWithUnit = qtyDirect ? null : normText.match(new RegExp(`(\\d+(?:\\.\\d+)?)\\s+([a-z]+)\\s+(?:of\\s+)?(?:${escapeRegex(alias)})`, "i"));
+      const qtyBefore = qtyDirect || qtyWithUnit;
+      if (qtyBefore) {
+        explicitQty = true;
+        const userQty = parseFloat(qtyBefore[1]);
+        const unit = qtyWithUnit ? classifyPortionUnit(qtyWithUnit[2], f.typicalPortionDescription, f.typicalPortionGrams) : null;
+        if (unit && unit.fraction !== null) {
+          quantity = unit.cls === "unknown" ? 1 : userQty * unit.fraction;  // never N portions
+          if (unit.estimated) quantityEstimated = true;
+        } else {
+          const defaultQty = portionDefaultCount(f.typicalPortionDescription);
+          if (userQty > 0 && defaultQty > 0 && userQty !== defaultQty) quantity = userQty / defaultQty;
+        }
+        break;
+      }
+    }
+    // VAGUE PER-FOOD AMOUNT (2026-07-23 live: "half a Vienna" logged the 2-vienna default and
+    // the client argued the log DOWN — trust killer). "Half a <food>" = 0.5 of ONE item vs the
+    // portion's default count; "some/a few/a bit of <food>" = half the default. Lean LOW.
+    // Skipped when a global size phrase already scaled the segment (no double-halving).
+    let vagueQty = false;
+    if (!explicitQty && sizeMultiplier === 1) {
+      for (const alias of allAliases) {
+        const a = escapeRegex(alias);
+        // Match on the RAW text: normalisation rewrites "a"→"1", destroying "a bit of".
+        const halfM = segText.match(new RegExp(`\\bhalf\\s+(?:a\\s+|an\\s+|the\\s+|of\\s+(?:a\\s+|the\\s+)?)?(?:${a})`, "i"));
+        const vagueM = !halfM && segText.match(new RegExp(`\\b(?:some|a few|a couple(?:\\s+of)?|a bit of|a little(?:\\s+bit)?(?:\\s+of)?|a small piece of|a taste of)\\s+(?:${a})`, "i"));
+        if (halfM) {
+          quantity = 0.5 / Math.max(1, portionDefaultCount(f.typicalPortionDescription));
+          vagueQty = true;
+        } else if (vagueM) {
+          quantity = 0.5;
+          vagueQty = true;
+        }
+        if (vagueQty) break;
+      }
+    }
+    quantity = quantity * sizeMultiplier;
+    // ADAPTIVE PORTION (2026-07-17): when the client stated NO amount and NO size word,
+    // their own median portion of this food (portion-memory, >=3 logs, clamped) beats
+    // the table default. Memory fills silence; it never overrides what they said —
+    // and a vague amount ("some", "half a") IS speech, so memory stays out of its way.
+    if (!explicitQty && !vagueQty && sizeMultiplier === 1 && personal) {
+      const pp = personalPortionFor(personal, f.name, f.typicalPortionCalories, f.typicalPortionProtein);
+      if (pp.personal) {
+        return {
+          ...f,
+          adjustedCalories: pp.kcal,
+          adjustedProtein: pp.protein,
+          adjustedDescription: `${f.typicalPortionDescription} — your usual`,
+          quantity: 1,
+          portionSource: "personal" as const,
+        };
+      }
+    }
+    // PORTION PROVENANCE (2026-07-19): every inferred portion carries HOW it was decided —
+    // the audit-trail atom the reviews keep asking for, and the signal the confidence layer
+    // reads. "default" = a bare guess (no amount, no size word, no history) — the only case
+    // that's genuinely uncertain.
+    const portionSource = explicitQty ? "explicit" as const : vagueQty ? "vague" as const : sizeMultiplier !== 1 ? "size" as const : "default" as const;
+    return {
+      ...f,
+      adjustedCalories: Math.round(f.typicalPortionCalories * quantity),
+      adjustedProtein: Math.round(f.typicalPortionProtein * quantity),
+      adjustedDescription: scalePortionDescription(f.typicalPortionDescription, quantity),
+      quantity,
+      portionSource,
+      // Identity verified, quantity estimated — "2 spoons of pap" is db-true about pap, a guess about how much.
+      origin: quantityEstimated ? "ai" as const : undefined,
+    };
   });
 }


### PR DESCRIPTION
Implements one bounded release-governor cut tracked by #114. Does NOT close #114.

server/handlers/food-context.ts is reduced from 1486 to 1371 by moving portion quantity parsing into the existing portion-memory owner. Behaviour remains covered by the existing and added positive regressions. Authoritative CI proved TypeScript, unit-baseline (zero NEW), product suites, routing/tracking/production-parity green; only standing release governors remain. No budget was raised.