### PR TITLE
A daily constraint is durable day state, not a 24-message conclusion (#194)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,10 @@ jobs:
       # today; whether the proactive decision reads them is only answerable against a database.
       - name: Proactive decision authority on real PostgreSQL
         run: npx tsx script/pg-proactive-authority-acceptance.ts
+      # A DAILY CONSTRAINT IS ABOUT WHAT SURVIVES (#194). The defect was a 24-message window, and
+      # a fixture that returns the same rows to every query cannot demonstrate a window.
+      - name: Daily constraint lifecycle on real PostgreSQL
+        run: npx tsx script/pg-daily-constraint-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/migrations/0010_daily_constraints.sql
+++ b/migrations/0010_daily_constraints.sql
@@ -1,0 +1,39 @@
+-- 0010 — DAILY CONSTRAINTS: what the client ruled out today, recorded when they said it (#194)
+--
+-- Reproduced on main@c420c48 against real PostgreSQL:
+--
+--   after the two declarations:            foodDayClosed=true   trainingDeclined=true
+--   after 26 further ordinary messages:    foodDayClosed=false  trainingDeclined=false
+--
+-- The client reopened nothing. readHeldConstraints re-derives today's constraints by replaying
+-- chat history, and that replay is ORDER BY created_at DESC LIMIT 24 — so on a busy day the
+-- declaration falls out of the window and a closed food day silently reopens itself. The client
+-- who talks to us most is the one this fails for.
+--
+-- APPEND-ONLY. A reopening does not edit the closure; it is a second row. The day's effective
+-- state is the newest decision, and the assertion before it stays on the record, which is what
+-- lets anyone answer "was the coach allowed to say that at 20:00" a week later.
+--
+-- NOTHING HERE DECIDES ANYTHING. The recognisers in one-action.ts stay the only things that read
+-- a message; readHeldConstraints stays the only reader of the state. This is where the answer
+-- lives, not a second opinion about what it should be.
+
+CREATE TABLE IF NOT EXISTS public.daily_constraints (
+  id                SERIAL PRIMARY KEY,
+  user_id           UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  day               TEXT NOT NULL,
+  kind              TEXT NOT NULL,
+  state             TEXT NOT NULL,
+  via               TEXT NOT NULL,
+  source_message_id TEXT,
+  said_at           TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS daily_constraints_user_day_kind_idx
+  ON public.daily_constraints (user_id, day, kind);
+
+-- A provider retry of the same message must not append a second identical assertion. NULL source
+-- ids do not collide in PostgreSQL, which is correct: a constraint resolved by a workout being
+-- logged has no provider message and may legitimately recur on another day.
+CREATE UNIQUE INDEX IF NOT EXISTS daily_constraints_user_source_kind_uidx
+  ON public.daily_constraints (user_id, source_message_id, kind);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787500000000,
       "tag": "0009_canonical_client_truth",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787600000000,
+      "tag": "0010_daily_constraints",
+      "breakpoints": true
     }
   ]
 }

