### PR TITLE
Run reporting Gauntlet after blocking test red

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,8 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-      - run: npm ci
+      - id: dependencies
+        run: npm ci
       - name: Type check
         run: npm run check
       - name: Test suite
@@ -75,5 +76,6 @@ jobs:
       # SLICE 5 DELETES the `continue-on-error` line. A fully green gauntlet is the gate on the
       # live flip; from that moment on, red is a broken build like anything else.
       - name: Gauntlet (reporting only until Slice 5)
+        if: ${{ !cancelled() && steps.dependencies.outcome == 'success' }}
         run: npm run gauntlet
         continue-on-error: true


### PR DESCRIPTION
Implements issue #153 exactly from `main@30bc23e`.

- gives the existing test-job `npm ci` step an outcome ID
- runs the existing single Gauntlet step when dependencies installed and the job was not cancelled, even after a blocking typecheck or `npm test` failure
- leaves `npm test` blocking and leaves the Gauntlet's existing step-level `continue-on-error: true` unchanged
- skips the Gauntlet when setup/install did not make dependencies available

Diff: `.github/workflows/test.yml` only; no product code, test semantics, assertions, budgets, or architecture changes.

Baseline proof on current-main PR #151: install/typecheck succeeded, Test suite failed on standing architecture debt, Gauntlet was skipped, job conclusion was failure. This PR's Actions run is the real standing-red control for the repaired ordering.

Refs #153