### PR TITLE
Prevent raw fallback when outbound preparation fails

### DIFF
--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -9192,6 +9192,31 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
     assert.match(clean.text, /1 ?850 kcal/, "a clean reply was rewritten");
   });
 
+  test("reactive: a thrown outbound preparation sends the canonical repair, never its draft", async () => {
+    const { prepareReactiveOutbound, REACTIVE_OUTBOUND_REPAIR } = await import("../server/outbound-authority");
+    const unsafeDraft = "INTERNAL: unverified weight trend says the client gained muscle";
+    const prepared = await prepareReactiveOutbound("whatsapp:+27000000886", async () => {
+      throw new Error(`forced preparation failure for ${unsafeDraft}`);
+    });
+
+    assert.equal(prepared.blocked, true, "a thrown preparation was treated as safe");
+    assert.equal(prepared.text, REACTIVE_OUTBOUND_REPAIR, "the delivery seam did not receive the canonical repair");
+    assert.notEqual(prepared.text, unsafeDraft, "the original unsafe draft reached the delivery seam");
+    assert.ok(prepared.text.trim().length > 0, "the preparation exception left the client with silence");
+
+    const ordinary = { text: "Your prepared reply stays byte-identical.", blocked: false } as const;
+    const unchanged = await prepareReactiveOutbound("whatsapp:+27000000887", async () => ordinary);
+    assert.equal(unchanged, ordinary, "successful preparation was rewritten by the exception guard");
+  });
+
+  test("reactive: sendFinal cannot restore the raw-draft preparation fallback", () => {
+    const sendFinalBody = wa.slice(wa.indexOf("async function sendFinal"), wa.indexOf("async function sendParts"));
+    assert.match(sendFinalBody, /prepareReactiveOutbound\(phone,/,
+      "sendFinal bypassed the outbound owner's reactive exception policy");
+    assert.doesNotMatch(sendFinalBody, /preparation failed, sending raw|out\s*=\s*text/,
+      "sendFinal can still deliver the original draft after preparation throws");
+  });
+
   test("delivery: the rate gate is the caller's policy, and a reply does not carry it", async () => {
     // ACCEPTANCE — "reactive replies are never queued behind proactive traffic". The send-rate
     // gate is proactive-only ON PURPOSE: throttling a reply would make a client wait to protect a

--- a/server/outbound-authority.ts
+++ b/server/outbound-authority.ts
@@ -221,7 +221,29 @@ function checkOutboundMessage(body: string | null | undefined): OutboundCheck {
 }
 
 /** What a client hears when the floor refuses a reactive draft. Never an apology, never silence. */
-const REACTIVE_REPAIR = "Let me check that properly before I answer — give me one sec and ask me again.";
+export const REACTIVE_OUTBOUND_REPAIR = "Let me check that properly before I answer — give me one sec and ask me again.";
+
+/**
+ * A reactive preparation attempt is never allowed to fail open to its draft. Keeping this
+ * exception policy beside the canonical repair prevents either delivery door from inventing
+ * its own fallback. The callback shape also makes the throw path directly testable without I/O.
+ */
+export async function prepareReactiveOutbound(
+  recipientKey: string,
+  prepare: () => Promise<OutboundPrepared>,
+): Promise<OutboundPrepared> {
+  try {
+    return await prepare();
+  } catch (e: any) {
+    console.error(`[OUTBOUND_AUTHORITY] BLOCKED reactive send to ${recipientKey.slice(-8)} — preparation failed: ${e?.message || e}`);
+    const failure: OutboundPrepared = {
+      text: REACTIVE_OUTBOUND_REPAIR,
+      blocked: true,
+      detail: "preparation failed",
+    };
+    return failure;
+  }
+}
 
 export async function prepareOutbound(
   mode: "reactive" | "proactive",
@@ -246,7 +268,7 @@ export async function prepareOutbound(
     }
     console.error(`[OUTBOUND_AUTHORITY] BLOCKED reactive draft to ${recipientKey.slice(-8)} — ${verdict.reason}: ${verdict.detail}`);
     // Reactive: the client is waiting, so they get a safe sentence rather than nothing.
-    return { text: REACTIVE_REPAIR, blocked: true, reason: verdict.reason, detail: verdict.detail };
+    return { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, reason: verdict.reason, detail: verdict.detail };
   }
 
   // Shaping stays in this order: a claim spanning a bubble split has to be checked before the
@@ -277,13 +299,13 @@ export async function prepareOutbound(
         + `to ${recipientKey.slice(-8)} — ${leak.reason}`);
       return mode === "proactive"
         ? { text: "", blocked: true, detail: leak.reason }
-        : { text: REACTIVE_REPAIR, blocked: true, detail: leak.reason };
+        : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: leak.reason };
     }
     return { text: out, blocked: false };
   } catch (e: any) {
     console.error(`[OUTBOUND_AUTHORITY] BLOCKED ${mode} send to ${recipientKey.slice(-8)} — preparation failed: ${e?.message || e}`);
     return mode === "proactive"
       ? { text: "", blocked: true, detail: "preparation failed" }
-      : { text: REACTIVE_REPAIR, blocked: true, detail: "preparation failed" };
+      : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: "preparation failed" };
   }
 }

