### PR TITLE
Attribute safety-critical early returns in turn ledger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,3 +119,5 @@ jobs:
         run: npm run db:migrate
       - name: Targeted multi-day food correction on real PostgreSQL
         run: npx tsx script/pg-correction-acceptance.ts
+      - name: Safety early-return turn attribution on real PostgreSQL
+        run: npx tsx script/pg-safety-turn-acceptance.ts

--- a/script/pg-safety-turn-acceptance.ts
+++ b/script/pg-safety-turn-acceptance.ts
@@ -1,0 +1,164 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the #175 safety-turn attribution contract.
+ *
+ * A fixture can observe turnUser calls, but it cannot prove the asynchronous recordTurn write,
+ * its user foreign key, or its build provenance survived the real handleMessage boundary. This
+ * script drives that boundary against the same committed schema production deploys.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-safety-turn-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.APP_VERSION = "issue-175-safety";
+process.env.NODE_ENV = "production";
+delete process.env.RAILWAY_GIT_COMMIT_SHA;
+delete process.env.COACH_ALERT_PHONE;
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { crisisReply } = await import("../server/crisis-reply");
+const { eq, and } = await import("drizzle-orm");
+
+const phones = {
+  crisis: "whatsapp:+27000000175",
+  acute: "whatsapp:+27000001175",
+  life: "whatsapp:+27000004175",
+  quit: "whatsapp:+27000005175",
+  delete: "whatsapp:+27000002175",
+  reset: "whatsapp:+27000003175",
+};
+
+for (const phone of Object.values(phones)) {
+  await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+}
+
+async function seed(phone: string, name: string, onboardingState = "START") {
+  const [user] = await db.insert(schema.users).values({
+    phoneNumber: phone,
+    name,
+    onboardingState,
+    subscriptionStatus: "active",
+    popiConsent: true,
+    popiConsentAt: new Date(),
+    programmePhase: 1,
+    programmeWeek: 1,
+    programmeDayInWeek: 1,
+    trainingMode: "home",
+    stepsTarget: 8500,
+    createdAt: new Date(),
+    lastActiveAt: new Date(),
+  } as any).returning();
+  return user;
+}
+
+async function ledgerRows(userId: string, inputText: string): Promise<any[]> {
+  return db.select().from(schema.turnLedger).where(and(
+    eq(schema.turnLedger.userId, userId),
+    eq(schema.turnLedger.inputText, inputText),
+  ));
+}
+
+async function awaitOneTurn(userId: string, inputText: string): Promise<any> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const rows = await ledgerRows(userId, inputText);
+    if (rows.length > 0) {
+      if (rows.length !== 1) throw new Error(`${JSON.stringify(inputText)} produced ${rows.length} turn rows; expected exactly one`);
+      return rows[0];
+    }
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  throw new Error(`${JSON.stringify(inputText)} produced no attributable turn row`);
+}
+
+let failed = 0;
+const createdIds: string[] = [];
+function check(ok: unknown, description: string): void {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${description}`);
+}
+
+REAL("\n=== #175 SAFETY TURN ATTRIBUTION ===");
+
+const crisisInput = "I want to kill myself";
+const crisisResponse = await handleMessage(phones.crisis, crisisInput);
+const [crisisUser] = await db.select().from(schema.users).where(eq(schema.users.phoneNumber, phones.crisis));
+if (!crisisUser) throw new Error("first-contact crisis did not receive a durable identity");
+createdIds.push(crisisUser.id);
+const crisisTurn = await awaitOneTurn(crisisUser.id, crisisInput);
+check(crisisResponse === crisisReply("friend"), "first-contact crisis response is the existing deterministic safe reply");
+check(crisisTurn.userId === crisisUser.id, "crisis turn is attributable to the exact client id");
+check(crisisTurn.reply === crisisResponse, "crisis ledger holds the final client reply");
+check(crisisTurn.version === "issue-175-safety", "crisis turn exposes exact build provenance to Coach Health");
+const crisisUsers = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.phoneNumber, phones.crisis));
+check(crisisUsers.length === 1, "first-contact crisis identity binding creates exactly one user");
+const crisisChats = await db.select({ id: schema.chatHistory.id }).from(schema.chatHistory).where(and(
+  eq(schema.chatHistory.userId, crisisUser.id), eq(schema.chatHistory.intent, "CRISIS"),
+));
+check(crisisChats.length === 1, "crisis behavior logs exactly one crisis chat event");
+
+const acuteUser = await seed(phones.acute, "Acute Client");
+createdIds.push(acuteUser.id);
+const acuteInput = "I have chest pain and cannot breathe";
+const acuteResponse = await handleMessage(phones.acute, acuteInput);
+const acuteTurn = await awaitOneTurn(acuteUser.id, acuteInput);
+check(/10177/.test(acuteResponse) && /do not wait/i.test(acuteResponse), "acute path returns the existing emergency response without a model");
+check(acuteTurn.userId === acuteUser.id && acuteTurn.reply === acuteResponse, "acute turn is recorded once for the exact client");
+check(acuteTurn.version === "issue-175-safety", "acute turn is queryable by the exact build");
+
+const lifeInput = "my grandfather passed away this morning";
+const lifeResponse = await handleMessage(phones.life, lifeInput);
+const [lifeUser] = await db.select().from(schema.users).where(eq(schema.users.phoneNumber, phones.life));
+if (!lifeUser) throw new Error("first-contact life-context turn did not receive a durable identity");
+createdIds.push(lifeUser.id);
+const lifeTurn = await awaitOneTurn(lifeUser.id, lifeInput);
+check(/sorry/i.test(lifeResponse), "life-context path keeps its existing comfort-first response");
+check(lifeTurn.userId === lifeUser.id, "life-context early return is attributable before onboarding");
+
+const quitUser = await seed(phones.quit, "Quit Client", "COMPLETE");
+createdIds.push(quitUser.id);
+const quitInput = "I want to quit";
+const quitResponse = await handleMessage(phones.quit, quitInput);
+const quitTurn = await awaitOneTurn(quitUser.id, quitInput);
+check(!/0800 567 567/.test(quitResponse), "programme quit still uses quit-save rather than crisis policy");
+check(quitTurn.userId === quitUser.id, "quit-save early return is attributable to the existing client");
+
+const deleteUser = await seed(phones.delete, "Delete Client", "COMPLETE");
+createdIds.push(deleteUser.id);
+const deletePrompt = "delete my data";
+const deletePromptResponse = await handleMessage(phones.delete, deletePrompt);
+await awaitOneTurn(deleteUser.id, deletePrompt);
+check(/Reply \*DELETE\*/.test(deletePromptResponse), "POPIA confirmation behavior is unchanged");
+const deleteResponse = await handleMessage(phones.delete, "DELETE");
+const deleteTurn = await awaitOneTurn(deleteUser.id, "DELETE");
+check(/permanently deleted/i.test(deleteResponse), "confirmed POPIA deletion still completes");
+check(deleteTurn.userId === deleteUser.id && deleteTurn.version === "issue-175-safety", "confirmed deletion retains an attributable audit turn on the pseudonymised user id");
+const originalDeletePhone = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.phoneNumber, phones.delete));
+check(originalDeletePhone.length === 0, "confirmed deletion does not recreate the original phone identity");
+
+const oldResetUser = await seed(phones.reset, "Reset Client");
+createdIds.push(oldResetUser.id);
+const resetResponse = await handleMessage(phones.reset, "reset");
+const [newResetUser] = await db.select().from(schema.users).where(eq(schema.users.phoneNumber, phones.reset));
+if (!newResetUser) throw new Error("reset did not create its existing fresh-start user");
+createdIds.push(newResetUser.id);
+const resetTurn = await awaitOneTurn(newResetUser.id, "reset");
+check(/Fresh start/i.test(resetResponse), "reset behavior is unchanged");
+check(newResetUser.id !== oldResetUser.id, "reset still replaces the old account identity");
+check(resetTurn.userId === newResetUser.id, "reset audit turn follows the replacement user instead of a deleted foreign key");
+
+for (const id of createdIds) {
+  await pool.query("DELETE FROM users WHERE id = $1", [id]);
+}
+
+REAL(`\npg-safety-turn-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/server/handlers/safety.ts
+++ b/server/handlers/safety.ts
@@ -1,11 +1,12 @@
 /**
  * Safety + data-management guards.
- * Run at the very top of handleMessage, before user lookup.
+ * Run at the very top of handleMessage, before ordinary user lookup/routing. A matched branch may
+ * bind the minimum identity needed for turn attribution, but it never waits on model reasoning.
  * Return a string to short-circuit, or null to fall through.
  */
 
 import twilio from "twilio";
-import { db, pool } from "../db";
+import { db, pool, getOrCreateUser } from "../db";
 import {
   users, chatHistory, stepLogs, workoutLogs, weightLogs,
   weeklyCheckins, clothingCheckins, bodyMeasurements,
@@ -20,7 +21,7 @@ import { markLifeQuiet } from "../life-quiet";
 import { isCrisisMessage, crisisReply, crisisAlertBody } from "../crisis-reply";
 import { asksForExport, formatExport } from "../data-export";
 import { sastDayKey } from "../sast";
-import { logChat } from "./chat-log";
+import { logChat, turnUser } from "./chat-log";
 
 // Send a Twilio message with exponential-backoff retries. On complete failure,
 // records a row in adminEvents so the coach can find missed alerts on reload.
@@ -76,6 +77,30 @@ const TERMINAL_PATTERNS = [
   /\bchmod\b|\bchown\b/i,
 ];
 
+/**
+ * Safety owns the early return; turn-context owns attribution. Bind the identity already resolved
+ * by a safety branch before that branch returns so handleMessage's one existing recordTurn call can
+ * write the same turn. This adds no second ledger and makes no routing decision.
+ */
+function bindKnownSafetyUser<T extends { id?: string | null } | undefined>(user: T): T {
+  if (user?.id) turnUser(user.id);
+  return user;
+}
+
+/**
+ * Crisis/acute/life replies must not depend on the identity store being healthy. The existing
+ * get-or-create owner gives known and first-contact clients one durable identity when available;
+ * failure leaves the safety branch free to return its existing safest reply.
+ */
+async function ensureSafetyTurnUser(phone: string): Promise<any | undefined> {
+  try {
+    return bindKnownSafetyUser(await getOrCreateUser(phone));
+  } catch (e: any) {
+    console.error("[SAFETY_TURN_IDENTITY] attribution unavailable; safety response continues:", e?.message || e);
+    return undefined;
+  }
+}
+
 export async function runSafetyGuards(
   phone: string,
   message: string,
@@ -89,7 +114,7 @@ export async function runSafetyGuards(
   if (looksLikeQuitMoment(message)) {
     const qu = await db.select({ id: users.id, name: users.name, createdAt: users.createdAt, totalWorkoutsCompleted: users.totalWorkoutsCompleted })
       .from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    const u = qu[0];
+    const u = bindKnownSafetyUser(qu[0]);
     if (u) {
       const weeks = u.createdAt ? Math.max(1, Math.round((Date.now() - new Date(u.createdAt).getTime()) / (7 * 86_400_000))) : 1;
       const reply = quitSaveReply({
@@ -112,20 +137,20 @@ export async function runSafetyGuards(
   // server/life-context.ts for the compliance posture.
   const life = readLifeContext(message);
   if (life && !isCrisisMessage(m)) {
-    const lu = await db.select({ id: users.id, name: users.name }).from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    const reply = lifeContextReply(life, (lu[0]?.name || "").split(" ")[0]);
+    const lifeUser = await ensureSafetyTurnUser(phone);
+    const reply = lifeContextReply(life, (lifeUser?.name || "").split(" ")[0]);
     // Comfort that isn't followed by silence is just a nice sentence — go quiet on nudges too.
-    if (lu[0]?.id) markLifeQuiet(lu[0].id, life).catch(() => {});
-    try { await logChat(lu[0]?.id || "unknown", message, reply, `LIFE_${life.context.toUpperCase()}`); } catch (e) { console.warn("[non-fatal]", e); }
+    if (lifeUser?.id) markLifeQuiet(lifeUser.id, life).catch(() => {});
+    try { await logChat(lifeUser?.id || "unknown", message, reply, `LIFE_${life.context.toUpperCase()}`); } catch (e) { console.warn("[non-fatal]", e); }
     return reply;
   }
 
   // ---- CRISIS ----
   if (isCrisisMessage(m)) {
-    const crisisUser = await db.select({ id: users.id, name: users.name }).from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    const crisisName = crisisUser[0]?.name || "friend";
+    const crisisUser = await ensureSafetyTurnUser(phone);
+    const crisisName = crisisUser?.name || "friend";
     const reply = crisisReply(crisisName);
-    try { await logChat(crisisUser[0]?.id || "unknown", message, reply, "CRISIS"); } catch (e) { console.warn("[non-fatal]", e); }
+    try { await logChat(crisisUser?.id || "unknown", message, reply, "CRISIS"); } catch (e) { console.warn("[non-fatal]", e); }
     const coachAlertPhone = process.env.COACH_ALERT_PHONE;
     if (!coachAlertPhone) {
       console.error(`[CRISIS] ⚠️  COACH_ALERT_PHONE not configured — coach NOT notified! Client: ${crisisName} (${phone}). Message: "${message.slice(0, 150)}"`);
@@ -154,10 +179,10 @@ export async function runSafetyGuards(
   const benignStroke = /\bstroke of (?:luck|genius)\b|\b(?:breast|back|free|butterfly|side|swim(?:ming)?|paddle|broad|key)\s*-?\s*strokes?\b|\bbreaststroke\b|\bbackstroke\b/i.test(m);
   const strokeEmergency = /\bstrokes?\b/i.test(m) && !benignStroke;
   if (nonStrokeEmergency || strokeEmergency) {
-    const acuteUser = await db.select({ id: users.id, name: users.name }).from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    const acuteName = acuteUser[0]?.name || "friend";
+    const acuteUser = await ensureSafetyTurnUser(phone);
+    const acuteName = acuteUser?.name || "friend";
     const acuteReply = `This sounds like it could be a medical emergency. Stop what you're doing and call *10177* (SA ambulance) or go to your nearest emergency room immediately. Do not wait. Health first — everything else can wait.`;
-    try { await logChat(acuteUser[0]?.id || "unknown", message, acuteReply, "ACUTE_MEDICAL"); } catch (e) { console.warn("[non-fatal]", e); }
+    try { await logChat(acuteUser?.id || "unknown", message, acuteReply, "ACUTE_MEDICAL"); } catch (e) { console.warn("[non-fatal]", e); }
     const coachAlertPhone = process.env.COACH_ALERT_PHONE;
     if (!coachAlertPhone) {
       console.error(`[ACUTE_MEDICAL] ⚠️  COACH_ALERT_PHONE not configured — coach NOT notified! Client: ${acuteName} (${phone}). Message: "${message.slice(0, 150)}"`);
@@ -212,7 +237,7 @@ export async function runSafetyGuards(
   if (asksForExport(m)) {
     const eu = await db.select().from(users).where(eq(users.phoneNumber, phone)).limit(1);
     if (eu.length === 0) return "No account found for this number.";
-    const u = eu[0];
+    const u = bindKnownSafetyUser(eu[0]);
     const [ws, ml] = await Promise.all([
       db.select({ at: weightLogs.loggedAt, kg: weightLogs.weight }).from(weightLogs).where(eq(weightLogs.userId, u.id)).orderBy(desc(weightLogs.loggedAt)),
       db.select({ at: mealLogs.loggedAt, kcal: mealLogs.kcalInt, protein: mealLogs.proteinInt }).from(mealLogs).where(eq(mealLogs.userId, u.id)).orderBy(desc(mealLogs.loggedAt)),
@@ -256,7 +281,7 @@ export async function runSafetyGuards(
     // Unknown number: not this handler's business. Standing down rather than answering
     // keeps one owner for "no account found" — the branch below already says it.
     if (existing.length === 0) return null;
-    const uid = existing[0].id;
+    const uid = bindKnownSafetyUser(existing[0]).id;
     const had = await db.select({ id: progressPhotos.id }).from(progressPhotos).where(eq(progressPhotos.userId, uid));
     await db.delete(progressPhotos).where(eq(progressPhotos.userId, uid));
     // The consent stamp goes with them — it recorded permission to hold photos we no longer hold.
@@ -274,7 +299,8 @@ export async function runSafetyGuards(
   if (/delete my data|forget me|remove my account|popia delete|delete me|erase my data/i.test(m)) {
     const existing = await db.select({ id: users.id, name: users.name }).from(users).where(eq(users.phoneNumber, phone)).limit(1);
     if (existing.length === 0) return "No account found for this number.";
-    const name = existing[0].name || "there";
+    const boundDeleteUser = bindKnownSafetyUser(existing[0]);
+    const name = boundDeleteUser.name || "there";
     await db.update(users).set({ awaitingInputType: "delete_confirm" }).where(eq(users.phoneNumber, phone));
     return `${name}, this will permanently delete all your data — workouts, steps, food logs, measurements, weight history, and your profile. This cannot be undone.\n\nReply *DELETE* (in capitals) to confirm, or anything else to cancel.`;
   }
@@ -282,7 +308,7 @@ export async function runSafetyGuards(
   if (m === "delete") {
     const existing = await db.select().from(users).where(eq(users.phoneNumber, phone)).limit(1);
     if (existing.length > 0 && existing[0].awaitingInputType === "delete_confirm") {
-      const uid = existing[0].id;
+      const uid = bindKnownSafetyUser(existing[0]).id;
       console.log(`[POPIA DELETE] User ${uid} (${phone}) requested data deletion at ${new Date().toISOString()}`);
       await db.transaction(async (tx) => {
         await tx.delete(chatHistory).where(eq(chatHistory.userId, uid));
@@ -334,7 +360,7 @@ export async function runSafetyGuards(
   // Two-step: bare "reset" asks for confirmation; "yes reset" actually wipes.
   if (m === "yes reset" || m === "yes, reset" || m === "confirm reset") {
     const existing = await db.select({ id: users.id }).from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    await db.transaction(async (tx) => {
+    const resetUser = await db.transaction(async (tx) => {
       if (existing.length > 0) {
         const uid = existing[0].id;
         await tx.delete(gptCosts).where(eq(gptCosts.userId, uid));
@@ -360,7 +386,7 @@ export async function runSafetyGuards(
         // start-cancel-start loop through the POPIA path. Do not add it to this transaction.
         await tx.delete(users).where(eq(users.id, uid));
       }
-      await tx.insert(users).values({
+      const [created] = await tx.insert(users).values({
         phoneNumber: phone,
         subscriptionStatus: "inactive",
         onboardingState: "WELCOME",
@@ -371,8 +397,10 @@ export async function runSafetyGuards(
         stepsTarget: 8500,
         createdAt: new Date(),
         lastActiveAt: new Date(),
-      });
+      }).returning({ id: users.id });
+      return created;
     });
+    bindKnownSafetyUser(resetUser);
     await pool.query("DELETE FROM memories WHERE phone = $1", [phone]).catch((e: any) =>
       console.error("[RESET] memories delete failed (non-fatal):", e?.message)
     );
@@ -387,12 +415,13 @@ export async function runSafetyGuards(
       (existing[0].totalWorkoutsCompleted ?? 0) > 0
     );
     if (hasData) {
+      bindKnownSafetyUser(existing[0]);
       const sessions = existing[0].totalWorkoutsCompleted || 0;
       const sessionNote = sessions > 0 ? ` You have *${sessions} session${sessions === 1 ? "" : "s"}* logged.` : "";
       return `⚠️ This will permanently delete all your data — workouts, food logs, weight history, everything.${sessionNote}\n\nReply *yes reset* to confirm, or anything else to go back.`;
     }
     // No meaningful data yet — wipe immediately
-    await db.transaction(async (tx) => {
+    const resetUser = await db.transaction(async (tx) => {
       if (existing.length > 0) {
         const uid = existing[0].id;
         await tx.delete(gptCosts).where(eq(gptCosts.userId, uid));
@@ -418,7 +447,7 @@ export async function runSafetyGuards(
         // start-cancel-start loop through the POPIA path. Do not add it to this transaction.
         await tx.delete(users).where(eq(users.id, uid));
       }
-      await tx.insert(users).values({
+      const [created] = await tx.insert(users).values({
         phoneNumber: phone,
         subscriptionStatus: "inactive",
         onboardingState: "WELCOME",
@@ -429,8 +458,10 @@ export async function runSafetyGuards(
         stepsTarget: 8500,
         createdAt: new Date(),
         lastActiveAt: new Date(),
-      });
+      }).returning({ id: users.id });
+      return created;
     });
+    bindKnownSafetyUser(resetUser);
     await pool.query("DELETE FROM memories WHERE phone = $1", [phone]).catch((e: any) =>
       console.error("[RESET] memories delete failed (non-fatal):", e?.message)
     );


### PR DESCRIPTION
Closes #175.

## What changed

- Bind the existing turn context from inside the current safety owner before crisis, acute, life-context, quit-save, export, delete, or reset returns.
- Crisis, acute, and life-context paths reuse the atomic get-or-create identity owner. Identity failure is non-blocking for the deterministic safety response.
- Privacy paths bind only an existing account, preserving the existing “no account found” behaviour.
- Reset binds the replacement user created by the existing transaction, so the ledger never targets a deleted foreign key.
- Add a real-PostgreSQL acceptance control to the existing ephemeral Postgres CI job.

Safety remains the first policy/response authority. No model, onboarding, general routing, alert, or ledger owner was added or reordered.

## Controls

- Crisis and acute paths exercise real handleMessage and require exactly one turnLedger row with exact user, reply, and build provenance.
- First-contact crisis proves one user row, one crisis chat event, and one turn row.
- Life-context and quit-save early returns are attributable.
- POPIA confirmation and confirmed deletion remain attributable without recreating the phone identity.
- Reset attribution follows the replacement user.
- The test is red on revert because removing the safety-side turnUser binding yields no row for each early return.

## Local verification

- npm run check — pass
- npm run test:safety — 82/82
- integration-tests — 38/38
- unit-baseline — 1053/1057 on base and head; 0 new failures
- tracking contract — pass
- onboarding E2E — pass
- golden regression — pass

The real-PostgreSQL acceptance is intentionally executed by the PR’s ephemeral Postgres Actions job; this workstation has no local PostgreSQL runtime.