### PR TITLE
"This morning" is a slot claim, not a snack (#174)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -825,6 +825,59 @@ test("explicitMealSlot: the J1 message keeps its breakfast, whatever the clock s
 });
 
 // ============================================================
+// "THIS MORNING" IS A SLOT CLAIM (#174 — first divergence found by the #170 Journey Lab)
+//
+// Through the real front door and real PostgreSQL, "This morning I had 3 eggs and 2 slices of
+// toast" was written with meal_label = 'snack': nothing recognised the phrase, so extractMealLabel
+// asked the send clock, which knows when the message arrived and nothing about when the food was
+// eaten. parseMealDate has read "this morning" as 8am SAST for months — the meaning existed and
+// simply never reached the slot.
+// ============================================================
+
+test("explicitMealSlot: the Journey Lab message — 'This morning' is breakfast", () => {
+  assert.equal(explicitMealSlot("This morning I had 3 eggs and 2 slices of toast"), "breakfast");
+});
+
+test("explicitMealSlot: a named day's morning is breakfast too, and says nothing about the date", () => {
+  assert.equal(explicitMealSlot("Yesterday morning I had eggs"), "breakfast");
+  assert.equal(explicitMealSlot("Monday morning I had oats"), "breakfast");
+  assert.equal(explicitMealSlot("I had a banana in the morning"), "breakfast");
+});
+
+// THE ORDER IN THAT FUNCTION IS LOAD-BEARING, and this is the control that proves the new branch
+// did not disturb it. An explicitly named other meal sits ABOVE the bare forms, so a message
+// carrying both a morning phrase and a named meal must still resolve to the named meal — exactly
+// as it did before, when the morning phrase was invisible.
+test("explicitMealSlot: a named meal still outranks a morning phrase in the same message", () => {
+  assert.equal(explicitMealSlot("This morning I had eggs, and for lunch I had rice"), "lunch");
+  assert.equal(explicitMealSlot("I skipped breakfast this morning and had a snack"), "snack");
+});
+
+// OVER-FIRE. The claim is about a phrase naming the morning PERIOD, not about the word appearing.
+test("explicitMealSlot: 'morning' with no temporal determiner is not a slot claim", () => {
+  assert.equal(explicitMealSlot("Morning coach, I had rice"), null);
+  assert.equal(explicitMealSlot("I had chicken and rice"), null);
+});
+
+// DELIBERATELY NOT WIDENED (#174 control 3). Afternoon spans lunch and the snack after it, so a
+// slot for it would be invented rather than surfaced. It still falls to clock inference.
+test("explicitMealSlot: 'this afternoon' is NOT mapped to lunch", () => {
+  assert.equal(explicitMealSlot("This afternoon I had a sandwich"), null);
+  assert.equal(explicitMealSlot("This evening I had rice"), null);
+});
+
+// THE SLOT AND THE DAY ARE DIFFERENT QUESTIONS WITH DIFFERENT OWNERS, and the new branch must not
+// blur them: parseMealDate keeps answering "which day", explicitMealSlot only "which meal".
+test("'yesterday morning' keeps yesterday's date while gaining the breakfast slot", async () => {
+  const { parseMealDate, sastDayKey } = await import("../server/sast");
+  const at = parseMealDate("Yesterday morning I had eggs");
+  assert.ok(at, "parseMealDate must still resolve a date for this phrase");
+  assert.notEqual(sastDayKey(at!), sastDayKey(new Date()), "it must not become today");
+  assert.equal(sastDayKey(at!), sastDayKey(new Date(Date.now() - 86_400_000)));
+  assert.equal(explicitMealSlot("Yesterday morning I had eggs"), "breakfast");
+});
+
+// ============================================================
 // THE REALITY HARNESS MUST NOT PAGE A HUMAN (Reality run, 2026-08-12)
 //
 // Journey 4 says "I missed gym on Monday because my back was sore". detectEscalation read

