### PR TITLE
refactor: move media voice failure tracking to its existing owner

### DIFF
--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -48,7 +48,8 @@ import { sendWhatsApp } from "../scheduler/shared";
 import { coachHomeEquipmentFromPhoto } from "./equipment-vision";
 import { macroCardMarker, mealTitleFromReply } from "../macro-card-attach";
 import { downscaleForVision } from "../image-downscale";
-import { checkVoiceLength } from "../media-limits";
+import { checkVoiceLength, bumpVoiceFailure, clearVoiceFailure } from "../media-limits";
+export { bumpVoiceFailure, clearVoiceFailure } from "../media-limits";
 import { nutritionGuardrailNudge } from "../nutrition-guardrails";
 import { commitFoodLog } from "./food-context";
 import { itemsFromVisionText } from "../serving-units";
@@ -66,29 +67,6 @@ function sastToday(): string {
   const sast = new Date(Date.now() + 2 * 3_600_000);
   return sast.toISOString().slice(0, 10);
 }
-
-// VOICE NOTE FAILURE TRACKER — escalates to "please type" after 3 fails in 30 min.
-const voiceFailureMap = new Map<string, { count: number; lastAt: number }>();
-const VOICE_FAILURE_RESET_MS = 30 * 60 * 1000;
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, val] of voiceFailureMap.entries()) {
-    if (now - val.lastAt > VOICE_FAILURE_RESET_MS) voiceFailureMap.delete(key);
-  }
-}, 15 * 60 * 1000);
-
-export function bumpVoiceFailure(userId: string): number {
-  const now = Date.now();
-  const prev = voiceFailureMap.get(userId);
-  const count = prev && (now - prev.lastAt) < VOICE_FAILURE_RESET_MS ? prev.count + 1 : 1;
-  voiceFailureMap.set(userId, { count, lastAt: now });
-  return count;
-}
-
-export function clearVoiceFailure(userId: string): void {
-  voiceFailureMap.delete(userId);
-}
-
 // WORKOUT IDENTIFICATION (TikTok/IG screenshots & video frames)
 
 interface IdentifiedExercise {

--- a/server/media-limits.ts
+++ b/server/media-limits.ts
@@ -20,12 +20,13 @@ export const VOICE_MAX_SECONDS = 180;
 // as client behaviour or persisting an inferred fact.
 const voiceFailureMap = new Map<string, { count: number; lastAt: number }>();
 const VOICE_FAILURE_RESET_MS = 30 * 60 * 1000;
-setInterval(() => {
+const voiceFailureCleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, val] of voiceFailureMap.entries()) {
     if (now - val.lastAt > VOICE_FAILURE_RESET_MS) voiceFailureMap.delete(key);
   }
 }, 15 * 60 * 1000);
+voiceFailureCleanupTimer.unref();
 
 export function bumpVoiceFailure(userId: string): number {
   const now = Date.now();

--- a/server/media-limits.ts
+++ b/server/media-limits.ts
@@ -15,6 +15,30 @@
 /** Past this, a voice note stops being a message and starts being a podcast. */
 export const VOICE_MAX_SECONDS = 180;
 
+// Repeated transcription failures should stop consuming retries and offer a typed fallback.
+// This is in-process only: it protects the media boundary without treating a delivery failure
+// as client behaviour or persisting an inferred fact.
+const voiceFailureMap = new Map<string, { count: number; lastAt: number }>();
+const VOICE_FAILURE_RESET_MS = 30 * 60 * 1000;
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, val] of voiceFailureMap.entries()) {
+    if (now - val.lastAt > VOICE_FAILURE_RESET_MS) voiceFailureMap.delete(key);
+  }
+}, 15 * 60 * 1000);
+
+export function bumpVoiceFailure(userId: string): number {
+  const now = Date.now();
+  const prev = voiceFailureMap.get(userId);
+  const count = prev && (now - prev.lastAt) < VOICE_FAILURE_RESET_MS ? prev.count + 1 : 1;
+  voiceFailureMap.set(userId, { count, lastAt: now });
+  return count;
+}
+
+export function clearVoiceFailure(userId: string): void {
+  voiceFailureMap.delete(userId);
+}
+
 // Rough bitrates by container (bits/sec). WhatsApp sends Opus in Ogg at ~16kbps; the others are
 // only reached when a client forwards a file, so a conservative guess is fine — we only need the
 // right order of magnitude to tell a 40-second note from a 20-minute one.


### PR DESCRIPTION
Refs #114

## Release governor cut: `server/handlers/media.ts`

Moves the existing in-process voice-transcription failure counter and expiry cleanup from the general media dispatcher to the existing `server/media-limits.ts` owner. The media handler re-exports the same two functions, preserving the routes and regression-test import contract and all retry/fallback behaviour.

- Guard-counted `media.ts`: 1572 -> 1550 (target met)
- No module added; no prompt, routing, decision, Coach Health, or scheduler change

Verification completed locally:

- `npm run check` PASS
- direct voice failure contract (first=1, second=2, clear resets to 1) PASS
- `npm run check:filesize` reports `media.ts: 1550`; it remains globally red only for the repository's pre-existing 1200 global budget and unrelated oversized files
- direct `gap-tests` cannot start locally because the checked-out dependency tree lacks `@napi-rs/canvas`; authoritative PR CI is requested for affected media/photo/voice/tracking/routing/production-parity suites and merge-base baseline checks.