### PR TITLE
A weigh verb licenses the number without a unit (#176)

### DIFF
--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -104,6 +104,11 @@ const MUST_NOT_WRITE: [string, string][] = [
   ["weight", "Is 92kg good?"],
   ["weight", "I want to weigh 85kg"],
   ["weight", "my target weight is 85kg"],
+  // …AND WITHOUT A VERB, A NAKED NUMBER IS STILL NOT A BODY WEIGHT (#176). This is the control on
+  // the loosening above: nothing licenses reading a bare number as a weigh-in, and the failure
+  // mode of guessing is a false point on the client's own trend line.
+  ["weight", "83.9"],
+  ["weight", "I used to weigh 90"],
   ["workout", "Is my workout done?"],
   ["workout", "Have I trained today?"],
   ["workout", "did my workout?"],
@@ -156,6 +161,11 @@ const MUST_WRITE: [string, string][] = [
   ["weight", "weighed 84kg this morning"],
   ["weight", "my weight is 84kg today"],
   ["weight", "I'm trying to lose weight, weighed 84kg this morning"],
+  // NO UNIT, BUT A VERB (#176). The Journey Lab found this reaching the not-understood fallback
+  // with zero weight_logs rows: the door demanded a literal "kg" even after an explicit weigh
+  // verb, so the client stated their weight and the record said they had not.
+  ["weight", "I weighed 83.9 this morning"],
+  ["weight", "my weight is 84"],
   ["workout", "workout done"],
   ["workout", "I trained chest today"],
   ["workout", "gym done"],

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -4324,6 +4324,38 @@ test("weight reports detected; lift logs are not", () => {
 });
 
 // ============================================================
+// THE VERB IS EVIDENCE TOO (#176 — Journey Lab divergence)
+//
+// This gate required a literal "kg", so "I weighed 83.9 this morning" matched nothing,
+// statedWeight() never saw the turn, and the client got "I didn't quite catch that" with ZERO
+// weight_logs rows. Targets were not recalculated and the trend gained a hole they cannot see.
+// ============================================================
+
+test("a weigh verb licenses the number without a unit (#176)", () => {
+  assert.ok(looksLikeWeightReport("I weighed 83.9 this morning"), "the Journey Lab message");
+  assert.ok(looksLikeWeightReport("I weighed 83.9"));
+  assert.ok(looksLikeWeightReport("weighed in at 82.9 this morning"));
+  assert.ok(looksLikeWeightReport("my weight is 84"));
+});
+
+// AND WITHOUT THE VERB, A NAKED NUMBER IS STILL NOT A BODY WEIGHT. Nothing licenses reading one,
+// and the failure mode of guessing is a false entry on the client's own trend line.
+test("a bare number is not a weigh-in, with or without context (#176)", () => {
+  assert.ok(!looksLikeWeightReport("83.9"), "a naked number says nothing about what it measures");
+  assert.ok(!looksLikeWeightReport("84"));
+  assert.ok(!looksLikeWeightReport("I had 83.9g of rice"));
+  assert.ok(!looksLikeWeightReport("I paid 200 for the gym"));
+  assert.ok(!looksLikeWeightReport("8000 steps"));
+  assert.ok(!looksLikeWeightReport("I had 200g rice and 150g chicken"));
+});
+
+// THE HISTORICAL AND ASPIRATIONAL FORMS STAY OUT — both name a weight that is not today's.
+test("past and goal weights are still not weigh-ins (#176)", () => {
+  assert.ok(!looksLikeWeightReport("I used to weigh 90"));
+  assert.ok(!looksLikeWeightReport("my goal weight is 80"));
+});
+
+// ============================================================
 // verifyBrainReply — the self-correcting loop's checks (pure)
 // ============================================================
 

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -27,7 +27,7 @@ import { generateMilestoneVoiceScript } from "../gpt";
 import { logChat, turnMutation, turnAlreadyWrote } from "./chat-log";
 import { sastDayKey } from "../sast";
 import { journeyMustKeepFacts } from "../understanding/messy-intake";
-import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, reportedInSomeClause, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen, getDisplayName } from "../utils";
+import { sastDayStart, parseMealDate, mealDateLabel, isFutureIntent, reportedInSomeClause, looksLikeQuestion, mentionsNotDone, sessionCountsIn, statedWhen, getDisplayName, WEIGHED_NUMBER_RE } from "../utils";
 import { applyRetroSessionState } from "../day-ledger";
 import { readTrainingDay } from "../one-action";
 import { invalidatePatternCache } from "../cache";
@@ -144,12 +144,19 @@ export async function handleWorkoutCommands(ctx: {
   // Only fires if message is clearly about body weight, not exercise weight
   // ONE WEIGH-IN SHAPE, APPLIED TO WHATEVER TEXT IT IS GIVEN. Factored out of the two inline
   // tests below so the same recogniser can read a single clause — no second weight recogniser.
+  // THE VERB IS EVIDENCE TOO (#176, Journey Lab divergence). Every alternative below demanded a
+  // literal `kg`, so "I weighed 83.9 this morning" was not a weigh-in to this door at all: the
+  // client got "I didn't quite catch that" and ZERO weight_logs rows, targets were not
+  // recalculated, and the trend gained a hole they cannot see. WEIGHED_NUMBER_RE is the one
+  // shape where the unit is optional, and it is optional precisely because the VERB already says
+  // what the number measures. A bare "83.9" is still not a weigh-in — nothing licenses reading a
+  // naked number as a body weight, and a wrong guess writes a false point on their own trend.
   const weighInShape = (t: string) => /^(\d{2,3}(?:\.\d+)?)\s*kg[.!]?$/i.test(t)
-    || /\b(?:weigh(?:ed|s|ing)?|morning weight|body weight|on the scale|scale said|scale reads|weighed in|my weight)\b.*\b(\d{2,3}(?:\.\d+)?)\s*kg\b/i.test(t)
+    || WEIGHED_NUMBER_RE.test(t)
     || /\b(\d{2,3}(?:\.\d+)?)\s*kg\b.*\b(?:today|this morning|just weighed)\b/i.test(t);
   const isStandaloneWeight = /^(\d{2,3}(?:\.\d+)?)\s*kg[.!]?$/i.test(m);
   const isWeightCheckIn = (
-    /\b(?:weigh(?:ed|s|ing)?|morning weight|body weight|on the scale|scale said|scale reads|weighed in|my weight)\b.*\b(\d{2,3}(?:\.\d+)?)\s*kg\b/i.test(m)
+    WEIGHED_NUMBER_RE.test(m)
     || /\b(\d{2,3}(?:\.\d+)?)\s*kg\b.*\b(?:today|this morning|just weighed)\b/i.test(m)
   );
   // A QUESTION IN ONE CLAUSE DOES NOT ERASE A REPORT IN ANOTHER (2026-08-26, issue #63). The two
@@ -178,7 +185,11 @@ export async function handleWorkoutCommands(ctx: {
   if ((isStandaloneWeight || isWeightCheckIn || !!weightClause)
       && !isRetrospectiveWeight && !isFutureIntent(weightText)
       && !looksLikeQuestion(weightText) && !EXERCISE_PATTERN.test(weightText)) {
-    const kgMatch = weightText.match(/(\d{2,3}(?:\.\d+)?)\s*kg/i);
+    // The unit form first, so a message carrying both a unit and a verb still reads the unit's
+    // number. Only when there is no unit at all does the verb-anchored shape supply it — the same
+    // precedence the recogniser above uses, so what gets WRITTEN cannot disagree with what got
+    // RECOGNISED (#176).
+    const kgMatch = weightText.match(/(\d{2,3}(?:\.\d+)?)\s*kg/i) || weightText.match(WEIGHED_NUMBER_RE);
     if (kgMatch) {
       const kg = parseFloat(kgMatch[1]);
       if (Number.isFinite(kg) && kg >= 30 && kg <= 250) {

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -945,8 +945,52 @@ export function looksLikeWaterReport(raw: string): boolean {
         && !/\b(?:enough|too much|too little|target|goal|supposed to|meant to)\b/i.test(m));
 }
 
+/**
+ * THE UNIT IS EVIDENCE, NOT THE ONLY EVIDENCE (#176, Journey Lab divergence).
+ *
+ * This required a literal `kg`, so "I weighed 83.9 this morning" matched nothing, statedWeight()
+ * never saw the turn, and the client was answered with "I didn't quite catch that" while ZERO
+ * weight_logs rows were written. Targets were not recalculated and the trend gained a hole they
+ * cannot see: they told us, and the record says they did not.
+ *
+ * TWO SHAPES, AND THE DIFFERENCE IS THE WHOLE RULE. With a unit ("83.9kg") the unit says what the
+ * number is, so no verb is needed — unchanged. Without one, the VERB has to say it, so an explicit
+ * weigh/weight prefix becomes REQUIRED. A bare "83.9" is therefore still not a weigh-in, and
+ * neither is a price, a portion or a step count: nothing licenses reading a naked number as a body
+ * weight, and guessing writes a false point on the client's own trend line.
+ *
+ * PLAUSIBILITY STAYS WITH handleWeightLog, which already answers an impossible number with "that
+ * doesn't look right". A second opinion here would be a second owner of the same question.
+ */
+const WEIGH_SAYS_SO = String.raw`(?:i\s+)?(?:weigh(?:ed)?(?:\s+in)?(?:\s+at)?\s*|my\s+weight\s*(?:is|:)?\s*|weight\s*(?:is|:)?\s*)`;
+/** The write door's wider weigh vocabulary — scale phrasings included. Declared once, read twice. */
+const WEIGH_SAYS_SO_WORDS = String.raw`weigh(?:ed|s|ing)?|morning weight|body weight|on the scale|scale said|scale reads|weighed in|my weight`;
+const BODY_NUMBER = String.raw`\d{2,3}(?:[.,]\d{1,2})?`;
+const WEIGH_TAIL = String.raw`\s*(?:today|this morning)?\s*[.!]?\s*$`;
+const WEIGHT_REPORT_RE = new RegExp(
+  `^\\s*(?:${WEIGH_SAYS_SO})?${BODY_NUMBER}\\s*kgs?${WEIGH_TAIL}`
+  + `|^\\s*${WEIGH_SAYS_SO}${BODY_NUMBER}${WEIGH_TAIL}`, "i");
+
+/**
+ * THE SAME RULE, FOR THE DOOR THAT ACTUALLY WRITES (#176).
+ *
+ * looksLikeWeightReport decides whether a turn is a weigh-in for the brain-skip and the
+ * fact-preservation floor; the WRITE happens in handlers/workout.ts, which has always carried its
+ * own recogniser and its own copy of the weigh vocabulary. Two answers to one question — "did the
+ * client state a body weight" — which is why #176 had to be fixed twice: the gate was widened and
+ * the client still got "I didn't quite catch that", because the door had never heard of it.
+ *
+ * Not merged, because they genuinely differ — this one is unanchored and its vocabulary is wider.
+ * But it lives HERE, beside its sibling, so the next person to widen one can see the other.
+ * Capture group 1 is the number, so what RECOGNISES the weigh-in also supplies what gets written
+ * and the two cannot disagree. The unit is optional here and only here: the verb has already said
+ * what the number measures, and a bare "83.9" still matches nothing.
+ */
+export const WEIGHED_NUMBER_RE = new RegExp(
+  String.raw`\b(?:${WEIGH_SAYS_SO_WORDS})\b.*?\b(\d{2,3}(?:\.\d+)?)\s*(?:kgs?\b)?`, "i");
+
 export function looksLikeWeightReport(m: string): boolean {
-  return /^\s*(?:i\s+)?(?:weigh(?:ed)?(?:\s+in)?(?:\s+at)?\s*|my\s+weight\s*(?:is|:)?\s*|weight\s*(?:is|:)?\s*)?\d{2,3}(?:[.,]\d{1,2})?\s*kgs?\s*(?:today|this morning)?\s*[.!]?\s*$/i.test(m);
+  return WEIGHT_REPORT_RE.test(m);
 }
 
 // ONE shared answer to "is this message ASKING, or REPORTING?" — the systemic


### PR DESCRIPTION
Closes #176.

## The defect

The Journey Lab found `I weighed 83.9 this morning` answered with *"Sorry Kam, I didn't quite catch that"* and **zero** `weight_logs` rows. The client stated their weight in the most ordinary English there is; targets were not recalculated and the trend gained a hole they cannot see.

## Correction to the diagnosis — there were two owners, not one

The issue (and my own #173 report) named `looksLikeWeightReport`, which does require a literal `kg`. **Widening it alone changed nothing.** The runtime trace showed the actual write door is `weighInShape` in `server/handlers/workout.ts`, which carries its own recogniser, its own copy of the weigh vocabulary, and its own `kg`-only number extraction:

```
after widening utils.ts only:
"I weighed 83.9 this morning"  →  "Sorry Kam, I didn't quite catch that"  weight_logs=[]
```

Both had to learn the same rule, which is why this touches two files rather than the one the static reading suggested. Static analysis produced the candidate; the trace determined the truth.

## The rule

With a unit (`83.9kg`) the **unit** says what the number is, so no verb is needed — unchanged. Without one the **verb** has to say it, so an explicit weigh/weight prefix becomes required.

A bare `83.9` is therefore still not a weigh-in, and neither is a price, a portion or a step count. Nothing licenses reading a naked number as a body weight, and guessing writes a false point on the client's own trend line.

## `WEIGHED_NUMBER_RE` lives beside its sibling

The door's shape moved into `utils.ts` next to `looksLikeWeightReport` rather than becoming a **third** home for weight recognition. The two answers to *"did the client state a body weight"* are now readable against each other — precisely what would have stopped this being fixed twice. They are not merged, because they genuinely differ (the door's is unanchored, its vocabulary wider). Its capture group is the number, so the pattern that **recognises** the weigh-in also supplies the value that gets **written**, and the two cannot disagree.

Plausibility and same-day-correction semantics stay with `handleWeightLog`, unchanged and proven unchanged below.

## Controls

| # | Control | Result |
|---|---|---|
| 1 | `I weighed 83.9 this morning` → exactly one 83.9 write, one reply | ✓ |
| 2 | `83.9kg`, `I weigh 83.9 kg`, same-day correction unchanged | ✓ |
| 3 | Generic `83.9` is not a weight report | ✓ |
| 4 | Food quantities, prices, steps with similar numbers do not over-fire | ✓ |
| 5 | `this morning` does not alter the value or day | ✓ (83.9, today) |
| 6 | Same-day duplicate/correction still owned by `handleWeightLog` | ✓ (one row) |
| 7 | Turn mutation evidence reflects the durable write | ✓ |
| 8 | Red-on-revert | ✓ |

`unit-tests` 1057 → 1060, `tracking-contract` 27 → 29 must-not-write and 14 → 16 must-write cases, all driven through the real front door.

## Measured on real PostgreSQL

```
"I weighed 83.9 this morning"       weight=["83.9"]  meals=0 steps=0  mut=["INSERT weight=83.9kg"]
"83.9"                              weight=[]        meals=0 steps=0  mut=null
"I had 200g rice and 150g chicken"  weight=[]        meals=1 steps=0
"I paid 200 for the gym"            weight=[]        meals=0 steps=0  mut=null
"I used to weigh 90"                weight=[]        meals=0 steps=0  mut=null
"I want to weigh 85"                weight=[]        meals=0 steps=0  mut=null
"84.2kg"                            weight=["84.2"]  mut=["INSERT weight=84.2kg"]
"I weighed 83.9kg this morning"     weight=["83.9"]  mut=["INSERT weight=83.9kg"]
"I did 8000 steps"                  weight=[]        steps=1
"scale said 79.4"                   weight=["79.4"]  mut=["INSERT weight=79.4kg"]
same-day correction                 rows=["84.2"] — one row, one reply
```

`I used to weigh 90` and `I want to weigh 85` write nothing because the door's existing retrospective and future-intent brakes catch them — the recogniser says *a weight was named*, the brakes say *but not today's*. That division is unchanged.

## Red on revert

Restoring the literal-`kg`-only gate on **both** owners reproduces the exact Journey Lab symptom:

```
"I weighed 83.9 this morning"  →  "Sorry Kam, I didn't quite catch that"  weight_logs=[]
unit-tests:          1059/1060  ✗ a weigh verb licenses the number without a unit (#176)
tracking contract:   2/72 violations — "I weighed 83.9 this morning" wrote nothing
                                       "my weight is 84" wrote nothing
```

## No budget raised

Naming the door's shape cost one counted regex literal. Paid back in the same change: `utils.ts`'s weigh vocabulary is now declared once and read by both patterns instead of twice, so `regexLiterals` is back at **449**. `utils.ts` stays under its line budget by trimming **this change's own comments**, not another file's.

## Verification

| Suite | Result |
|---|---|
| `npm test` | 36/37 green, 1 covered nothing (`normalizer-replay-tests`, pre-existing) |
| `npm run test:unit:baseline --base=origin/main` | PASS — 0 branch-introduced failures |
| `npm run check` (tsc) | clean |
| `pg-correction-acceptance` / `pg-safety-turn-acceptance` | GREEN / GREEN |
| `check:filesize` / `check:arch` | 236 files OK; 239/449/32/26 all at budget |
| `check:schema` / `check:sast` / `check:names` | OK; 61/61; 97/97 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_