### PR TITLE
P1 #152: a closed food day reopens when the client says they are eating after all

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1275,6 +1275,123 @@ const MUST_WRITE: [string, string][] = [
         ])) {
           failures.push(`A legitimate meal suggestion on an open day was flagged as a closed-day violation — every meal recommendation would become a candidate`);
         }
+
+        // ── #152: A REOPENING ENDS THE CLOSURE, HERE TOO ────────────────────────────────────────
+        // readHeldConstraints lets the client's newest explicit decision stand, so this detector
+        // had to learn the same rule or it would file the very replies the reversal makes correct.
+        if (await caught("after a genuine reopening", [
+          turn("t-r-close", USER.id, day0 + 60_000, CLOSED, "Noted — that is the day closed."),
+          turn("t-r-open", USER.id, day0 + 120_000, "actually I changed my mind, I'm having dinner", "👍"),
+          turn("t-r-offer", USER.id, day0 + 180_000, "what should I eat?", OFFERED),
+        ])) {
+          failures.push(`Coach Health flagged a meal suggestion made AFTER the client reopened their food day — the detector would file every correct post-reversal reply as a closed-day violation`);
+        }
+        // ...and a closure that was never reversed still flags. Without this, "a reopening
+        // anywhere clears everything" would pass the case above and silence the real defect.
+        if (!await caught("reopened, then closed again", [
+          turn("t-r2-open", USER.id, day0 + 60_000, "actually I'm having dinner", "👍"),
+          turn("t-r2-close", USER.id, day0 + 120_000, CLOSED, "Noted — that is the day closed."),
+          turn("t-r2-offer", USER.id, day0 + 180_000, "what should I eat?", OFFERED),
+        ])) {
+          failures.push(`A food offer after the client closed the day AGAIN was not flagged — the newest decision must win in the detector as well as in the product`);
+        }
+      }
+
+      /**
+       * #152 — REOPENING A CLOSED FOOD DAY, THROUGH THE REAL DOOR.
+       *
+       * #138 and #144 fixed the opposite failure: offering food after a closure. The closure then
+       * had no way back, so a client who closed the day and genuinely ate was refused for the rest
+       * of it, every time they asked. Graded on what the client actually receives, because the
+       * whole defect was that the meal door kept standing down.
+       *
+       * History is supplied NEWEST FIRST, which is how the production query returns it
+       * (recentClientMessagesStamped: ORDER BY created_at DESC). Feeding it oldest-first would
+       * invert the ordering case and quietly grade the opposite of what production does.
+       */
+      {
+        const CLOSE = "I am done eating today";
+        const REOPEN = "actually I changed my mind, I'm having dinner";
+        const DAY_CLOSED = /leaving it there|done eating today/i;
+        const askAfter = async (historyNewestFirst: string[]) => {
+          freshTurn();
+          g.__KAMLIFE_STUB_USER = { ...USER };
+          g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.mealLogs, [{
+            id: "ml-152", userId: USER.id, loggedAt: new Date(dayStart.getTime() + 60_000),
+            at: new Date(dayStart.getTime() + 60_000),
+            kcalInt: 2100, proteinInt: 188, carbsInt: 200, fatInt: 70,
+            kcal: 2100, protein: 188, carbs: 200, fat: 70, calories: 2100,
+            mealLabel: "dinner", label: "dinner", source: "text",
+            items: [{ name: "Chicken", kcal: 2100, protein: 188 }], rawMessage: "dinner", sourceMessageId: null,
+          }]]]);
+          g.__KAMLIFE_STUB_PGROWS = historyNewestFirst.map((text, i) => ({
+            message_in: text,
+            created_at: new Date(dayStart.getTime() + (historyNewestFirst.length - i) * 60_000),
+          }));
+          const reply = String(await handleMessage(USER.phoneNumber, "what should I eat?").catch(() => ""));
+          delete g.__KAMLIFE_STUB_PGROWS;
+          delete g.__KAMLIFE_STUB_ROWS;
+          return reply;
+        };
+
+        // 1 — THE REVERSAL ITSELF.
+        if (DAY_CLOSED.test(await askAfter([REOPEN, CLOSE]))) {
+          failures.push(`A client who closed their food day and then said "${REOPEN}" was still refused a meal — an explicit change of mind has no way back and they are locked out until midnight`);
+        }
+        // 2 — AND THE CLOSURE STILL HOLDS WITHOUT ONE. This is #138, re-asserted here: the cut
+        //     must not have bought the reversal by weakening the constraint.
+        if (!DAY_CLOSED.test(await askAfter(["did 9000 steps", CLOSE]))) {
+          failures.push(`An unrelated message after a closure reopened the food day — the constraint no longer survives the turn that follows it`);
+        }
+        // 3 — OVER-FIRE: asking for a meal is not deciding to eat one.
+        if (!DAY_CLOSED.test(await askAfter([CLOSE]))) {
+          failures.push(`The meal request itself reopened the closed day — every "what should I eat?" would cancel the client's own decision`);
+        }
+        // 4 — AMBIGUITY: considering is not deciding.
+        if (!DAY_CLOSED.test(await askAfter(["thinking about dinner", CLOSE]))) {
+          failures.push(`"thinking about dinner" silently reopened a closed food day — a mention of food is not a decision to eat`);
+        }
+        // 5 — ORDERING: the newest explicit decision wins, in both directions.
+        if (!DAY_CLOSED.test(await askAfter([CLOSE, REOPEN, CLOSE]))) {
+          failures.push(`A client who reopened and then closed the day AGAIN was still treated as open — the newest decision must win, not the first or the loudest`);
+        }
+        // 6 — CONTROL: a day nobody closed is open, so none of the above passes by never closing.
+        if (DAY_CLOSED.test(await askAfter(["did 9000 steps"]))) {
+          failures.push(`A day the client never closed came back closed — the door is standing down on its own`);
+        }
+      }
+
+      /**
+       * #152 — USER AND DAY ISOLATION, on the reader Coach Health uses.
+       *
+       * The reversal must be as narrowly scoped as the closure it cancels: one person changing
+       * their mind cannot open somebody else's day, and yesterday's change of mind cannot open
+       * today. Graded on foodCloseLookup, which is where both facts are keyed.
+       */
+      {
+        const { foodCloseLookup } = await import("../server/held-constraints");
+        const d0 = dayStart.getTime();
+        const OTHER = "stub-other-client-0000000000000001";
+        const closed = (uid: string, at: number) => ({ userId: uid, at, input: "I am done eating today" });
+        const opened = (uid: string, at: number) => ({ userId: uid, at, input: "actually I'm having dinner" });
+
+        const crossUser = foodCloseLookup([closed(USER.id, d0 + 60_000), opened(OTHER, d0 + 120_000)]);
+        if (crossUser(USER.id, d0 + 180_000) === null) {
+          failures.push(`Another client's change of mind reopened this client's closed day — one person saying "I'm having dinner" would cancel everybody else's constraint`);
+        }
+        const crossDay = foodCloseLookup([
+          closed(USER.id, d0 + 60_000),
+          opened(USER.id, d0 - 6 * 3_600_000),   // yesterday, in SAST terms
+        ]);
+        if (crossDay(USER.id, d0 + 180_000) === null) {
+          failures.push(`Yesterday's change of mind reopened today's closed day — a decision about one day became a standing preference`);
+        }
+        // ...and within the day, the reversal does work. Without this the two checks above pass
+        // on a lookup that simply ignores reopenings.
+        const sameDay = foodCloseLookup([closed(USER.id, d0 + 60_000), opened(USER.id, d0 + 120_000)]);
+        if (sameDay(USER.id, d0 + 180_000) !== null) {
+          failures.push(`A same-day reopening did not clear the closure in the reader Coach Health uses — the detector and the product would disagree about the same client`);
+        }
       }
 
       /**

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1313,7 +1313,7 @@ const MUST_WRITE: [string, string][] = [
         const CLOSE = "I am done eating today";
         const REOPEN = "actually I changed my mind, I'm having dinner";
         const DAY_CLOSED = /leaving it there|done eating today/i;
-        const askAfter = async (historyNewestFirst: string[]) => {
+        const askAfter = async (historyNewestFirst: string[], ask = "what should I eat?") => {
           freshTurn();
           g.__KAMLIFE_STUB_USER = { ...USER };
           g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[schema.mealLogs, [{
@@ -1328,7 +1328,7 @@ const MUST_WRITE: [string, string][] = [
             message_in: text,
             created_at: new Date(dayStart.getTime() + (historyNewestFirst.length - i) * 60_000),
           }));
-          const reply = String(await handleMessage(USER.phoneNumber, "what should I eat?").catch(() => ""));
+          const reply = String(await handleMessage(USER.phoneNumber, ask).catch(() => ""));
           delete g.__KAMLIFE_STUB_PGROWS;
           delete g.__KAMLIFE_STUB_ROWS;
           return reply;
@@ -1379,6 +1379,77 @@ const MUST_WRITE: [string, string][] = [
         //     reopen" and cases 7 and 8 would pass while the feature was gone.
         if (DAY_CLOSED.test(await askAfter(["I'm having dinner tonight after all", CLOSE]))) {
           failures.push(`A genuine same-day reversal stopped working once the future-day and zero-food guards were added — the guards took the feature with them`);
+        }
+
+        /**
+         * THE TURN'S OWN WORDS (#152, CTO re-adjudication). readHeldConstraints reads HISTORY, and
+         * the message being answered is not in it yet — so "I'm eating now, what should I eat?"
+         * carried its own reversal into a door that was looking everywhere except at it. live.ts
+         * folded the current message in for CLOSURE only, so the fold could tighten the constraint
+         * and never release it.
+         *
+         * Graded where each door can actually be reached. The SMART NEXT MEAL door is reachable
+         * for the CLOSURE direction — a current-message closure with no history at all must still
+         * close the day — and for the history direction (case 3 above). It is NOT reachable for the
+         * release direction: any message that states eating is claimed by the food clarifier first,
+         * on this branch and on main alike, so the reply is identical either way and would prove
+         * nothing. That direction is graded on the Meaning Engine's state below, which is the
+         * consumer that actually differed.
+         */
+        // Graded on the requirement, not on one door's wording: a client who closed the day in the
+        // same breath as the ask must not be SOLD A MEAL. Which owner answers is not this cut's
+        // business — several may legitimately claim an utterance that closes the day.
+        const SELLS_A_MEAL = /Next Meal Suggestion|Pick one:|Start with:/i;
+        const sameTurnClose = await askAfter([], "I am done eating today, what should I eat?");
+        if (SELLS_A_MEAL.test(sameTurnClose)) {
+          failures.push(`A closure stated in the SAME turn as the ask was ignored and the client was sold a meal they had just refused: "${sameTurnClose.split("\n").filter(Boolean)[0]}"`);
+        }
+        const bothInOne = await askAfter([], "I'm eating now but I am done eating today, what should I eat?");
+        if (SELLS_A_MEAL.test(bothInOne)) {
+          failures.push(`One utterance carrying BOTH a reversal and a closure was treated as open and sold a meal — the conservative tie-break must hold inside a single message: "${bothInOne.split("\n").filter(Boolean)[0]}"`);
+        }
+      }
+
+      /**
+       * #152 — THE CURRENT TURN'S OWN WORDS, AND BOTH DOORS READING THEM THE SAME WAY.
+       *
+       * The release direction cannot be graded on the SMART NEXT MEAL reply: any message that
+       * states eating is claimed by the food clarifier before the meal door, on this branch and on
+       * main alike, so the reply is byte-identical either way and would prove nothing. It IS
+       * graded here, on the seam owner and on the state the Meaning Engine actually computes —
+       * which is the consumer that differed, because live.ts folded the current message in for
+       * closure only and could therefore tighten the constraint but never release it.
+       */
+      {
+        const { foodDayClosedWith } = await import("../server/held-constraints");
+        const cases: Array<[string, boolean, boolean, string]> = [
+          // [current message, held-from-history, expected effective closed, why]
+          ["I'm eating now, what should I eat?", true, false, "the reversal is in the turn being answered"],
+          ["what should I eat?", true, true, "an ask is not a decision — history stands"],
+          ["I'm having dinner tomorrow, what should I eat?", true, true, "a plan for another day"],
+          ["I'm eating nothing else today, what should I eat?", true, true, "a commitment to eat nothing"],
+          ["I'm eating now but I am done eating today", true, true, "closure wins inside one utterance"],
+          ["I'm eating now, what should I eat?", false, false, "nothing was closed to begin with"],
+        ];
+        for (const [msg, held, expected, why] of cases) {
+          const got = foodDayClosedWith(held, msg);
+          if (got !== expected) {
+            failures.push(`The turn's own words were read wrongly — "${msg}" with held=${held} gave closed=${got}, expected ${expected} (${why})`);
+          }
+        }
+
+        // BOTH DOORS, ONE ANSWER. The Meaning Engine builds its DayState from this same owner, so
+        // the deterministic meal door and the coaching decision cannot disagree about one sentence.
+        // Graded on the engine's real state rather than on its wording.
+        const { canonicalDecision } = await import("../server/understanding/live");
+        freshTurn();
+        g.__KAMLIFE_STUB_USER = { ...USER };
+        g.__KAMLIFE_STUB_PGROWS = [{ message_in: "I am done eating today", created_at: new Date(dayStart.getTime() + 60_000) }];
+        const closedStill = await canonicalDecision({ ...USER }, "what should I eat?").catch(() => null);
+        const reopened = await canonicalDecision({ ...USER }, "I'm eating now, what should I eat?").catch(() => null);
+        delete g.__KAMLIFE_STUB_PGROWS;
+        if (closedStill && reopened && closedStill.todo === reopened.todo && /eat|protein|meal/i.test(String(reopened.todo))) {
+          failures.push(`The Meaning Engine reached the SAME food instruction whether or not the turn reopened the day ("${reopened.todo}") — the current message is not reaching its held state, so the engine and the meal door are deciding from different facts`);
         }
       }
 

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1359,6 +1359,27 @@ const MUST_WRITE: [string, string][] = [
         if (DAY_CLOSED.test(await askAfter(["did 9000 steps"]))) {
           failures.push(`A day the client never closed came back closed — the door is standing down on its own`);
         }
+        // 7 — A DECISION ABOUT ANOTHER DAY IS NOT A DECISION ABOUT THIS ONE (CTO hold on #155).
+        //     readHeldConstraints filters by WHEN a message was sent, never by which day the
+        //     sentence is about, so tomorrow's plan carried the full commitment shape and would
+        //     have reopened tonight.
+        if (!DAY_CLOSED.test(await askAfter(["I'm having dinner tomorrow", CLOSE]))) {
+          failures.push(`"I'm having dinner tomorrow" reopened TODAY's closed food day — a plan for another day cancelled a constraint about this one`);
+        }
+        if (!DAY_CLOSED.test(await askAfter(["I'll eat tomorrow", CLOSE]))) {
+          failures.push(`"I'll eat tomorrow" reopened today's closed food day — the same defect in its plainest form`);
+        }
+        // 8 — A ZERO-FOOD STATEMENT IS THE CONSTRAINT RESTATED, NOT WITHDRAWN. "I'm eating nothing
+        //     else today" carries the positive prefix "I'm eating", so the commitment shape alone
+        //     read the plainest restatement of the closure as its cancellation.
+        if (!DAY_CLOSED.test(await askAfter(["I'm eating nothing else today", CLOSE]))) {
+          failures.push(`"I'm eating nothing else today" reopened the closed food day — a commitment to eat NOTHING was read as a decision to eat`);
+        }
+        // 9 — AND THE GENUINE REVERSAL STILL WORKS. Without this, both guards could be "never
+        //     reopen" and cases 7 and 8 would pass while the feature was gone.
+        if (DAY_CLOSED.test(await askAfter(["I'm having dinner tonight after all", CLOSE]))) {
+          failures.push(`A genuine same-day reversal stopped working once the future-day and zero-food guards were added — the guards took the feature with them`);
+        }
       }
 
       /**
@@ -1391,6 +1412,22 @@ const MUST_WRITE: [string, string][] = [
         const sameDay = foodCloseLookup([closed(USER.id, d0 + 60_000), opened(USER.id, d0 + 120_000)]);
         if (sameDay(USER.id, d0 + 180_000) !== null) {
           failures.push(`A same-day reopening did not clear the closure in the reader Coach Health uses — the detector and the product would disagree about the same client`);
+        }
+
+        // COACH HEALTH MUST AGREE WITH THE PRODUCT ON THE TWO OVER-FIRES (CTO hold on #155). If it
+        // did not, a reply that the product correctly withheld would still be judged against an
+        // "open" day — or worse, a correct closed-day reply would be filed as a violation.
+        for (const [label, said] of [
+          ["a plan for tomorrow", "I'm having dinner tomorrow"],
+          ["a commitment to eat nothing", "I'm eating nothing else today"],
+        ] as const) {
+          const look = foodCloseLookup([
+            closed(USER.id, d0 + 60_000),
+            { userId: USER.id, at: d0 + 120_000, input: said },
+          ]);
+          if (look(USER.id, d0 + 180_000) === null) {
+            failures.push(`Coach Health treated ${label} ("${said}") as a reopening — the detector and the product now disagree about whether this client's day is closed`);
+          }
         }
       }
 

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -37,7 +37,7 @@ import { sastDayStart, looksLikeDirectionRequest, classifyPainReport , getDispla
 import { isDespairNotAQuestion } from "../despair";
 import { SA_FOODS_SEED } from "../foods";
 import { turnEvidence } from "./chat-log";
-import { readHeldConstraints } from "../held-constraints";
+import { readHeldConstraints, foodDayClosedWith } from "../held-constraints";
 import { getDayLedger, getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
@@ -342,7 +342,11 @@ export async function handleMiscCommands(ctx: {
     // because "suggesting more food contradicts the day's assessment". The difference is only
     // whose assessment it is: there the ledger's, here the client's own — and theirs outranks it.
     const held = await readHeldConstraints(phone, user);
-    if (held.foodDayClosed) {
+    // ...AND THIS TURN'S OWN WORDS (#152). readHeldConstraints reads history, and the message being
+    // answered is not in it yet, so "I'm eating now, what should I eat?" carried its own reversal
+    // and was still refused. Same owner as the Meaning Engine uses, so both doors read one sentence
+    // the same way; a closure inside the utterance still wins.
+    if (foodDayClosedWith(held.foodDayClosed, message)) {
       const landed = `You finished on *${todayCals} kcal* and *${todayProt}g protein*.`;
       // needsProtein is this branch's existing bar for "a gap worth acting on". A 1g shortfall is
       // not a reason to reopen a decision they made; a real one is worth naming for TOMORROW,

--- a/server/held-constraints.ts
+++ b/server/held-constraints.ts
@@ -141,6 +141,31 @@ function foodDayClosedNow(todaysNewestFirst: Array<{ text: string }>): boolean {
   return false;
 }
 
+/**
+ * THE TURN'S OWN WORDS COUNT TOO (#152, CTO re-adjudication on #155).
+ *
+ * readHeldConstraints reads chat HISTORY, and the message being handled is not in it yet. So a
+ * client who closed the day earlier and then sent ONE turn carrying both the reversal and the ask
+ *
+ *     "I'm eating now, what should I eat?"
+ *
+ * was still refused: the reopening was sitting in the very message the door was answering, and the
+ * door was looking everywhere except at it. live.ts already folded the current message in — but for
+ * CLOSURE only (`held.foodDayClosed || foodDayIsClosed(message)`), so the fold could tighten the
+ * constraint and never release it.
+ *
+ * SAME TIE-BREAK AS foodDayClosedNow, deliberately: within one utterance a closure outranks a
+ * reopening, because a turn cannot be ordered against itself and the conservative direction is the
+ * one that does not sell food to someone who may have just stopped. This is that rule applied to a
+ * single newest statement, so the two readers cannot disagree about the same sentence — which is
+ * the whole reason it is a function here rather than a line spelled out at each door.
+ */
+export function foodDayClosedWith(heldFromHistory: boolean, currentMessage: string): boolean {
+  if (foodDayIsClosed(currentMessage)) return true;
+  if (foodDayIsReopened(currentMessage)) return false;
+  return heldFromHistory;
+}
+
 // ── WHAT AN OUTBOUND MESSAGE IS ASKING FOR ───────────────────────────────────────────────────
 //
 // Deliberately narrow, and deliberately about the ASK rather than the topic. "You ate well today"

