### PR TITLE
#158 replay: a contraction is the same correction as the spelled-out form

### DIFF
--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -7859,6 +7859,44 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
     assert.equal(parseIdentityCorrection("not brown, it was white")?.right, "white");
   });
 
+  // THE CONTRACTION IS THE COMMON FORM (#158, 2026-09-04, recovered-contract replay). Every
+  // pattern in this owner, and its own guard, look for the WORD "not". "wasn't" does not contain
+  // it, so the plainest way a person says this returned null, the owner never claimed the turn,
+  // and the message fell through to the ordinary food logger — which logged BOTH the corrected
+  // food AND the one the client had just denied onto the named day. Reproduced through the real
+  // door on current main before the fix: a second INSERT on Tuesday carrying pap AND rice.
+  test("identity correction: a contraction is the same correction as the spelled-out form", () => {
+    for (const said of [
+      "Tuesday wasn't rice, it was pap",
+      "Tuesday was not rice, it was pap",
+    ]) {
+      const c = parseIdentityCorrection(said);
+      assert.ok(c, `must parse: "${said}"`);
+      assert.equal(c!.right, "pap", said);
+      assert.equal(c!.wrong, "rice", said);
+    }
+    assert.deepEqual(
+      parseIdentityCorrection("Tuesday wasn't rice, it was pap"),
+      parseIdentityCorrection("Tuesday was not rice, it was pap"),
+      "the two spellings are one correction — if they ever differ, the owner has two answers again",
+    );
+    assert.equal(parseIdentityCorrection("it wasn't tuna, it was pilchards")?.right, "pilchards");
+  });
+
+  test("identity correction: OVER-FIRE — a contraction is not automatically a food swap", () => {
+    // The guard that stops the expansion turning every negated sentence into a correction. These
+    // all contain an expanded "not" after the change and must still fall through.
+    for (const said of [
+      "I didn't train today",
+      "it wasn't that bad",
+      "I wasn't hungry",
+      "that isn't going to happen",
+      "I don't feel well",
+    ]) {
+      assert.equal(parseIdentityCorrection(said), null, `must not read as a food swap: "${said}"`);
+    }
+  });
+
   test("identity correction: NOT fired by ordinary 'not' sentences", () => {
     for (const msg of [
       "I'm not sure what to eat", "not today", "why not", "I'm not hungry",

--- a/server/food-identity-correction.ts
+++ b/server/food-identity-correction.ts
@@ -53,7 +53,20 @@ function clean(s: string): string {
  * one — "I'm not sure", "not today", "I did not train" and quantity corrections all fall through.
  */
 export function parseIdentityCorrection(message: string): IdentityCorrection | null {
-  const s = (message || "").trim();
+  /**
+   * THE CONTRACTION IS THE COMMON FORM (#158, 2026-09-04). Every pattern below, and the guard
+   * on the next line, look for the WORD `not`. "wasn't" does not contain it, so
+   *
+   *     "Tuesday wasn't rice, it was pap"
+   *
+   * — the plainest way a person says this — returned null, this owner never claimed the turn, and
+   * the message fell through to the ordinary food logger, which logged BOTH pap and the rice the
+   * client had just denied onto Tuesday. Reproduced on current main before this change.
+   *
+   * Expanded once, here, rather than by teaching four regexes a second spelling: the shapes are
+   * unchanged and there is still one place that decides what a correction looks like.
+   */
+  const s = (message || "").trim().replace(/\b(was|were|is|are|does|did|do)n[''\u2019]t\b/gi, "$1 not");
   if (!s || !/\bnot\b/i.test(s)) return null;
   if (NOT_A_SWAP.test(s)) return null;
 


### PR DESCRIPTION
Issue #158, replayed on current main first. Base `main@4610be1`, head **`cef2e29`** (verified with `git rev-parse`). 2 files.

Old PR #48 was **not** merged, rebased, cherry-picked, or read for implementation.

## Replay result — five of seven contracts already hold

Driven through the real pipeline, reading both the INSERT and UPDATE channels:

| # | contract | result | evidence |
|---|---|---|---|
| 1 | two events in one message | **GREEN** | two rows — Breakfast 360/24, Lunch 600/56 — `items` populated on both, shared `sourceMessageId`, **one** chat row, **one** reply |
| 2 | intra-message correction | **GREEN** | breakfast persists as the corrected 3 eggs (186/16), not both versions; lunch untouched at 600/56 |
| 3 | food + non-food isolation | **GREEN** | steps 5000 written as steps, food event written separately, one reply carries both |
| 4 | multi-day structured identity | **RED** | all three rows carry `items: []` while the reply itself names the foods |
| 5 | later correction targets Tuesday | **RED** | a **new** Tuesday row containing pap **and the rice the client had just denied**, plus `⚠️ I could not price *tuesday, wasn*` |
| 6 | ordinary single meal | **GREEN** | unchanged — one row, one reply |
| 7 | one final client-facing reply | **GREEN** | every multi-event turn above returns a single WhatsApp message |

## First divergence — and it is upstream of the `items` question

Case 5 was **byte-identical whether the stored rows carried `items` or not**. That proves the correction never consulted them: `parseIdentityCorrection` returned `null` and this owner never claimed the turn.

Every pattern in it, and its own guard, look for the **word** `not`. `wasn't` does not contain it.

```
before   "Tuesday wasn't rice, it was pap"   -> null
         "Tuesday was not rice, it was pap"  -> { right: pap, wrong: rice }
```

So the plainest way a person says this fell through to the ordinary food logger, which logged the denied food back onto the named day.

**The fix** expands the contraction once, at the top of the one owner, rather than teaching four regexes a second spelling. The shapes are unchanged and there is still one place that decides what a correction looks like. Through the real door the same message now **UPDATEs** the row and sets `corrected`, instead of inserting a duplicate carrying the denied food.

## Controls

- **Positive:** both spellings parse, and the two results are asserted **equal** — so they cannot drift into two answers.
- **Over-fire:** `I didn't train today` · `it wasn't that bad` · `I wasn't hungry` · `that isn't going to happen` · `I don't feel well` — all contain an expanded `not` after this change and must still fall through.
- **Red on revert:** removing the expansion fails on the issue's own sentence.

## What I could not prove offline — stated, not implied

Case 5's **row targeting**, and the consequence of case 4's `items: []`, both depend on `amendRecentMeal` selecting the newest matching row — and the deterministic fixture **ignores `orderBy`**. There is no `DATABASE_URL` in this environment and the Railway host is blocked by the recorded egress policy, so the fixture cannot honestly represent which row a correction lands on. I am not claiming those.

**Case 4 stays RED and unfixed here.** It is a second divergence, and the issue asks for the first only. It is now the more interesting one: with the claim working, a correction against a multi-day row with `items: []` has nothing structured to edit and overwrites the day rather than editing within it. That wants real Postgres and its own bounded cut.

## Verification vs `main@4610be1`

`tsc` clean · unit **1057/1057** · production-parity **142/142** · routing-audit **322/322** · gap-tests **350/350** · food-scanner **48/48** · tracking-contract green

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical — untouched |
| ownership · names · reach · SAST | OK · 97/97 · 8 · 61/61 | identical |

No new parser, event store, router, state machine or correction engine. No budget raised, no architecture or normalizer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_