### PR TITLE
P1 #156: the milestone comeback register asks the re-entry owner whether the client was away

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -48,7 +48,7 @@ const { explicitMealSlot } = await import("../server/understanding/actions");
 // TransformError and NOT ONE of its ~300 tests ran, reporting nothing rather than failing.
 // script/check-architecture.ts now parses every suite in the npm test chain so this cannot hide
 // again. Add new tests further down, beside their subject.
-const { selectModel } = await import("../server/gpt");
+const { selectModel, milestoneEmotion } = await import("../server/gpt");
 const { scanForSAFoods } = await import("../server/handlers/food-scanner");
 // These were written as CommonJS require() inside an ESM module, so every test below
 // that used them threw "require is not defined" — they had never executed. Bound once here.
@@ -4263,6 +4263,67 @@ test("PROBE: an async failure in this suite is actually observed", async () => {
 // EVERY ASYNC CASE MUST LAND BEFORE THE TALLY. Without this the counts below are printed while
 // most of the file is still running, which is what made the whole suite advisory.
 await Promise.all(pending);
+
+
+// MILESTONE REGISTER — "HAS THIS CLIENT BEEN AWAY?" HAS ONE OWNER (#156, 2026-09-04).
+//
+// The register used to read absence by regexing "(N days silent)" back out of the prose
+// buildPatternSummary had just generated. That number is 7 minus the DISTINCT DAYS THE CLIENT
+// SPOKE in a rolling week — logging density, not contact. Reproduced on current main before the
+// change: a client who messaged TODAY but checks in twice a week produced
+//
+//     "PATTERN CONTEXT: Kam has logged 2 of the last 7 days (5 days silent)."
+//     prose regex -> daysSilent=5 -> lapsed -> comeback
+//     contactState -> daysSinceLastContact=0, isReturning=false
+//
+// so a present client was told to their face that they had gone quiet.
+{
+  // milestoneEmotion comes from the gap-tests-wide gpt import above: unit-tests has no other
+  // reason to load server/gpt.ts, and adding one there left the process alive after the last
+  // assertion — 1055 green and then a hang to CI's timeout. This suite already loads it.
+  const { RETURNING_DAYS, contactState } = await import("../server/understanding/reentry");
+  const SPARSE = "PATTERN CONTEXT: Kam has logged 2 of the last 7 days (5 days silent). Protein target is 195g/day.";
+  const DENSE = "PATTERN CONTEXT: Kam has logged 6 of the last 7 days (1 day silent). Protein target is 195g/day.";
+
+  test("milestone register: a present client is not put in the comeback register by sparse logging", () => {
+    // The divergent shape. Everything else about this summary is neutral, so the only thing that
+    // could move the register is the absence signal.
+    assert.notEqual(milestoneEmotion(SPARSE, false), "comeback",
+      "a client who spoke today must not be told they went quiet because they log twice a week");
+  });
+
+  test("milestone register: a genuinely returning client is eligible for comeback, however dense their week was", () => {
+    assert.equal(milestoneEmotion(DENSE, true), "comeback",
+      "a client past the canonical re-entry threshold must reach the comeback register even after a dense week");
+    // ...and the threshold is the canonical one, not a second copy.
+    const away = new Date(Date.now() - RETURNING_DAYS * 86_400_000);
+    assert.ok(contactState(away).isReturning, "the fixture must actually be past RETURNING_DAYS");
+  });
+
+  test("milestone register: training inactivity still moves the register on its own", () => {
+    // Present client, dense week — only the training signal is in play.
+    assert.equal(milestoneEmotion(DENSE + " No training sessions logged this week.", false), "comeback",
+      "training inactivity is an independent signal and must survive the re-entry cut");
+    assert.equal(milestoneEmotion(DENSE + " Last training was 6 days ago.", false), "comeback",
+      "a stale last-session date is an independent signal too");
+  });
+
+  test("milestone register: struggling and thriving still set the tone independently of contact", () => {
+    assert.equal(milestoneEmotion(DENSE + " needs direct accountability", false), "comeback",
+      "a struggling pattern still outranks a calm week");
+    assert.equal(milestoneEmotion(DENSE + " Food logging is consistent, a solid habit.", false), "celebratory",
+      "a thriving pattern still earns the celebratory register");
+    assert.equal(milestoneEmotion(DENSE, false), "warm",
+      "and a neutral week is neither — the default must not have moved");
+  });
+
+  test("milestone register: absence is contact, not logging density", () => {
+    // The pair that isolates the fix: identical prose, opposite contact state, opposite register.
+    assert.notEqual(milestoneEmotion(SPARSE, false), milestoneEmotion(SPARSE, true),
+      "the same pattern summary must give different registers for a present and an absent client — otherwise the decision is still reading the prose");
+    assert.equal(milestoneEmotion(SPARSE, true), "comeback");
+  });
+}
 
 console.log(`\ngap-tests: ${passed}/${passed + failed} passed`);
 if (failures.length > 0) {

--- a/server/gpt.ts
+++ b/server/gpt.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { contactState } from "./understanding/reentry";
 import { readHealthState } from "./health-state";
 import { db, recordedIntent } from "./db";
 import { users, chatHistory, weightLogs, stepLogs, workoutLogs, mealLogs, gptCosts } from "../shared/schema";
@@ -1193,6 +1194,33 @@ export async function askCoachK(userMessage: string, user: any, extraInstruction
 
 export type MilestoneType = "weight_loss" | "goal_reached_fat_loss" | "goal_reached_muscle" | "workout_sessions";
 
+/**
+ * THE MILESTONE REGISTER — and "has this client been away?" has an owner (#156, 2026-09-04).
+ *
+ * This read absence by regexing "(N days silent)" back out of the prose buildPatternSummary had
+ * just generated. That number is 7 minus the count of DISTINCT DAYS THE CLIENT SPOKE in a rolling
+ * week, which is not the same question: a client who messaged this morning but checks in twice a
+ * week scores 5 "silent" days and was put in the comeback register — told to their face that they
+ * went quiet — on the day they were present. Reproduced on current main before this change.
+ *
+ * `isReturning` comes from understanding/reentry, which owns the threshold (RETURNING_DAYS) and is
+ * the same answer every other consumer of re-entry uses. Absence is contact, not logging density.
+ *
+ * The other three signals are unchanged and stay independent: training inactivity, a struggling
+ * pattern and a thriving one each still move the register on their own. This cut is only about
+ * where absence comes from.
+ */
+export function milestoneEmotion(patternSummary: string, isReturning: boolean): VoiceEmotion {
+  const lastTrainMatch = patternSummary.match(/Last training was (\d+) days ago/i);
+  const daysSinceTraining = lastTrainMatch ? parseInt(lastTrainMatch[1], 10) : 0;
+  const trainingLapsed = daysSinceTraining >= 5 || /No training sessions logged this week/i.test(patternSummary);
+  const struggling = /too hard or wanting to quit|needs direct accountability|consistently under/i.test(patternSummary);
+  const thriving = /solid habit|at or above target|Food logging is consistent/i.test(patternSummary);
+  // Hitting a milestone after going quiet or struggling = a comeback: firm first,
+  // proud second — never a soft "how are you". Otherwise match their momentum.
+  return (isReturning || trainingLapsed || struggling) ? "comeback" : thriving ? "celebratory" : "warm";
+}
+
 export async function generateMilestoneVoiceScript(
   user: any,
   milestoneType: MilestoneType,
@@ -1231,18 +1259,7 @@ export async function generateMilestoneVoiceScript(
   // Pick the emotional register from the REAL pattern data, then let it drive both
   // the words (prompt below) and the voice delivery (returned to the caller).
   // buildPatternSummary already computed these signals — read them back out.
-  const silentMatch = patternSummary.match(/\((\d+)\s+days?\s+silent\)/i);
-  const daysSilent = silentMatch ? parseInt(silentMatch[1], 10) : 0;
-  const lastTrainMatch = patternSummary.match(/Last training was (\d+) days ago/i);
-  const daysSinceTraining = lastTrainMatch ? parseInt(lastTrainMatch[1], 10) : 0;
-  const lapsed = daysSilent >= 4 || daysSinceTraining >= 5
-    || /No training sessions logged this week/i.test(patternSummary);
-  const struggling = /too hard or wanting to quit|needs direct accountability|consistently under/i.test(patternSummary);
-  const thriving = /solid habit|at or above target|Food logging is consistent/i.test(patternSummary);
-
-  // Hitting a milestone after going quiet or struggling = a comeback: firm first,
-  // proud second — never a soft "how are you". Otherwise match their momentum.
-  const emotion: VoiceEmotion = (lapsed || struggling) ? "comeback" : thriving ? "celebratory" : "warm";
+  const emotion = milestoneEmotion(patternSummary, contactState(user.lastActiveAt).isReturning);
 
   const toneHint = emotion === "comeback"
     ? "They went quiet or had a rough stretch before hitting this. Do NOT open soft and do NOT ask how they are. In the first sentence, name the gap directly and firmly — they know they slipped. Then give real respect that they showed up and hit this number anyway. Firm first, proud second."


### PR DESCRIPTION
Closes #156. Base `main@c4e9f55`. Head `c9b7680` (verified with `git rev-parse`). 2 files.

Old PR #91 was **neither merged nor rebased** — nothing from it is in this diff.

## Replayed on current main first — the divergence is still there

`generateMilestoneVoiceScript` decided absence by regexing `(N days silent)` back out of the prose `buildPatternSummary` had just generated. That number is `7 - daysWithLogs`, and `daysWithLogs` counts **distinct days the client spoke** in a rolling week — logging density, not contact.

Run against the real builder on a seeded week, before any change:

```
client messaged TODAY, spoke on 2 of the last 7 days
  buildPatternSummary -> "...has logged 2 of the last 7 days (5 days silent)."
  the prose regex     -> daysSilent=5 -> lapsed -> comeback
  contactState        -> daysSinceLastContact=0, isReturning=false
  AGREE? NO — DIVERGENT
```

So a client who was present that morning was put in the comeback register, whose tone hint opens *"They went quiet… name the gap directly and firmly — they know they slipped."*

## The fix, from the owner that already exists

`understanding/reentry` owns the threshold (`RETURNING_DAYS`) and answers this for every other consumer. `milestoneEmotion` now takes `isReturning` from `contactState(user.lastActiveAt)`; the `(N days silent)` read is gone. **No second predicate, no new threshold.**

**The other three signals are untouched and stay independent** — training inactivity (both the `>= 5 days` form and *"No training sessions logged this week"*), a struggling pattern, and a thriving one each still move the register on their own. This cut is only about where absence comes from.

The decision is now a pure exported function so it can be graded without the network, which is what the issue asks for instead of inventing live evidence.

## Controls — behavioural, at that seam

| case | register |
|---|---|
| present + sparse logging | **not** comeback |
| returning + dense week | comeback — and the fixture asserts it is genuinely past `RETURNING_DAYS` rather than writing the number out again |
| training inactivity, present client | comeback, on its own |
| struggling / thriving / plain | comeback / celebratory / warm — unchanged |
| **isolation pair** | the *same* summary must give different registers for a present and an absent client |

The isolation pair is the one that proves the prose is no longer being read at all.

**Red on revert:** restoring the prose-regex absence fails **three** — both divergent shapes and the isolation pair — while the training, struggling and thriving cases stay green. That green is the proof they are independent of this change.

## Two harness mistakes, caught before they could mislead

Worth recording, because one of them is a repeat of something this repo has already paid for:

1. The controls first went into `unit-tests`, whose only reason to load `server/gpt.ts` would have been this test. Result: **1055 green and then a hang to CI's timeout**. They live in `gap-tests`, which already loads that module and exits cleanly.
2. They were then appended **after** that suite's `process.exit(0)` and silently never ran. The red-on-revert check is what exposed it — it came back green when it had to be red. A control that cannot fail is worth nothing, and this is the second time in this session that checking the *negative* caught a test that was not executing.

## Verification vs `main@c4e9f55`

`tsc` clean · **gap-tests 350/350** (345 + 5) · unit **1055/1055** (exit 0, no hang) · production-parity **142/142** · routing-audit **322/322** · tracking-contract green · food-scanner **48/48**

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical |
| ownership · names · reach · SAST | OK · 97/97 · 8 · 61/61 | identical |

`gpt.ts` 1423 → 1439 against its 1450 budget. No budget raised, nothing suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_