--- a/server/understanding/actions.ts
+++ b/server/understanding/actions.ts
@@ -35,6 +35,31 @@ export function explicitMealSlot(msg: string): "breakfast" | "lunch" | "dinner" 
   if (/\blunch\b/i.test(lo)) return "lunch";
   if (/\b(?:dinner|supper)\b/i.test(lo)) return "dinner";
   if (/\bbreakfast\b/i.test(lo)) return "breakfast";
+  // SAYING WHEN YOU ATE IS SAYING WHICH MEAL IT WAS (#174, first Journey Lab divergence).
+  //
+  // "This morning I had 3 eggs and 2 slices of toast" was stored with meal_label = 'snack',
+  // because nothing here recognised the phrase and extractMealLabel then asked the SEND CLOCK —
+  // which knows when the message arrived and nothing about when the food was eaten. The client
+  // stated the meal period in the most ordinary way there is and the record disagreed with them.
+  //
+  // Not cosmetic, and not one row: the morning job looks for mealLabel === "breakfast", meal-repeat
+  // copies by label, and resolveInferredSlot demotes later meals by which slots are already used.
+  // A breakfast filed as a snack breaks all three, silently.
+  //
+  // THE PRODUCT ALREADY OWNS THIS MEANING — parseMealDate has read "this morning" as 8am SAST, and
+  // "<day> morning" as the same, since long before this. What was missing is that the answer never
+  // reached the SLOT. So this is the existing meaning taught to the existing owner, not a second
+  // slot parser: one line, in the function the executor and food-context already share.
+  //
+  // LAST, DELIBERATELY, beside bare "breakfast" rather than beside "for breakfast". The order in
+  // this function is load-bearing: an explicitly named other meal outranks a bare mention, so
+  // "This morning I had eggs, and for lunch I had rice" still resolves to lunch exactly as it did
+  // — the branches above are untouched and cannot be reached differently.
+  //
+  // MORNING ONLY. "this afternoon" is deliberately NOT here: afternoon spans lunch and the snack
+  // after it, so mapping it to a slot would be inventing a meaning rather than surfacing one, and
+  // an afternoon phrase still falls to clock inference exactly as before.
+  if (/\b(?:this|yesterday|early|in the|the|(?:mon|tues|wednes|thurs|fri|satur|sun)day)\s+morning\b/i.test(lo)) return "breakfast";
   return null;
 }
 


### PR DESCRIPTION
Closes #174. First divergence found by the #170 Journey Lab. Two files, one behavioural line.

## The defect

Through the real front door and real PostgreSQL, `This morning I had 3 eggs and 2 slices of toast` was durably written with `meal_logs.meal_label = 'snack'`. Nothing recognised the phrase, so `extractMealLabel` fell through to the **send clock** — which knows when the message arrived and nothing about when the food was eaten. The client stated the meal period in the most ordinary way there is and their own record disagreed with them.

Not cosmetic and not one row: the morning job looks for `mealLabel === "breakfast"`, meal-repeat copies by label, and `resolveInferredSlot` demotes later meals by which slots are already used. A breakfast filed as a snack breaks all three, silently.

## The fix — existing meaning, existing owner

`parseMealDate` has read `this morning` as **8am SAST**, and `<day> morning` as the same, since long before this. The row's `logged_at` is `08:00 SAST` both before and after this change — the meaning was already there, it just never reached the **slot**.

So this is one line added to `explicitMealSlot()`, the function the executor and food-context already share. No second slot parser, no new module, no new date semantics.

**Placed last, deliberately** — beside bare `breakfast`, not beside `for breakfast`. The order in that function is load-bearing: an explicitly named other meal outranks a bare mention. `This morning I had eggs, and for lunch I had rice` still resolves to **lunch**, and every branch above is untouched.

