### PR TITLE
Scope the morning slot claim to the eating event (#182)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -859,6 +859,38 @@ test("explicitMealSlot: 'morning' with no temporal determiner is not a slot clai
   assert.equal(explicitMealSlot("I had chicken and rice"), null);
 });
 
+// ============================================================
+// AND THE MORNING MUST BE WHEN THEY ATE (#182 — over-fire found in the merged #174 fix)
+//
+// The first cut tested the WHOLE message, so "I train in the morning; I just had rice" relabelled
+// the rice as breakfast at an evening send time: the word belonged to the training clause and the
+// slot was taken from it anyway. Same class of error as the one the branch exists to fix, pointing
+// the other way — a time attached to the wrong event still contradicts the client's own record.
+// ============================================================
+
+test("explicitMealSlot: a morning phrase in ANOTHER clause does not label the food (#182)", () => {
+  assert.equal(explicitMealSlot("I train in the morning; I just had rice"), null);
+  assert.equal(explicitMealSlot("I go to gym in the morning; I just ate pap"), null);
+});
+
+test("explicitMealSlot: a coordinating conjunction separates the events too (#182)", () => {
+  assert.equal(explicitMealSlot("I walk in the morning and had rice"), null);
+  assert.equal(explicitMealSlot("This morning I trained and then had rice"), null);
+});
+
+// …AND A NAMED MEAL IN THE SECOND CLAUSE KEEPS ITS OWN SLOT, which is the control that proves the
+// scoping did not simply switch the branch off: the message still resolves, just not to breakfast.
+test("explicitMealSlot: 'I walk in the morning and had dinner at 7pm' stays dinner (#182)", () => {
+  assert.equal(explicitMealSlot("I walk in the morning and had dinner at 7pm"), "dinner");
+  assert.equal(explicitMealSlot("This morning I trained and then had breakfast"), "breakfast");
+});
+
+// BOTH WORD ORDERS ARE THE SAME CLAIM. People put the time on either side of the verb.
+test("explicitMealSlot: the time may sit before or after the eating verb (#182)", () => {
+  assert.equal(explicitMealSlot("Had eggs this morning"), "breakfast");
+  assert.equal(explicitMealSlot("this morning, I had eggs"), "breakfast");
+});
+
 // DELIBERATELY NOT WIDENED (#174 control 3). Afternoon spans lunch and the snack after it, so a
 // slot for it would be invented rather than surfaced. It still falls to clock inference.
 test("explicitMealSlot: 'this afternoon' is NOT mapped to lunch", () => {

--- a/server/understanding/actions.ts
+++ b/server/understanding/actions.ts
@@ -59,9 +59,41 @@ export function explicitMealSlot(msg: string): "breakfast" | "lunch" | "dinner" 
   // MORNING ONLY. "this afternoon" is deliberately NOT here: afternoon spans lunch and the snack
   // after it, so mapping it to a slot would be inventing a meaning rather than surfacing one, and
   // an afternoon phrase still falls to clock inference exactly as before.
-  if (/\b(?:this|yesterday|early|in the|the|(?:mon|tues|wednes|thurs|fri|satur|sun)day)\s+morning\b/i.test(lo)) return "breakfast";
+  //
+  // AND IT MUST BE THE EATING THAT HAPPENED IN THE MORNING (#182). The first cut of this tested
+  // the WHOLE message, so "I train in the morning; I just had rice" relabelled the rice as
+  // breakfast at 8pm: the word belonged to the training clause and the slot was taken from it
+  // anyway. Same class of error as the one this branch exists to fix, pointing the other way —
+  // a time attached to the wrong event is still a record that contradicts the client.
+  if (MORNING_MEAL_RE.test(lo)) return "breakfast";
   return null;
 }
+
+/**
+ * "THIS MORNING" ATTACHED TO THE EATING, NOT TO WHATEVER ELSE THE MESSAGE MENTIONS (#182).
+ *
+ * People put the time on either side of the verb — "this morning I had eggs" and "I had a banana
+ * in the morning" are the same claim — so both orders are here, and nothing else is.
+ *
+ * WHAT THE GAP MAY NOT CONTAIN IS THE WHOLE RULE. A clause boundary (. ! ? ; newline) or a
+ * coordinating conjunction (and, then, but, so, before, after, plus) means the morning phrase and
+ * the eating verb belong to DIFFERENT events, and a time from one event may not label the other:
+ *
+ *   "I train in the morning; I just had rice"      → the ; blocks it   → falls to the clock
+ *   "I walk in the morning and had rice"           → the and blocks it → falls to the clock
+ *   "this morning, I had eggs"                     → a comma is not a new event → breakfast
+ *
+ * Deliberately NOT clausesOf(): that splitter ends clauses at sentence terminators only, so the
+ * semicolon case above is one clause to it and the over-fire would survive. This is the same
+ * bounded-window shape the food and constraint matchers in this codebase already use, tightened
+ * with the conjunctions, and it stays inside the one slot owner rather than beside it.
+ */
+const MORNING = String.raw`(?:this|yesterday|early|the|(?:mon|tues|wednes|thurs|fri|satur|sun)day)\s+morning`;
+const ATE = String.raw`(?:had|ate|eaten|eating|having)`;
+const GAP = String.raw`(?:(?!\b(?:and|then|but|so|before|after|plus)\b)[^.!?;\n])`;
+const MORNING_MEAL_RE = new RegExp(
+  `\\b${MORNING}\\b${GAP}{0,25}?\\b(?:i\\s+)?(?:just\\s+)?${ATE}\\b`
+  + `|\\b${ATE}\\b${GAP}{0,40}?\\b${MORNING}\\b`, "i");
 
 export type CoachAction =
   // Pure conversation — the default and the safe fallback. Coach K just talks.


### PR DESCRIPTION
Closes #182. Repair of the over-fire Codex found in my merged #174 fix. Two files.

## The over-fire

#174 taught the explicit slot owner that `this morning` names a meal period, but tested the **whole message**. So:

```
"I train in the morning; I just had rice"   →  breakfast
```

The word belonged to the training clause and the slot was taken from it anyway. Same class of error as the one the branch exists to fix, pointing the other way — a time attached to the wrong event still produces a record that contradicts the client.

## The repair

The morning branch now requires the phrase and the eating verb to belong to the **same event**. Both word orders are the same claim, so both match (`this morning I had eggs`, `I had a banana in the morning`) and nothing else does.

**What the gap between them may not contain is the whole rule**: a clause boundary (`.` `!` `?` `;` newline) or a coordinating conjunction (`and`, `then`, `but`, `so`, `before`, `after`, `plus`) means two different events, and a time from one may not label the other. A comma is not a new event, so `this morning, I had eggs` still resolves.

**Deliberately not `clausesOf()`** — that splitter ends clauses at sentence terminators only, so the semicolon case above is a single clause to it and the over-fire would have survived. This stays inside the one slot owner rather than beside it: still no second slot parser.

## Measured, not asserted

`extractMealLabel` takes the moment as a parameter, so the clock can be varied without faking one. At a **20:00 SAST** send clock:

```
breakfast  "This morning I had 3 eggs and 2 slices of toast"     ← #174 holds
dinner     "I train in the morning; I just had rice"             ← control 3
dinner     "I walk in the morning and had rice"                  ← same family
dinner     "I had rice"                                          ← the baseline
```

The two over-fire messages now behave **exactly like the bare report** — that is control 3's contract: they retain the actual food-event slot semantics rather than being forced anywhere.

## Controls — `script/gap-tests.ts`, 356 → 360

| # | Control | Result |
|---|---|---|
| 1 | `This morning I had 3 eggs and 2 slices of toast` → breakfast | ✓ |
| 2 | `Yesterday morning` / `Monday morning` → breakfast + correct date | ✓ |
| 3 | `I train in the morning; I just had rice` → not forced to breakfast | ✓ |
| 4 | `I walk in the morning and had dinner at 7pm` → dinner | ✓ |
| 5 | `This morning I trained and then had breakfast` → breakfast | ✓ |
| 6 | `for breakfast`, `breakfast was`, `morning meal` unchanged | ✓ (branches untouched) |
| 7 | No cross-clause bleed — conjunction form too (`…and had rice`) | ✓ |
| 8 | Same foods, kcal, protein, items, dates, row count, reply count | ✓ — real PG below |
| 9 | Real PostgreSQL control + Journey Lab replay | ✓ |
| 10 | Red-on-revert, **both** directions | ✓ |

Controls 4 and 5 are the ones that prove the scoping did not simply switch the branch off: the message still resolves, just not to breakfast-by-accident.

## Red on revert — both directions

| Revert | Result |
|---|---|
| Remove morning support entirely | #174 case returns to the clock's guess (`dinner` @ 20:00); **4 tests fail** |
| Restore the whole-message match | Over-fire returns — same message reads `breakfast` while bare `I had rice` reads `dinner`; **2 tests fail** |

Neither direction is green. The mechanism is load-bearing in both.

## Real PostgreSQL

Through `handleMessage` against real PG: one row per message, correct foods and macros, one reply each.

```
"This morning I had 3 eggs and 2 slices of toast"  parts=1 rows=1  breakfast 491kcal/31p ["Eggs","Toast"]
"I train in the morning; I just had rice"          parts=1 rows=1  220kcal/5p  ["Rice"]
"I walk in the morning and had rice"               parts=1 rows=1  220kcal/5p  ["Rice"]
```

The container clock sat at 05h SAST for this run — inside the breakfast window — so the two over-fire rows take `breakfast` **from the clock**, not from the branch. That is the correct outcome at that hour and it is why control 3 is graded deterministically and at an explicit evening clock above, where the two answers actually differ.

## Journey Lab replay

Unmodified `script/journey-lab.ts` from `feat/journey-lab-170`: **RED — 7 of 253**, identical to the post-#174 state. No journey lost a check, no green journey turned red, and the DAILY TRUTH slot assertion stays green.

## Verification

| Suite | Result |
|---|---|
| `npm test` | 36/37 green, 1 covered nothing (`normalizer-replay-tests`, pre-existing) |
| `npm run test:unit:baseline -- --base=b84a8ef` | PASS — 1057/1057 both sides, 0 introduced |
| `npm run check` (tsc) | clean |
| `pg-correction-acceptance` / `pg-safety-turn-acceptance` | GREEN / GREEN |
| `check:filesize` / `check:arch` | 236 files OK; 239 modules, 449 regexes, 32 deciders, 26 crons — all at budget |
| `check:schema` / `check:sast` / `check:names` | OK; 61/61; 97/97 |

No budget raised, no suppression, no assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_