### PR TITLE
Adjudicate the six LEGACY_LOCAL proactive owners (#180)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,10 @@ jobs:
       # same way cannot tell two readers apart, which is how the divergence survived.
       - name: Fallback reads canonical truth on real PostgreSQL
         run: npx tsx script/pg-fallback-truth-acceptance.ts
+      # ONE COACH, PROACTIVELY AND REACTIVELY (#180). Held constraints are rows the client wrote
+      # today; whether the proactive decision reads them is only answerable against a database.
+      - name: Proactive decision authority on real PostgreSQL
+        run: npx tsx script/pg-proactive-authority-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -81,13 +81,15 @@ const BUDGET = {
    * behavioural instruction: monday's weigh-in reminder and diet-break restore, programme's weekly
    * check-in and plateau ladder, business's supplement nudge, onboarding's step-sync catch-up.
    *
-   * Set to the measured figure, and it may only FALL. Two of the six are waiting on P0-7 (one pace
-   * owner) rather than on wiring — naming that here is what stops it being rediscovered in a
-   * transcript. The senders classified RECOGNITION, RESOURCE and OPERATIONAL are not in this
+   * Set to the measured figure, and it may only FALL. 6 → 1 on 2026-09-05 (#180): four were
+   * adjudicated as measurement prompts, product-surface teaching, a question about the client's
+   * own routine, and a target-change announcement — none of them a next-move decision — and
+   * runWeeklyMondayCheckin was migrated. The ONE that remains, runPlateauDetection, is a
+   * multi-week experiment rather than a daily decision wearing a schedule, and waits on P0-7. The senders classified RECOGNITION, RESOURCE and OPERATIONAL are not in this
    * number because they carry no next-move instruction at all; that is a decision recorded per
    * job in the register, not an exemption anyone can take silently.
    */
-  localDecisionSenders: 6,
+  localDecisionSenders: 1,
   /**
    * GUARD #15 — see directLedgerReads above. Client-facing reads of weight_logs that do not go
    * through getWeightTruth, and therefore cannot honour do_not_mention.
@@ -112,7 +114,7 @@ const BUDGET = {
    *
    * LOWER THIS as each of those lands. Never raise it.
    */
-  directWeightReads: 15,
+  directWeightReads: 14,
   /**
    * GUARD #16 — see handRolledDayBuckets above. SQL that decides which SAST day a ledger row
    * belongs to, written somewhere other than the owner.

--- a/script/check-sast.ts
+++ b/script/check-sast.ts
@@ -21,7 +21,7 @@ const CANONICAL = ["server/sast.ts"];
 
 // Today's count, 2026-07-28. LOWER THIS as call sites migrate. Never raise it: a rise means a
 // new hand-rolled day boundary was written, which is the exact bug this exists to stop.
-const BUDGET = 61;  // 2026-09-03: utils temporal attribution moved to canonical sast.ts
+const BUDGET = 59;  // 2026-09-03: utils temporal attribution moved to canonical sast.ts
                     // 2026-08-13: client-snapshot dropped its local SAST key for sast.sastDayKey
 
 const RAW_OFFSET = /\b2\s*\*\s*3[_,]?600[_,]?000\b|\b7[_,]?200[_,]?000\b/g;

--- a/script/pg-proactive-authority-acceptance.ts
+++ b/script/pg-proactive-authority-acceptance.ts
@@ -1,0 +1,176 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — one coach, proactively and reactively (#180).
+ *
+ * THE CONTRADICTION THIS EXISTS TO STOP, reproduced on this branch's parent. One client, one
+ * moment, having said in their own words "I am not training today":
+ *
+ *   canonical owner        state=INVESTIGATE action=come_back
+ *                          "Just say hi. That's the whole ask today."
+ *   runWeeklyMondayCheckin "Complete 3 sessions. That is all."
+ *
+ * Not a difference of phrasing. The decision owner reads held constraints — what this client
+ * already told us today — and the week-3 branch read nothing at all. The outbound floor can refuse
+ * a forbidden sentence; it cannot make two coaches into one.
+ *
+ * WHAT IS GRADED HERE, AND WHAT IS NOT. The proactive jobs send; there is no capture seam for a
+ * message body, and script/trace-proactive.ts already says so plainly rather than inventing one.
+ * So this grades the thing that actually decides — chooseAction, the single owner both the
+ * reactive door and the proactive senders now consume — under identical seeded client state, and
+ * the scheduling guarantees that must survive the migration. The CLASSIFICATION of each sender is
+ * graded where declarations belong, in check-architecture's register guard, whose own note is
+ * that reading the source IS reading the subject when the subject is a declaration.
+ *
+ * Requires DATABASE_URL. Skips loudly without one.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-proactive-authority-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.NORMALIZER = "off";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test"; process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { canonicalNextMove, PROACTIVE_SENDERS } = await import("../server/scheduler/proactive-decision");
+const { readHeldConstraints } = await import("../server/held-constraints");
+const { claimDailySlot } = await import("../server/scheduler/shared");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+async function seed(over: Record<string, any> = {}): Promise<any> {
+  // THROUGH DRIZZLE, NOT A HAND-MAPPED ROW. The first cut of this built the client object by
+  // renaming snake_case columns by hand and missed several — so every seeded client read as a
+  // stranger of fourteen weeks and every decision came back `come_back`, which would have made
+  // §2's control unfalsifiable. The decision owner takes the row the product gives it.
+  const phone = `whatsapp:+2790${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2800, proteinTarget: 195, stepsTarget: 8500, currentWeight: "84.5",
+    heightCm: 178, gender: "male", age: 35, trainingMode: "gym", trainingDaysPerWeek: 3,
+    totalWorkoutsCompleted: 6, lastActiveAt: new Date(),
+    createdAt: new Date(Date.now() - 21 * 86_400_000),
+    programmeStartDate: new Date(Date.now() - 21 * 86_400_000), programmeWeek: 3,
+    ...over,
+  } as any).returning();
+  return u;
+}
+
+const said = (uid: string, text: string) => pool.query(
+  `INSERT INTO chat_history (user_id, message_in, message_out, intent, created_at)
+   VALUES ($1,$2,'ok','GENERAL', now())`, [uid, text]);
+
+// ── §1 A CONSTRAINT THE CLIENT STATED BINDS THE PROACTIVE COACH ─────────────────────────────
+REAL("\n§1 'I am not training today' — the case that used to contradict");
+const a = await seed();
+await said(a.id, "I am not training today");
+const heldA = await readHeldConstraints(a.phoneNumber, a);
+chk(heldA.trainingDeclined === true, "the constraint is read from the client's own words",
+  JSON.stringify(heldA));
+const moveA = await canonicalNextMove(a, { hour: 18 });
+chk(moveA.action.kind !== "train", "the proactive move is not a training instruction",
+  `action=${moveA.action.kind}`);
+chk(!/complete \d+ sessions|hit the gym|train today/i.test(moveA.line),
+  "…and its wording instructs no session either", moveA.line.slice(0, 120));
+chk(moveA.held.trainingDeclined === true,
+  "the move carries the constraint it was decided under, so the floor can check it");
+
+// ── §2 THE CONTROL: WITHOUT THE CONSTRAINT, TRAINING IS STILL REACHABLE ─────────────────────
+//
+// §1 is satisfied by a coach that never asks anyone to train. This is what stops that reading.
+REAL("\n§2 a PRESENT client who declared nothing — training must still be reachable");
+// Present, and present in the way the ladder MEASURES presence. Its first rung is
+// `daysSinceAnyLog >= 3` — logs, not chat — so a control client who has been chatting but logging
+// nothing still reads as gone and gets the come-back move whatever else is true. That would have
+// made this control unfalsifiable, which is exactly what it is here to prevent. This one has been
+// logging: food yesterday and today, steps today.
+const b = await seed();
+await pool.query(
+  `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+   VALUES ($1, now() - interval '1 day', 'lunch', 600, 45, $2, 'seed', 'sa_scanner'),
+          ($1, now(),                     'lunch', 600, 45, $2, 'seed', 'sa_scanner')`,
+  [b.id, JSON.stringify([{ name: "chicken", grams: 150 }])]);
+await pool.query(
+  `INSERT INTO step_logs (user_id, logged_at, steps, provenance, resolved_day)
+   VALUES ($1, now(), 6000, 'client_report', to_char(now() AT TIME ZONE 'Africa/Johannesburg','YYYY-MM-DD'))`,
+  [b.id]);
+const heldB = await readHeldConstraints(b.phoneNumber, b);
+chk(heldB.trainingDeclined === false, "no constraint is invented from silence", JSON.stringify(heldB));
+const moveB = await canonicalNextMove(b, { hour: 18 });
+chk(moveB.action.kind !== "come_back",
+  "a present client is not treated as absent — the absence rung stands down",
+  `action=${moveB.action.kind}`);
+chk(moveB.action.kind !== moveA.action.kind,
+  "the decision genuinely differs once the constraint is gone",
+  `declined → ${moveA.action.kind} | present+undeclared → ${moveB.action.kind}`);
+chk(moveB.line.trim().length > 0 || moveB.action.kind === "hold",
+  "…and it is still a real decision, not an empty one", `action=${moveB.action.kind}`);
+
+// ── §3 ONE OWNER, TWO SCHEDULES: THE SAME STATE DECIDES THE SAME WAY ────────────────────────
+//
+// chooseAction is consumed by the reactive door (understanding/live, misc-commands) and by the
+// proactive senders. Called twice against one unchanged client, it must not drift — a decision
+// that depends on WHICH schedule asked is two coaches wearing one name.
+REAL("\n§3 the same client state decides the same way, asked twice");
+const twice = await canonicalNextMove(a, { hour: 18 });
+chk(twice.action.kind === moveA.action.kind, "the action is stable for unchanged state",
+  `${moveA.action.kind} vs ${twice.action.kind}`);
+chk(twice.held.trainingDeclined === moveA.held.trainingDeclined,
+  "…and so are the constraints it read");
+
+// A FOOD CLOSURE BINDS IT TOO — the other half of held-constraints, on the same path.
+REAL("\n§3b a closed food day binds the proactive coach as well");
+const c = await seed();
+await said(c.id, "I'm not eating anything else today");
+const heldC = await readHeldConstraints(c.phoneNumber, c);
+chk(heldC.foodDayClosed === true, "the closure is read", JSON.stringify(heldC));
+const moveC = await canonicalNextMove(c, { hour: 20 });
+chk(!/\beat\b|\bmeal\b|protein tonight/i.test(moveC.line) || moveC.action.kind === "hold",
+  "the proactive move does not sell food to a client who closed the day",
+  `action=${moveC.action.kind} line=${moveC.line.slice(0, 110)}`);
+
+// ── §4 THE ADJUDICATION ITSELF ──────────────────────────────────────────────────────────────
+//
+// A declaration, graded where declarations live. The six that were LEGACY_LOCAL are named here so
+// this file fails if anyone quietly re-adds a local coaching ladder under an old name.
+REAL("\n§4 the six adjudicated senders");
+const clsOf = (job: string) => PROACTIVE_SENDERS.find(s => s.job === job)?.cls;
+const expected: Array<[string, string]> = [
+  ["runWeightReminder", "RESOURCE"],
+  ["runDietBreakCheck", "OPERATIONAL"],
+  ["runSupplementReminder", "RECOGNITION"],
+  ["runStepSyncCatchup", "RESOURCE"],
+  ["runWeeklyMondayCheckin", "CANONICAL"],
+  ["runPlateauDetection", "LEGACY_LOCAL"],
+];
+for (const [job, cls] of expected) chk(clsOf(job) === cls, `${job} → ${cls}`, `is ${clsOf(job)}`);
+const stillLegacy = PROACTIVE_SENDERS.filter(s => s.cls === "LEGACY_LOCAL").map(s => s.job);
+chk(stillLegacy.length === 1 && stillLegacy[0] === "runPlateauDetection",
+  "exactly one local decider remains, and it is the multi-week experiment", JSON.stringify(stillLegacy));
+
+// ── §5 SCHEDULING, CAPS AND DEDUPE SURVIVE THE MIGRATION ────────────────────────────────────
+//
+// Converging the instruction must not cost the guarantees that stop one coach becoming three
+// messages. The migrated job still claims its daily slot, and a claim is once per client per day.
+REAL("\n§5 the daily slot claim still gates the migrated job");
+const d = await seed();
+const first = await claimDailySlot(d.id, "weekly_checkin");
+const second = await claimDailySlot(d.id, "weekly_checkin");
+chk(first === true, "the first claim succeeds");
+chk(second === false, "the second is refused — a restart cannot double the send");
+const e = await seed();
+chk((await claimDailySlot(e.id, "weekly_checkin")) === true,
+  "and one client's claim does not consume another's");
+
+REAL(`\npg-proactive-authority-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/server/scheduler/jobs/monday.ts
+++ b/server/scheduler/jobs/monday.ts
@@ -186,10 +186,15 @@ export async function runDietBreakCheck(): Promise<void> {
     for (const client of expired) {
       // Claim before restoring + sending so a recycle can't double-fire the notice.
       if (!(await claimProactive(client.id, "diet_break_end", todaySAST()))) continue;
+      // OPERATIONAL, AND NOW ACTUALLY OPERATIONAL (#180). This announced a target change — which
+      // is the adaptive-targets owner's business, exactly like runAutoCalAdjust — and then added
+      // "Log your food today", a next-move instruction chosen right here. The announcement is the
+      // message; what to do about it is canonicalNextMove's decision, on its own schedule, with
+      // the client's held constraints in front of it. One sentence removed, no ladder left.
       const restored = client.dietBreakCalTarget!;
       await db.update(users).set({ calorieTarget: restored, dietBreakEndsAt: null, dietBreakCalTarget: null }).where(eq(users.id, client.id));
       const name = (client.name || "").split(" ")[0] || "there";
-      await sendWhatsApp(client.phoneNumber, `${name}, diet break is done. Back to the deficit.\n\n*Your targets from today:*\n• Calories: ${restored} kcal/day\n• Protein: ${client.proteinTarget || 120}g/day — unchanged\n\nYour metabolism is reset. Your glycogen is full. Now we push harder than before. Log your food today.`).catch((e: unknown) => console.error("[monday] diet-break restore WA failed:", client.id, e));
+      await sendWhatsApp(client.phoneNumber, `${name}, diet break is done. Back to the deficit.\n\n*Your targets from today:*\n• Calories: ${restored} kcal/day\n• Protein: ${client.proteinTarget || 120}g/day — unchanged\n\nYour metabolism is reset. Your glycogen is full.`).catch((e: unknown) => console.error("[monday] diet-break restore WA failed:", client.id, e));
       await new Promise(r => setTimeout(r, 300));
     }
     if (expired.length > 0) console.log(`[SCHEDULER] Diet break expired: ${expired.length} clients restored`);

--- a/server/scheduler/jobs/programme.ts
+++ b/server/scheduler/jobs/programme.ts
@@ -7,6 +7,8 @@ import {
 } from "../shared";
 import { getGoalProfile } from "../../goal-profiles";
 import { getWeightTruth } from "../../day-ledger";
+import { canonicalNextMove } from "../proactive-decision";
+import { sastHour } from "../../sast";
 
 export async function runPhaseAdvancement(): Promise<void> {
   console.log("[SCHEDULER] JOB: Phase advancement check");
@@ -85,27 +87,30 @@ export async function runWeeklyMondayCheckin(): Promise<void> {
       const goal = client.goalType || "fat_loss";
       const streak = client.workoutStreak || 0;
       let msg = "";
-      if (week === 1) msg = `${name}, Week 1. This week is about building the habit, not the body — the physical changes come later.\n\nExpect: some soreness, hunger changes, maybe lower energy by day 3. All normal. Your only job this week: complete ${planned} sessions and log every meal. Nothing else.\n\nSend me your first meal of the day.`;
-      else if (week === 2) msg = `${name}, Week 2. The soreness from last week means your muscles responded. ${sessions} sessions banked.\n\nExpect: energy starts stabilising. Scale might go up slightly (water and glycogen) — ignore it, it normalises by week 3. Focus: hit your step target of ${(client.stepsTarget || 8500).toLocaleString()} every day this week.`;
-      else if (week === 3) msg = `${name}, Week 3 — this is the hardest week. Not because it got heavier, but because the mirror has not changed yet and motivation is low.\n\nThis is normal. The physical changes are happening inside — metabolism adapting, muscle fibres rebuilding. Visible results show at week 4–6 for most people. You are 7 days away from seeing the shift.\n\nComplete ${planned} sessions. That is all.`;
-      else if (week === 4) msg = `${name}, Week 4 — one full month in. ${sessions} sessions. This is where it starts to show.\n\nExpect: clothes fitting slightly differently, energy more consistent, strength up on at least one exercise. This week: push harder — more reps or more weight on every exercise. You built the foundation. Now use it.`;
-      else if (week <= 8) msg = `${name}, Week ${week} — ${sessions} sessions in the bank. Target for this week: ${planned} sessions and ${sessions + planned} total. ${streak >= 3 ? `You are on a ${streak}-session streak — do not break it.` : "Get the streak going."}`;
+      if (week === 1) msg = `${name}, Week 1. This week is about building the habit, not the body — the physical changes come later.\n\nExpect: some soreness, hunger changes, maybe lower energy by day 3. All normal. The habit is the whole job this week.`;
+      else if (week === 2) msg = `${name}, Week 2. The soreness from last week means your muscles responded. ${sessions} sessions banked.\n\nExpect: energy starts stabilising. Scale might go up slightly (water and glycogen) — ignore it, it normalises by week 3. Your step target is ${(client.stepsTarget || 8500).toLocaleString()}/day.`;
+      else if (week === 3) msg = `${name}, Week 3 — this is the hardest week. Not because it got heavier, but because the mirror has not changed yet and motivation is low.\n\nThis is normal. The physical changes are happening inside — metabolism adapting, muscle fibres rebuilding. Visible results show at week 4–6 for most people. You are 7 days away from seeing the shift.`;
+      else if (week === 4) msg = `${name}, Week 4 — one full month in. ${sessions} sessions. This is where it starts to show.\n\nExpect: clothes fitting slightly differently, energy more consistent, strength up on at least one exercise. You built the foundation.`;
+      else if (week <= 8) msg = `${name}, Week ${week} — ${sessions} sessions in the bank. ${streak >= 3 ? `You are on a ${streak}-session streak.` : ""}`;
       else if (week <= 12) {
         const goalMsg = goal === "fat_loss" ? "Fat loss compounds from here — the early weeks built the foundation." : goal === "muscle_gain" ? "Muscle building accelerates after week 8 — progressive overload is everything now." : !getGoalProfile(goal).weightIsGoal ? "This is where the habit becomes who you are — steadier energy, better sleep, movement that just happens. Keep showing up." : "Your body is recomposing — fat down, muscle up. The scale may not move much but the mirror will.";
-        msg = `${name}, Week ${week} — ${sessions} total sessions. ${goalMsg} One focus this week: log your lifts and add weight or reps to every exercise.`;
+        msg = `${name}, Week ${week} — ${sessions} total sessions. ${goalMsg}`;
       } else {
         msg = `${name}, Week ${week} — ${sessions} sessions. You are in the top 5% of people who stick with a programme this long. What is your goal for this week? One specific thing.`;
       }
-      // MONDAY SCALE ACCOUNTABILITY (2026-07-17 founder: "extremely held accountable
-      // ... somebody is there doing it with them"): if the morning weigh-in prompt
-      // went unanswered, the evening check-in leads with the scale — one combined
-      // message, never a separate nag on an already-busy Monday.
-      const sastMidnight = new Date(new Date(Date.now() + 2 * 3_600_000).setUTCHours(0, 0, 0, 0) - 2 * 3_600_000);
-      const weighedToday = await db.select({ id: weightLogs.id }).from(weightLogs)
-        .where(and(eq(weightLogs.userId, client.id), gte(weightLogs.loggedAt, sastMidnight))).limit(1);
-      if (weighedToday.length === 0) {
-        msg = `⚖️ First things first — what did the scale say this morning? Send me the number (e.g. *82.4kg*). Even if it's up, send it: the number is data, not judgment, and Monday's weigh-in is how we steer your whole week.\n\n${msg}`;
-      }
+      // MONDAY SCALE ACCOUNTABILITY, NOW THROUGH THE ONE DECISION OWNER (#180). This read
+      // weight_logs itself and prepended its own weigh-in demand — a third opinion on the same
+      // question, beside runWeightReminder's Monday ritual and chooseAction's `weigh` rung, each
+      // with its own staleness rule. The founder's ask ("extremely held accountable ... somebody
+      // is there doing it with them") is unchanged: canonicalNextMove chooses `weigh` when the
+      // scale is genuinely stale, and it is the only thing here that may now instruct.
+      //
+      // THE FACTS STAY LOCAL, THE INSTRUCTION DOES NOT — the same migration runEvening-
+      // Accountability and runSundayWeeklyReport already made. What each week feels like, and
+      // what to expect from it, is real phase-specific knowledge no daily decision can produce;
+      // "Complete ${planned} sessions" is a next-move choice, and it was being made twice.
+      const move = await canonicalNextMove(client, { hour: sastHour() });
+      if (move.line) msg = `${msg}\n\n${move.line}`;
       // Daily-slot claim before send (preserves daily-cap reach; DB-backed, restart-safe).
       if (await claimDailySlot(client.id, "weekly_checkin")) { await sendWhatsApp(client.phoneNumber, msg); }
     } catch (err) { console.error(`[SCHEDULER] Weekly check-in error — ${client.phoneNumber}:`, err); }

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -219,10 +219,10 @@ export const PROACTIVE_SENDERS: readonly ProactiveSender[] = [
     because: "A progress report against the record." },
   { job: "runMondayGroceries", file: "monday", cls: "RESOURCE",
     because: "Delivers the shopping list artefact." },
-  { job: "runWeightReminder", file: "monday", cls: "LEGACY_LOCAL",
-    because: "Asks for a weigh-in on its own schedule; chooseAction owns the `weigh` rung and its staleness rule. Not yet migrated." },
-  { job: "runDietBreakCheck", file: "monday", cls: "LEGACY_LOCAL",
-    because: "Restores targets (operational) and then instructs — 'Log your food today'. The instruction half is not yet canonical." },
+  { job: "runWeightReminder", file: "monday", cls: "RESOURCE",
+    because: "Adjudicated 2026-09-05 (#180). A measurement prompt on a fixed weekly ritual — the class this doctrine already names, and the same reading as runMonthlyMeasurements. It reads no client state to pick WHAT to say, honours do_not_mention by standing down entirely, and asks for the number the scale gives. It duplicates chooseAction's `weigh` rung in the sense that both may ask; it cannot contradict it, because neither can tell the client to do anything else." },
+  { job: "runDietBreakCheck", file: "monday", cls: "OPERATIONAL",
+    because: "Adjudicated 2026-09-05 (#180). 'Log your food today' — the one locally-chosen instruction — is deleted. What remains announces a target change the adaptive-targets owner made, which is runAutoCalAdjust's reading exactly: the change is the message." },
 
   // ── programme.ts ──────────────────────────────────────────────────────────────────────────
   { job: "runPhaseAdvancement", file: "programme", cls: "RESOURCE",
@@ -231,10 +231,10 @@ export const PROACTIVE_SENDERS: readonly ProactiveSender[] = [
     because: "Checkpoint questions about the goal, plus a Week 9 choice. It asks." },
   { job: "runInjuryFollowup", file: "programme", cls: "RECOGNITION",
     because: "Asks how the injury is; adjusts only on the answer." },
-  { job: "runWeeklyMondayCheckin", file: "programme", cls: "LEGACY_LOCAL",
-    because: "A per-week script that instructs — 'Complete N sessions', 'hit your step target', 'add weight or reps'. Twelve local branches. Not yet migrated." },
+  { job: "runWeeklyMondayCheckin", file: "programme", cls: "CANONICAL",
+    because: "Migrated 2026-09-05 (#180). What each programme week FEELS like is real phase knowledge no daily decision can produce, and it stays. Every instruction that followed it is gone — including the weigh-in demand it prepended off its own weight_logs read, a third opinion beside runWeightReminder and chooseAction's `weigh` rung. The move now comes from canonicalNextMove." },
   { job: "runPlateauDetection", file: "programme", cls: "LEGACY_LOCAL",
-    because: "Its own three-rung intervention ladder (cut carbs → add 2,000 steps → hold). A real pace owner is P0-7; until then it is named, not blessed." },
+    because: "Adjudicated 2026-09-05 (#180) and DELIBERATELY LEFT. It is the one of the six that is not a daily next-move decision wearing a schedule: it is a multi-week experiment — change one lever, stamp a baseline, verify against a weigh-in seven days later, iterate or stop. canonicalNextMove answers 'what is the one thing today', which cannot express 'we changed carbs last week, so this week we change steps instead'. Converging it would delete a capability, not remove a duplicate authority. It waits on the pace owner (P0-7), and it is the LAST one." },
 
   // ── business.ts ───────────────────────────────────────────────────────────────────────────
   { job: "runSubscriptionExpiryCheck", file: "business", cls: "OPERATIONAL", because: "Billing." },
@@ -251,8 +251,8 @@ export const PROACTIVE_SENDERS: readonly ProactiveSender[] = [
     because: "A costed shopping plan for the month-end squeeze. The list is the message." },
   { job: "runPaydayShoppingNudge", file: "business", cls: "RESOURCE",
     because: "A costed buy-list keyed to the pay cycle, pointing at the shopping-list owner." },
-  { job: "runSupplementReminder", file: "business", cls: "LEGACY_LOCAL",
-    because: "Instructs on a supplement the client logged before. Harmless today, but it is an instruction chosen locally." },
+  { job: "runSupplementReminder", file: "business", cls: "RECOGNITION",
+    because: "Adjudicated 2026-09-05 (#180). It asks — 'creatine taken yet?' — about a supplement the CLIENT chose and logged. It decides nothing from their day and prescribes nothing; a question about their own routine is the class this doctrine calls recognition." },
 
   // ── onboarding.ts ─────────────────────────────────────────────────────────────────────────
   { job: "runEarlyOnboarding", file: "onboarding", cls: "RESOURCE",
@@ -261,8 +261,8 @@ export const PROACTIVE_SENDERS: readonly ProactiveSender[] = [
   { job: "runReferralNudge", file: "onboarding", cls: "OPERATIONAL", because: "Growth ask." },
   { job: "runGoalReassessment", file: "onboarding", cls: "RECOGNITION",
     because: "Asks whether the stated goal still matches what they are chasing." },
-  { job: "runStepSyncCatchup", file: "onboarding", cls: "LEGACY_LOCAL",
-    because: "Asks for a step figure on its own trigger; `walk` and `log` are chooseAction's rungs. Not yet migrated." },
+  { job: "runStepSyncCatchup", file: "onboarding", cls: "RESOURCE",
+    because: "Adjudicated 2026-09-05 (#180). Read the message rather than the job name: it lists the three ways to get steps into the product — type a number, send a screenshot, reply 'connect steps'. It teaches the product's surface, which is runEarlyOnboarding's reading, and never tells anyone to walk." },
 
   // ── trial.ts / reminders.ts / narrative.ts / media-recovery.ts / spend-watchdog.ts ─────────
   { job: "runTrialCountdown", file: "trial", cls: "OPERATIONAL", because: "Trial expiry and conversion." },


### PR DESCRIPTION
Closes #180.

## The contradiction, reproduced first

One client, one moment, having said in their own words *"I am not training today"*:

```
canonical owner          state=INVESTIGATE action=come_back
                         "Just say hi. That's the whole ask today."
runWeeklyMondayCheckin   "Complete 3 sessions. That is all."
```

Not a difference of phrasing. The decision owner reads held constraints — what this client already told us today — and the week-3 branch read **nothing at all**.

## The adjudication

Each of the six was read for what its message actually *does*, not what its name suggests.

| Sender | Verdict | Why |
|---|---|---|
| `runWeightReminder` | **RESOURCE** | A measurement prompt on a fixed weekly ritual — the class the doctrine already names, and `runMonthlyMeasurements`' reading exactly. Reads no client state to choose *what* to say; stands down entirely on `do_not_mention`. |
| `runStepSyncCatchup` | **RESOURCE** | Read the message, not the job name: it lists the three ways to get steps into the product. Teaches the surface, as `runEarlyOnboarding` does. Never tells anyone to walk. |
| `runSupplementReminder` | **RECOGNITION** | It *asks* — "creatine taken yet?" — about a supplement the client chose and logged. |
| `runDietBreakCheck` | **OPERATIONAL** | After deleting its one locally-chosen instruction (*"Log your food today"*). What remains announces a target change the adaptive-targets owner made — `runAutoCalAdjust`'s reading. |
| `runWeeklyMondayCheckin` | **CANONICAL** | Migrated. |
| `runPlateauDetection` | **LEGACY_LOCAL** | Deliberately — see below. |

`localDecisionSenders` **6 → 1**.

### The migration

`runWeeklyMondayCheckin` keeps what only it knows — what each programme week *feels* like and what to expect from it. Every instruction that followed is gone, including the weigh-in demand it prepended off **its own `weight_logs` read**: a third opinion beside `runWeightReminder`'s Monday ritual and `chooseAction`'s `weigh` rung, each with its own staleness rule.

The founder's accountability ask is unchanged — `canonicalNextMove` chooses `weigh` when the scale is genuinely stale, and is now the only thing here that may instruct. The architecture guard confirmed the bypass went with it: **`directWeightReads` 15 → 14**.

### Why `runPlateauDetection` stays

This is the adjudication, not an omission. It is the one of the six that is **not a daily next-move decision wearing a schedule**: it is a multi-week experiment — change one lever, stamp a baseline, verify against a weigh-in seven days later, iterate or stop. `canonicalNextMove` answers *"what is the one thing today"*, which cannot express *"we changed carbs last week, so this week we change steps instead"*.

Converging it would **delete a capability**, not remove a duplicate authority. It waits on the pace owner (P0-7) — and it is now the last one. The guard's own budget note already anticipated this.

## Proof — `script/pg-proactive-authority-acceptance.ts`, in the PG job

Held constraints are rows the client wrote today, so whether the proactive decision reads them is only answerable against a database.

**What it grades, and what it does not.** The jobs send, and there is no capture seam for a message body — `script/trace-proactive.ts` already says so plainly rather than inventing one. So this grades the thing that *decides*: `chooseAction`, the single owner both doors now consume, under identical seeded state, plus the scheduling guarantees that had to survive. The classifications are graded where declarations belong, in the register.

| § | Control | Result |
|---|---|---|
| 1 | A stated "not training today" binds the proactive coach | ✓ |
| 2 | **Control**: a present, undeclared client — training still reachable, decision genuinely differs | ✓ |
| 3 | Same state, asked twice, decides the same way | ✓ |
| 3b | A closed food day binds it too | ✓ |
| 4 | All six classifications, and that exactly one local decider remains | ✓ |
| 5 | Daily-slot claim, dedupe and per-client isolation survive the migration | ✓ |

**Two controls found my own harness wrong before they passed**, and both are recorded in the file:

- the first cut hand-mapped snake_case columns and missed several, so every seeded client read as a stranger of fourteen weeks and *every* decision came back `come_back` — which would have made §2 unfalsifiable;
- the second gave the control client chat history, but the ladder measures presence by **logs** (`daysSinceAnyLog >= 3`), so it still read as gone. It now seeds meals and steps, and the control genuinely discriminates.

## Red on revert

Restoring the local ladder fails 2 acceptance checks **and** trips the architecture guard:

```
FAIL  runWeeklyMondayCheckin → CANONICAL
FAIL  exactly one local decider remains, and it is the multi-week experiment
✗ localDecisionSenders: 2 — budget 1. Something got MORE complicated.
```

## Verification

| Suite | Result |
|---|---|
| `npm test` | 36/37 green, 1 covered nothing (`normalizer-replay-tests`, pre-existing) |
| `npm run test:unit:baseline --base=origin/main` | PASS — 0 branch-introduced failures |
| `npm run check` (tsc) | clean |
| 6 × PostgreSQL acceptance lanes | GREEN ×6 |
| Journey Lab | GREEN — 266/266 |
| safety-audit / filesize / arch / schema | green, all at budget |

Two budgets **fell** and were locked in as the guards asked: `directWeightReads` 15 → 14, `check-sast` 61 → 59. None raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_