### PR TITLE
P0-1: a combo meal may not be built out of another food's words

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -1864,6 +1864,58 @@ test("food scan: toast/stew combos don't double-count their bread/stew alternate
   assert.deepEqual(scanNames("big plate of pap and stew"), ["Pap and stew"], "vague 'stew' keeps the combo");
 });
 
+// A COMBO MAY NOT BORROW ITS WORDS FROM ANOTHER FOOD (#114 P0-1, 2026-09-03, founder's typed
+// message). "Pap and chicken livers" returned BOTH "Chicken livers" AND the combo "Chicken and
+// pap" — 858 kcal and 95g protein for one plate, and the client was told they had eaten chicken
+// they never had. The combo's alias "pap and chicken" (chars 0-14) overlaps "chicken livers"
+// (chars 8-21): the dish was assembled out of a word that belongs to the livers.
+//
+// Graded on the identity AND the charge, because either alone can pass while the other is wrong:
+// dropping the phantom without keeping the pap loses food the client ate, and keeping both entries
+// at half portions would double-count differently.
+test("food scan: 'Pap and chicken livers' is one plate, and there is no invented chicken", () => {
+  const names = scanNames("Pap and chicken livers");
+  assert.ok(names.includes("Chicken livers"), `the livers must survive: ${names.join(", ")}`);
+  assert.ok(names.some(n => /^pap/i.test(n)), `the pap the client ate must survive: ${names.join(", ")}`);
+  assert.ok(!names.includes("Chicken and pap"),
+    `the combo borrowed "chicken" from the livers and charged a second dish: ${names.join(", ")}`);
+  assert.ok(!names.some(n => n === "Chicken thigh" || n === "Chicken breast"),
+    `no independent chicken entity may be invented: ${names.join(", ")}`);
+  // CHARGED ONCE. The bug was visible as a number long before anyone read the entry list.
+  const kcal = adjustFoodsForSegment(scanForSAFoods("Pap and chicken livers") as any, "Pap and chicken livers")
+    .reduce((s: number, f: any) => s + f.adjustedCalories, 0);
+  assert.ok(kcal < 700, `one plate of pap and livers cannot be ${kcal} kcal — that is the double charge`);
+});
+
+test("food scan: a combo whose span is its own is untouched (both word orders)", () => {
+  // CONTROL. The rule must fire on BORROWED words only. Here the overlap between the combo and
+  // the standalone Pap is the combo bundling its own component, which is legitimate — without
+  // this, "drop a combo that overlaps anything" would delete every combo in the table.
+  assert.deepEqual(scanNames("pap and chicken"), ["Chicken and pap"], "combo survives, one dish");
+  assert.deepEqual(scanNames("chicken and pap"), ["Chicken and pap"], "and in the other word order");
+  // The two halves still work alone, so the fix did not simply suppress one of them.
+  assert.deepEqual(scanNames("chicken livers"), ["Chicken livers"], "livers alone unaffected");
+  assert.ok(scanNames("pap").some(n => /^pap/i.test(n)), "pap alone unaffected");
+});
+
+test("food scan: every combo in the table still resolves to itself", () => {
+  // CONTROL, deliberately exhaustive. The new pass sees every combo, so a rule that is subtly too
+  // greedy would show up here rather than in production. These are the phrases the combos exist for.
+  for (const [phrase, expected] of [
+    ["pap and wors", "Pap and wors"], ["fish and chips", "Fish and chips"],
+    ["eggs on toast", "Eggs on toast"], ["peanut butter on bread", "Peanut butter on bread"],
+    ["oats with milk", "Oats with milk"], ["cereal with milk", "Cereal with milk"],
+    ["mince and pap", "Mince and pap"], ["pap and stew", "Pap and stew"],
+    ["pap and spinach", "Pap and spinach"], ["pap and pilchards", "Pap and pilchards"],
+    ["chicken and rice", "Chicken and rice"], ["rice and chicken", "Chicken and rice"],
+  ] as const) {
+    assert.deepEqual(scanNames(phrase), [expected], `"${phrase}" must still be one dish`);
+  }
+  // And the regression the combo dedup was originally written for stays fixed.
+  const listed = scanNames("i had lentils, rice and chicken breast");
+  assert.ok(!listed.includes("Chicken and rice"), `no phantom combo when parts are listed: ${listed.join(", ")}`);
+});
+
 test("food scan: a specific sandwich suppresses the generic 'Sandwich' (no double bread)", () => {
   assert.deepEqual(scanNames("peanut butter sandwich"), ["Peanut butter on bread"], "PB sandwich = one item");
   // but a bare/filling sandwich with no specific match keeps 'Sandwich' for the bread

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -251,8 +251,61 @@ function applyClientNaming(foods: SAFood[], aliases: Map<string, string>): SAFoo
 // phantom "Chicken and rice", double-counting the chicken). Combo dedup: 2+ components
 // matched separately → the client listed them individually, drop the phantom combo; ≤1
 // matched → the client named the dish, keep the combo and drop the stray component.
-function finalizeMatches(matched: SAFood[], lower: string): SAFood[] {
+function finalizeMatches(matched: SAFood[], lower: string, aliases?: Map<string, string>): SAFood[] {
   let cleaned = [...matched];
+
+  /**
+   * PASS 2b: A COMBO THAT BORROWED ITS WORDS FROM SOMETHING ELSE (#114 P0-1, 2026-09-03).
+   *
+   * "Pap and chicken livers" logged 858 kcal and told the client they had eaten "Chicken livers
+   * AND Chicken and pap" — a plate of livers, plus a whole second dish of chicken they never had.
+   * Both entries matched honestly: `chicken livers` at chars 8–21, and the combo's alias
+   * `pap and chicken` at chars 0–14. They OVERLAP on the word "chicken", and the combo is built
+   * out of a word that belongs to the livers.
+   *
+   * Nothing could see that, because match POSITIONS were thrown away. The substring dedup in
+   * scanForSAFoods compares alias TEXT ("chicken livers" is not inside "pap and chicken", so
+   * neither dominates) and PASS 3 below compares component NAMES (no chicken cut matched, so the
+   * combo looked unchallenged). Two correct rules, both blind to the same fact.
+   *
+   * THE RULE, and both halves of it are load-bearing. The overlap has to STRADDLE: the two spans
+   * intersect and neither contains the other, so each side owns text the other does not. A
+   * CONTAINED span is the combo covering its own words — "peanut butter sandwich" contains the
+   * generic "sandwich", and treating that as borrowing deleted the real dish (caught by gap-tests
+   * on the first draft of this pass). And the straddling food must be one the combo does NOT
+   * bundle, because a combo overlapping its own component is the combo doing its job, which
+   * PASS 3 below already resolves properly.
+   *
+   * "pap and chicken" [0,14] and "chicken livers" [8,21] straddle, and Chicken livers is not a
+   * component of "Chicken and pap" — so the combo is the phantom and the livers survive.
+   * Deliberately runs BEFORE PASS 3, so that dropping the phantom leaves the real Pap standing
+   * rather than letting it be swept away as the phantom's stray component.
+   */
+  if (aliases && aliases.size > 0) {
+    const spanOf = (name: string): [number, number] | null => {
+      const alias = aliases.get(name);
+      if (!alias) return null;
+      const m = new RegExp(`\\b(?:na|ne|no|nga|nge|ka|le|ku|se|di|ma)?${escapeRegex(alias)}(?:es|s)?\\b`, "i").exec(lower);
+      return m ? [m.index, m.index + m[0].length] : null;
+    };
+    const phantomCombos = new Set<string>();
+    for (const combo of cleaned) {
+      const bundled = COMBO_OVERRIDES[combo.name];
+      if (!bundled) continue;
+      const comboSpan = spanOf(combo.name);
+      if (!comboSpan) continue;
+      const borrowed = cleaned.some(other => {
+        if (other.name === combo.name || COMBO_OVERRIDES[other.name] || bundled.includes(other.name)) return false;
+        const s = spanOf(other.name);
+        if (!s) return false;
+        const intersects = comboSpan[0] < s[1] && s[0] < comboSpan[1];
+        const contains = (a: [number, number], b: [number, number]) => a[0] <= b[0] && b[1] <= a[1];
+        return intersects && !contains(comboSpan, s) && !contains(s, comboSpan);
+      });
+      if (borrowed) phantomCombos.add(combo.name);
+    }
+    if (phantomCombos.size > 0) cleaned = cleaned.filter(f => !phantomCombos.has(f.name));
+  }
 
   // PASS 3: Combo meal dedup
   const comboNames = cleaned.filter(f => COMBO_OVERRIDES[f.name]).map(f => f.name);
@@ -409,7 +462,7 @@ export function scanForSAFoods(msg: string, opts?: { exactOnly?: boolean }): SAF
   // exactOnly: callers gating AUTO-logging (no eating verb present) must not act on
   // fuzzy guesses — fuzzy matched "building phase" to mopani worms and logged a fake
   // meal over a goal-change request (caught by routing-audit).
-  if (matched.length > 0 || opts?.exactOnly) return applyClientNaming(finalizeMatches(matched, lower), matchedAlias);
+  if (matched.length > 0 || opts?.exactOnly) return applyClientNaming(finalizeMatches(matched, lower, matchedAlias), matchedAlias);
 
   const words = lower.replace(/[^a-z\s]/g, "").split(/\s+/).filter(w => w.length >= 4 && !FUZZY_BLACKLIST.has(w));
   const combos: string[] = [...words];
@@ -450,7 +503,7 @@ export function scanForSAFoods(msg: string, opts?: { exactOnly?: boolean }): SAF
     }
   }
 
-  return applyClientNaming(finalizeMatches(matched, lower), matchedAlias);
+  return applyClientNaming(finalizeMatches(matched, lower, matchedAlias), matchedAlias);
 }
 
 export function parseFoodLogTotalsFromMessageOut(messageOut: string): { calories: number; protein: number } | null {


### PR DESCRIPTION
#114 P0-1, adjudicated. Base `main@d7db80f`. `utils.ts` untouched.

## The failure

```
IN   Pap and chicken livers
OUT  Got it — Chicken livers and Chicken and pap. 👌
     Pap and chicken — good protein. Add spinach or butternut...
LOG  [MEAL_LOG] INSERT meal kcal=858 prot=95
```

One plate, charged twice, plus a whole dish of chicken the client never ate.

## First divergence

Both entries matched honestly:

| entry | alias | span in `pap and chicken livers` |
|---|---|---|
| Chicken livers | `chicken livers` | 8–21 |
| Chicken and pap | `pap and chicken` | 0–14 |

They **overlap on the word "chicken"** — the dish was assembled out of a word that belongs to the livers.

Nothing could see that, because match **positions were thrown away** before any resolution ran. The substring dedup in `scanForSAFoods` compares alias *text* (`chicken livers` is not inside `pap and chicken`, so neither dominates); the combo dedup in `finalizeMatches` compares component *names* (no chicken cut matched, so the combo looked unchallenged). Two correct rules, both blind to the same fact.

## The fix, in the owner that already exists

`finalizeMatches` now receives the alias each entry matched on — the map `scanForSAFoods` was *already* keeping for `applyClientNaming` — and resolves overlapping spans before the existing combo dedup. No special-case sentence patch, no new module, no new regex literal.

> A combo is dropped when its span **straddles** the span of a food it does **not bundle**.

Both halves are load-bearing:

- **Straddle, not merely intersect.** A *contained* span is the combo covering its own words. `peanut butter sandwich` contains the generic `sandwich`; my first draft treated that as borrowing and deleted the real dish — gap-tests caught it.
- **A food it does not bundle.** A combo overlapping its own component is the combo doing its job, which the existing PASS 3 resolves properly.

It runs **before** the combo dedup deliberately: dropping the phantom first leaves the real Pap standing instead of letting it be swept away as the phantom's stray component.

```
before   [Chicken livers | Chicken and pap]              858 kcal
after    [Pap (stiff maize porridge) | Chicken livers]   588 kcal
```

## Controls — each removes a mechanism, each reddens a different case

| control | removed | gap-tests failure |
|---|---|---|
| **A** (red-on-revert) | the whole pass | *'Pap and chicken livers' is one plate, and there is no invented chicken* |
| **B** | the containment guard | *PB sandwich = one item* |
| **C** | the bundled-component guard | *no extra Toast on top of the combo* |

No guard is dead weight.

**Positive:** the livers survive · the pap the client ate survives · no independent chicken entity · the plate is charged **once** (asserted as kcal, not just as an entry list — the bug was a number before it was a name) · all twelve combo phrases in the table still resolve to themselves in **both word orders** · the regression the combo dedup was originally written for (`i had lentils, rice and chicken breast`) stays fixed.

**Measured across 18 scanner probes against main: exactly one line changed.** The other 17 are byte-identical.

## Coach Health recurrence — no honest general invariant, and why

The observable would be *"the reply named a food the client did not say"*. Deciding which foods the client said **is `scanForSAFoods`**. So a Coach Health invariant has two options and both are bad:

- call the scanner — then the detector agrees with the parser by construction. It would report clean on exactly the input that used to fail, and could never catch a *future* scanner error, because it asks the erring component whether it erred.
- re-implement the check — the duplicate parser the adjudication explicitly forbade.

So this is locked where a pure deterministic function should be locked: a unit control with a red-on-revert proof, not a production detector that cannot fail honestly.

One thing Coach Health *could* see parser-free is a food turn whose logged kcal is implausible for the number of food words typed. I am naming it rather than building it — it needs an invented threshold and would be noisy, and inventing one to satisfy a checklist is how this queue becomes unreadable.

## Verification vs `main@d7db80f`

`tsc` clean · **gap-tests 338/338** (335 + 3 new) · food-scanner **48/48** · unit **1053/1053** · production-parity **142/142** · tracking-contract green · routing-audit green

| guard | main | this branch |
|---|---|---|
| file-size | utils.ts 1386 ✗ (only) | utils.ts 1386 ✗ (only) |
| `messageDeciders` | 32 / 31 ✗ | 32 ✗ |
| `looksLikePredicates` | 21 / 20 ✗ | 21 ✗ |
| `authorshipPoints` | 423 / 420 ✗ | 423 ✗ |
| ownership · names · reach | OK · 97/97 · 8 | identical |

`food-scanner.ts` 942 → 995 against the 1200 default. No budget raised, nothing suppressed. Codex's `utils.ts` lane is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_