### PR TITLE
#160: multi-day food rows keep the foods that produced them

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -1454,6 +1454,67 @@ const MUST_WRITE: [string, string][] = [
       }
 
       /**
+       * #160 — A MULTI-DAY CATCH-UP MUST LEAVE ITEMS BEHIND, NOT JUST TOTALS.
+       *
+       * The multi-day path already had the correct per-day adjusted foods in hand: it used them to
+       * compute each row's kcal/protein and to name the foods in the reply. It then handed the
+       * durable row `items: []`. So three correctly dated, correctly totalled rows carried no
+       * per-item identity — on exactly the path a later "Tuesday wasn't rice" needs it.
+       *
+       * Graded on the rows the real turn writes, not on the reply, because the reply was already
+       * right and that is what made this invisible.
+       */
+      {
+        freshTurn();
+        g.__KAMLIFE_STUB_USER = { ...USER };
+        g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>();
+        g.__KAMLIFE_STUB_WRITES = [];
+        await handleMessage(USER.phoneNumber,
+          "Monday I had eggs and toast. Tuesday I had rice and chicken. Wednesday I had pap and livers.").catch(() => "");
+        const rows = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === schema.mealLogs).map((w: any) => w.values);
+        delete g.__KAMLIFE_STUB_ROWS;
+
+        if (rows.length !== 3) {
+          failures.push(`A three-day catch-up wrote ${rows.length} food rows, expected one per named day`);
+        } else {
+          const groups = new Set(rows.map((r: any) => String(r.sourceMessageId || "")));
+          if (groups.size !== 1) failures.push(`The three days did not share one event group: ${JSON.stringify([...groups])}`);
+          const days = rows.map((r: any) => new Date(r.loggedAt).toDateString());
+          if (new Set(days).size !== 3) failures.push(`The three rows are not on three distinct days: ${JSON.stringify(days)}`);
+
+          for (const r of rows as any[]) {
+            const items = Array.isArray(r.items) ? r.items : [];
+            const day = new Date(r.loggedAt).toDateString();
+            if (items.length === 0) {
+              failures.push(`${day} was logged with no structured items — the reply names the foods and the ledger forgets them, so a later named correction has nothing to edit`);
+              continue;
+            }
+            // The item numbers must be the SAME adjusted objects the row total came from. If they
+            // ever disagree, the row and the reply were computed from different food sets.
+            const kcal = items.reduce((t: number, i: any) => t + (i.kcal || 0), 0);
+            const prot = items.reduce((t: number, i: any) => t + (i.protein || 0), 0);
+            if (kcal !== r.kcalInt || prot !== r.proteinInt) {
+              failures.push(`${day}: items sum to ${kcal} kcal / ${prot}g but the row says ${r.kcalInt} / ${r.proteinInt} — the durable items are not the foods that produced the total`);
+            }
+            if (items.some((i: any) => !i.name || i.grams === undefined || i.category === undefined)) {
+              failures.push(`${day}: an item is missing the shape the ordinary scanner rows carry: ${JSON.stringify(items[0])}`);
+            }
+          }
+
+          // NO CROSS-DAY BLEED. A food named on one day may not appear on another.
+          const named = (r: any) => (r.items || []).map((i: any) => String(i.name).toLowerCase()).join(" ");
+          const [mon, tue, wed] = rows.map(named);
+          if (/rice/.test(mon) || /rice/.test(wed)) {
+            failures.push(`Tuesday's rice bled into another day — Monday: "${mon}", Wednesday: "${wed}"`);
+          }
+          if (/liver/.test(mon) || /liver/.test(tue)) {
+            failures.push(`Wednesday's liver bled into another day — Monday: "${mon}", Tuesday: "${tue}"`);
+          }
+          if (!/rice/.test(tue)) failures.push(`Tuesday lost its own food: "${tue}"`);
+        }
+      }
+
+      /**
        * #152 — USER AND DAY ISOLATION, on the reader Coach Health uses.
        *
        * The reversal must be as narrowly scoped as the closure it cancels: one person changing

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -131,6 +131,29 @@ async function getStreakNote(userId: string, streak: number, name: string): Prom
 
 type HandleMessageFn = (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[]) => Promise<string>;
 
+/**
+ * ADJUSTED FOODS -> THE DURABLE ROW'S ITEMS. One shape, one place (#160, 2026-09-04).
+ *
+ * This mapping was written out twice in this file — once for the single-meal row and once per
+ * eating event — and the multi-day row, which had the same adjusted foods in hand, wrote `items:
+ * []` instead. Three spellings of one rule, one of them empty. Naming it costs nothing and is the
+ * smaller change: no new owner, and the two existing copies collapse into it.
+ *
+ * Quantity is carried as `grams` because that is what the existing rows carry; kcal and protein
+ * are the ADJUSTED values, so an item's numbers always add up to the row total computed from the
+ * same objects.
+ */
+function itemsFromAdjusted(foods: any[]) {
+  return (foods || []).map((f: any) => ({
+    name: f.name,
+    grams: Math.round((f.typicalPortionGrams || 100) * (f.quantity || 1)),
+    kcal: f.adjustedCalories,
+    protein: f.adjustedProtein,
+    category: f.category,
+    origin: f.origin || "db",
+  }));
+}
+
 export async function handleFoodContext(ctx: {
   phone: string;
   message: string;
@@ -774,7 +797,15 @@ export async function handleFoodContext(ctx: {
       for (const p of multiPlan) {
         const c = await commitFoodLog({
           userId: user.id, phone, rawMessage: p.raw, source: "text",
-          kcalInt: p.kcal, proteinInt: p.prot, carbsInt: 0, fatInt: 0, items: [],
+          // THE SENTENCE REMEMBERED WHAT THEY ATE AND THE LEDGER FORGOT IT (#160, 2026-09-04).
+          // p.foods is the SAME adjusted set that produced p.kcal/p.prot two lines up and names
+          // the foods in the reply below; only the durable row was handed `items: []`. So a
+          // multi-day catch-up left three correctly dated, correctly totalled rows with no
+          // per-item identity — on exactly the path a later "Tuesday wasn't rice" needs it.
+          // Nothing is reparsed here: the same objects, through the same mapping the single-meal
+          // and event-bucket rows already use.
+          kcalInt: p.kcal, proteinInt: p.prot, carbsInt: 0, fatInt: 0,
+          items: itemsFromAdjusted(p.foods),
           mealLabel: extractMealLabel(p.raw, p.date, { kcal: p.kcal, protein: p.prot }, user, slotCtxMulti),
           loggedAt: p.date, sourceMessageId: eventGroupId,
         });
@@ -1060,14 +1091,7 @@ export async function handleFoodContext(ctx: {
       const { carbs: totalCarbs, fat: totalFat } = carbsFatOf(allAdjustedFoods);
       const firstSegLabel = mealSegments.find(s => s.label)?.label
         || extractMealLabel(message, undefined, { kcal: totalCals, protein: Math.round(totalProtein) }, user, await getSlotContext(user.id));
-      const scannerItems = allAdjustedFoods.map(f => ({
-        name: f.name,
-        grams: Math.round((f.typicalPortionGrams || 100) * (f.quantity || 1)),
-        kcal: f.adjustedCalories,
-        protein: f.adjustedProtein,
-        category: f.category,
-        origin: f.origin || "db",
-      }));
+      const scannerItems = itemsFromAdjusted(allAdjustedFoods);
       // ── ONE ROW PER EATING EVENT (2026-08-17, migration 0004) ───────────────────────────────
       // "eggs in the morning, pap at lunch" is TWO events, stored as one row with one date and one
       // label. Each event now gets its own row, date and label, linked by sourceMessageId so the
@@ -1106,12 +1130,7 @@ export async function handleFoodContext(ctx: {
             rawMessage: bucket.text.slice(0, 1000),
             source: "sa_scanner",
             kcalInt: kcal, proteinInt: prot, carbsInt: carbs, fatInt: fat,
-            items: bucket.foods.map((f: any) => ({
-              name: f.name,
-              grams: Math.round((f.typicalPortionGrams || 100) * (f.quantity || 1)),
-              kcal: f.adjustedCalories, protein: f.adjustedProtein,
-              category: f.category, origin: f.origin || "db",
-            })),
+            items: itemsFromAdjusted(bucket.foods),
             mealLabel: bucket.label
               || extractMealLabel(bucket.text, ownDate, { kcal, protein: prot }, user, slotCtx),
             loggedAt: ownDate,


### PR DESCRIPTION
Issue #160 — the second current-main divergence from the same #158 Event Model replay. Base `main@3fa864c`, head **`82d9310`** (verified with `git rev-parse`). 2 files.

Old PR #48 was **not** merged, rebased, cherry-picked or read.

## The defect, as reproduced

The multi-day path already had the correct per-day adjusted foods in `multiPlan[].foods` — it used them to compute each row's kcal/protein **and** to name the foods in the client's reply. It then handed the durable row `items: []`.

```
before   ROW Mon  kcal=360 prot=24  items=[]
         ROW Tue  kcal=580 prot=56  items=[]
         ROW Wed  kcal=593 prot=51  items=[]

after    ROW Mon  kcal=360 prot=24  items=["Eggs on toast|360kcal|24p|200g"]
         ROW Tue  kcal=580 prot=56  items=["Chicken and rice|580kcal|56p|400g"]
         ROW Wed  kcal=593 prot=51  items=["Pap …|330kcal|7p|200g",
                                           "Ox liver|263kcal|44p|150g"]
```

**Nothing is reparsed.** The same `p.foods` objects, through the same mapping the single-meal and event-bucket rows already use. Dates, labels, totals, event group and the reply are byte-identical to before.

## One shape, one place

That mapping was already written out **twice** in this file — once for the single-meal row, once per eating event — and the multi-day row wrote `[]`. Three spellings of one rule, one of them empty. Naming it as `itemsFromAdjusted` was the *smaller* change: no new owner, and the two existing copies collapse into it. No new event store, parser, router, state machine, correction engine or schema.

Carbs and fat on this row remain `0`, as before — they are row totals rather than identity, and changing them would change what the row says.

## Controls — on the rows a real turn writes, not on the reply

The reply was already right, and that is exactly what made this invisible.

| control | asserts |
|---|---|
| three named days | one row per day · one shared event group · three distinct dates · every row's `items` non-empty |
| **items are the foods** | each row's item kcal and protein sum **exactly** to that row's total, and carry the same shape the scanner rows carry |
| no cross-day bleed | Tuesday's rice on no other day · Wednesday's liver on no other day · Tuesday still has its own food |
| single meal | unchanged — one row, items as before |
| same-day multi-event | unchanged — two rows, correct items, no collapse |
| non-food isolation | multi-day workout/steps stay with `backfillAttributedDays`: steps `[8000, 5000]`, one workout row, no food row |

**Red on revert — two, each catching a different way to get it wrong:**

| control | failure |
|---|---|
| `items: []` restored | all three days report *"was logged with no structured items"* |
| every day gets every food | each row's items sum to **1533 kcal** against its own 360 / 580 / 593, and the bleed assertions fire |

The second one matters: without the sum check, "put something in `items`" would pass while the row and the reply were computed from different food sets.

## Proof boundary — stated, not implied

**The targeted-correction replay from #158 is not claimed here.** `amendRecentMeal` selects the newest matching row and the deterministic fixture **ignores `orderBy`**; there is no `DATABASE_URL` in this environment and the Railway host is blocked by the recorded egress policy. So which row a later *"Tuesday wasn't rice"* lands on cannot be honestly shown from here.

What this PR proves is that **the identity a targeted correction needs is now durably present**. The real-DB targeting check stays open and explicit, and I did not repair the fixture into a second database to manufacture it.

## Verification vs `main@3fa864c`

`tsc` clean · tracking-contract green · unit **1057/1057** · production-parity **142/142** · routing-audit **322/322** · gap-tests **350/350** · food-scanner **48/48**

| guard | main | branch |
|---|---|---|
| file-size | 236 files OK (none over budget) | 236 files OK — `food-context` 1385 → 1404 against its 1450 |
| `messageDeciders` · `looksLikePredicates` · `authorshipPoints` | 32 ✗ · 21 ✗ · 423 ✗ | identical — untouched |
| ownership · names · reach · SAST | OK · 97/97 · 8 · 61/61 | identical |

No budget raised, no architecture counter chasing, no normalizer work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_