--- a/script/pg-daily-constraint-acceptance.ts
+++ b/script/pg-daily-constraint-acceptance.ts
@@ -1,0 +1,159 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — a daily constraint is durable day state (#194).
+ *
+ * REPRODUCED ON main@c420c48, and the reason this file exists:
+ *
+ *   after the two declarations:          foodDayClosed=true   trainingDeclined=true
+ *   after 26 further ordinary messages:  foodDayClosed=false  trainingDeclined=false
+ *
+ * The client reopened nothing. readHeldConstraints rebuilt today's constraints by replaying chat
+ * history, and that replay is ORDER BY created_at DESC LIMIT 24 — so the declaration fell out of
+ * the window and a closed food day silently reopened itself. The client who talks to us most is
+ * the one it failed for.
+ *
+ * WHY REAL POSTGRESQL: the whole claim is about what SURVIVES. A fixture that returns the same
+ * rows to every query cannot demonstrate a window, and the window is the defect.
+ *
+ * Requires DATABASE_URL. Skips loudly without one.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-daily-constraint-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.NORMALIZER = "off"; process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test"; process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { readHeldConstraints, recordDailyConstraint } = await import("../server/held-constraints");
+const { sastDayKey } = await import("../server/sast");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+async function seed() {
+  const phone = `whatsapp:+2788${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, goalType: "fat_loss", calorieTarget: 2800, proteinTarget: 195,
+    stepsTarget: 8500, currentWeight: "84.5", lastActiveAt: new Date(),
+  } as any).returning();
+  return u;
+}
+/** An ordinary turn, recorded exactly as the front door records one. */
+const turn = async (u: any, text: string, sourceMessageId?: string) => {
+  await pool.query(
+    `INSERT INTO chat_history (user_id,message_in,message_out,intent,created_at) VALUES ($1,$2,'ok','GENERAL', now())`,
+    [u.id, text]);
+  await recordDailyConstraint(u, text, sourceMessageId);
+};
+const evidence = async (uid: string) => (await pool.query(
+  `SELECT day, kind, state, via FROM daily_constraints WHERE user_id=$1 ORDER BY id`, [uid])).rows;
+
+// ── §1 A CLOSURE SURVIVES A BUSY DAY ────────────────────────────────────────────────────────
+REAL("\n§1 a food closure survives more than 24 later messages");
+const a = await seed();
+await turn(a, "I'm not eating anything else today");
+await turn(a, "I'm not training today");
+let h = await readHeldConstraints(a.phoneNumber, a);
+chk(h.foodDayClosed === true && h.trainingDeclined === true,
+  "both constraints hold when they are stated", JSON.stringify(h));
+for (let i = 0; i < 30; i++) await turn(a, `ordinary message number ${i}`);
+h = await readHeldConstraints(a.phoneNumber, a);
+chk(h.foodDayClosed === true, "the food closure is still held after 30 later messages", JSON.stringify(h));
+chk(h.trainingDeclined === true, "and so is the training decline", JSON.stringify(h));
+
+// ── §2 AN EXPLICIT REOPENING RELEASES IT ────────────────────────────────────────────────────
+REAL("\n§2 an explicit reopening releases the day");
+await turn(a, "actually I changed my mind, I'm having dinner");
+h = await readHeldConstraints(a.phoneNumber, a);
+chk(h.foodDayClosed === false, "the day is open again on the client's newest decision", JSON.stringify(h));
+chk(h.trainingDeclined === true, "…and the training decline is untouched by a food reopening",
+  JSON.stringify(h));
+
+// ── §3 THE ASSERTION IS STILL ON THE RECORD ─────────────────────────────────────────────────
+REAL("\n§3 append-only: the closure survives its own reversal");
+const ev = await evidence(a.id);
+chk(ev.some(r => r.kind === "food" && r.state === "asserted"), "the closure row is still there",
+  JSON.stringify(ev.filter(r => r.kind === "food")));
+chk(ev.some(r => r.kind === "food" && r.state === "released"), "and so is the release");
+chk(ev.filter(r => r.kind === "food").length === 2,
+  "exactly two food rows — nothing was edited in place", String(ev.filter(r => r.kind === "food").length));
+
+// ── §4 MOVING THE WORKOUT INTO TODAY REVERSES THE DECLINE ───────────────────────────────────
+//
+// The workout ledger IS the evidence of resolution here — append-only, durable, and already the
+// thing every other surface trusts about training. A second row saying what it already says would
+// be a second answer to one question.
+REAL("\n§4 a session logged today reverses the decline");
+await db.insert(schema.workoutLogs).values({ userId: a.id, workoutCompleted: true } as any);
+h = await readHeldConstraints(a.phoneNumber, a);
+chk(h.trainingDeclined === false, "the decline is resolved by the session actually happening",
+  JSON.stringify(h));
+
+// ── §5 QUESTIONS, HISTORY AND INTENTIONS DO NOT MUTATE TODAY ────────────────────────────────
+REAL("\n§5 asking, reporting the past, and stating a plan change nothing");
+const b = await seed();
+for (const t of [
+  "should I stop eating for today?",
+  "am I done training today?",
+  "yesterday I was not eating anything else",
+  "tomorrow I'm not training",
+  "I was done eating last night",
+]) await turn(b, t);
+h = await readHeldConstraints(b.phoneNumber, b);
+chk(h.foodDayClosed === false, "no closure was invented", JSON.stringify(h));
+chk(h.trainingDeclined === false, "no decline was invented", JSON.stringify(h));
+chk((await evidence(b.id)).length === 0, "and nothing was written at all",
+  JSON.stringify(await evidence(b.id)));
+
+// ── §6 YESTERDAY DOES NOT LEAK INTO TODAY ───────────────────────────────────────────────────
+//
+// TODAY ONLY is the rule held-constraints.ts opens with. A stored constraint makes it easier to
+// break than a replayed one did, so it is graded directly against a row dated yesterday.
+REAL("\n§6 yesterday's constraint does not bind today");
+const c = await seed();
+const yesterday = sastDayKey(new Date(Date.now() - 86_400_000));
+await db.insert(schema.dailyConstraints).values([
+  { userId: c.id, day: yesterday, kind: "food", state: "asserted", via: "said" },
+  { userId: c.id, day: yesterday, kind: "training", state: "asserted", via: "said" },
+] as any);
+h = await readHeldConstraints(c.phoneNumber, c);
+chk(h.foodDayClosed === false && h.trainingDeclined === false,
+  "a constraint dated yesterday binds nothing today", JSON.stringify(h));
+// …and the control: the same rows dated TODAY must bind, or §6 proves only that the reader is broken.
+await db.insert(schema.dailyConstraints).values([
+  { userId: c.id, day: sastDayKey(new Date()), kind: "food", state: "asserted", via: "said" },
+] as any);
+h = await readHeldConstraints(c.phoneNumber, c);
+chk(h.foodDayClosed === true, "CONTROL: the same row dated today does bind", JSON.stringify(h));
+
+// ── §7 ONE CLIENT'S CONSTRAINT IS THEIR OWN ─────────────────────────────────────────────────
+REAL("\n§7 isolation");
+const d = await seed();
+h = await readHeldConstraints(d.phoneNumber, d);
+chk(h.foodDayClosed === false && h.trainingDeclined === false,
+  "a fresh client inherits nobody's day", JSON.stringify(h));
+
+// ── §8 A PROVIDER RETRY APPENDS NOTHING ─────────────────────────────────────────────────────
+REAL("\n§8 the same provider message twice");
+const e = await seed();
+await turn(e, "I'm not eating anything else today", "SM-CONSTRAINT-1");
+const afterFirst = (await evidence(e.id)).length;
+await turn(e, "I'm not eating anything else today", "SM-CONSTRAINT-1");
+chk((await evidence(e.id)).length === afterFirst, "a retry of one message adds no second row",
+  `${afterFirst} → ${(await evidence(e.id)).length}`);
+chk((await readHeldConstraints(e.phoneNumber, e)).foodDayClosed === true,
+  "…and the day is still closed");
+
+REAL(`\npg-daily-constraint-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-proactive-authority-acceptance.ts
+++ b/script/pg-proactive-authority-acceptance.ts
@@ -37,7 +37,7 @@ console.log = console.warn = console.error = () => {};
 const { pool, db } = await import("../server/db");
 const schema = await import("../shared/schema");
 const { canonicalNextMove, PROACTIVE_SENDERS } = await import("../server/scheduler/proactive-decision");
-const { readHeldConstraints } = await import("../server/held-constraints");
+const { readHeldConstraints, recordDailyConstraint } = await import("../server/held-constraints");
 const { claimDailySlot } = await import("../server/scheduler/shared");
 
 let failed = 0;
@@ -65,14 +65,20 @@ async function seed(over: Record<string, any> = {}): Promise<any> {
   return u;
 }
 
-const said = (uid: string, text: string) => pool.query(
-  `INSERT INTO chat_history (user_id, message_in, message_out, intent, created_at)
-   VALUES ($1,$2,'ok','GENERAL', now())`, [uid, text]);
+// A turn, recorded the way the front door records one. The constraint is a durable row now
+// (#194) rather than a sentence re-derived from the last 24 messages, so saying it and storing it
+// are the same step here as they are in production.
+const said = async (u: any, text: string) => {
+  await pool.query(
+    `INSERT INTO chat_history (user_id, message_in, message_out, intent, created_at)
+     VALUES ($1,$2,'ok','GENERAL', now())`, [u.id, text]);
+  await recordDailyConstraint(u, text);
+};
 
 // ── §1 A CONSTRAINT THE CLIENT STATED BINDS THE PROACTIVE COACH ─────────────────────────────
 REAL("\n§1 'I am not training today' — the case that used to contradict");
 const a = await seed();
-await said(a.id, "I am not training today");
+await said(a, "I am not training today");
 const heldA = await readHeldConstraints(a.phoneNumber, a);
 chk(heldA.trainingDeclined === true, "the constraint is read from the client's own words",
   JSON.stringify(heldA));
@@ -130,7 +136,7 @@ chk(twice.held.trainingDeclined === moveA.held.trainingDeclined,
 // A FOOD CLOSURE BINDS IT TOO — the other half of held-constraints, on the same path.
 REAL("\n§3b a closed food day binds the proactive coach as well");
 const c = await seed();
-await said(c.id, "I'm not eating anything else today");
+await said(c, "I'm not eating anything else today");
 const heldC = await readHeldConstraints(c.phoneNumber, c);
 chk(heldC.foodDayClosed === true, "the closure is read", JSON.stringify(heldC));
 const moveC = await canonicalNextMove(c, { hour: 20 });

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2529,8 +2529,10 @@ async function main() {
     ledger: { proteinTarget?: number; who: string },
   ): Promise<string[]> {
     const { runEveningAccountability } = await import("../server/scheduler/jobs/evening");
-    const { shadowReplies, sentProactive, mealLogs, workoutLogs, weightLogs, stepLogs, chatHistory } =
+    const { shadowReplies, sentProactive, mealLogs, workoutLogs, weightLogs, stepLogs, chatHistory, dailyConstraints } =
       await import("../shared/schema");
+    const { constraintsAssertedBy } = await import("../server/held-constraints");
+    const { sastDayKey } = await import("../server/sast");
     const g = globalThis as any;
     const today = new Date();
 
@@ -2577,6 +2579,17 @@ async function main() {
           { id: 1, weight: "83.4", w: "83.4", at: new Date(NOW - 20 * 86_400_000), loggedAt: new Date(NOW - 20 * 86_400_000) },
         ]],
         [stepLogs, [{ avg: 9000, steps: 9000, at: today, loggedAt: today }]],
+        // WHAT THEY RULED OUT TODAY IS A ROW NOW (#194), not a sentence re-derived from the last
+        // 24 chat messages — that window is what let a real client's closed day silently reopen
+        // after a busy afternoon. saidToday is still the fixture; it is folded through
+        // constraintsAssertedBy, the SAME pure rule the front door writes with, so this harness
+        // cannot drift from the product's own definition of what a sentence asserts. Every
+        // assertion in the four cases below is unchanged, prohibitions and controls alike.
+        [dailyConstraints, saidToday.flatMap(r =>
+          constraintsAssertedBy(String(r.message_in || "")).map(c => ({
+            userId: `parity-${ledger.who}`, day: sastDayKey(new Date()),
+            kind: c.kind, state: c.state, via: "said",
+          })))],
       ]);
       const writes: Array<{ table: any; values: any }> = [];
       g.__KAMLIFE_STUB_WRITES = writes;
@@ -2675,18 +2688,22 @@ async function main() {
   // has migrated still cannot say it. Without this the migration protects only what it touched.
   check("P0-4b . the outbound floor blocks a contradiction from an unmigrated sender", async () => {
     const { enforceOutboundTruth } = await import("../server/outbound-authority");
+    const { dailyConstraints } = await import("../shared/schema");
+    const { sastDayKey } = await import("../server/sast");
     const g = globalThis as any;
     const out = await serialise(async () => {
-      g.__KAMLIFE_STUB_PGROWS = (sql: string) => (/chat_history/i.test(String(sql))
-        ? [{ message_in: "I'm not training today", created_at: new Date() },
-           { message_in: "I'm done eating for today", created_at: new Date() }]
-        : []);
+      // The two constraints are rows now (#194) rather than sentences replayed from chat history.
+      // The floor's job is unchanged and so are all three assertions below, control included.
+      g.__KAMLIFE_STUB_ROWS = new Map<any, any[]>([[dailyConstraints, [
+        { userId: USER.id, day: sastDayKey(new Date()), kind: "training", state: "asserted", via: "said" },
+        { userId: USER.id, day: sastDayKey(new Date()), kind: "food", state: "asserted", via: "said" },
+      ]]]);
       const r = {
         train: await enforceOutboundTruth(USER.id, "whatsapp:+27000000301", "Kam, get today's session done before bed."),
         eat: await enforceOutboundTruth(USER.id, "whatsapp:+27000000302", "Kam, get to 140g protein tonight."),
         recognition: await enforceOutboundTruth(USER.id, "whatsapp:+27000000303", "Kam, 9,000 steps today. Strong."),
       };
-      delete g.__KAMLIFE_STUB_PGROWS;
+      delete g.__KAMLIFE_STUB_ROWS;
       return r;
     });
     assert.ok(!out.train.ok && out.train.reason === "contradicts_held_constraint",

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -489,7 +489,15 @@ const MUST_WRITE: [string, string][] = [
         const t = marker.match(/\/card\/([^.]+)\.png/);
         return t ? getCard(t[1]) : null;
       };
-      const closure = () => [{ message_in: "I'm done eating for the day", created_at: new Date(FROZEN - 600_000) }];
+      // THE CLOSURE IS NOW A ROW, NOT A REPLAYED SENTENCE (#194). This used to seed a chat message
+      // and let readHeldConstraints re-derive the closure from the last 24 of them — which is the
+      // window that let a real client's closed day silently reopen after a busy afternoon. The
+      // CONTRACT below is unchanged and none of it is relaxed; only the way this fixture puts the
+      // client into a closed day changed, to the way the product now records it.
+      const { sastDayKey } = await import("../server/sast");
+      const closure = () => new Map<any, any[]>([[schema.dailyConstraints, [
+        { userId: USER.id, day: sastDayKey(new Date()), kind: "food", state: "asserted", via: "said" },
+      ]]]);
 
       const today = await todayRows(USER, false);
       const cardFor = (mealName: string, foodDayClosed: boolean) => mealCard({
@@ -510,15 +518,15 @@ const MUST_WRITE: [string, string][] = [
         ["the meal-log card", "Chicken and rice", () => macroCardMarker({ user: USER, mealName: "Chicken and rice", mealKcal: 600 })],
       ];
       for (const [what, mealName, emit] of MARKERS) {
-        delete g.__KAMLIFE_STUB_PGROWS;
+        delete g.__KAMLIFE_STUB_ROWS;
         resetDump();                       // the dump window collapses repeat cards to one
         const openA = pngOf(await emit());
         resetDump();
         const openB = pngOf(await emit());
-        g.__KAMLIFE_STUB_PGROWS = closure();
+        g.__KAMLIFE_STUB_ROWS = closure();
         resetDump();
         const closed = pngOf(await emit());
-        delete g.__KAMLIFE_STUB_PGROWS;
+        delete g.__KAMLIFE_STUB_ROWS;
 
         if (!openA || !openB || !closed) {
           failures.push(`${what} produced no image, so its closed-day wiring is ungraded — this proves nothing`);
@@ -542,9 +550,9 @@ const MUST_WRITE: [string, string][] = [
           failures.push(`${what} did not emit the open-day card — expected "${cardFor(mealName, false).sub}"`);
         }
       }
-      g.__KAMLIFE_STUB_PGROWS = closure();
+      g.__KAMLIFE_STUB_ROWS = closure();
       const held = await readHeldConstraints(USER.phoneNumber, USER as any).catch(() => ({ foodDayClosed: false } as any));
-      delete g.__KAMLIFE_STUB_PGROWS;
+      delete g.__KAMLIFE_STUB_ROWS;
 
       // THE CUSTOMER OUTCOME, on the card the production path actually emitted.
       if (sells(closedCard.sub)) {
@@ -561,7 +569,7 @@ const MUST_WRITE: [string, string][] = [
       }
     } finally {
       Date.now = realNow;
-      delete g.__KAMLIFE_STUB_PGROWS;
+      delete g.__KAMLIFE_STUB_ROWS;
       if (priorRows === undefined) delete g.__KAMLIFE_STUB_ROWS; else g.__KAMLIFE_STUB_ROWS = priorRows;
     }
   }
@@ -1320,6 +1328,8 @@ const MUST_WRITE: [string, string][] = [
        * invert the ordering case and quietly grade the opposite of what production does.
        */
       {
+        const { constraintsAssertedBy } = await import("../server/held-constraints");
+        const { sastDayKey: dayKeyOf } = await import("../server/sast");
         const CLOSE = "I am done eating today";
         const REOPEN = "actually I changed my mind, I'm having dinner";
         const DAY_CLOSED = /leaving it there|done eating today/i;
@@ -1334,12 +1344,23 @@ const MUST_WRITE: [string, string][] = [
             mealLabel: "dinner", label: "dinner", source: "text",
             items: [{ name: "Chicken", kcal: 2100, protein: 188 }], rawMessage: "dinner", sourceMessageId: null,
           }]]]);
-          g.__KAMLIFE_STUB_PGROWS = historyNewestFirst.map((text, i) => ({
-            message_in: text,
-            created_at: new Date(dayStart.getTime() + (historyNewestFirst.length - i) * 60_000),
-          }));
+          // THE HISTORY IS RECORDED THE WAY THE PRODUCT RECORDS IT (#194) — folded oldest-first
+          // through constraintsAssertedBy, the SAME pure rule the front-door writer uses. Not a
+          // copy of it: a mirror is free to drift from the thing it claims to be about, which is
+          // how a constraint suite stays green while the product forgets the constraint. Every
+          // assertion below is unchanged; only the mechanism that puts the client into that state
+          // moved from a replayed window to the durable row the product now writes.
+          const oldestFirst = [...historyNewestFirst].reverse();
+          const constraintRows: any[] = [];
+          for (const text of oldestFirst) {
+            for (const r of constraintsAssertedBy(text)) {
+              constraintRows.push({ userId: USER.id, day: dayKeyOf(new Date()), kind: r.kind, state: r.state, via: "said" });
+            }
+          }
+          // Newest last in insertion order; readHeldConstraints takes the newest per kind.
+          (g.__KAMLIFE_STUB_ROWS as Map<any, any[]>).set(schema.dailyConstraints, constraintRows.reverse());
           const reply = String(await handleMessage(USER.phoneNumber, ask).catch(() => ""));
-          delete g.__KAMLIFE_STUB_PGROWS;
+          delete g.__KAMLIFE_STUB_ROWS;
           delete g.__KAMLIFE_STUB_ROWS;
           return reply;
         };
@@ -1457,7 +1478,7 @@ const MUST_WRITE: [string, string][] = [
         g.__KAMLIFE_STUB_PGROWS = [{ message_in: "I am done eating today", created_at: new Date(dayStart.getTime() + 60_000) }];
         const closedStill = await canonicalDecision({ ...USER }, "what should I eat?").catch(() => null);
         const reopened = await canonicalDecision({ ...USER }, "I'm eating now, what should I eat?").catch(() => null);
-        delete g.__KAMLIFE_STUB_PGROWS;
+        delete g.__KAMLIFE_STUB_ROWS;
         if (closedStill && reopened && closedStill.todo === reopened.todo && /eat|protein|meal/i.test(String(reopened.todo))) {
           failures.push(`The Meaning Engine reached the SAME food instruction whether or not the turn reopened the day ("${reopened.todo}") — the current message is not reaching its held state, so the engine and the meal door are deciding from different facts`);
         }
@@ -2081,13 +2102,16 @@ const MUST_WRITE: [string, string][] = [
               kcalInt: o.kcal, proteinInt: o.protein, kcal: o.kcal, protein: o.protein, carbs: 0, fat: 0,
             }]],
             [schema.stepLogs, []], [schema.workoutLogs, []], [schema.weightLogs, []],
+            // THE CLOSURE IS A ROW NOW (#194), not a sentence replayed out of the last 24 messages.
+            // Every assertion in this block is unchanged — including the ones that matter most,
+            // that an unrelated message must not reopen the day and that the newest decision wins.
+            [schema.dailyConstraints, o.closed
+              ? [{ userId: USER.id, day: sastToday(), kind: "food", state: "asserted", via: "said" }]
+              : []],
           ]);
           g.__KAMLIFE_STUB_WRITES = [];
-          g.__KAMLIFE_STUB_PGROWS = o.closed
-            ? [{ message_in: "I'm done eating for the day", created_at: new Date(Date.now() - 3_600_000) }]
-            : [];
           const out = String(await handleMessage(USER.phoneNumber, "what should I eat next?").catch(() => ""));
-          delete g.__KAMLIFE_STUB_PGROWS;
+          delete g.__KAMLIFE_STUB_ROWS;
           return out;
         };
         const offersFood = (r: string) => /Balanced option|Light option|Pick one:|\(~\d+ kcal/i.test(r);

--- a/server/held-constraints.ts
+++ b/server/held-constraints.ts
@@ -26,9 +26,12 @@
  */
 
 import { foodDayIsClosed, foodDayIsReopened, trainingDayIsDeclined } from "./one-action";
-import { recentClientMessagesStamped } from "./memory";
+import { db } from "./db";
+import { dailyConstraints, workoutLogs, users } from "../shared/schema";
+import { and, eq, desc, gte } from "drizzle-orm";
 import { readHealthState } from "./health-state";
-import { sastDaysBetween, sastDayKey } from "./sast";
+import { parseMealDate, isFutureIntent, isAskingNotReporting } from "./utils";
+import { sastDayKey, sastDayStart } from "./sast";
 
 export interface HeldConstraints {
   /** They said they are done eating for today. */
@@ -54,16 +57,139 @@ export async function readHeldConstraints(
 ): Promise<HeldConstraints> {
   const sick = client ? !!readHealthState(client).isSick : false;
   try {
-    const stamped = await recentClientMessagesStamped(phone);
-    const todays = stamped.filter(s => sastDaysBetween(s.at) === 0);
-    return {
-      foodDayClosed: foodDayClosedNow(todays),
-      trainingDeclined: todays.some(s => trainingDayIsDeclined(s.text)),
-      sick,
-    };
+    const day = sastDayKey(new Date());
+    // NEWEST DECISION PER KIND, FOR TODAY ONLY. The rows are append-only, so "is the day closed"
+    // is the state of the latest row rather than the existence of any row — a reopening does not
+    // delete the closure, it outranks it.
+    // THE PHONE IS STILL A VALID KEY, and that is not a convenience. The outbound floor calls this
+    // with `recipientUser ?? null` — it has a phone and often no row — so a reader that needed a
+    // client object would have returned "no constraints" there and silently switched off the one
+    // gate standing between an unmigrated sender and a client who said they were done for the day.
+    // The id is used when the caller has one; otherwise the user is resolved by phone, exactly as
+    // this function did before it read a table.
+    const uid = (client as any)?.id
+      ?? (await db.select({ id: users.id }).from(users).where(eq(users.phoneNumber, phone)).limit(1))[0]?.id;
+    if (!uid) return { ...NO_CONSTRAINTS, sick };
+    const rows = await db.select().from(dailyConstraints)
+      .where(and(eq(dailyConstraints.userId, uid), eq(dailyConstraints.day, day)))
+      .orderBy(desc(dailyConstraints.saidAt), desc(dailyConstraints.id));
+    const newest = (kind: string) => rows.find(r => r.kind === kind);
+
+    // A SESSION LOGGED TODAY RESOLVES A DECLINE, and the workout ledger IS that evidence —
+    // append-only, durable, and already the thing every other surface trusts about training.
+    // Recording a second row to say what the first row already says would be a second answer.
+    let trainingDeclined = newest("training")?.state === "asserted";
+    if (trainingDeclined) {
+      const done = await db.select({ id: workoutLogs.id }).from(workoutLogs)
+        .where(and(eq(workoutLogs.userId, uid), gte(workoutLogs.loggedAt, sastDayStart())))
+        .limit(1);
+      if (done.length > 0) trainingDeclined = false;
+    }
+    return { foodDayClosed: newest("food")?.state === "asserted", trainingDeclined, sick };
   } catch (e: any) {
     console.warn(`[HELD_CONSTRAINTS] unreadable for ${String(phone).slice(-8)}: ${e?.message || e}`);
     return { ...NO_CONSTRAINTS, sick };
+  }
+}
+
+/**
+ * RECORD WHAT THEY JUST RULED OUT, WHEN THEY SAY IT (#194).
+ *
+ * The reader above used to rebuild today's constraints by replaying chat history, and that replay
+ * is `ORDER BY created_at DESC LIMIT 24`. Reproduced on real PostgreSQL: a client closed their
+ * food day and declined training, had twenty-six ordinary messages, and both constraints were
+ * gone — with the client having changed nothing. The engaged client is the one it failed for.
+ *
+ * NO SECOND PARSER. foodDayIsClosed, foodDayIsReopened and trainingDayIsDeclined are still the
+ * only things that read a message; this only decides where the answer is kept. The tie-break
+ * inside one utterance is foodDayClosedNow's, unchanged and shared, so the two cannot disagree
+ * about the same sentence.
+ *
+ * Fails soft. A constraint we could not record is the behaviour we had yesterday, and the turn
+ * itself must not die because bookkeeping did.
+ */
+/**
+ * WHAT THIS SENTENCE ASSERTS ABOUT TODAY — the whole rule, in one pure place.
+ *
+ * Exported so the writer below and the contract suite share ONE definition. A test that folds its
+ * own copy of this over a history grades a mirror, and a mirror is free to drift from the thing it
+ * claims to be about — which is precisely how a constraint suite could stay green while the
+ * product forgot the constraint.
+ *
+ * Returns [] for anything that is not a decision about TODAY. A closure inside one utterance still
+ * outranks a reopening inside it: a turn cannot be ordered against itself, and the conservative
+ * direction is the one that does not sell food to someone who may have just stopped.
+ */
+export function constraintsAssertedBy(message: string): Array<{ kind: string; state: string }> {
+  // A CONSTRAINT IS ABOUT TODAY, SO A SENTENCE ABOUT ANOTHER DAY ASSERTS NOTHING (#194).
+  //
+  // "yesterday I was not eating anything else" and "I was done eating last night" both satisfy
+  // foodDayIsClosed — the same words in the past tense. While the state was re-derived from a
+  // 24-message window that was survivable noise; recorded, it would close TODAY on the strength
+  // of a story about last night, permanently. parseMealDate is the temporal owner every food path
+  // already asks which day a sentence is about, and isFutureIntent is the shared floor for a plan.
+  //
+  // AND ASKING IS NOT DECIDING. "should I stop eating for today?" satisfies foodDayIsClosed — a
+  // real over-fire, and one that predates this change: the old reader would have closed the day on
+  // that question too, for as long as the window held it. isAskingNotReporting is the floor this
+  // codebase already shares for exactly that distinction, and its documented bias is the right one
+  // here — answering a report as a question is recoverable; silently closing someone's food day
+  // because they asked about it is not.
+  if (isAskingNotReporting(message)) return [];
+  // THE DAY AND FUTURE GUARDS APPLY TO THE ASSERTIONS, NOT THE RELEASE — and the asymmetry is the
+  // point, twice over.
+  //
+  // First, the safe directions differ: wrongly asserting a constraint SILENCES the coach for the
+  // rest of someone's day, while wrongly releasing one only lets it speak. Second, the release
+  // recogniser already owns these guards. foodDayIsReopened was built with its own future-day and
+  // zero-food tests (#155); parseMealDate is a MEAL-date resolver, not a general "which day is
+  // this sentence about" oracle, and it has heuristics of its own — asked before dawn it reads
+  // "I'm having dinner tonight after all" as YESTERDAY's dinner. Gating the release on it took the
+  // reversal away, which is the whole feature #152 exists to give back, and locked a client who
+  // changed their mind out until midnight again.
+  const asserts = (m: string) => {
+    const named = parseMealDate(m);
+    if (named && sastDayKey(named) !== sastDayKey(new Date())) return false;
+    return !isFutureIntent(m);
+  };
+  const rows: Array<{ kind: string; state: string }> = [];
+  if (asserts(message) && foodDayIsClosed(message)) rows.push({ kind: "food", state: "asserted" });
+  else if (foodDayIsReopened(message)) rows.push({ kind: "food", state: "released" });
+  if (asserts(message) && trainingDayIsDeclined(message)) rows.push({ kind: "training", state: "asserted" });
+  return rows;
+}
+
+export async function recordDailyConstraint(
+  client: { id: string } | null | undefined,
+  message: string,
+  sourceMessageId?: string,
+): Promise<void> {
+  if (!client?.id) return;
+  // A CONSTRAINT IS ABOUT TODAY, SO A SENTENCE ABOUT ANOTHER DAY ASSERTS NOTHING (#194).
+  //
+  // "yesterday I was not eating anything else" and "I was done eating last night" both satisfy
+  // foodDayIsClosed — they are the same words in the past tense. While the state was re-derived
+  // from a 24-message window that was survivable noise; recorded, it would close TODAY on the
+  // strength of a story about last night, permanently. parseMealDate is the temporal owner every
+  // food path already asks which day a sentence is about, and isFutureIntent is the shared floor
+  // for a plan. Neither is new, and neither reads the constraint — they only say whether this
+  // sentence is about today at all.
+  //
+  // AND ASKING IS NOT DECIDING. "should I stop eating for today?" satisfies foodDayIsClosed — a
+  // real over-fire, and one that predates this change: the old reader would have closed the day on
+  // that question too, for however long the window held it. isAskingNotReporting is the floor this
+  // codebase already shares for exactly this distinction, and its documented bias is the right one
+  // here — answering a report as a question is recoverable, silently closing someone's food day
+  // because they asked about it is not.
+  const rows = constraintsAssertedBy(message);
+  if (rows.length === 0) return;
+  const day = sastDayKey(new Date());
+  for (const r of rows) {
+    await db.insert(dailyConstraints)
+      .values({ userId: client.id, day, kind: r.kind, state: r.state, via: "said",
+        sourceMessageId: sourceMessageId || null })
+      .onConflictDoNothing()
+      .catch((e: any) => console.warn("[HELD_CONSTRAINTS] not recorded:", e?.message || e));
   }
 }
 
@@ -117,29 +243,14 @@ export function foodCloseLookup(
 }
 
 /**
- * THE NEWEST EXPLICIT DECISION WINS (#152, 2026-09-03).
- *
- * This was `todays.some(foodDayIsClosed)` — once anything today closed the day, nothing could
- * open it, so a client who closed at 19:55 and then said "actually I changed my mind, I'm having
- * dinner" was refused for the rest of the night, every time they asked.
- *
- * `some` also throws away the one thing that settles a contradiction: WHEN each was said. The
- * statements are already newest-first, so the first one that is a decision about eating today is
- * the decision that stands, and everything older is history. Nothing is stored; the effective
- * state is derived from the client's own ordered words, which is what "held" has always meant here.
- *
- * A CLOSURE INSIDE A SINGLE MESSAGE OUTRANKS A REOPENING INSIDE IT. "I'll have dinner, then I'm
- * done eating" is one utterance with both, and one turn cannot be ordered against itself — so the
- * tie goes to the constraint, which is the direction that does not sell food to someone who may
- * have just stopped.
+ * foodDayClosedNow IS GONE (#194). It folded the newest explicit decision out of today's chat
+ * history, and it was the last thing reading that window for this purpose: the decision is now
+ * recorded when it is made, so there is nothing left to re-derive. Its rule survives unchanged in
+ * recordDailyConstraint above — a closure inside one utterance still outranks a reopening inside
+ * it, because a turn cannot be ordered against itself and the conservative direction is the one
+ * that does not sell food to someone who may have just stopped. Same rule, one place, written
+ * down once rather than replayed.
  */
-function foodDayClosedNow(todaysNewestFirst: Array<{ text: string }>): boolean {
-  for (const s of todaysNewestFirst) {
-    if (foodDayIsClosed(s.text)) return true;
-    if (foodDayIsReopened(s.text)) return false;
-  }
-  return false;
-}
 
 /**
  * THE TURN'S OWN WORDS COUNT TOO (#152, CTO re-adjudication on #155).

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -56,7 +56,7 @@ import { mustStayDeterministic } from "./understanding/action-router";
 import { attributeMultiDayReport } from "./understanding/day-relative-situation";
 import { recordMessageSeen, recordReplyPath } from "./self-check";
 import { normalizerFidelity, normalizerLive } from "./normalizer-fidelity";
-import { carriesFeelingClause } from "./unlogged-notice";import { looksLikeDirectionRequest } from "./daily-direction";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, reportedInSomeClause, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
+import { carriesFeelingClause } from "./unlogged-notice";import { recordDailyConstraint } from "./held-constraints";import { looksLikeDirectionRequest } from "./daily-direction";import { looksLikeQuestion, looksLikeSurplusDeficitQuestion, getDisplayName, checkGptRateLimit, sastToday, parseMealDate, isRetroactiveMeal, mealDateLabel, isFutureIntent, normaliseMsisdn, stripInventedRetroDate, mentionsNotDone, reportedInSomeClause, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, hasGoalChangeVocabulary, isBareGreeting, looksLikeStepsTargetChange, looksLikeBillingOrCancel, looksLikeLowMobility, looksLikeDefeatedNoResults, looksLikeDigestiveIssue, looksLikeFoodDislike, looksLikeOvertrainingPlan, classifyPainReport, looksLikeWorkoutRequest } from "./utils";
 import { invalidatePatternCache } from "./cache";
 import { conditionWelcome, mentionsConditionOrMedication } from "./condition-welcome";
 import { captureSymptom } from "./quality-signals";
@@ -124,6 +124,8 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
   // contact is created below, once the guards have stood down.
   let user: any | undefined = await bindClientTruth(phone, message, sourceMessageId);
   if (user) turnUser(user.id);
+  // …and what they just ruled out for today is RECORDED, not rediscovered later (#194).
+  await recordDailyConstraint(user, message, sourceMessageId);
 
   // ---- SAFETY + DATA GUARDS (crisis, medical, terminal, delete, reset) ----
   const safetyResult = await runSafetyGuards(phone, message, m, { sourceMessageId, boundUser: user });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -551,6 +551,42 @@ export const clientTruthCommits = pgTable("client_truth_commits", {
 
 export type ClientTruthCommit = typeof clientTruthCommits.$inferSelect;
 
+// === DAILY CONSTRAINTS — what the client ruled out today, recorded when they said it (#194) ===
+//
+// held-constraints.ts opens by naming the defect this table closes: "the constraint lived for
+// exactly one expression and then evaporated." Binding it to a reader fixed the first version of
+// that; the reader still RE-DERIVED it from the last 24 chat messages, so on a busy day the
+// declaration fell out of the window and the constraint evaporated again — proven on real
+// PostgreSQL: closed at 09:00, gone by message 25, with the client having changed nothing.
+//
+// APPEND-ONLY, AND THAT IS THE POINT. A reopening does not edit the closure; it is a second row.
+// The day's effective state is the newest decision, and the assertion that came before it is
+// still on the record — which is what lets anyone answer "was the coach allowed to say that at
+// 20:00" a week later. Nothing here decides anything: the recognisers in one-action.ts remain the
+// only things that read a message, and readHeldConstraints remains the only reader of the state.
+export const dailyConstraints = pgTable("daily_constraints", {
+  id: serial("id").primaryKey(),
+  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  /** The SAST day this constraint is about — never a timestamp, because "today" is the whole rule. */
+  day: text("day").notNull(),
+  /** food | training */
+  kind: text("kind").notNull(),
+  /** asserted | released */
+  state: text("state").notNull(),
+  /** What resolved it: said | workout_logged. The client's words, or their actions. */
+  via: text("via").notNull(),
+  /** The provider message this came from, when there was one — makes a retry idempotent. */
+  sourceMessageId: text("source_message_id"),
+  saidAt: timestamp("said_at").defaultNow().notNull(),
+}, (table) => ({
+  userDayKindIdx: index("daily_constraints_user_day_kind_idx").on(table.userId, table.day, table.kind),
+  sourceIdempotency: uniqueIndex("daily_constraints_user_source_kind_uidx")
+    .on(table.userId, table.sourceMessageId, table.kind),
+}));
+
+export type DailyConstraint = typeof dailyConstraints.$inferSelect;
+
+
 // === SENT PROACTIVE — durable dedupe for scheduled messages ===
 // Each scheduled proactive send claims a row (userId, messageKey, dedupeWindow).
 // The unique index below guarantees the same (user, messageKey, window) can only


