### PR TITLE
Commit client truth before coaching reads it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
       # every client-stated step count silently left untrusted.
       - name: Step provenance bridge on real PostgreSQL
         run: npx tsx script/pg-step-provenance-acceptance.ts
+      - name: Canonical client truth ordering on real PostgreSQL
+        run: npx tsx script/pg-client-truth-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     "client_intelligence_profiles",
     "quality_signals",
     "client_understanding",
+    "client_truth_commits",
     "reminders",
   ],
 });

--- a/migrations/0009_canonical_client_truth.sql
+++ b/migrations/0009_canonical_client_truth.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "truth_revision" integer DEFAULT 0 NOT NULL;
+
+ALTER TABLE "client_understanding"
+  ADD COLUMN IF NOT EXISTS "source_revision" integer DEFAULT 0 NOT NULL;
+
+CREATE TABLE IF NOT EXISTS "client_truth_commits" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "source_message_id" text,
+  "revision" integer NOT NULL,
+  "operations" jsonb NOT NULL,
+  "received_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "client_truth_commits_user_source_uidx"
+  ON "client_truth_commits" ("user_id", "source_message_id");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "client_truth_commits_user_revision_uidx"
+  ON "client_truth_commits" ("user_id", "revision");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1787400000000,
       "tag": "0008_step_provenance_regex_repair",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1787500000000,
+      "tag": "0009_canonical_client_truth",
+      "breakpoints": true
     }
   ]
 }

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -178,8 +178,10 @@ const ACTION_FILES: Record<string, "guarded" | "must-act" | "bookkeeping" | "AT 
   // independent authorities on "a new eating event happened". Both now hand rows to
   // commitFoodLog and write nothing themselves, which is the whole point of the cut: this list
   // shrinking is what convergence looks like from the governor's side.
-  // food-context.ts was here until commitFoodLog — the write door — moved to server/day-ledger.ts.
-  // It now parses and decides and hands rows to that one owner; it writes nothing itself.
+  // New-meal writes moved from food-context.ts to commitFoodLog in day-ledger.ts. The correction
+  // path still transactionally relabels/removes the previously resolved row, so it remains an
+  // action file and is guarded by its explicit correction/reference predicates.
+  "server/handlers/food-context.ts": "guarded",
   "server/handlers/food-log-mgmt.ts": "guarded",
   "server/handlers/media.ts": "guarded",
   "server/handlers/workout.ts": "guarded",