--- a/server/routes/whatsapp.ts
+++ b/server/routes/whatsapp.ts
@@ -12,6 +12,7 @@ import { captureQualitySignal } from "../quality-signals";
 import { recordMediaJob, completeMediaJob } from "../media-jobs";
 import { provenanceGate, shadowDoor } from "../verifiers/response-gate";
 import { humanizeReply, stripInternalMarkers, isDuplicateOutbound } from "../reply-hygiene";
+import { prepareOutbound, prepareReactiveOutbound } from "../outbound-authority";
 
 // COMEBACK RECOGNITION (2026-07-13 retention P0): when a client messages after ≥3 days
 // of silence, their FIRST reply back opens with a warm welcome — the return must feel
@@ -57,26 +58,20 @@ async function sendFinal(phone: string, text: string, media: string | string[] |
   // prepareOutbound runs the floor, then the same provenance and hygiene in the same order. The
   // only reactive difference is the failure policy: a client is holding their phone, so a refused
   // draft becomes a safe sentence rather than silence. P0-C below still owns the empty case.
-  let out = text;
+  let userId: string | null = null;
+  let userRow: { id: string; profileNotes: string | null } | null = null;
   try {
-    const { prepareOutbound } = await import("../outbound-authority");
-    let userId: string | null = null;
-    let userRow: { id: string; profileNotes: string | null } | null = null;
-    try {
-      const rows = await db.select({ id: users.id, profileNotes: users.profileNotes })
-        .from(users).where(eq(users.phoneNumber, phone)).limit(1);
-      userRow = (rows[0] as any) ?? null;
-      userId = userRow?.id ?? null;
-    } catch (e: any) {
-      // The floor degrades honestly without a recipient: the turn-free checks still apply.
-      console.warn(`[SEND_FINAL] recipient lookup failed for ${phone.slice(-8)}: ${e?.message || e}`);
-    }
-    const prepared = await prepareOutbound("reactive", userId, phone, out, userRow);
-    out = prepared.text;
+    const rows = await db.select({ id: users.id, profileNotes: users.profileNotes })
+      .from(users).where(eq(users.phoneNumber, phone)).limit(1);
+    userRow = (rows[0] as any) ?? null;
+    userId = userRow?.id ?? null;
   } catch (e: any) {
-    console.warn("[SEND_FINAL] preparation failed, sending raw:", e?.message || e);
-    out = text;
+    // The floor degrades honestly without a recipient: the turn-free checks still apply.
+    console.warn(`[SEND_FINAL] recipient lookup failed for ${phone.slice(-8)}: ${e?.message || e}`);
   }
+  const prepared = await prepareReactiveOutbound(phone,
+    () => prepareOutbound("reactive", userId, phone, text, userRow));
+  let out = prepared.text;
   // THE DOOR (2026-08-04). Provenance asked whether it is true. Hygiene asked whether it
   // is shaped like a person. These two ask the questions nobody owned: is this internal,
   // and have we already said exactly this?


### PR DESCRIPTION
Implements only the CODEX exact cut from the 3 Sep PASS 3 adjudication on #114.

- removes the reactive delivery door's fail-open raw-draft fallback
- reuses the canonical reactive repair from the outbound authority
- preserves normal successful preparation byte-for-byte and leaves downstream marker stripping, dedupe, shadow, TTS, and delivery ordering unchanged
- adds forced-throw and red-on-revert regression controls

Local verification:
- `npm run check` - pass
- unit baseline comparator - base 1049/1053, head 1051/1055, NEW 0
- current-main Windows reach/architecture/SAST harness noise remains unrelated and untouched

Refs #114