### PR TITLE
Expose effective runtime modes on health

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4132,6 +4132,26 @@ test("deploy identity does not depend on the app's own routing", () => {
   assert.equal(named.length, responses.length, "every one of them names the build");
 });
 
+test("deploy identity reports the effective engine and normalizer modes", async () => {
+  const { runningBuild } = await import("../server/routes/health");
+  const previousEngine = process.env.ENGINE_LIVE;
+  const previousNormalizer = process.env.NORMALIZER;
+  try {
+    process.env.ENGINE_LIVE = "on";
+    process.env.NORMALIZER = "off";
+    assert.deepEqual(runningBuild().runtime, { engineLive: "on", normalizer: "off" },
+      "the health snapshot must expose the effective killswitch states, not merely the build");
+
+    process.env.ENGINE_LIVE = "off";
+    delete process.env.NORMALIZER;
+    assert.deepEqual(runningBuild().runtime, { engineLive: "off", normalizer: "on" },
+      "the snapshot must report each owner's effective default state");
+  } finally {
+    if (previousEngine === undefined) delete process.env.ENGINE_LIVE; else process.env.ENGINE_LIVE = previousEngine;
+    if (previousNormalizer === undefined) delete process.env.NORMALIZER; else process.env.NORMALIZER = previousNormalizer;
+  }
+});
+
 test("the self-test does not trip its own gate", async () => {
   const V = await import("../server/brain/reply-verifier");
   const routes = readFileSync("server/routes.ts", "utf-8");

--- a/server/normalizer-fidelity.ts
+++ b/server/normalizer-fidelity.ts
@@ -46,6 +46,11 @@ export interface Fidelity {
   reason: string;
 }
 
+/** The production front-door dial. Unset is live; only the explicit killswitch disables it. */
+export function normalizerLive(): boolean {
+  return process.env.NORMALIZER !== "off";
+}
+
 // "Did they tell us how they feel?" and "is this a question?" both already have owners —
 // carriesFeelingClause (shared with the unlogged-food notice) and looksLikeQuestion. This file
 // asks them rather than keeping a second copy of either, so a miss is fixed in one place. The

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,7 +55,7 @@ import { bareReactionFallback } from "./reaction-guard";
 import { mustStayDeterministic } from "./understanding/action-router";
 import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { recordMessageSeen, recordReplyPath } from "./self-check";
-import { normalizerFidelity } from "./normalizer-fidelity";
+import { normalizerFidelity, normalizerLive } from "./normalizer-fidelity";
 import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, reportedInSomeClause, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeDirectionRequest, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
 import { invalidatePatternCache } from "./cache";
 import { conditionWelcome, mentionsConditionOrMedication } from "./condition-welcome";
@@ -588,7 +588,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   /** Every exit for a durable-write turn closes through the decision owner — see
    *  understanding/live.closeCoachingTurn and tracking-contract-tests LAW 4. */
   const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user }); if (feedbackReply !== null) turnEvidence({ conversationalOnly: true });
-  if (feedbackReply !== null && mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply); if (feedbackReply !== null) commitFact(turn, "workout", feedbackReply); if (process.env.NORMALIZER !== "off" && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
+  if (feedbackReply !== null && mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply); if (feedbackReply !== null) commitFact(turn, "workout", feedbackReply); if (normalizerLive() && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
     try {
       const pre = await Promise.race([
         intentPromise,

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -6,6 +6,8 @@ import { eq, sql } from "drizzle-orm";
 import { requireAdminKey } from "./auth";
 import { deliveryStats, jobRegistry, dailyProactiveCount, DAILY_PROACTIVE_CAP } from "../scheduler/shared";
 import { isTwilioCircuitOpen } from "../utils";
+import { engineLive } from "../understanding/live";
+import { normalizerLive } from "../normalizer-fidelity";
 
 /**
  * WHICH BUILD IS ANSWERING (2026-08-20).
@@ -19,9 +21,13 @@ import { isTwilioCircuitOpen } from "../utils";
  * deploy check must not depend on the application's own routing being correct; that is the one
  * thing it exists to test.
  */
-function runningBuild() {
+export function runningBuild() {
   return {
     version: (process.env.RAILWAY_GIT_COMMIT_SHA || "").slice(0, 7) || process.env.APP_VERSION || "dev",
+    runtime: {
+      engineLive: engineLive() ? "on" as const : "off" as const,
+      normalizer: normalizerLive() ? "on" as const : "off" as const,
+    },
     bootedAt: new Date(Date.now() - process.uptime() * 1000).toISOString(),
   };
 }

--- a/server/self-check.ts
+++ b/server/self-check.ts
@@ -30,6 +30,7 @@ import { db } from "./db";
 import { schedulerState } from "../shared/schema";
 import { like, sql } from "drizzle-orm";
 import { provenanceMode } from "./verifiers/response-gate";
+import { normalizerLive } from "./normalizer-fidelity";
 
 // ── WHICH BRAIN ANSWERED? ────────────────────────────────────────────────────────────────────
 // (2026-07-30, reviewer: "why does an unconditional fallback exist at all? A system that cannot
@@ -248,7 +249,7 @@ export function capabilities(): Capability[] {
       impact: "Messy phrasing is no longer rewritten before routing, so more messages miss their handler.",
       severity: "degraded",
       fix: "NORMALIZER is set to off in Railway — unset it to resume.",
-      ok: () => (process.env.NORMALIZER || "").toLowerCase() !== "off",
+      ok: () => normalizerLive(),
     },
 
     // ── COSMETIC: it still works, it just looks worse. ──────────────────────────────────────


### PR DESCRIPTION
Implements only the `/health` runtime-provenance cut from #114 on `main@4a4a510`.

- adds the effective Meaning Engine and normalizer modes to the existing build snapshot returned on every `/health` path
- reads `ENGINE_LIVE` through its existing `engineLive()` owner
- gives the existing normalizer owner one reusable live-mode helper, preserving the current exact `NORMALIZER=off` killswitch semantics
- keeps the existing endpoint, build SHA, startup state, database behavior, and product policy unchanged
- adds runtime controls for engine-on/normalizer-off and engine-off/normalizer-default-on

Verification before push:
- `npm run check` - PASS
- `npm run check:names` - PASS (97 ? 97)
- unit merge-base comparator - base 1051/1055, head 1051/1055, NEW 0
- focused gap suite - new control PASS; existing unrelated Windows hunger child-process failure remains

No architecture consolidation and no product/health-policy change are included.

Refs #114