### PR TITLE
P1: a follow-up that names no subject belongs to the conversation, not to a topic

### DIFF
--- a/script/routing-audit.ts
+++ b/script/routing-audit.ts
@@ -598,8 +598,27 @@ const CASES: Case[] = [
     const SESSION_SERVE = /Reply \*DONE\* when finished|Next Session \(Day/i;
     const SESSION_LOGGED = /Session \d+ (?:logged|—|in)\b|First workout done|got it, logged to/i;
     const FOOD_LOGGED = /\*Food logged|Food logged ✅|Running total today|Meal total:/i;
+    const CALORIE_LECTURE = /you never have to understand calories or count anything/i;
+    const CONFUSION_LEAD = /here'?s the one that matters/i;
     const x = (name: string, msg: string, c: Partial<Case> = {}): Case => ({ name: `xintent: ${name}`, msg, ...c });
     return [
+      // A BARE PRONOUN NAMES NO SUBJECT (#114 P1, 2026-09-03, founder). "what does that mean"
+      // was claimed by the calorie explainer with no calorie word in it, so a client who had just
+      // been told "7.0kg to go: 92kg now, 85kg the goal" and asked what that meant was answered
+      // "you never have to understand calories or count anything" — a lecture on a subject nobody
+      // had raised. Without a "?" it was then read as CONFUSION and answered with the day's action.
+      // Two owners, one cause: a follow-up whose subject is whatever was just discussed belongs to
+      // the path that can see the conversation, not to a topic handler or to the daily ladder.
+      x("bare pronoun follow-up is not a calorie question", "what does that mean",
+        { reject: [CALORIE_LECTURE, CONFUSION_LEAD] }),
+      x("bare pronoun follow-up, with a question mark", "what does this mean?",
+        { reject: [CALORIE_LECTURE, CONFUSION_LEAD] }),
+      // OVER-FIRE CONTROLS. The explainer still owns a question that says what it is about —
+      // without these, "never claim" would pass the two cases above.
+      x("naming the number still reaches the explainer", "what does the number mean?",
+        { expect: [CALORIE_LECTURE] }),
+      x("a pronoun beside a real calorie word still reaches it",
+        "I am confused about calories, what does that mean", { expect: [CALORIE_LECTURE] }),
       // "flu" in the sentence, but nobody here is sick — template must stay holstered
       x("flu going around at work", "The flu is going around at work",
         { reject: [SICK_TPL] }),

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -22,7 +22,7 @@ import { replyWithButtons } from "../twilio-interactive";
 // exact label as a message, which the deterministic handlers already understand.
 const MENU_BUTTONS = ["Log food", "Today's workout", "My progress"];
 import { getPrimaryWorkoutGifUrl } from "../exercise-media";
-import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, extractStepTargetChange, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, looksLikeWorkoutRequest, parseSickDays, isReturnFromSicknessQuestion, nextDayDate, isMultiPartAsk , spaceName} from "../utils";
+import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, extractStepTargetChange, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, looksLikeWorkoutRequest, parseSickDays, isReturnFromSicknessQuestion, nextDayDate, isMultiPartAsk, looksLikeQuestion, spaceName} from "../utils";
 import { educationNote, remainingInMeals } from "../education";
 import { getTodayWorkoutState, getTodaySlot } from "../workout-state";
 import { generateMealPlan } from "../meal-plan";
@@ -1360,7 +1360,13 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
     // target moved from 10,000 to 6,000; this branch called it confusion, promised "let me
     // put it simply", explained nothing, and told him to stand on a scale. Never answer a
     // real question with the day's action. Defer — the engine is ahead of this now.
-    if (ctx.isQuestion || /\?/.test(message)) return null;
+    // AND A QUESTION MARK IS NOT WHAT MAKES ONE (#114 P1, 2026-09-03). The rule above is right and
+    // the test was half of utils.looksLikeQuestion — its punctuation line, without its interrogative
+    // openers. So "what does that mean", asked with no "?" after the coach had just answered about
+    // weight, was read as confusion and answered with the day's action instead of the subject the
+    // client was asking about. The canonical owner decides it now; a second spelling of "is this a
+    // question" in a handler is what let this one through.
+    if (ctx.isQuestion || looksLikeQuestion(message)) return null;
     // And no preamble that promises a simplification the next line does not deliver.
     const lead = firstName ? `${firstName} — here's the one that matters:` : `Here's the one that matters:`;
     // Only fall back to the menu if the one action could not be built at all. A sitemap is a

--- a/server/handlers/numbers-literacy.ts
+++ b/server/handlers/numbers-literacy.ts
@@ -152,7 +152,22 @@ export async function handleNumbersLiteracy(ctx: { message: string; m: string; u
   // ---- CALORIE CONFUSION — the client is already number-free by default; if they
   // somehow have figures on (opted in, then overwhelmed) turn them off, and either
   // way give the reassuring data-bundle explanation. Counting is OUR job, never theirs.
-  const isCalorieConfusion = /\b(what(?:'?s| is| are)?\s+(?:a |the )?calories?\b|don.?t (understand|get|know)( what)? (calories|kcal|this number|these numbers|the numbers)|calories?.*confus|confus.*calories?|too many numbers|what does (that|this|the number|kcal|calories?) mean|what(?:'?s| is)?\s+a?\s*kcal|explain (the )?calories?|i don.?t count calories|never counted calories)\b/i.test(m)
+  /**
+   * A BARE PRONOUN NAMES NO SUBJECT (#114 P1, 2026-09-03, founder).
+   *
+   * This alternation used to read `what does (that|this|the number|kcal|calories?) mean`, so
+   * "what does that mean" claimed the turn unconditionally — with no calorie word anywhere in it.
+   * A client who had just been told "7.0kg to go: 92kg now, 85kg the goal" and asked what that
+   * meant was answered: "you never have to understand calories or count anything." The active
+   * subject was weight; the coach delivered a lecture on a subject nobody had raised.
+   *
+   * "the number", "kcal" and "calories" say what they are about and still claim. "that" and
+   * "this" say nothing, so they are not this handler's to answer — a follow-up whose subject is
+   * whatever was just discussed belongs to the path that can see the conversation. The second
+   * clause below is unchanged and still catches a pronoun beside a real calorie word
+   * ("I'm confused, what does that mean about my calories").
+   */
+  const isCalorieConfusion = /\b(what(?:'?s| is| are)?\s+(?:a |the )?calories?\b|don.?t (understand|get|know)( what)? (calories|kcal|this number|these numbers|the numbers)|calories?.*confus|confus.*calories?|too many numbers|what does (the number|the numbers|kcal|calories?) mean|what(?:'?s| is)?\s+a?\s*kcal|explain (the )?calories?|i don.?t count calories|never counted calories)\b/i.test(m)
     || (/\bcalor|kcal\b/i.test(m) && /\b(confused|lost|don.?t understand|makes? no sense|too complicated|i.?m not good with numbers)\b/i.test(m));
   if (isCalorieConfusion) {
     if (isFull) {


### PR DESCRIPTION
#114 P1. Base `main@4a4a510`. 3 files.

## What the trace found

The founder asked what the coach's answer meant, right after being told *"7.0kg to go: 92kg now, 85kg the goal"*, and lost the weight conversation. I traced the **claimant** rather than the reply text, and there were two owners with one cause:

| # | owner | what it did |
|---|---|---|
| 1 | `numbers-literacy` | claimed `what does that mean` as a **calorie** question and answered *"you never have to understand calories or count anything"* |
| 2 | `early-commands` | then read it as **confusion** and answered with the day's action |

**1 — the alternation was `what does (that|this|the number|kcal|calories?) mean`.** So a bare pronoun claimed the turn with no calorie word anywhere in it. `the number`, `kcal` and `calories` say what they are about and still claim; `that` and `this` say nothing. The second clause is untouched and still catches a pronoun beside a real calorie word.

**2 — that branch already carries the rule**, written after a live 2026-07-31 failure: *"A QUESTION IS NEVER CONFUSION … never answer a real question with the day's action."* It tested it with `/\?/.test(message)` — which is the **punctuation line of `utils.looksLikeQuestion` without its interrogative openers**. So the same question asked without a `?` was read as confusion. The canonical owner decides it now; a second spelling of "is this a question" inside a handler is what let it through.

```
before   "what does that mean"  ->  CALORIE_EXPLAINER, then CONFUSED_ONE_ACTION
after    "what does that mean"  ->  the coach, with the client's snapshot and
                                    memory — exactly like "what does it mean?"
```

Both spellings of the follow-up now reach the same place, which is the coherence this was raised for.

## Controls — in `routing-audit`, graded on each claimant's own copy

| control | asserts |
|---|---|
| **reject** | `what does that mean` and `what does this mean?` get neither the calorie lecture nor the confusion lead |
| **over-fire** | `what does the number mean?` still reaches the explainer, and so does `I am confused about calories, what does that mean` |
| **red on revert** | pronoun back in the calorie alternation → **both** pronoun cases fail; `/\?/` back in the confusion guard → **only** the no-question-mark case fails |

The over-fire pair matters because without it "never claim" would pass the two rejects. The two red-on-revert controls redden *different* cases, which is what proves each half is separately load-bearing rather than one masking the other.

## What this PR does not claim

Offline the model is unreachable, so a turn that now reaches the coach degrades to the deterministic fallback. **That the answer then speaks to the prior subject is not asserted here and cannot be from this environment** — the recorded egress blocker. What *is* asserted is where the turn goes, which is the divergence and is fully deterministic.

One related observation I did **not** act on, to keep this bounded: the punctuation-only follow-up (`???`) gets an explicit *"they are responding to your previous message"* context built from the last exchange, and the worded follow-up does not. That is a context-assembly difference inside the GPT block, a separate owner and a separate cut.

## Verification vs `main@4a4a510`

`tsc` clean · **routing-audit 322/322** (318 + 4) · unit **1055/1055** · production-parity **142/142** · tracking-contract green · gap-tests **344/344** · food-scanner **48/48**

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical |
| ownership · names · reach | OK · 97/97 · 8 | identical |

No budget raised, no new predicate, no new module — the fix uses `utils.looksLikeQuestion`, which already existed, and removes a partial duplicate of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_