### PR DESCRIPTION
Closes #194.

## Reproduced first, on real PostgreSQL

```
after the two declarations:          foodDayClosed=true   trainingDeclined=true
after 26 further ordinary messages:  foodDayClosed=false  trainingDeclined=false
```

The client reopened nothing. `readHeldConstraints` rebuilt today's constraints by replaying chat history, and that replay is `ORDER BY created_at DESC LIMIT 24` — so the declaration fell out of the window and a **closed food day silently reopened itself**.

`held-constraints.ts` opens by naming this exact failure: *"the constraint lived for exactly one expression and then evaporated."* Binding it to a reader fixed the first version; the window was just a longer expression. The client who talks to us most is the one it failed for.

## The change

One append-only table. A reopening does not edit the closure — it is a second row, and the day's effective state is the newest decision. That is what lets anyone answer *"was the coach allowed to say that at 20:00"* a week later.

**No second parser.** `foodDayIsClosed`, `foodDayIsReopened` and `trainingDayIsDeclined` remain the only things that read a message; `readHeldConstraints` remains the only reader of the state. `constraintsAssertedBy` is exported so the writer and the contract suites share **one** definition — a suite folding its own copy grades a mirror, and a mirror drifts from the product while staying green.

## Two real over-fires surfaced, both predating this change