@@ -889,7 +891,10 @@ for (const [key, frozen] of Object.entries(FROZEN) as Array<[keyof typeof BUDGET
 // Every action file is declared, and the AT RISK list may only shrink.
 const actionFiles = files.filter(f => {
   const src = read(f);
-  return /db\s*\.\s*(insert|update)\s*\(/.test(src) && /\.test\((?:m|message|lower)\b/.test(src);
+  // A transaction-scoped write is still a write. Restricting this detector to the global `db`
+  // identifier made an action owner disappear from the governor the moment its write was made
+  // correctly atomic through `tx`.
+  return /(?:db|tx)\s*\.\s*(insert|update)\s*\(/.test(src) && /\.test\((?:m|message|lower)\b/.test(src);
 });
 for (const f of actionFiles) {
   if (!(f in ACTION_FILES)) {

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3980,14 +3980,17 @@ test("verifier: it still catches the thing it was built to catch", () => {
 
 // ── CUT 7: MEMORY IS FIELDS, NOT SEARCH ─────────────────────────────────────────────────────
 
-test("cut7: durable facts are learned at the front door, not inside the GPT handler", () => {
+test("cut7: durable facts commit at the front door before coaching reads the user", () => {
   const strip = (x: string) => x.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
   const routes = strip(readFileSync("server/routes.ts", "utf-8"));
   const gptBlock = strip(readFileSync("server/handlers/gpt-block.ts", "utf-8"));
   // THE DEFECT: the detectors sat last in the pipeline, so "my knee is killing me, had chicken
   // and pap" routed to the food handler and the injury was never recorded — while programme.ts
   // kept building sessions from users.injuries, which stayed NULL.
-  assert.ok(/recordClientFacts\(user, message\)/.test(routes), "every message is heard, not just GPT ones");
+  assert.ok(/user = await recordClientFacts\(user, message, sourceMessageId\)/.test(routes),
+    "every message is committed and the same turn receives the refreshed projection");
+  assert.ok(routes.indexOf("user = await recordClientFacts") < routes.indexOf("let normalizedQuestion"),
+    "truth commits before routing/normalization consumers");
   assert.ok(!/storeMemory\(phone, `Client reported injury/.test(gptBlock),
     "the prose detectors in the GPT handler are gone");
   assert.ok(!/storeMemory\(phone, `Life situation update/.test(gptBlock), "…both blocks of them");
@@ -4027,6 +4030,35 @@ test("cut7: one owner for the injury append", () => {
     assert.ok(!/const existingInj = \(user\.injuries \|\| ""\)\.toLowerCase\(\)/.test(src),
       `${f} no longer carries its own copy`);
   }
+});
+
+test("canonical truth: projection is built from the latest row and preserves independent facts", async () => {
+  const { projectClientFacts } = await import("../server/memory");
+  const first = projectClientFacts(
+    { injuries: "knee", doNotMention: "weight" },
+    { injuries: "shoulder", doNotMention: "my ex" },
+  );
+  assert.equal(first.patch.injuries, "knee, shoulder", "a concurrent injury is appended to the locked row");
+  assert.equal(first.patch.doNotMention, "weight, my ex", "one new boundary cannot erase another");
+  assert.deepEqual(first.operations.map((o: any) => o.fact), ["injuries", "doNotMention"]);
+  assert.equal(first.operations[0].previousValue, "knee", "lineage retains the replaced projection");
+});
+
+test("canonical truth: factual understanding always comes from the committed projection", async () => {
+  const { seedUnderstanding } = await import("../server/understanding/seed");
+  const seeded = seedUnderstanding({
+    name: "Thandi", dietaryRestrictions: "vegan", doNotMention: "weight",
+    lifeContext: "new baby", workSchedule: "night_shift",
+  } as any);
+  assert.ok(seeded.profile.keyFacts.includes("dietary restriction: vegan"));
+  assert.ok(seeded.profile.keyFacts.includes("do not mention: weight"));
+  assert.ok(seeded.profile.keyFacts.includes("life right now: new baby"));
+  assert.ok(seeded.profile.keyFacts.includes("work pattern: night shift"));
+
+  const store = readFileSync("server/understanding/store.ts", "utf-8");
+  assert.ok(/keyFacts: seed\.profile\.keyFacts/.test(store), "stored narrative cannot replace factual slots");
+  assert.ok(/setWhere: lte\(clientUnderstanding\.sourceRevision, sourceRevision\)/.test(store),
+    "a slow earlier turn cannot overwrite understanding from a newer fact revision");
 });
 
 // ── CUT 8: DON'T-MENTION IS BOUND TO THE MOUTH ──────────────────────────────────────────────

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3987,13 +3987,46 @@ test("cut7: durable facts commit at the front door before coaching reads the use
   // THE DEFECT: the detectors sat last in the pipeline, so "my knee is killing me, had chicken
   // and pap" routed to the food handler and the injury was never recorded — while programme.ts
   // kept building sessions from users.injuries, which stayed NULL.
-  assert.ok(/user = await recordClientFacts\(user, message, sourceMessageId\)/.test(routes),
-    "every message is committed and the same turn receives the refreshed projection");
-  assert.ok(routes.indexOf("user = await recordClientFacts") < routes.indexOf("const safetyResult = await runSafetyGuards"),
-    "truth commits before safety and every later routing/normalization consumer");
+  assert.ok(/await bindClientTruth\(phone, message, sourceMessageId\)/.test(routes),
+    "every message is committed at the door, and the same turn receives the refreshed projection");
   assert.ok(!/storeMemory\(phone, `Client reported injury/.test(gptBlock),
     "the prose detectors in the GPT handler are gone");
   assert.ok(!/storeMemory\(phone, `Life situation update/.test(gptBlock), "…both blocks of them");
+});
+
+// A SAFETY TURN IS STILL AN ACCEPTED TURN, AND ACCEPTED TURNS GET EXACTLY ONE REVISION.
+//
+// This replaces two string searches: the literal `recordClientFacts(user, message,
+// sourceMessageId)` had to appear in routes.ts ABOVE the literal `runSafetyGuards`. They passed
+// for the right reason once and then failed for the wrong one — the commit moved into
+// bindClientTruth, its owner in memory.ts, and the behaviour did not change at all. A test that
+// fails when correct code is reorganised is measuring the file, not the product.
+//
+// WHAT THIS ASSERTS, AND ONLY THIS: a crisis message returns from the safety guard before any
+// other handler runs, and that turn still lands EXACTLY ONE truth commit — never zero (the turn
+// was accepted, so it is attributable) and never two (the door and the guard must not both
+// commit it). Whether the commit precedes the guard is a durable-ordering property and is graded
+// where it can be graded honestly: pg-client-truth-acceptance and pg-safety-turn-acceptance, on
+// real PostgreSQL, against the revision numbers themselves.
+test("cut7: a crisis early-return lands exactly one truth commit — not zero, not two", async () => {
+  const g = globalThis as any;
+  const schema = await import("../shared/schema");
+  const { handleMessage } = await import("../server/routes");
+  const priorUser = g.__KAMLIFE_STUB_USER, priorWrites = g.__KAMLIFE_STUB_WRITES;
+  try {
+    g.__KAMLIFE_STUB_USER = {
+      id: "u-truth-order", phoneNumber: "whatsapp:+27000000191", name: "Kam",
+      onboardingState: "COMPLETE", subscriptionStatus: "active", popiConsent: true,
+      goalType: "fat_loss", calorieTarget: 2800, proteinTarget: 195, truthRevision: 0,
+    };
+    g.__KAMLIFE_STUB_WRITES = [];
+    const reply = String(await handleMessage("whatsapp:+27000000191", "I want to kill myself") ?? "");
+    const commits = (g.__KAMLIFE_STUB_WRITES || []).filter((w: any) => w.table === schema.clientTruthCommits);
+    assert.ok(/SADAG|0800 567 567/i.test(reply), "the turn really did take the crisis early-return");
+    assert.equal(commits.length, 1, "…and it is attributable: one revision, and only one");
+  } finally {
+    g.__KAMLIFE_STUB_USER = priorUser; g.__KAMLIFE_STUB_WRITES = priorWrites;
+  }
 });
 
 test("cut7: an injury reaches the column the programme actually reads", async () => {

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3989,8 +3989,8 @@ test("cut7: durable facts commit at the front door before coaching reads the use
   // kept building sessions from users.injuries, which stayed NULL.
   assert.ok(/user = await recordClientFacts\(user, message, sourceMessageId\)/.test(routes),
     "every message is committed and the same turn receives the refreshed projection");
-  assert.ok(routes.indexOf("user = await recordClientFacts") < routes.indexOf("let normalizedQuestion"),
-    "truth commits before routing/normalization consumers");
+  assert.ok(routes.indexOf("user = await recordClientFacts") < routes.indexOf("const safetyResult = await runSafetyGuards"),
+    "truth commits before safety and every later routing/normalization consumer");
   assert.ok(!/storeMemory\(phone, `Client reported injury/.test(gptBlock),
     "the prose detectors in the GPT handler are gone");
   assert.ok(!/storeMemory\(phone, `Life situation update/.test(gptBlock), "…both blocks of them");

--- a/script/pg-client-truth-acceptance.ts
+++ b/script/pg-client-truth-acceptance.ts
@@ -1,0 +1,138 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — canonical client truth.
+ *
+ * The contract depends on row locks, transaction ordering, unique source IDs and conditional
+ * upserts. The deterministic DB stub cannot prove any of those, so this suite runs only in the
+ * ephemeral PostgreSQL CI service after committed migrations have been applied.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-client-truth-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { and, eq } = await import("drizzle-orm");
+const { handleMessage } = await import("../server/routes");
+const { recordClientFacts } = await import("../server/memory");
+const { seedUnderstanding } = await import("../server/understanding/seed");
+const { loadUnderstanding, saveUnderstanding } = await import("../server/understanding/store");
+
+let failed = 0;
+const check = (ok: unknown, description: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${description}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const phone = `whatsapp:+2796${String(Math.floor(Math.random() * 900000) + 100000)}`;
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+const [user] = await db.insert(schema.users).values({
+  phoneNumber: phone,
+  name: "Truth Client",
+  onboardingState: "COMPLETE",
+  subscriptionStatus: "active",
+  popiConsent: true,
+  popiConsentAt: new Date(),
+  goalType: "fat_loss",
+  calorieTarget: 2200,
+  proteinTarget: 140,
+  stepsTarget: 8000,
+  trainingMode: "gym",
+  trainingDaysPerWeek: 3,
+  createdAt: new Date(),
+  lastActiveAt: new Date(),
+} as any).returning();
+
+const readUser = async () => (await db.select().from(schema.users).where(eq(schema.users.id, user.id)).limit(1))[0];
+const readCommits = async () => db.select().from(schema.clientTruthCommits)
+  .where(eq(schema.clientTruthCommits.userId, user.id))
+  .orderBy(schema.clientTruthCommits.revision);
+
+REAL("\n=== CANONICAL CLIENT TRUTH ===");
+
+// §1 THE REAL FRONT DOOR: current-turn evidence must commit before any handler owns the turn.
+const frontDoorReply = await handleMessage(
+  phone,
+  "my knee has been killing me since Saturday and I had chicken and pap",
+  undefined, undefined, undefined,
+  "SM-TRUTH-FRONT",
+);
+let current = await readUser();
+check(current.injuries === "knee", "raw mixed-intent input committed the injury through the real front door", String(current.injuries));
+check(Number(current.truthRevision) === 1, "the first accepted turn advanced revision exactly once", String(current.truthRevision));
+check(String(frontDoorReply || "").trim().length > 0, "the same turn still produced a client reply");
+
+// §2 TWO STALE CALLERS: both begin with the same row, but the lock/re-read must preserve both.
+const stale = { ...current };
+await Promise.all([
+  recordClientFacts(stale, "I hurt my shoulder yesterday", "SM-TRUTH-A"),
+  recordClientFacts(stale, "I injured my ankle yesterday", "SM-TRUTH-B"),
+]);
+current = await readUser();
+const injurySet = new Set(String(current.injuries || "").split(",").map((s: string) => s.trim()));
+check(["knee", "shoulder", "ankle"].every(x => injurySet.has(x)),
+  "concurrent fact commits preserve every injury", String(current.injuries));
+check(Number(current.truthRevision) === 3, "two concurrent changes receive distinct ordered revisions", String(current.truthRevision));
+
+// §3 SOURCE IDEMPOTENCY: retrying the exact provider message cannot mutate or append evidence.
+const beforeRetry = JSON.stringify(await readCommits());
+await recordClientFacts(stale, "I injured my back yesterday", "SM-TRUTH-A");
+current = await readUser();
+check(!String(current.injuries || "").includes("back"), "a reused provider source ID is applied once");
+check(JSON.stringify(await readCommits()) === beforeRetry, "a provider retry adds no second evidence commit");
+
+// §4 BOUNDARIES ARE INDEPENDENT: a later boundary cannot silently revoke the earlier one.
+await recordClientFacts(current, "please don't mention my weight", "SM-TRUTH-C");
+current = await readUser();
+await recordClientFacts(current, "please don't mention my ex", "SM-TRUTH-D");
+current = await readUser();
+check(/weight/i.test(current.doNotMention || "") && /\bex\b/i.test(current.doNotMention || ""),
+  "two prohibited topics remain active together", String(current.doNotMention));
+
+const commits = await readCommits();
+check(commits.length === 5, "one append-only evidence commit exists per effective source mutation", String(commits.length));
+check(commits.map(c => c.revision).join(",") === "1,2,3,4,5", "fact revisions have no duplicates or gaps",
+  commits.map(c => c.revision).join(","));
+check((commits[1].operations as any[])[0]?.previousValue != null,
+  "evidence retains the previous projection value for correction lineage");
+
+// §5 FACTUAL CONTEXT PRECEDENCE + STALE DERIVED-WRITE REJECTION.
+await pool.query(`UPDATE users SET dietary_restrictions = 'vegan', truth_revision = 6 WHERE id = $1`, [user.id]);
+current = await readUser();
+const canonicalSeed = seedUnderstanding(current);
+const newer = structuredClone(canonicalSeed);
+newer.profile.lifeStory = "newer narrative";
+newer.profile.keyFacts = ["model invented: eats everything"];
+await saveUnderstanding(user.id, newer, 6);
+
+const older = structuredClone(canonicalSeed);
+older.profile.lifeStory = "stale narrative";
+older.profile.keyFacts = ["stale model fact"];
+await saveUnderstanding(user.id, older, 5);
+
+const loaded = await loadUnderstanding(user.id, seedUnderstanding(current));
+const [stored] = await db.select().from(schema.clientUnderstanding)
+  .where(and(eq(schema.clientUnderstanding.userId, user.id), eq(schema.clientUnderstanding.sourceRevision, 6)));
+check(loaded.profile.keyFacts.includes("dietary restriction: vegan"),
+  "canonical structured restriction outranks persisted model keyFacts", JSON.stringify(loaded.profile.keyFacts));
+check(!loaded.profile.keyFacts.some(x => /invented|stale model/.test(x)), "stored narrative contributes no factual slots");
+check(stored?.profile && (stored.profile as any).lifeStory === "newer narrative",
+  "a slow revision-5 save cannot overwrite revision-6 understanding", JSON.stringify(stored?.profile));
+
+await pool.query("DELETE FROM users WHERE id = $1", [user.id]);
+REAL(`\npg-client-truth-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-safety-turn-acceptance.ts
+++ b/script/pg-safety-turn-acceptance.ts
@@ -100,6 +100,10 @@ check(crisisTurn.reply === crisisResponse, "crisis ledger holds the final client
 check(crisisTurn.version === "issue-175-safety", "crisis turn exposes exact build provenance to Coach Health");
 const crisisUsers = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.phoneNumber, phones.crisis));
 check(crisisUsers.length === 1, "first-contact crisis identity binding creates exactly one user");
+const crisisTruth = await db.select().from(schema.clientTruthCommits)
+  .where(eq(schema.clientTruthCommits.userId, crisisUser.id));
+check(crisisTruth.length === 1 && crisisTruth[0].revision === 1,
+  "first-contact crisis receives exactly one canonical truth revision before returning");
 const crisisChats = await db.select({ id: schema.chatHistory.id }).from(schema.chatHistory).where(and(
   eq(schema.chatHistory.userId, crisisUser.id), eq(schema.chatHistory.intent, "CRISIS"),
 ));

--- a/server/handlers/safety.ts
+++ b/server/handlers/safety.ts
@@ -22,6 +22,7 @@ import { isCrisisMessage, crisisReply, crisisAlertBody } from "../crisis-reply";
 import { asksForExport, formatExport } from "../data-export";
 import { sastDayKey } from "../sast";
 import { logChat, turnUser } from "./chat-log";
+import { recordClientFacts } from "../memory";
 
 // Send a Twilio message with exponential-backoff retries. On complete failure,
 // records a row in adminEvents so the coach can find missed alerts on reload.
@@ -92,9 +93,19 @@ function bindKnownSafetyUser<T extends { id?: string | null } | undefined>(user:
  * get-or-create owner gives known and first-contact clients one durable identity when available;
  * failure leaves the safety branch free to return its existing safest reply.
  */
-async function ensureSafetyTurnUser(phone: string): Promise<any | undefined> {
+async function ensureSafetyTurnUser(
+  phone: string,
+  message: string,
+  sourceMessageId?: string,
+  boundUser?: any,
+): Promise<any | undefined> {
   try {
-    return bindKnownSafetyUser(await getOrCreateUser(phone));
+    // A known user was already committed at the route boundary. A first-contact safety user must
+    // be created here so the safety response remains independent of ordinary routing, then their
+    // accepted turn receives the same canonical truth revision as every other turn.
+    if (boundUser) return bindKnownSafetyUser(boundUser);
+    const created = await getOrCreateUser(phone);
+    return bindKnownSafetyUser(await recordClientFacts(created, message, sourceMessageId));
   } catch (e: any) {
     console.error("[SAFETY_TURN_IDENTITY] attribution unavailable; safety response continues:", e?.message || e);
     return undefined;
@@ -105,6 +116,7 @@ export async function runSafetyGuards(
   phone: string,
   message: string,
   m: string,
+  context: { sourceMessageId?: string; boundUser?: any } = {},
 ): Promise<string | null> {
 
   // ---- THE QUIT MOMENT — "I don't know how I will do this anymore" ----
@@ -137,7 +149,7 @@ export async function runSafetyGuards(
   // server/life-context.ts for the compliance posture.
   const life = readLifeContext(message);
   if (life && !isCrisisMessage(m)) {
-    const lifeUser = await ensureSafetyTurnUser(phone);
+    const lifeUser = await ensureSafetyTurnUser(phone, message, context.sourceMessageId, context.boundUser);
     const reply = lifeContextReply(life, (lifeUser?.name || "").split(" ")[0]);
     // Comfort that isn't followed by silence is just a nice sentence — go quiet on nudges too.
     if (lifeUser?.id) markLifeQuiet(lifeUser.id, life).catch(() => {});
@@ -147,7 +159,7 @@ export async function runSafetyGuards(
 
   // ---- CRISIS ----
   if (isCrisisMessage(m)) {
-    const crisisUser = await ensureSafetyTurnUser(phone);
+    const crisisUser = await ensureSafetyTurnUser(phone, message, context.sourceMessageId, context.boundUser);
     const crisisName = crisisUser?.name || "friend";
     const reply = crisisReply(crisisName);
     try { await logChat(crisisUser?.id || "unknown", message, reply, "CRISIS"); } catch (e) { console.warn("[non-fatal]", e); }
@@ -179,7 +191,7 @@ export async function runSafetyGuards(
   const benignStroke = /\bstroke of (?:luck|genius)\b|\b(?:breast|back|free|butterfly|side|swim(?:ming)?|paddle|broad|key)\s*-?\s*strokes?\b|\bbreaststroke\b|\bbackstroke\b/i.test(m);
   const strokeEmergency = /\bstrokes?\b/i.test(m) && !benignStroke;
   if (nonStrokeEmergency || strokeEmergency) {
-    const acuteUser = await ensureSafetyTurnUser(phone);
+    const acuteUser = await ensureSafetyTurnUser(phone, message, context.sourceMessageId, context.boundUser);
     const acuteName = acuteUser?.name || "friend";
     const acuteReply = `This sounds like it could be a medical emergency. Stop what you're doing and call *10177* (SA ambulance) or go to your nearest emergency room immediately. Do not wait. Health first — everything else can wait.`;
     try { await logChat(acuteUser?.id || "unknown", message, acuteReply, "ACUTE_MEDICAL"); } catch (e) { console.warn("[non-fatal]", e); }

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -229,8 +229,8 @@ export async function retrieveMemories(phone: string, query: string): Promise<st
 // So: one detector set, one writer, typed columns, read by the decision and by the programme.
 
 import { db } from "./db";
-import { users } from "../shared/schema";
-import { eq } from "drizzle-orm";
+import { clientTruthCommits, users } from "../shared/schema";
+import { and, eq, sql } from "drizzle-orm";
 import { looksLikeQuestion, isFutureIntent } from "./utils";
 import { foodConstraints } from "./food-swaps";
 
@@ -344,37 +344,105 @@ export function addFact(existing: string | null | undefined, item: string): stri
   return `${cur}, ${clean}`;
 }
 
+export interface ClientFactOperation {
+  fact: keyof DurableFacts;
+  operation: "assert";
+  previousValue: string | null;
+  value: string;
+  provenance: "client_explicit";
+}
+
 /**
- * Write what this message told us, if anything. Fire-and-forget: never blocks or fails a reply.
+ * Build the users-row projection and its evidence operations from the latest locked row.
+ * This function is pure so the precedence rule is testable without pretending the DB stub can
+ * model PostgreSQL row locks. Durable list facts append; a new boundary never erases an unrelated
+ * boundary. Work schedule is a single current slot and therefore replaces its earlier value.
+ */
+export function projectClientFacts(
+  current: any,
+  facts: DurableFacts,
+): { patch: Record<string, string>; operations: ClientFactOperation[] } {
+  const patch: Record<string, string> = {};
+  const operations: ClientFactOperation[] = [];
+  const appendFacts: Array<keyof Pick<DurableFacts,
+    "injuries" | "medicalConditions" | "dietaryRestrictions" | "lifeContext" | "doNotMention"
+  >> = ["injuries", "medicalConditions", "dietaryRestrictions", "lifeContext", "doNotMention"];
+
+  for (const fact of appendFacts) {
+    const asserted = facts[fact];
+    if (!asserted) continue;
+    const previous = current?.[fact] == null ? null : String(current[fact]);
+    const next = addFact(previous, asserted);
+    if (!next || next === previous) continue;
+    patch[fact] = next;
+    operations.push({ fact, operation: "assert", previousValue: previous, value: next, provenance: "client_explicit" });
+  }
+
+  if (facts.workSchedule && facts.workSchedule !== current?.workSchedule) {
+    const previous = current?.workSchedule == null ? null : String(current.workSchedule);
+    patch.workSchedule = facts.workSchedule;
+    operations.push({
+      fact: "workSchedule", operation: "assert", previousValue: previous,
+      value: facts.workSchedule, provenance: "client_explicit",
+    });
+  }
+  return { patch, operations };
+}
+
+/**
+ * Commit what this message told us before the turn is coached.
  *
  * Called from the FRONT DOOR, not from the GPT handler, which is the whole point — the old
  * detectors sat last in the pipeline, so an injury mentioned alongside a meal was routed to the
- * food handler and never recorded at all.
+ * food handler and never recorded at all. The user row is locked and re-read inside the transaction:
+ * building a patch from the request's stale user object would lose simultaneous facts.
+ *
+ * The returned row is the immutable factual context for the rest of this turn. A Twilio source ID
+ * makes delivery retries idempotent; separate identical utterances without the same source remain
+ * separate turns. Errors fail open for availability but never masquerade as a successful commit.
  */
-export async function recordClientFacts(user: any, message: string): Promise<void> {
+export async function recordClientFacts(user: any, message: string, sourceMessageId?: string): Promise<any> {
+  const facts = detectFacts(message);
   try {
-    const f = detectFacts(message);
-    if (Object.keys(f).length === 0) return;
+    const committed = await db.transaction(async (tx) => {
+      // Drizzle transactions use one checked-out connection. Lock first, then re-read from that
+      // same connection so two messages cannot both derive a replacement from the same old row.
+      await tx.execute(sql`SELECT id FROM users WHERE id = ${user.id} FOR UPDATE`);
+      const rows = await tx.select().from(users).where(eq(users.id, user.id)).limit(1);
+      const current = rows[0] || user;
 
-    const patch: Record<string, string> = {};
-    const inj = f.injuries ? addFact(user.injuries, f.injuries) : null;
-    if (inj && inj !== user.injuries) patch.injuries = inj;
-    const cond = f.medicalConditions ? addFact(user.medicalConditions, f.medicalConditions) : null;
-    if (cond && cond !== user.medicalConditions) patch.medicalConditions = cond;
-    const diet = f.dietaryRestrictions ? addFact(user.dietaryRestrictions, f.dietaryRestrictions) : null;
-    if (diet && diet !== user.dietaryRestrictions) patch.dietaryRestrictions = diet;
-    const life = f.lifeContext ? addFact(user.lifeContext, f.lifeContext) : null;
-    if (life && life !== user.lifeContext) patch.lifeContext = life;
-    // NOT appended — a new request replaces the old one. "Don't mention my weight" then later
-    // "don't mention my ex" should not leave us avoiding a growing list forever.
-    if (f.doNotMention && f.doNotMention !== user.doNotMention) patch.doNotMention = f.doNotMention;
-    if (f.workSchedule && f.workSchedule !== user.workSchedule) patch.workSchedule = f.workSchedule;
+      const source = String(sourceMessageId || "").trim() || null;
+      if (source) {
+        const prior = await tx.select({ id: clientTruthCommits.id })
+          .from(clientTruthCommits)
+          .where(and(eq(clientTruthCommits.userId, user.id), eq(clientTruthCommits.sourceMessageId, source)))
+          .limit(1);
+        if (prior.length) return current;
+      }
 
-    if (Object.keys(patch).length === 0) return;
-    await db.update(users).set(patch).where(eq(users.id, user.id));
-    console.log(`[FACTS] ...${String(user.id).slice(-6)} learned ${Object.keys(patch).join(", ")}`);
+      const { patch, operations } = projectClientFacts(current, facts);
+      // Every accepted source advances the context clock, even when it carries no durable profile
+      // mutation. Otherwise two ordinary model turns share a revision and a slow older save can
+      // still overwrite the newer understanding.
+      const revision = Math.max(0, Number(current.truthRevision) || 0) + 1;
+
+      await tx.update(users).set({ ...patch, truthRevision: revision }).where(eq(users.id, user.id));
+      await tx.insert(clientTruthCommits).values({
+        userId: user.id,
+        sourceMessageId: source,
+        revision,
+        operations: operations as any,
+        receivedAt: new Date(),
+      });
+      return { ...current, ...patch, truthRevision: revision };
+    });
+    if ((committed?.truthRevision || 0) !== (user?.truthRevision || 0)) {
+      console.log(`[FACTS] ...${String(user.id).slice(-6)} committed truth revision ${committed.truthRevision}`);
+    }
+    return committed;
   } catch (e) {
     console.warn("[FACTS] non-fatal:", (e as any)?.message || e);
+    return { ...user, __factCommitFailed: true };
   }
 }
 
@@ -615,5 +683,3 @@ export async function answerRecall(user: any, message: string): Promise<string> 
     currentWeightKg: user?.currentWeight,
   });
 }
-
-

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -446,6 +446,33 @@ export async function recordClientFacts(user: any, message: string, sourceMessag
   }
 }
 
+/**
+ * WHO IS THIS, AND WHAT DID THEY JUST TELL US — bound and committed before anything routes.
+ *
+ * Lives here, with recordClientFacts, rather than inline at the door: the door's job is to decide
+ * where a turn goes, and it cannot do that honestly until this has already happened. Keeping the
+ * lookup and the commit as one named step is also what stops the two drifting apart — the commit
+ * must read the row this returns, not a staler one fetched somewhere else.
+ *
+ * BINDING AN EXISTING IDENTITY MUST NEVER CREATE ONE. "delete my data" from a number we have
+ * never seen has to keep answering "no account found", so this returns undefined for an unknown
+ * caller and the door creates only after the guards have stood down.
+ *
+ * FAILS OPEN, DELIBERATELY. If the database is unreachable the turn still runs: a client in
+ * crisis must reach the safety guards whether or not we could record what they said. The
+ * alternative — refusing the turn because bookkeeping failed — is the one outcome that cannot be
+ * allowed to happen here.
+ */
+export async function bindClientTruth(phone: string, message: string, sourceMessageId?: string): Promise<any | undefined> {
+  try {
+    const existing = await db.select().from(users).where(eq(users.phoneNumber, phone)).limit(1);
+    return existing[0] ? await recordClientFacts(existing[0], message, sourceMessageId) : undefined;
+  } catch (e: any) {
+    console.error("[TRUTH_COMMIT] unavailable before routing; safety remains live:", e?.message || e);
+    return undefined;
+  }
+}
+
 /** The six facts as one context line for the coach. Replaces the embedded prose. */
 export async function factsLine(phone: string): Promise<string> {
   try {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -118,20 +118,24 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
   try {
   recordMessageSeen();  let m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
 
-  // Bind and commit the turn's factual context before ANY routing decision, including safety and
-  // life-context early returns. Persistence is attempted, never required for a safe response: a
-  // database outage must not prevent crisis guidance from reaching the client.
+  // Bind an EXISTING identity and commit the turn's factual context before any routing decision.
+  // Do not create an unknown account here: "delete my data" from an unknown number must remain
+  // "no account found". First-contact safety/life branches create+commit through their own
+  // fail-open identity helper, while ordinary first-contact turns create below after guards stand down.
   let user: any | undefined;
   try {
-    user = await getOrCreateUser(phone);
-    turnUser(user.id);
-    user = await recordClientFacts(user, message, sourceMessageId);
+    const existing = await db.select().from(users).where(eq(users.phoneNumber, phone)).limit(1);
+    user = existing[0];
+    if (user) {
+      turnUser(user.id);
+      user = await recordClientFacts(user, message, sourceMessageId);
+    }
   } catch (e: any) {
     console.error("[TRUTH_COMMIT] unavailable before routing; safety remains live:", e?.message || e);
   }
 
   // ---- SAFETY + DATA GUARDS (crisis, medical, terminal, delete, reset) ----
-  const safetyResult = await runSafetyGuards(phone, message, m);
+  const safetyResult = await runSafetyGuards(phone, message, m, { sourceMessageId, boundUser: user });
   if (safetyResult !== null) return safetyResult;
 
   if (!user) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -118,24 +118,33 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
   try {
   recordMessageSeen();  let m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
 
+  // Bind and commit the turn's factual context before ANY routing decision, including safety and
+  // life-context early returns. Persistence is attempted, never required for a safe response: a
+  // database outage must not prevent crisis guidance from reaching the client.
+  let user: any | undefined;
+  try {
+    user = await getOrCreateUser(phone);
+    turnUser(user.id);
+    user = await recordClientFacts(user, message, sourceMessageId);
+  } catch (e: any) {
+    console.error("[TRUTH_COMMIT] unavailable before routing; safety remains live:", e?.message || e);
+  }
+
   // ---- SAFETY + DATA GUARDS (crisis, medical, terminal, delete, reset) ----
   const safetyResult = await runSafetyGuards(phone, message, m);
   if (safetyResult !== null) return safetyResult;
 
-  let user = await getOrCreateUser(phone);
-  turnUser(user.id);
+  if (!user) {
+    user = await getOrCreateUser(phone);
+    turnUser(user.id);
+    user = await recordClientFacts(user, message, sourceMessageId);
+  }
 
   // QR ACQUISITION SOURCE — a scanned join-QR prefills "(ref: gymA)"; capture once, then strip.
   if (!user.signupSource && !mediaUrl && message && (await captureSignupSource(user, phone, message))) {
     message = stripSignupSource(message);
     m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
   }
-
-  // Durable client truth is part of accepting the turn, not background telemetry. Commit it from
-  // the raw client words before any coaching path reads the user. recordClientFacts locks and
-  // re-reads the latest row, then returns the exact projection/revision every consumer in this
-  // turn must share. A webhook retry reuses sourceMessageId and therefore cannot apply twice.
-  user = await recordClientFacts(user, message, sourceMessageId);
 
   // Page coach on crisis/injury signals immediately — fires even if onboarding/POPIA returns early
   if (message && message.length > 2) checkEscalation(user.id, message).catch(e => console.error("[ESCALATION_CHECK]", e?.message || e));

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -122,7 +122,7 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
   const safetyResult = await runSafetyGuards(phone, message, m);
   if (safetyResult !== null) return safetyResult;
 
-  const user = await getOrCreateUser(phone);
+  let user = await getOrCreateUser(phone);
   turnUser(user.id);
 
   // QR ACQUISITION SOURCE — a scanned join-QR prefills "(ref: gymA)"; capture once, then strip.
@@ -130,6 +130,12 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
     message = stripSignupSource(message);
     m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
   }
+
+  // Durable client truth is part of accepting the turn, not background telemetry. Commit it from
+  // the raw client words before any coaching path reads the user. recordClientFacts locks and
+  // re-reads the latest row, then returns the exact projection/revision every consumer in this
+  // turn must share. A webhook retry reuses sourceMessageId and therefore cannot apply twice.
+  user = await recordClientFacts(user, message, sourceMessageId);
 
   // Page coach on crisis/injury signals immediately — fires even if onboarding/POPIA returns early
   if (message && message.length > 2) checkEscalation(user.id, message).catch(e => console.error("[ESCALATION_CHECK]", e?.message || e));
@@ -500,12 +506,6 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // capitalisation intact — `m` is already lower-cased and whitespace-collapsed, which is fine for
   // matching but is not their message.
   const originalMessageForFidelity = message;
-
-  // CUT 7 — durable facts are learned at the FRONT DOOR, on the raw text, for the same reason the
-  // turn facts are. The old detectors sat inside the GPT handler, last in the pipeline, so "my
-  // knee is killing me, had chicken and pap" routed to food and the injury was never recorded —
-  // and programme.ts, which trains around users.injuries, never heard about the knee.
-  void recordClientFacts(user, message);
 
   // CUT 2 — the facts are counted on the client's RAW text, here, before the rewriter below can
   // replace it. Cut 1 counted them after, so a two-fact note rewritten down to one fact reached

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,7 +17,7 @@ import { handleOnboarding, getMenuText, getOnboardingMealPlan } from "./onboardi
 import { saysNotWorking } from "./despair";
 import { getShoppingList, formatShoppingList } from "./shopping-lists";
 import { nutritionAgent, programmingAgent, mindsetAgent, adminAgent, routeToAgent } from "./agents";
-import { recordClientFacts } from "./memory";
+import { recordClientFacts, bindClientTruth } from "./memory";
 import { generateVoiceNote, getVoiceFilePath, voiceFileExists } from "./tts";
 import { sendWhatsApp } from "./scheduler";
 import { recordConversion } from "./ab";
@@ -118,21 +118,12 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
   try {
   recordMessageSeen();  let m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
 
-  // Bind an EXISTING identity and commit the turn's factual context before any routing decision.
-  // Do not create an unknown account here: "delete my data" from an unknown number must remain
-  // "no account found". First-contact safety/life branches create+commit through their own
-  // fail-open identity helper, while ordinary first-contact turns create below after guards stand down.
-  let user: any | undefined;
-  try {
-    const existing = await db.select().from(users).where(eq(users.phoneNumber, phone)).limit(1);
-    user = existing[0];
-    if (user) {
-      turnUser(user.id);
-      user = await recordClientFacts(user, message, sourceMessageId);
-    }
-  } catch (e: any) {
-    console.error("[TRUTH_COMMIT] unavailable before routing; safety remains live:", e?.message || e);
-  }
+  // The turn's factual context is committed before ANY routing decision — bindClientTruth in
+  // memory.ts owns the lookup, the commit and the fail-open. It never creates an account, so
+  // "delete my data" from an unknown number still answers "no account found"; ordinary first
+  // contact is created below, once the guards have stood down.
+  let user: any | undefined = await bindClientTruth(phone, message, sourceMessageId);
+  if (user) turnUser(user.id);
 
   // ---- SAFETY + DATA GUARDS (crisis, medical, terminal, delete, reset) ----
   const safetyResult = await runSafetyGuards(phone, message, m, { sourceMessageId, boundUser: user });

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -433,7 +433,7 @@ export async function runMeaningEngineLive(ctx: {
     if (!result) return null; // fail-open → existing pipeline runs
 
     // Grow the client's durable memory (fail-open — a save miss never blocks the reply).
-    if (user?.id) saveUnderstanding(user.id, result.state).catch(() => {});
+    if (user?.id) saveUnderstanding(user.id, result.state, Math.max(0, Number(user.truthRevision) || 0)).catch(() => {});
 
     // THE INVERSION — Coach K decided on an action. Validate happened in the engine;
     // here we execute it (dry-run in shadow) and, in `on` mode, let the deterministic

--- a/server/understanding/seed.ts
+++ b/server/understanding/seed.ts
@@ -39,6 +39,16 @@ function keyFactsFromUser(user: any): string[] {
   const facts: string[] = [];
   const inj = (user?.injuries || "").trim();
   if (inj && inj.toLowerCase() !== "none") facts.push(`injury/limitation: ${inj}`);
+  // Constraints and boundaries outrank descriptive profile colour. These are factual slots from
+  // the committed users projection; a persisted model narrative must never be their second owner.
+  const restrictions = (user?.dietaryRestrictions || "").trim();
+  if (restrictions && restrictions.toLowerCase() !== "none") facts.push(`dietary restriction: ${restrictions.slice(0, 120)}`);
+  const boundary = (user?.doNotMention || "").trim();
+  if (boundary && boundary.toLowerCase() !== "none") facts.push(`do not mention: ${boundary.slice(0, 120)}`);
+  const lifeContext = (user?.lifeContext || "").trim();
+  if (lifeContext && lifeContext.toLowerCase() !== "none") facts.push(`life right now: ${lifeContext.slice(0, 120)}`);
+  const workSchedule = (user?.workSchedule || "").trim();
+  if (workSchedule && workSchedule !== "standard") facts.push(`work pattern: ${workSchedule.replace(/_/g, " ")}`);
   const goal = user?.goalType;
   if (goal) facts.push(`goal: ${String(goal).replace(/_/g, " ")}`);
   const job = (user?.jobType || user?.lifeSituation || "").trim();
@@ -54,7 +64,7 @@ function keyFactsFromUser(user: any): string[] {
   const med = (user?.medicalConditions || "").trim();
   if (med && med.toLowerCase() !== "none") facts.push(`medical: ${med.slice(0, 60)}`);
   if (user?.trainingMode) facts.push(`trains: ${String(user.trainingMode).replace(/_/g, " ")}${user?.homeEquipment ? ` (${user.homeEquipment})` : ""}, ${user?.trainingDaysPerWeek || "?"} days/week`);
-  return facts.slice(0, 10);
+  return facts.slice(0, 12);
 }
 
 export function seedUnderstanding(user: any, snapshot?: string): UnderstandingState {

--- a/server/understanding/store.ts
+++ b/server/understanding/store.ts
@@ -13,7 +13,7 @@
  * seed. The table (client_understanding) is created by `npm run db:push`.
  */
 
-import { eq } from "drizzle-orm";
+import { eq, lte } from "drizzle-orm";
 import { db } from "../db";
 import { clientUnderstanding } from "../../shared/schema";
 import {
@@ -42,7 +42,9 @@ export async function loadUnderstanding(userId: string, seed: UnderstandingState
       profile: {
         name: seed.profile.name || stored.profile.name,
         lifeStory: stored.profile.lifeStory || seed.profile.lifeStory,
-        keyFacts: stored.profile.keyFacts.length ? stored.profile.keyFacts : seed.profile.keyFacts,
+        // Factual slots are rebuilt from the committed users projection every turn. Stored
+        // understanding is model-derived narrative/observation and may never overrule them.
+        keyFacts: seed.profile.keyFacts,
         preferences: seed.profile.preferences,
       },
       observations: stored.observations,
@@ -56,14 +58,17 @@ export async function loadUnderstanding(userId: string, seed: UnderstandingState
   }
 }
 
-export async function saveUnderstanding(userId: string, state: UnderstandingState): Promise<void> {
+export async function saveUnderstanding(userId: string, state: UnderstandingState, sourceRevision = 0): Promise<void> {
   try {
     const durable = persistableUnderstanding(state);
     await db.insert(clientUnderstanding)
-      .values({ userId, profile: durable.profile as any, observations: durable.observations as any, updatedAt: new Date() })
+      .values({ userId, profile: durable.profile as any, observations: durable.observations as any, sourceRevision, updatedAt: new Date() })
       .onConflictDoUpdate({
         target: clientUnderstanding.userId,
-        set: { profile: durable.profile as any, observations: durable.observations as any, updatedAt: new Date() },
+        set: { profile: durable.profile as any, observations: durable.observations as any, sourceRevision, updatedAt: new Date() },
+        // A slow earlier turn may finish its model call after a newer fact commit. Reject it rather
+        // than allowing its whole JSON blob to erase the newer turn's understanding.
+        setWhere: lte(clientUnderstanding.sourceRevision, sourceRevision),
       });
   } catch (e) {
     console.warn("[UNDERSTANDING_STORE] save failed (non-fatal):", (e as any)?.message || e);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -70,6 +70,10 @@ export const users = pgTable(
     dietaryRestrictions: text("dietary_restrictions"), // comma-separated, like medical_conditions
     lifeContext: text("life_context"),                 // night shifts, new baby, retrenched, moved
     doNotMention: text("do_not_mention"),              // topics the client asked us to drop
+    // Monotonic version of accepted client context. Every turn increments this while holding
+    // the user row lock, whether or not it changes a durable profile fact. Derived/model memory
+    // is stamped with this revision so a slow older turn cannot overwrite newer truth.
+    truthRevision: integer("truth_revision").notNull().default(0),
     programmePhase: integer("programme_phase").default(1),
     programmeWeek: integer("programme_week").default(1),
     programmeDayInWeek: integer("programme_day_in_week").default(1),
@@ -520,10 +524,32 @@ export const clientUnderstanding = pgTable("client_understanding", {
   userId: uuid("user_id").primaryKey().references(() => users.id, { onDelete: "cascade" }),
   profile: jsonb("profile"),           // { name, lifeStory, keyFacts[], preferences }
   observations: jsonb("observations"), // { confidenceTrend, frustrationLevel, readinessToPush, trustLevel }
+  sourceRevision: integer("source_revision").notNull().default(0),
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
 export type ClientUnderstanding = typeof clientUnderstanding.$inferSelect;
+
+// === CLIENT TRUTH COMMITS — ordered evidence behind the current user projection ===
+// The users row remains the fast current-state projection. This append-only row records which
+// client message was accepted, any factual operations it caused, and the revision coaching saw.
+// A nullable sourceMessageId deliberately permits internal/admin turns; PostgreSQL unique indexes
+// allow multiple NULLs while making a real Twilio MessageSid idempotent per client.
+export const clientTruthCommits = pgTable("client_truth_commits", {
+  id: serial("id").primaryKey(),
+  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  sourceMessageId: text("source_message_id"),
+  revision: integer("revision").notNull(),
+  operations: jsonb("operations").notNull(),
+  receivedAt: timestamp("received_at").defaultNow().notNull(),
+}, (table) => ({
+  sourceIdempotency: uniqueIndex("client_truth_commits_user_source_uidx")
+    .on(table.userId, table.sourceMessageId),
+  userRevisionIdx: uniqueIndex("client_truth_commits_user_revision_uidx")
+    .on(table.userId, table.revision),
+}));
+
+export type ClientTruthCommit = typeof clientTruthCommits.$inferSelect;
 
 // === SENT PROACTIVE — durable dedupe for scheduled messages ===
 // Each scheduled proactive send claims a row (userId, messageKey, dedupeWindow).


### PR DESCRIPTION
## Why

Current-turn durable facts were written fire-and-forget from the request's stale `user` object. Coaching could therefore miss a restriction or injury in its own turn, and two concurrent messages could overwrite each other's appended facts. Persisted understanding could also replace fresher structured facts and a slow older model turn could overwrite a newer understanding blob.

## What changed

- Commits every accepted client turn on one Drizzle/PostgreSQL transaction before routing continues.
- Locks and re-reads the user row before constructing fact projections.
- Returns the committed projection/revision to every downstream consumer in the same turn.
- Uses provider `sourceMessageId` for per-client idempotency.
- Adds monotonic `truth_revision` and append-only `client_truth_commits` evidence with previous values and provenance.
- Preserves multiple independent `do_not_mention` boundaries instead of replacing the earlier one.
- Makes structured user facts—including restrictions, boundaries, life context and work pattern—the only owner of `UnderstandingState.profile.keyFacts`.
- Revision-guards `client_understanding` upserts so a slow older turn cannot overwrite a newer one.
- Corrects the architecture governor so transaction-scoped writes remain visible; this also surfaced and truthfully classifies the existing correction writes in `food-context.ts`.

## Acceptance evidence

Local:

- `npm run check` — PASS
- unit tests — 1060/1060
- integration tests — 38/38
- schema safety — PASS
- architecture governor — PASS, budgets unchanged
- file-size guard — PASS
- tracking contract — PASS
- decision state/runtime — 12/12
- gap suite — 368/369; the only non-green case is the workspace's Node 24 `tsx` IPC socket restriction in a child process. It exits before loading KamLife code; CI Node 20 remains the adjudicator.

New real-PostgreSQL CI acceptance proves:

- mixed-intent facts commit through the actual front door;
- two stale concurrent callers preserve both facts and receive distinct revisions;
- a retried provider source applies once;
- multiple prohibited topics survive independently;
- evidence commits preserve previous projection values;
- canonical restrictions outrank stored model key facts;
- a slow older understanding save cannot overwrite a newer revision.

## Explicit boundary

This is the transactional truth + factual-context cut. It does not claim the full correction/resolution lifecycle, replacement of held constraints, GPT/proactive policy convergence, or the action/outcome loop. Those remain subsequent cuts; this PR establishes the ordering and authority they require.