--- a/server/held-constraints.ts
+++ b/server/held-constraints.ts
@@ -25,7 +25,7 @@
  * training today" said on Tuesday must not silence Wednesday. That is what `doNotMention` is for.
  */
 
-import { foodDayIsClosed, trainingDayIsDeclined } from "./one-action";
+import { foodDayIsClosed, foodDayIsReopened, trainingDayIsDeclined } from "./one-action";
 import { recentClientMessagesStamped } from "./memory";
 import { readHealthState } from "./health-state";
 import { sastDaysBetween, sastDayKey } from "./sast";
@@ -57,7 +57,7 @@ export async function readHeldConstraints(
     const stamped = await recentClientMessagesStamped(phone);
     const todays = stamped.filter(s => sastDaysBetween(s.at) === 0);
     return {
-      foodDayClosed: todays.some(s => foodDayIsClosed(s.text)),
+      foodDayClosed: foodDayClosedNow(todays),
       trainingDeclined: todays.some(s => trainingDayIsDeclined(s.text)),
       sick,
     };
@@ -80,19 +80,65 @@ export async function readHeldConstraints(
  * rule this file opens with. sastDayKey owns the boundary; a hand-rolled midnight would be a
  * second answer to it.
  *
- * Returns EARLIEST closure per client-day, and a lookup that answers null when there is none.
+ * AND A REOPENING ENDS IT (#152, 2026-09-03). readHeldConstraints now lets the client's newest
+ * explicit decision stand, so this had to learn the same thing or Coach Health would flag the very
+ * replies the reversal makes correct — a meal suggestion after "I'm having dinner" would be filed
+ * as a closed-day violation forever. Same two recognisers, same ordering rule: a closure is in
+ * force at a moment only when no reopening sits between it and that moment.
+ *
+ * Returns the closure IN FORCE at the asked-about time, or null.
  */
 export function foodCloseLookup(
   turns: Array<{ userId: string | null; at: number; input: string }>,
 ): (userId: string | null, at: number) => number | null {
-  const byClientDay = new Map<string, number>();
+  type Decision = { at: number; closed: boolean };
+  const byClientDay = new Map<string, Decision[]>();
   for (const t of turns) {
-    if (!foodDayIsClosed(t.input)) continue;
+    // A closure inside one utterance outranks a reopening inside it — the same tie-break
+    // foodDayClosedNow makes, so the two readers cannot disagree about one message.
+    const closed = foodDayIsClosed(t.input);
+    if (!closed && !foodDayIsReopened(t.input)) continue;
     const key = `${t.userId}::${sastDayKey(t.at)}`;
-    const prev = byClientDay.get(key);
-    if (prev === undefined || t.at < prev) byClientDay.set(key, t.at);
+    const list = byClientDay.get(key) || [];
+    list.push({ at: t.at, closed });
+    byClientDay.set(key, list);
   }
-  return (userId, at) => byClientDay.get(`${userId}::${sastDayKey(at)}`) ?? null;
+  for (const list of byClientDay.values()) list.sort((a, b) => a.at - b.at);
+  return (userId, at) => {
+    const list = byClientDay.get(`${userId}::${sastDayKey(at)}`);
+    if (!list) return null;
+    let inForce: number | null = null;
+    for (const d of list) {
+      if (d.at > at) break;              // said after the turn being judged — not yet true of it
+      inForce = d.closed ? d.at : null;  // the latest decision at or before `at` is the one that holds
+    }
+    return inForce;
+  };
+}
+
+/**
+ * THE NEWEST EXPLICIT DECISION WINS (#152, 2026-09-03).
+ *
+ * This was `todays.some(foodDayIsClosed)` — once anything today closed the day, nothing could
+ * open it, so a client who closed at 19:55 and then said "actually I changed my mind, I'm having
+ * dinner" was refused for the rest of the night, every time they asked.
+ *
+ * `some` also throws away the one thing that settles a contradiction: WHEN each was said. The
+ * statements are already newest-first, so the first one that is a decision about eating today is
+ * the decision that stands, and everything older is history. Nothing is stored; the effective
+ * state is derived from the client's own ordered words, which is what "held" has always meant here.
+ *
+ * A CLOSURE INSIDE A SINGLE MESSAGE OUTRANKS A REOPENING INSIDE IT. "I'll have dinner, then I'm
+ * done eating" is one utterance with both, and one turn cannot be ordered against itself — so the
+ * tie goes to the constraint, which is the direction that does not sell food to someone who may
+ * have just stopped.
+ */
+function foodDayClosedNow(todaysNewestFirst: Array<{ text: string }>): boolean {
+  for (const s of todaysNewestFirst) {
+    if (foodDayIsClosed(s.text)) return true;
+    if (foodDayIsReopened(s.text)) return false;
+  }
+  return false;
 }
 
 // ── WHAT AN OUTBOUND MESSAGE IS ASKING FOR ───────────────────────────────────────────────────

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -411,6 +411,37 @@ export function foodDayIsClosed(text: string): boolean {
   return false;
 }
 
+/**
+ * THE REVERSAL OF THAT CONSTRAINT — they have decided to eat after all (#152, 2026-09-03).
+ *
+ * A closure is held for the rest of the SAST day, which is right: "I'm done eating today" said at
+ * 19:55 must still silence a dinner suggestion at 20:10. But it had no way back, so a client who
+ * closed the day and then genuinely ate was refused for the rest of it, every time they asked.
+ *
+ * A STATED DECISION TO EAT, not a mention of food. The distinction is the whole of this function
+ * and it is the same one foodDayIsClosed makes above: the shape is (a first-person commitment) +
+ * (the act of eating or a meal to eat), so
+ *
+ *     "actually I changed my mind, I'm having dinner"   reopens   — a decision
+ *     "I'm eating"                                      reopens
+ *     "what should I eat?"                              does NOT  — a question, no commitment
+ *     "thinking about dinner"                           does NOT  — considering is not deciding
+ *     "I'm having a bad day"                            does NOT  — `having` needs a meal after it
+ *
+ * NO REVERSAL-MARKER FORM. "changed my mind" / "actually" beside any eating word was the obvious
+ * second clause and it is deliberately absent: "actually I'm not eating anymore" carries both the
+ * marker and the verb, so that clause would have read a plainer CLOSURE as a reopening. The
+ * commitment shape cannot do that — a closure negates the verb, and `I'm not eating` never
+ * matches `I'm` immediately followed by the act.
+ *
+ * Named without looksLike* for the same reason as its sibling: a DayState input, not a router.
+ */
+export function foodDayIsReopened(text: string): boolean {
+  const t = String(text || "");
+  if (!t.trim()) return false;
+  return /\b(?:i'?m|i am|i'?ll|i will|i'?ve decided to|decided to)\s+(?:going\s+to\s+|gonna\s+)?(?:eat(?:ing)?\b|hav(?:e|ing)\s+(?:a\s+|some\s+|my\s+|the\s+)?(?:dinner|supper|lunch|breakfast|brunch|meal|food|something(?:\s+to\s+eat)?)\b)/i.test(t);
+}
+
 export function chooseAction(s: DayState): OneAction {
   const struggle = readStruggle(s.biggestStruggle);
   const isBulk = s.goal === "muscle_gain";

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -434,11 +434,31 @@ export function foodDayIsClosed(text: string): boolean {
  * commitment shape cannot do that — a closure negates the verb, and `I'm not eating` never
  * matches `I'm` immediately followed by the act.
  *
+ * TWO WAYS THE COMMITMENT SHAPE ALONE STILL GOT IT WRONG (CTO hold on #155). Both are cases where
+ * the sentence carries the words of a decision to eat while saying the opposite of one about TODAY:
+ *
+ *     "I'm having dinner tomorrow"     a decision about ANOTHER DAY. readHeldConstraints filters by
+ *                                      WHEN a message was sent, never by which day it is about, so
+ *                                      tomorrow's plan would have reopened tonight. The guard is
+ *                                      the one asksForTrainingToday already uses for this exact
+ *                                      question: a named future day, with nothing anchoring it to
+ *                                      today, is not about today.
+ *     "I'm eating nothing else today"  a CLOSURE wearing the positive prefix. The act is followed
+ *                                      by a zero quantity, so the sentence commits to eating none —
+ *                                      reading it as a reopening would let the plainest restatement
+ *                                      of the constraint cancel the constraint.
+ *
  * Named without looksLike* for the same reason as its sibling: a DayState input, not a router.
  */
 export function foodDayIsReopened(text: string): boolean {
   const t = String(text || "");
   if (!t.trim()) return false;
+  // A decision about another day is not a decision about this one — unless the sentence also
+  // anchors itself to today, in which case the client is talking about both.
+  if (/\b(?:tomorrow|2moro|2morrow|next\s+week|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i.test(t)
+      && !/\b(?:today|tonight|now|this\s+(?:evening|afternoon|morning))\b/i.test(t)) return false;
+  // "eating nothing else today" is the constraint restated, not withdrawn.
+  if (/\b(?:eat|eating|hav(?:e|ing))\s+(?:absolutely\s+)?(?:no\s+more|nothing|no\s+food|zero)\b/i.test(t)) return false;
   return /\b(?:i'?m|i am|i'?ll|i will|i'?ve decided to|decided to)\s+(?:going\s+to\s+|gonna\s+)?(?:eat(?:ing)?\b|hav(?:e|ing)\s+(?:a\s+|some\s+|my\s+|the\s+)?(?:dinner|supper|lunch|breakfast|brunch|meal|food|something(?:\s+to\s+eat)?)\b)/i.test(t);
 }
 

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -74,8 +74,8 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
     //
     // It now asks the decision owner, on canonical state, under the same policy contract every
     // other caller uses. theNextMove is deleted.
-    const { chooseAction, underPolicy, foodDayIsClosed, trainingDayIsDeclined, PROACTIVE_LOG_FLOOR } = await import("../one-action");
-    const { readHeldConstraints } = await import("../held-constraints");
+    const { chooseAction, underPolicy, trainingDayIsDeclined, PROACTIVE_LOG_FLOOR } = await import("../one-action");
+    const { readHeldConstraints, foodDayClosedWith } = await import("../held-constraints");
     const { getProgressTruth, sessionsThisCalendarWeek } = await import("../day-ledger");
     const { sastHour } = await import("../sast");
     const { getTodayWorkoutState } = await import("../workout-state");
@@ -113,7 +113,9 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
       // of the turn that carried it. `held` is today's statements; the live message is folded in
       // because it has not reached chat_history yet. trainingDeclined is the twin, and until now
       // it had no field at all: routes.ts computed it into `_isWorkoutRefusal` and dropped it.
-      foodDayClosed: held.foodDayClosed || foodDayIsClosed(message || ""),
+      // The current turn can RELEASE the constraint as well as tighten it (#152) — one owner
+      // for that, so this door and the SMART NEXT MEAL door cannot read one sentence differently.
+      foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
       trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
     } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
          // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a


### PR DESCRIPTION
Closes the defect described in #152. Base `main@30bc23e`. 3 files.

## First divergence

`readHeldConstraints` derived the day's state with:

```ts
foodDayClosed: todays.some(s => foodDayIsClosed(s.text))
```

`some` cannot express a change of mind. It also throws away the one thing that settles a contradiction — **when** each statement was made — so no later message could ever outrank an earlier closure. And there was no reopening recogniser anywhere: `grep -rl "changed my mind" server/` returned nothing.

## Three changes, all in the existing owners

**1. `one-action.ts` gains `foodDayIsReopened` beside `foodDayIsClosed`** — a stated *decision* to eat, not a mention of food, built as the same kind of composed shape as its sibling: (a first-person commitment) + (the act of eating, or a meal to eat).

| message | reopens? |
|---|---|
| `actually I changed my mind, I'm having dinner` | **yes** |
| `I'm eating` | **yes** |
| `what should I eat?` | no — a question, no commitment |
| `thinking about dinner` | no — considering is not deciding |
| `I'm having a bad day` | no — `having` needs a meal after it |

**No reversal-marker clause.** "changed my mind" / "actually" beside any eating word was the obvious second form and is deliberately absent: *"actually I'm not eating anymore"* carries both the marker and the verb, so that clause would have read a plainer **closure** as a reopening. The commitment shape cannot — a closure negates the verb, and `I'm not eating` never matches `I'm` immediately before the act.

**2. `held-constraints.ts` derives the effective state from the client's ordered words.** The statements already arrive newest-first, so the first one that is a decision about eating today is the decision that stands. Nothing is stored, no second store exists; "held" still means what the client said. A closure inside a *single* message outranks a reopening inside it — one turn cannot be ordered against itself, so the tie goes to the constraint.

**3. `foodCloseLookup`** — the reader Coach Health uses — learned the same rule, or the detector would have filed every correct post-reversal reply as a closed-day violation forever.

## Controls — through the real door, on what the client receives

| # | sequence | result |
|---|---|---|
| 1 | close → reopen → ask | **open**, `MEAL_SUGGESTION` |
| 2 | close → unrelated → ask | still closed — #138 re-asserted, so the reversal was not bought by weakening the constraint |
| 3 | close → ask | still closed |
| 4 | close → `thinking about dinner` → ask | still closed |
| 5 | close → reopen → close → ask | closed, newest wins |
| 6 | never closed | open |

**User/day isolation:** another client's change of mind, and yesterday's, cannot open this day; a same-day one does — the third assertion is what stops the first two passing on a lookup that simply ignores reopenings.

**Coach Health:** a suggestion after a genuine reopening is clean; a suggestion after the day was closed *again* still flags.

## Red on revert — three, each on a different mechanism

| removed | what fails |
|---|---|
| the reopening recogniser | the product case, the Coach Health case **and** the lookup case |
| ordered walk → `some()` | **only** the product reversal — so the ordering is what carries it |
| lookup ignores order | **only** reopen-then-close-again — so newest-wins is proved in the detector too |

## Fixture note, recorded in the test

History is supplied **newest first**, as `recentClientMessagesStamped` returns it (`ORDER BY created_at DESC`). Oldest-first would invert case 5 and quietly grade the opposite of production — worth stating, because a stub that ignores `ORDER BY` will not tell you.

## Verification vs `main@30bc23e`

`tsc` clean · tracking-contract green · unit **1055/1055** · production-parity **142/142** · routing-audit **322/322** · gap-tests **344/344** · food-scanner **48/48**

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical |
| ownership · names · reach | OK · 97/97 · 8 | identical |

No new store, state machine, parser family or router. No budget raised, no normalizer or architecture work, `foodDayIsClosed` and the #138/#144 controls untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_