```
"should I stop eating for today?"   satisfies foodDayIsClosed
"I was done eating last night"      satisfies it too
```

Under the old window those were survivable noise. **Recorded**, they would close today on the strength of a question or a story about last night, and stay closed. `parseMealDate` and `isAskingNotReporting` / `isFutureIntent` are the owners this codebase already shares; neither is new.

### The guards apply to assertions, not to the release

My first cut applied them to everything and **took the reversal with it** — the feature #152 exists to give back. Two load-bearing reasons:

- the safe directions differ — wrongly asserting silences the coach for a day, wrongly releasing only lets it speak;
- `foodDayIsReopened` already owns its own future-day and zero-food guards from #155. `parseMealDate` in particular is a *meal-date* resolver with heuristics of its own: asked before dawn it reads `I'm having dinner tonight after all` as **yesterday's** dinner, which is exactly how gating the release on it locked a client who changed their mind out until midnight.

### A regression I introduced, caught by the suite

The outbound floor calls this with `recipientUser ?? null`. A reader that needed a client object returned "no constraints" there and **silently switched off** the one gate between an unmigrated sender and a client who said they were done for the day. The phone is a valid key again.

## Proof — `script/pg-daily-constraint-acceptance.ts`, in the PG job

The claim is about what *survives*, and a fixture that returns the same rows to every query cannot demonstrate a window.

