### PR TITLE
P1: the card may not order the meal it is confirming

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -112,6 +112,97 @@ test("unlogged: roast potatoes + mixed veggies is not an unpriced leftover after
 });
 
 
+// A CARD MAY NOT ORDER THE MEAL IT IS CONFIRMING (#114 P1, 2026-09-03, founder). The card that
+// acknowledges a log prints "<meal> logged." directly above the next move. On "chicken breast and
+// rice" — 61g of protein — the two lines read:
+//
+//     Kam: Chicken breast and Rice logged.
+//     Make your next meal a proper protein — chicken, fish or eggs
+//
+// Both true of the ledger (61 of 195), and still absurd: a man holding an empty plate is told to
+// go and make the plate. macro-card-attach already carries the rule in the founder's own words —
+// "A human coach never tells a man who just ate a meal to go and eat a meal" — applied to the bulk
+// eat-more branch and never to the two protein branches whose instruction IS the completed action.
+{
+  const { nextMoveLine, PROPER_PROTEIN_G } = CARD;
+  // 61g in of 195g: protLeft 134, the >= 60 branch. 16:00, so `earlyDay` cannot mask the result.
+  const short = (protIn: number) => [
+    { label: "Calories", current: 900, target: 2800 },
+    { label: "Protein", current: protIn, target: 195 },
+    { label: "Fat", current: 30, target: 84 },
+  ];
+  // 150g in of 195g: protLeft 45, the >= 35 branch.
+  const nearly = (protIn: number) => [
+    { label: "Calories", current: 2000, target: 2800 },
+    { label: "Protein", current: protIn, target: 195 },
+    { label: "Fat", current: 60, target: 84 },
+  ];
+
+  test("progress card: the meal just logged is not re-ordered by the card confirming it", () => {
+    for (const [rows, band] of [[short(61), ">=60"], [nearly(150), ">=35"]] as const) {
+      const line = nextMoveLine(rows, false, 16, false, false, true);
+      assert.ok(!/make (your |lunch )?(next meal )?a proper protein/i.test(line),
+        `${band}: the card ordered the meal it was confirming — "${line}"`);
+      assert.ok(!/^get a real protein into your next two meals$/i.test(line),
+        `${band}: the card restated the action just completed — "${line}"`);
+      assert.ok(/protein/i.test(line) && line.trim().length > 0,
+        `${band}: the protein lever must survive, the instruction just moves forward — "${line}"`);
+    }
+  });
+
+  test("progress card: OVER-FIRE — a plate with no real protein still gets the protein instruction", () => {
+    // The control that stops the fix becoming "never ask for protein after any log". Same day
+    // state, same clock; the only difference is that this plate was not a protein meal.
+    for (const [rows, band] of [[short(61), ">=60"], [nearly(150), ">=35"]] as const) {
+      const line = nextMoveLine(rows, false, 16, false, false, false);
+      assert.ok(/proper protein|real protein/i.test(line),
+        `${band}: a carb-only plate must still be told to get protein into the next meal — "${line}"`);
+    }
+  });
+
+  test("progress card: OVER-FIRE through the card — the THRESHOLD decides, not merely 'a meal landed'", () => {
+    // Graded through mealCard, because that is where the plate's protein is judged. The branch
+    // control above passes the flag by hand and so cannot see a threshold that says yes to
+    // everything — which is exactly the shape "any log counts as a protein meal" would take.
+    const { mealCard } = CARD;
+    const card = (mealProtein: number) => mealCard({
+      firstName: "Kam", mealName: "Pap + Spinach", rows: short(61) as any,
+      isBulk: false, usesNumbers: true, hour: 16, mealProtein,
+    }).sub;
+    // Tested as an INSTRUCTION, not as a phrase: "That's one proper protein down" reports what
+    // they did and contains the same words as the order they must not be given.
+    const ORDERS_A_MEAL = /\b(make|get)\b[^.]*\b(proper|real) protein\b/i;
+    assert.ok(ORDERS_A_MEAL.test(card(8)),
+      `an 8g plate is not a proper protein meal — the card must still ask for one: "${card(8)}"`);
+    assert.ok(!ORDERS_A_MEAL.test(card(61)),
+      `a 61g plate IS a proper protein meal — the card must not re-order it: "${card(61)}"`);
+    // The on-demand "Today" card answers a question; no plate just landed, so nothing is carried
+    // forward and its line must be unchanged from before this cut.
+    const onDemand = mealCard({
+      firstName: "Kam", mealName: "Today", rows: short(61) as any,
+      isBulk: false, usesNumbers: true, hour: 16,
+    }).sub;
+    assert.equal(onDemand, "Get a real protein into your next two meals",
+      `the on-demand card has no just-logged plate and must be untouched: "${onDemand}"`);
+  });
+
+  test("progress card: the 'just ate protein' test uses the band the card already owns", () => {
+    // One number for both halves. If PROPER_PROTEIN_G drifts from the >= 35 band below it, the
+    // card can call a plate a proper protein meal while still asking for one to close the gap.
+    assert.equal(PROPER_PROTEIN_G, 35, "the proper-protein threshold is the card's own 35g band");
+    // And the flag is inert once the gap is small enough that the instruction is no longer a
+    // repeat — those rungs ask for eggs or a shake, not for another meal.
+    const smallGap = [
+      { label: "Calories", current: 2400, target: 2800 },
+      { label: "Protein", current: 180, target: 195 },
+      { label: "Fat", current: 70, target: 84 },
+    ];
+    assert.equal(nextMoveLine(smallGap, false, 16, false, false, true),
+      nextMoveLine(smallGap, false, 16, false, false, false),
+      "a small remaining gap asks for a different, smaller action — it is not a repeat, so it must not change");
+  });
+}
+
 test("progress card: calories at/over target do not sell another meal", () => {
   const { nextMoveLine } = CARD;
   const rows = [

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -216,6 +216,41 @@ test("unlogged: roast potatoes + mixed veggies is not an unpriced leftover after
     }
   });
 
+  test("progress card: several small eating events do not add up to a proper protein meal", () => {
+    // #114 P1 review. One message can be several separate meals — "eggs this morning, pap at
+    // lunch" is two events, an album of four photos is four, and each commits its own row. The
+    // card's claim is about ONE plate, so the aggregate across those events may never answer it:
+    // four ~10g events sum to 40g and no plate among them was a protein meal.
+    const { biggestEventProtein, mealCard } = CARD;
+    const fourSmall = [{ protein: 10 }, { protein: 9 }, { protein: 11 }, { protein: 10 }];
+    const sum = fourSmall.reduce((t, e) => t + e.protein, 0);
+    assert.ok(sum >= PROPER_PROTEIN_G,
+      `the fixture must actually be dangerous: ${sum}g summed has to clear the ${PROPER_PROTEIN_G}g bar, or this proves nothing`);
+    assert.ok(biggestEventProtein(fourSmall) < PROPER_PROTEIN_G,
+      `four sub-threshold events combined into a proper protein meal: ${biggestEventProtein(fourSmall)}g`);
+
+    // ...and the card says so. Graded on the line, not on the number.
+    const sub = (mealProtein: number) => mealCard({
+      firstName: "Kam", mealName: "Eggs + Pap", rows: short(61) as any,
+      isBulk: false, usesNumbers: true, hour: 16, mealProtein,
+    }).sub;
+    assert.ok(/\b(make|get)\b[^.]*\b(proper|real) protein\b/i.test(sub(biggestEventProtein(fourSmall))),
+      `four small plates must still be told to get a real protein: "${sub(biggestEventProtein(fourSmall))}"`);
+    assert.ok(!/one proper protein down/i.test(sub(biggestEventProtein(fourSmall))),
+      `the card claimed a proper protein meal that no single event delivered: "${sub(biggestEventProtein(fourSmall))}"`);
+
+    // A REAL single event still qualifies — the control that stops this becoming "never".
+    const oneRealMeal = [{ protein: 8 }, { protein: 61 }];
+    assert.ok(biggestEventProtein(oneRealMeal) >= PROPER_PROTEIN_G,
+      `a genuine 61g event must still qualify: ${biggestEventProtein(oneRealMeal)}g`);
+    assert.ok(!/\b(make|get)\b[^.]*\b(proper|real) protein\b/i.test(sub(biggestEventProtein(oneRealMeal))),
+      `a real protein meal beside a snack must not be re-ordered: "${sub(biggestEventProtein(oneRealMeal))}"`);
+
+    // The single-event case — the common one — is unchanged.
+    assert.equal(biggestEventProtein([{ protein: 61 }]), 61, "one event answers with its own protein");
+    assert.equal(biggestEventProtein([]), 0, "no events is not a protein meal");
+  });
+
   test("progress card: the 'just ate protein' test uses the band the card already owns", () => {
     // One number for both halves. If PROPER_PROTEIN_G drifts from the >= 35 band below it, the
     // card can call a plate a proper protein meal while still asking for one to close the gap.

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -186,6 +186,36 @@ test("unlogged: roast potatoes + mixed veggies is not an unpriced leftover after
       `the on-demand card has no just-logged plate and must be untouched: "${onDemand}"`);
   });
 
+  test("progress card: the carry-forward line may not promise a target it cannot prove", () => {
+    // CTO adjudication on #148. `justAteProteinMeal` proves the plate that landed was >= 35g. It
+    // proves NOTHING about whether one more like it closes the day, and the >=35 branch runs from
+    // 35g owed to 59g owed. The first wording — "one more like that today and you're there" —
+    // was false across most of its own band: at 59g owed, another minimum qualifying meal leaves
+    // 24g.
+    //
+    // Written as the proof obligation rather than as a banned phrase, so a future re-wording is
+    // held to the same standard: a line may claim arrival only where the arithmetic gets there.
+    const CLAIMS_ARRIVAL = /you'?re there|you'?re done|and you'?re set|that'?s it\b|closes? it|sorted|target (?:hit|met|reached|done)|you'?re home/i;
+    for (let protLeft = 35; protLeft <= 59; protLeft++) {
+      const rows = [
+        { label: "Calories", current: 2000, target: 2800 },
+        { label: "Protein", current: 195 - protLeft, target: 195 },
+        { label: "Fat", current: 60, target: 84 },
+      ];
+      const line = nextMoveLine(rows, false, 16, false, false, true);
+      if (CLAIMS_ARRIVAL.test(line)) {
+        // One more meal at the minimum that qualifies as "a proper protein meal" is the best case
+        // the card can assume. If that still leaves a gap, arrival was not the card's to promise.
+        assert.ok(protLeft - PROPER_PROTEIN_G <= 0,
+          `with ${protLeft}g owed the card claimed arrival — one more ${PROPER_PROTEIN_G}g meal `
+          + `leaves ${protLeft - PROPER_PROTEIN_G}g: "${line}"`);
+      }
+      // Whatever it says, it still may not re-order the meal that just landed.
+      assert.ok(!/\b(make|get)\b[^.]*\b(proper|real) protein\b/i.test(line),
+        `with ${protLeft}g owed the card re-ordered the meal it was confirming: "${line}"`);
+    }
+  });
+
   test("progress card: the 'just ate protein' test uses the band the card already owns", () => {
     // One number for both halves. If PROPER_PROTEIN_G drifts from the >= 35 band below it, the
     // card can call a plate a proper protein meal while still asking for one to close the gap.

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -1169,7 +1169,7 @@ export async function handleFoodContext(ctx: {
 
       // BRANDED MACRO CARD (2026-07-21): a macro-goal client gets the orange progress-bar image on the log (marker stripped + sent as media downstream). Wellness clients get "" — no card forced on them. Fail-open.
       const cardName = allAdjustedFoods.map((f: any) => f.name).filter(Boolean).slice(0, 2).join(" + ") || mealLabel;
-      const macroCard = await macroCardMarker({ user, mealName: cardName, mealKcal: totalCals, forDate: scannerIsRetro ? scannerLoggedAt : undefined, achievementStreak: streakCelebration ? foodStreak : undefined });
+      const macroCard = await macroCardMarker({ user, mealName: cardName, mealProtein: Math.round(totalProtein), forDate: scannerIsRetro ? scannerLoggedAt : undefined, achievementStreak: streakCelebration ? foodStreak : undefined });
       const streakLine = achievementCardShown(user, streakCelebration ? foodStreak : undefined, macroCard) ? shortStreakNote(foodStreak, user.name || "") : streakCelebration;
       const guardrail = await nutritionGuardrailNudge(user); // "too much of something" health-standard nudge
       const plannedNote = plannedSegs.length > 0
@@ -1245,7 +1245,7 @@ export async function handleFoodContext(ctx: {
           : "";
         const fbCardName = gptFallbackResult.foods.map((f: any) => f.name).filter(Boolean).slice(0, 2).join(" + ") || "Meal";
         const fbStreakNote = await getStreakNote(user.id, fbStreak, user.name || "");
-        const fbCard = await macroCardMarker({ user, mealName: fbCardName, mealKcal: gptFallbackResult.totalKcal, forDate: gptIsRetro ? gptLoggedAt : undefined, achievementStreak: fbStreakNote ? fbStreak : undefined });
+        const fbCard = await macroCardMarker({ user, mealName: fbCardName, mealProtein: Math.round(gptFallbackResult.totalProtein || 0), forDate: gptIsRetro ? gptLoggedAt : undefined, achievementStreak: fbStreakNote ? fbStreak : undefined });
         return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}${fbStreakNote}${fbGuiltNote}${protClarifyNote}${fbDroppedNote}${cardOrTotals(fbCard, gptFallbackResult.totalKcal, gptFallbackResult.totalProtein, user)}`;
       }
     }
@@ -1334,7 +1334,7 @@ export async function handleFoodContext(ctx: {
         : "";
       const fb2CardName = gptFallbackResult.foods.map((f: any) => f.name).filter(Boolean).slice(0, 2).join(" + ") || "Meal";
       const fb2StreakNote = await getStreakNote(user.id, fb2Streak, user.name || "");
-      const fb2Card = await macroCardMarker({ user, mealName: fb2CardName, mealKcal: gptFallbackResult.totalKcal, forDate: fb2IsRetro ? fb2LoggedAt : undefined, achievementStreak: fb2StreakNote ? fb2Streak : undefined });
+      const fb2Card = await macroCardMarker({ user, mealName: fb2CardName, mealProtein: Math.round(gptFallbackResult.totalProtein || 0), forDate: fb2IsRetro ? fb2LoggedAt : undefined, achievementStreak: fb2StreakNote ? fb2Streak : undefined });
       return `${fallbackReply}${fbPattern ? "\n\n" + fbPattern : ""}${fbDay || ""}${fb2StreakNote}${fb2GuiltNote}${fb2ProtClarifyNote}${fb2DroppedNote}${cardOrTotals(fb2Card, gptFallbackResult.totalKcal, gptFallbackResult.totalProtein, user)}`;
     }
     // GPT returned null / is_food=false. If the user clearly signalled food (strong trigger),

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -15,7 +15,7 @@ import {
   computeFoodLogStreak, getFoodStreakCelebration, shortStreakNote,
   invalidateFoodTotalsCache,
 } from "./food-scanner";
-import { macroCardMarker, cardOrTotals, achievementCardShown, cardBaseUrl } from "../macro-card-attach";
+import { macroCardMarker, cardOrTotals, achievementCardShown, cardBaseUrl, biggestEventProtein } from "../macro-card-attach";
 import { cardWillAttach } from "../card-policy";
 import { claimOncePerDay } from "../once-daily";
 import { estimateCarbsFat } from "../macro-estimate";
@@ -1076,6 +1076,20 @@ export async function handleFoodContext(ctx: {
       // dedups on it, so four rows sharing the full text would drop three as duplicates.
       const eventBuckets = segmentBuckets.filter(b => b.foods.length > 0);
       const splitIntoEvents = eventBuckets.length >= 2;
+      /**
+       * THE BIGGEST SINGLE EATING EVENT, for the card's "did they just eat a proper protein meal"
+       * test (#114 P1 review). `totalProtein` is the whole MESSAGE — and this branch exists
+       * precisely because one message can be several separate meals. Four ~10g events sum to 40g
+       * and no plate among them was a protein meal, so the aggregate would have the card say
+       * "one proper protein down" about a meal that never happened.
+       *
+       * The claim is about ONE plate, so it is judged against one plate: the largest event here.
+       * The single-event path below is untouched, where the message and the event are the same
+       * thing and totalProtein is already the event's protein.
+       */
+      const cardEventProtein = splitIntoEvents
+        ? biggestEventProtein(eventBuckets.map(b => ({ protein: b.foods.reduce((t, f: any) => t + (f.adjustedProtein || 0), 0) })))
+        : Math.round(totalProtein);
       let committed!: Awaited<ReturnType<typeof commitFoodLog>>;
       if (splitIntoEvents) {
         const slotCtx = await getSlotContext(user.id);
@@ -1169,7 +1183,7 @@ export async function handleFoodContext(ctx: {
 
       // BRANDED MACRO CARD (2026-07-21): a macro-goal client gets the orange progress-bar image on the log (marker stripped + sent as media downstream). Wellness clients get "" — no card forced on them. Fail-open.
       const cardName = allAdjustedFoods.map((f: any) => f.name).filter(Boolean).slice(0, 2).join(" + ") || mealLabel;
-      const macroCard = await macroCardMarker({ user, mealName: cardName, mealProtein: Math.round(totalProtein), forDate: scannerIsRetro ? scannerLoggedAt : undefined, achievementStreak: streakCelebration ? foodStreak : undefined });
+      const macroCard = await macroCardMarker({ user, mealName: cardName, mealProtein: cardEventProtein, forDate: scannerIsRetro ? scannerLoggedAt : undefined, achievementStreak: streakCelebration ? foodStreak : undefined });
       const streakLine = achievementCardShown(user, streakCelebration ? foodStreak : undefined, macroCard) ? shortStreakNote(foodStreak, user.name || "") : streakCelebration;
       const guardrail = await nutritionGuardrailNudge(user); // "too much of something" health-standard nudge
       const plannedNote = plannedSegs.length > 0

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -1184,7 +1184,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       const photoReply = photoNumbersLow ? stripNumbersFromProse(photoReplyRaw) : photoReplyRaw;
       // BRANDED MACRO CARD on the PHOTO log too (2026-07-22 live: photo-logged drink missed it). Same contract as text; title = FOODS logged, not the model's preamble.
       const cardTitle = mealTitleFromReply(visionReply);
-      const photoCard = (!photoNumbersLow && photoDailyTotal) ? await macroCardMarker({ user, mealName: cardTitle, mealProtein: Math.round(totalPhotoProt || 0), forDate: photoIsRetro ? photoLoggedAt : undefined }) : "";
+      const photoCard = (!photoNumbersLow && photoDailyTotal) ? await macroCardMarker({ user, mealName: cardTitle, mealProtein: Math.round(primaryPhotoProt || 0), forDate: photoIsRetro ? photoLoggedAt : undefined }) : "";
       const photoGuardrail = await nutritionGuardrailNudge(user); // "too much of something" nudge
       return `${photoReply}${photoGuardrail}${await firstActionCelebration(user, phone, "meal")}${photoCard}`;
     } catch (err) {

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -1184,7 +1184,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       const photoReply = photoNumbersLow ? stripNumbersFromProse(photoReplyRaw) : photoReplyRaw;
       // BRANDED MACRO CARD on the PHOTO log too (2026-07-22 live: photo-logged drink missed it). Same contract as text; title = FOODS logged, not the model's preamble.
       const cardTitle = mealTitleFromReply(visionReply);
-      const photoCard = (!photoNumbersLow && photoDailyTotal) ? await macroCardMarker({ user, mealName: cardTitle, mealKcal: totalPhotoKcal, forDate: photoIsRetro ? photoLoggedAt : undefined }) : "";
+      const photoCard = (!photoNumbersLow && photoDailyTotal) ? await macroCardMarker({ user, mealName: cardTitle, mealProtein: Math.round(totalPhotoProt || 0), forDate: photoIsRetro ? photoLoggedAt : undefined }) : "";
       const photoGuardrail = await nutritionGuardrailNudge(user); // "too much of something" nudge
       return `${photoReply}${photoGuardrail}${await firstActionCelebration(user, phone, "meal")}${photoCard}`;
     } catch (err) {

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -265,7 +265,13 @@ export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), is
       : "Get a real protein into your next two meals";
   }
   if (protLeft >= 35) {
-    return justAteProteinMeal ? "Good protein in — one more like that today and you're there"
+    // NO CLOSURE THIS BRANCH CANNOT PROVE (CTO adjudication on #148). The first wording was
+    // "one more like that today and you're there". `justAteProteinMeal` proves the plate that
+    // landed was >= PROPER_PROTEIN_G — it says nothing about whether one more of the same closes
+    // the gap, and this branch runs anywhere from 35g to 59g owed. At 59g owed another minimum
+    // qualifying meal still leaves 24g, so "you're there" was a promise the data does not carry.
+    // Acknowledge the protein, carry the lever forward, claim nothing about arriving.
+    return justAteProteinMeal ? "Good protein in — keep that going at your next meal"
       : earlyDay ? "Make lunch a proper protein — chicken, fish or eggs"
       : "Make your next meal a proper protein — chicken, fish or eggs";
   }

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -171,6 +171,22 @@ function stripWrapQuotes(s: string): string {
  */
 export const PROPER_PROTEIN_G = 35;
 
+/**
+ * WHICH NUMBER ANSWERS "DID THEY JUST EAT A PROPER PROTEIN MEAL" (#114 P1 review).
+ *
+ * One message can be several separate eating events — "eggs this morning, pap at lunch" is two
+ * meals, and an album of four photos is four. Each commits its own row. The card's question is
+ * about ONE plate, so the aggregate across those events may never answer it: four ~10g events sum
+ * to 40g and no plate among them was a protein meal, which would have the card say "one proper
+ * protein down" about a meal that never happened.
+ *
+ * One owner for the rule, because both the text path and the photo path ask it and a second
+ * spelling would drift. A single-event message is the common case and returns its own protein.
+ */
+export function biggestEventProtein(events: Array<{ protein: number }>): number {
+  return events.reduce((max, e) => Math.max(max, Math.round(e?.protein || 0)), 0);
+}
+
 export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false, justAteProteinMeal = false): string {
   const r = (label: string) => rows.find(x => x.label === label);
   if (isPastDay) return "Yesterday's log — today's plate is a separate day";

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -157,7 +157,21 @@ function stripWrapQuotes(s: string): string {
 // so "Good start 👌" reached the founder as "Good start ☐" (2026-08-04 live, one hour after I
 // put them in). Emoji belong in the CHAT text, where WhatsApp renders them; on the card they
 // are a tofu box. His register survives without them — the words were always the voice.
-export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false): string {
+/**
+ * `justAteProteinMeal` — the meal this card is confirming WAS itself a proper protein meal.
+ *
+ * Not a new fact and not a new threshold: it is the same 35g this function already treats as
+ * "a proper protein meal closes it" two branches down, applied to the plate that just landed
+ * instead of to the gap that remains. See PROPER_PROTEIN_G.
+ */
+/**
+ * What this product already calls a proper protein meal: the plate that closes the 35g band
+ * below. One number, named once, so the "did they just eat one" test and the "is one still
+ * owed" test cannot drift apart.
+ */
+export const PROPER_PROTEIN_G = 35;
+
+export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false, justAteProteinMeal = false): string {
   const r = (label: string) => rows.find(x => x.label === label);
   if (isPastDay) return "Yesterday's log — today's plate is a separate day";
   const ratio = (x?: Row) => (x && x.target > 0 ? x.current / x.target : 0);
@@ -228,8 +242,33 @@ export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), is
   }
 
   // Protein is the one that actually moves the result, so it owns the instruction.
-  if (protLeft >= 60) return earlyDay ? "Chicken or eggs at lunch AND supper" : "Get a real protein into your next two meals";
-  if (protLeft >= 35) return earlyDay ? "Make lunch a proper protein — chicken, fish or eggs" : "Make your next meal a proper protein — chicken, fish or eggs";
+  //
+  // BUT NOT THE INSTRUCTION THEY JUST CARRIED OUT (#114 P1, 2026-09-03, founder). The card that
+  // confirms a meal prints `<meal> logged.` directly above this line, and on a client who had just
+  // sent "chicken breast and rice" — 61g of protein — the two lines read:
+  //
+  //     Kam: Chicken breast and Rice logged.
+  //     Make your next meal a proper protein — chicken, fish or eggs
+  //
+  // Both halves are true of the ledger (61 of 195), and the card still tells a man holding an
+  // empty plate to go and make the plate. This file already knows why that is wrong — the note
+  // above says it in the founder's own case: "A human coach never tells a man who just ate a meal
+  // to go and eat a meal." That reasoning was applied to the BULK eat-more branch and never to
+  // these two, which are the only other lines whose instruction can be the action just completed.
+  //
+  // The gap is unchanged and so is the lever; what changes is that the move goes FORWARD from what
+  // they did instead of restating it. The smaller rungs below are untouched: "add eggs or a shake"
+  // is a different, smaller action, not a repeat of the meal.
+  if (protLeft >= 60) {
+    return justAteProteinMeal ? "That's one proper protein down — same again at your next two meals"
+      : earlyDay ? "Chicken or eggs at lunch AND supper"
+      : "Get a real protein into your next two meals";
+  }
+  if (protLeft >= 35) {
+    return justAteProteinMeal ? "Good protein in — one more like that today and you're there"
+      : earlyDay ? "Make lunch a proper protein — chicken, fish or eggs"
+      : "Make your next meal a proper protein — chicken, fish or eggs";
+  }
   if (protLeft >= 18) return "Add eggs, tin fish or a shake today";
   if (protLeft > 0) return "One yoghurt or a boiled egg and you're done";
 
@@ -439,6 +478,9 @@ export function mealCard(opts: {
   isPastDay?: boolean;
   /** They said they are done eating today. The card's next move must agree with the decision's. */
   foodDayClosed?: boolean;
+  /** Protein in the meal this card is confirming. Absent on the on-demand "Today" card, which
+   *  is answering a question rather than acknowledging a plate. */
+  mealProtein?: number;
 }): AchievementCardData {
   const r = (label: string) => opts.rows.find(x => x.label === label);
   const prot = r("Protein");
@@ -458,7 +500,8 @@ export function mealCard(opts: {
     figure: opts.usesNumbers ? `${protSoFar}g` : verdict,
     unit: opts.usesNumbers ? (opts.isPastDay ? "protein yesterday" : "protein today") : (opts.isPastDay ? "yesterday" : "so far today"),
     line: `${opts.firstName ? opts.firstName + ": " : ""}${opts.mealName} logged.`,
-    sub: nextMoveLine(opts.rows, opts.isBulk, opts.hour, !!opts.isPastDay, !!opts.foodDayClosed),
+    sub: nextMoveLine(opts.rows, opts.isBulk, opts.hour, !!opts.isPastDay, !!opts.foodDayClosed,
+      !opts.isPastDay && (opts.mealProtein ?? 0) >= PROPER_PROTEIN_G),
   };
 }
 
@@ -476,7 +519,12 @@ async function dayClosedFor(user: any): Promise<boolean> {
   } catch { return false; }
 }
 
-export async function macroCardMarker(opts: { user: any; mealName: string; mealKcal: number; forDate?: Date; achievementStreak?: number }): Promise<string> {
+/**
+ * `mealProtein` replaces `mealKcal`, which every call site passed and nothing ever read. The card
+ * needs to know whether the plate it is confirming was itself a proper protein meal; it never
+ * needed that plate's calories. One live parameter in place of one dead one.
+ */
+export async function macroCardMarker(opts: { user: any; mealName: string; mealProtein: number; forDate?: Date; achievementStreak?: number }): Promise<string> {
   try {
     // A MILESTONE IS A MOMENT (2026-07-28, marketing review: "people don't share a receipt,
     // they share an achievement"). Seven days straight is about the person, and that is the
@@ -507,6 +555,7 @@ export async function macroCardMarker(opts: { user: any; mealName: string; mealK
       isBulk: today.isBulk,
       usesNumbers: getNumbersMode(opts.user) !== "low" && getGoalProfile(opts.user?.goalType).usesMacros,
       isPastDay,
+      mealProtein: opts.mealProtein,
     });
     noteCardSent(opts.user?.id);
     return cardMarker(base, renderAchievementCard(card));


### PR DESCRIPTION
#114 P1. Base `main@5827d7e`. No architecture-governor work touched.

## Reproduced

The card that acknowledges a food log prints `<meal> logged.` directly above the next move. On a client who had just sent `chicken breast and rice` — `[MEAL_LOG] prot=61` — the two lines read:

```
Kam: Chicken breast + Rice logged.
Get a real protein into your next two meals
```

Both halves are true of the ledger (61 of 195), and the card still tells a man holding an empty plate to go and make the plate.

## First divergence — and the rule was already written down

`macro-card-attach.ts` carries this exact reasoning, in the founder's own words, from his first gauntlet message:

> *"A human coach never tells a man who just ate a meal to go and eat a meal."*

That note sits above the **bulk eat-more** branch, where it was implemented as `earlyDay = hour < 11`. It was **never applied to the two protein branches** — the only other lines whose instruction can *be* the action just completed. `nextMoveLine` had the principle and half the coverage.

## The fix, in that owner

`nextMoveLine` takes `justAteProteinMeal`, and the two repeat-the-action rungs move forward instead of restating:

| protein still owed | before | after a proper protein meal |
|---|---|---|
| ≥ 60g | Get a real protein into your next two meals | **That's one proper protein down — same again at your next two meals** |
| ≥ 35g | Make your next meal a proper protein — chicken, fish or eggs | **Good protein in — one more like that today and you're there** |

The gap is unchanged and so is the lever. The smaller rungs below are untouched — *"add eggs, tin fish or a shake"* is a different, smaller action, not a repeat of the meal.

**No new threshold.** `PROPER_PROTEIN_G = 35` is the number this function already treats as *"a proper protein meal closes it"* one branch down — named once, and applied to the plate that landed instead of only to the gap that remains. A test asserts the two halves cannot drift apart.

**No new parameter either.** `macroCardMarker` already took `mealKcal`, which all four call sites passed and **nothing ever read**. That dead field becomes the live `mealProtein`, which each call site already had in hand for its own reply.

## Every case, through `mealCard`

| situation | `sub` line |
|---|---|
| protein meal just logged (61g) | *That's one proper protein down — same again at your next two meals* |
| carb-only plate just logged (8g) | *Get a real protein into your next two meals* — **unchanged** |
| on-demand "Today" card (no plate landed) | *Get a real protein into your next two meals* — **unchanged** |
| past-day card | *Yesterday's log — today's plate is a separate day* — **unchanged** |
| closed food day | *That's the day. Tomorrow get a real protein in at breakfast* — **unchanged** |

## Controls

**Positive** — 61g plate, both bands: no order to make a protein meal, and the protein lever survives.

**Over-fire** — 8g plate on the same day state and clock: still ordered. Graded at the branch **and through `mealCard`**, because the branch-level version passes the flag by hand and cannot see a threshold that says yes to everything — which is the shape this fix could most easily take too far.

**Red on revert:**

| control | failure |
|---|---|
| protein branches ignore the just-eaten meal | *the meal just logged is not re-ordered by the card confirming it* |
| threshold says yes to every meal | *an 8g plate is not a proper protein meal — the card must still ask for one* |
| `PROPER_PROTEIN_G` drops to 0 | both of the above, plus *the 'just ate protein' test uses the band the card already owns* |

One note on how the over-fire assertion is written: it tests the **instruction**, not the phrase. *"That's one proper protein down"* reports what they did and contains the same words as the order they must not be given — my first version of the assertion failed on exactly that, which is why it now matches `(make|get) … (proper|real) protein`.

## Verification vs `main@5827d7e`

`tsc` clean · **gap-tests 341/341** (338 + 3) · unit **1053/1053** · production-parity **142/142** · tracking-contract green · routing-audit **318/318** · food-scanner **48/48**

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical |
| ownership · names · reach · prompt integrity | OK · 97/97 · 8 · OK | identical |

No budget raised, nothing suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_