**Morning only.** `this afternoon` is deliberately excluded (control 3): afternoon spans lunch and the snack after it, so a slot for it would be inventing a meaning rather than surfacing one. Afternoon and evening phrases still fall to clock inference exactly as before.

## Controls — `script/gap-tests.ts`, 350 → 356

| # | Control | Result |
|---|---|---|
| 1 | The Journey Lab message → `breakfast` | ✓ |
| 1 | `yesterday morning` / `Monday morning` / `in the morning` → `breakfast` | ✓ |
| 2 | `for breakfast`, `breakfast was`, `morning meal` unchanged | ✓ (branches untouched; J1 test still green) |
| 2 | A named meal still outranks a morning phrase in the same message | ✓ |
| 3 | `this afternoon` and `this evening` stay unmapped | ✓ |
| 4 | Bare `Morning coach` and a message with no temporal phrase are not slot claims | ✓ |
| 5 | `parseMealDate("Yesterday morning…")` still lands on yesterday, not today | ✓ |
| 6 | Same foods, kcal, protein, items, `logged_at`, reply count | ✓ — see below |

Requirement 6 is proven directly rather than asserted. The same journey turn, with and without the mechanism, on real PostgreSQL:

```
with    breakfast | 590kcal/38p | 2026-09-04 06:00Z (08:00 SAST)
without dinner    | 590kcal/38p | 2026-09-04 06:00Z (08:00 SAST)
```

`kcal_int`, `protein_int`, `items` and `logged_at` are byte-identical. **Only the slot moved.**

## Red on revert (control 7), on real PostgreSQL

Deleting the one line:

- puts the durable label back to the clock's guess — `dinner` at 17h SAST, `snack` at another hour; **the variability is the defect**;
- returns the Journey Lab's DAILY TRUTH slot assertion to red;
- fails exactly the 3 new tests that depend on the mechanism (356 → 353), while the over-fire and ordering controls stay green — they assert *unchanged* behaviour, so they must.

## Journey proof — #173's lab replayed against this fix

Unmodified `script/journey-lab.ts` from `feat/journey-lab-170`, run against this branch on real PostgreSQL. Not committed here; not weakened; still not `continue-on-error`.

```
                              before (main@e76d819)   after (this branch)
1 · DAILY TRUTH               RED   51 checks, 4 ✗    RED   51 checks, 3 ✗
2 · MULTI-DAY / CORRECTION    GREEN 33 checks         GREEN 33 checks
3 · COMEBACK                  RED   38 checks, 1 ✗    RED   38 checks, 1 ✗
4 · GROCERY / SWAP            RED   50 checks, 3 ✗    RED   50 checks, 3 ✗
5 · TRAINING                  GREEN 40 checks         GREEN 40 checks
6 · MESSY REAL LIFE           GREEN 35 checks         GREEN 35 checks
7 · COACH HEALTH              GREEN                   GREEN
8 · PERTURBATION              GREEN                   GREEN
                              RED — 8 of 253          RED — 7 of 253
```

The DAILY TRUTH slot failure is gone; the three other known divergences (weigh-in silently lost, constraints announced-then-ignored, "help getting going again" unowned) remain visible and unaddressed, as #174 requires. No journey lost a check and no green journey turned red.

## Verification

| Suite | Result |
|---|---|
| `npm test` | 36/37 green, 1 covered nothing (`normalizer-replay-tests`, pre-existing) |
| `npm run test:unit:baseline -- --base=e76d819` | PASS — 1057/1057 both sides, 0 introduced |
| `npm run check` (tsc) | clean |
| `script/pg-correction-acceptance.ts` (real PG) | GREEN |
| `check:filesize` / `check:arch` | 236 files OK; 239 modules, 449 regexes, 32 deciders, 26 crons — all at budget |
| `check:schema` / `check:sast` / `check:names` | OK; 61/61; 97/97 |
| Gauntlet | RED, byte-identical to `main` (65/70, 3/3, 250/252) |

No budget raised, no suppression, no assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_