| # | Required proof | Result |
|---|---|---|
| 1 | Closure survives more than 24 later messages | ✓ (30) |
| 2 | Explicit reopening releases it | ✓ |
| 3 | Training decline survives the same pressure | ✓ |
| 4 | Moving the workout into today reverses the decline | ✓ |
| 5 | Questions, history and future statements do not mutate today | ✓ nothing written at all |
| 6 | Yesterday's constraint does not leak into today | ✓ + control: same row dated today *does* bind |
| 7 | Append-only evidence preserves assertion **and** resolution | ✓ two food rows, nothing edited |
| 8 | No second constraint parser or policy system | ✓ one exported rule, shared |

Plus isolation and provider-retry idempotency.

## Fixtures updated, assertions untouched

`tracking-contract` and `production-parity` established a closed day by seeding chat messages. Both now seed the durable row — `production-parity` by folding **its own fixture** through `constraintsAssertedBy`, so the harness cannot drift from the product's rule. Every prohibition and every control reads exactly as before.

## Red on revert

Restoring the re-derivation fails **6** checks, including "the food closure is still held after 30 later messages" and "the same row dated today does bind".

## One more thing, caught before it shipped

The journal entry's `when` collided with `0009`'s, and **drizzle silently skipped `0010` while reporting success** — a migration that would never have applied in production. Timestamps are strictly increasing again.

## Verification

| Suite | Result |
|---|---|
| `npm test` | 36/37 green, 1 covered nothing (`normalizer-replay-tests`, pre-existing) |
| `npm run test:unit:baseline --base=origin/main` | PASS — 0 branch-introduced failures |
| 7 × PostgreSQL acceptance lanes | GREEN ×7 |
| Journey Lab | GREEN — 266/266 |
| `production-parity` | 142/142 |
| filesize / arch / schema / sast / safety-audit | green, all at budget |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_