### PR TITLE
A fact in the same bubble as a question, and a fact a client takes back (#128 item 1)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4094,6 +4094,81 @@ test("canonical truth: factual understanding always comes from the committed pro
     "a slow earlier turn cannot overwrite understanding from a newer fact revision");
 });
 
+// ── #128/1: ONE BUBBLE, TWO SPEECH ACTS — AND A FACT THE CLIENT CAN TAKE BACK ───────────────
+//
+// Graded end to end on STATE, not on source shape: the sentence a client actually sends, through
+// the detector and the projection that writes the column, into foodConstraints — the owner every
+// plate, grocery and swap mouth consults. If the chain works, the coach stops offering chicken to
+// someone who said they are vegan, and starts offering it again the day they say they are not.
+
+test("#128/1: a constraint stated in the same bubble as the question still reaches the coach", async () => {
+  const { detectFacts, projectClientFacts } = await import("../server/memory");
+  const { foodConstraints } = await import("../server/food-swaps");
+
+  // What a real client types. Before this, the "?" made looksLikeQuestion true for the WHOLE
+  // message and every gated fact was dropped — they stated a constraint and were sold chicken.
+  for (const said of ["I'm vegan now, what should I eat?", "I'm vegan now. What should I eat?"]) {
+    const { patch } = projectClientFacts({}, detectFacts(said));
+    const c = foodConstraints({ dietaryRestrictions: patch.dietaryRestrictions as string });
+    assert.ok(c.vegan, `"${said}" writes a restriction the food owners can read`);
+    assert.ok(!c.allows("chicken breast"), "…and chicken is off the menu on the same turn");
+  }
+
+  const dairy = projectClientFacts({}, detectFacts("I can't eat dairy, what can I eat?")).patch;
+  assert.ok(foodConstraints({ dietaryRestrictions: dairy.dietaryRestrictions as string }).noDairy,
+    "the allergy clause is read even with the question attached");
+  assert.equal(detectFacts("my knee is killing me, what should I train?").injuries, "knee",
+    "and so is the injury — the programme filters on this column");
+
+  // THE GUARD IS NOT GONE, IT IS ASKED ABOUT THE RIGHT CLAUSE. If these start committing, the
+  // clause split has become a licence to record hypotheticals as facts.
+  assert.equal(detectFacts("what happens if I hurt my knee?").injuries, undefined,
+    "a one-clause hypothetical is still not an injury");
+  assert.equal(detectFacts("do I have diabetes?").medicalConditions, undefined, "asking is still not having");
+  assert.equal(detectFacts("I'm going to hurt my shoulder doing that").injuries, undefined,
+    "a plan is still not a report");
+});
+
+test("#128/1: a client can take a restriction back", async () => {
+  const { detectFacts, projectClientFacts } = await import("../server/memory");
+  const { foodConstraints } = await import("../server/food-swaps");
+
+  // THE STATE BEFORE — this is what makes the assertion below mean something.
+  assert.ok(!foodConstraints({ dietaryRestrictions: "vegan" }).allows("chicken breast"),
+    "while the fact stands, chicken is refused");
+
+  const { patch, operations } = projectClientFacts({ dietaryRestrictions: "vegan" },
+    detectFacts("I'm not vegan anymore"));
+  assert.equal(patch.dietaryRestrictions, null, "the column is cleared, not appended to");
+  assert.equal(operations[0].operation, "retract", "and the evidence says what happened");
+  assert.ok(foodConstraints({ dietaryRestrictions: patch.dietaryRestrictions as any }).allows("chicken breast"),
+    "the coach may offer chicken again");
+
+  // The old behaviour wrote the sentence itself into the column, and every owner greps for the
+  // bare word — so the retraction BANNED more than the assertion ever did.
+  const asWritten = foodConstraints({ dietaryRestrictions: "not vegan anymore" });
+  assert.ok(asWritten.vegan && asWritten.noFish,
+    "storing the retraction verbatim would ban meat, dairy and fish — which is why it must not be stored");
+
+  // A retraction removes ONE fact. An unrelated restriction is not collateral.
+  const mixed = projectClientFacts({ dietaryRestrictions: "vegan, allergic to peanuts" },
+    detectFacts("I'm not vegan anymore"));
+  assert.equal(mixed.patch.dietaryRestrictions, "allergic to peanuts", "the peanut allergy survives");
+
+  // Same for the body: a knee that healed does not take the shoulder with it.
+  const injury = projectClientFacts({ injuries: "knee, shoulder" }, detectFacts("my knee doesn't hurt anymore"));
+  assert.equal(injury.patch.injuries, "shoulder", "the resolved joint is removed and the other stays");
+
+  // NEGATIVE CONTROL — a bare "not X" in a food log is not a retraction. If these clear the
+  // column, a real allergy disappears because the client described their plate.
+  for (const said of ["I had chicken, not fish", "I'm having chicken not fish", "chicken, no fish"]) {
+    const kept = projectClientFacts({ dietaryRestrictions: "allergic to fish" }, detectFacts(said));
+    assert.equal(kept.patch.dietaryRestrictions, undefined, `"${said}" leaves the allergy alone`);
+  }
+  assert.equal(projectClientFacts({}, detectFacts("I'm not eating dairy")).patch.dietaryRestrictions,
+    "not eating dairy", "a restriction stated in the negative is still a restriction");
+});
+
 // ── CUT 8: DON'T-MENTION IS BOUND TO THE MOUTH ──────────────────────────────────────────────
 
 test("cut8: the reply path honours do_not_mention, above the meaningful-message gate", () => {

--- a/script/pg-client-truth-acceptance.ts
+++ b/script/pg-client-truth-acceptance.ts
@@ -132,6 +132,50 @@ check(!loaded.profile.keyFacts.some(x => /invented|stale model/.test(x)), "store
 check(stored?.profile && (stored.profile as any).lifeStory === "newer narrative",
   "a slow revision-5 save cannot overwrite revision-6 understanding", JSON.stringify(stored?.profile));
 
+// §6 ONE BUBBLE, TWO SPEECH ACTS — AND THE FACT THE CLIENT TAKES BACK (#128/1).
+//
+// Graded on the durable column and on the line the coach is actually given, through the real front
+// door, because that is where both defects lived: a constraint stated alongside a question never
+// reached the column at all, and a retraction reached it as a BAN. The stub cannot say either —
+// only a real row can be read back after the turn.
+REAL("\n=== A CONSTRAINT, A QUESTION, AND A RETRACTION ===");
+const { factsLine } = await import("../server/memory");
+
+const phone2 = `whatsapp:+2797${String(Math.floor(Math.random() * 900000) + 100000)}`;
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone2]);
+const [client2] = await db.insert(schema.users).values({
+  phoneNumber: phone2, name: "Constraint Client", onboardingState: "COMPLETE",
+  subscriptionStatus: "active", popiConsent: true, popiConsentAt: new Date(),
+  goalType: "fat_loss", calorieTarget: 2200, proteinTarget: 140, stepsTarget: 8000,
+  trainingMode: "gym", trainingDaysPerWeek: 3, createdAt: new Date(), lastActiveAt: new Date(),
+} as any).returning();
+const read2 = async () => (await db.select().from(schema.users).where(eq(schema.users.id, client2.id)).limit(1))[0];
+
+await handleMessage(phone2, "I'm vegan now, what should I eat?", undefined, undefined, undefined, "SM-VEG-1");
+let c2 = await read2();
+check(/vegan/i.test(String(c2.dietaryRestrictions || "")),
+  "a constraint stated in the same bubble as the question is committed", String(c2.dietaryRestrictions));
+const bannedLine = await factsLine(phone2);
+check(/Does not eat[^\n]*vegan/i.test(bannedLine),
+  "…and the coach is told about it on the very next read", bannedLine.replace(/\n/g, " | "));
+
+await handleMessage(phone2, "I'm not vegan anymore", undefined, undefined, undefined, "SM-VEG-2");
+c2 = await read2();
+check(c2.dietaryRestrictions == null,
+  "the retraction clears the column instead of appending to it", String(c2.dietaryRestrictions));
+const afterLine = await factsLine(phone2);
+check(!/Does not eat/i.test(afterLine),
+  "…and the coach stops being told this person cannot eat meat", afterLine.replace(/\n/g, " | "));
+check(Number(c2.truthRevision) === 2, "both turns are ordered evidence", String(c2.truthRevision));
+
+// NEGATIVE CONTROL, on the same door: describing a plate is not withdrawing an allergy.
+await pool.query(`UPDATE users SET dietary_restrictions = 'allergic to fish' WHERE id = $1`, [client2.id]);
+await handleMessage(phone2, "I had chicken, not fish", undefined, undefined, undefined, "SM-VEG-3");
+c2 = await read2();
+check(String(c2.dietaryRestrictions || "") === "allergic to fish",
+  "a bare 'not fish' in a food log leaves the real allergy standing", String(c2.dietaryRestrictions));
+
+await pool.query("DELETE FROM users WHERE id = $1", [client2.id]);
 await pool.query("DELETE FROM users WHERE id = $1", [user.id]);
 REAL(`\npg-client-truth-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
 await pool.end();

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -234,6 +234,9 @@ import { and, eq, sql } from "drizzle-orm";
 import { looksLikeQuestion, isFutureIntent } from "./utils";
 import { foodConstraints } from "./food-swaps";
 
+export type DurableFactField =
+  "injuries" | "medicalConditions" | "dietaryRestrictions" | "lifeContext" | "doNotMention" | "workSchedule";
+
 export interface DurableFacts {
   injuries?: string;
   medicalConditions?: string;
@@ -241,10 +244,70 @@ export interface DurableFacts {
   lifeContext?: string;
   doNotMention?: string;
   workSchedule?: string;
+  /**
+   * WHAT THE CLIENT JUST TOOK BACK — a value to REMOVE from the column, not one to store.
+   *
+   * Without this the detector only had one verb. "I'm not vegan anymore" was written into
+   * dietary_restrictions verbatim, and every food owner greps the column for the bare word:
+   * foodConstraints turned "not vegan anymore" into vegan + vegetarian + no dairy + no fish and
+   * said "Does not eat: vegan, vegan anymore" back to a client who had just told us the ban was
+   * over. Suppressing the assert is not enough either, because the column may already hold the
+   * fact from the day they adopted it — the sentence has to be able to undo it.
+   */
+  retract?: Partial<Record<DurableFactField, string>>;
 }
 
 /** Body parts we can actually train around — the vocabulary programme.ts already filters on. */
 const BODY_PART = /\b(knee|back|shoulder|hip|ankle|wrist|elbow|neck|groin|hamstring|calf|foot|heel)\b/i;
+
+/**
+ * THE RESTRICTION VOCABULARY, ONCE. The assert branch below already whitelists these words; the
+ * retraction has to speak the same language or it can only undo half of what it can create.
+ * Written as source strings rather than regex literals so the two readings stay one list.
+ */
+const RESTRICTION_WORD = String.raw`lactose intolerant|gluten.?free|dairy.?free|vegan|vegetarian`
+  + String.raw`|pescatarian|halaal|halal|kosher|lactose|gluten|dairy|peanuts?|nuts?|shellfish`
+  + String.raw`|seafood|eggs?|pork|beef|fish`;
+
+/**
+ * A RESTRICTION THE CLIENT IS TAKING BACK.
+ *
+ * Anchored on a first-person identity or an explicit undoing verb, never on a bare "not X" —
+ * "I had chicken, not fish" and "I'm having chicken not fish" must not wipe a real fish allergy,
+ * so the negation has to attach to the copula ("I'm not …"), to a past self ("I used to be …"),
+ * to a stopping verb, or carry "anymore" itself. "I'm not eating dairy" is deliberately NOT here:
+ * that is the restriction, stated in the negative, and belongs to the assert branch.
+ */
+const RESTRICTION_RETRACTED_RE = new RegExp(
+  String.raw`\b(?:i'?m|i\s+am|im)\s+(?:not|no\s+longer)\s+(?:really\s+|strictly\s+|a\s+)*`
+  + String.raw`(?:allergic\s+to\s+|intolerant\s+(?:to|of)\s+)?(${RESTRICTION_WORD})\b`
+  + String.raw`|\bi\s+(?:used\s+to\s+be|was)\s+(?:a\s+)?(${RESTRICTION_WORD})\b`
+  + String.raw`|\bi\s+(?:stopped|quit|gave\s+up)\s+(?:being\s+)?(?:a\s+)?(${RESTRICTION_WORD})\b`
+  + String.raw`|\bi\s+can\s+eat\s+(${RESTRICTION_WORD})\s+(?:again|now)\b`
+  + String.raw`|\b(?:not|no\s+longer)\s+(?:a\s+)?(${RESTRICTION_WORD})\s*(?:any\s?more)\b`,
+  "i");
+
+/**
+ * ONE BUBBLE IS NOT ONE SPEECH ACT.
+ *
+ * The guards below are right — a question or a plan must not rewrite a programme — but they were
+ * asked about the WHOLE message, and looksLikeQuestion is true if a "?" appears anywhere. So the
+ * most natural thing a client does on WhatsApp, state a constraint and ask the one useful question
+ * in the same breath, committed nothing at all:
+ *
+ *   "I'm vegan now, what should I eat?"        → {}
+ *   "I can't eat dairy, what can I eat?"       → {}
+ *   "my knee is killing me, what should I train?" → {}
+ *
+ * Drop the "?" and each one commits. The fix is not to weaken the guard, it is to ask it about the
+ * clause it belongs to: the question guard now judges the clause that is a question, and the
+ * report in front of it is still a report. Terminators are kept with their clause because the "?"
+ * IS the evidence.
+ */
+function clausesOf(raw: string): string[] {
+  const parts = (raw.match(/[^,.!?;\n]+[.!?;]?/g) || []).map(s => s.trim()).filter(Boolean);
+  return parts.length ? parts : [raw];
+}
 
 /**
  * WHAT THE CLIENT JUST TOLD US ABOUT THEMSELVES, AS FIELDS. Pure — no database, no model.
@@ -252,8 +315,32 @@ const BODY_PART = /\b(knee|back|shoulder|hip|ankle|wrist|elbow|neck|groin|hamstr
  * Deliberately narrow. Every one of these is written into a column the coach ACTS on, so a false
  * positive is not noise, it is a programme built around an injury the client does not have. The
  * old prose detectors could afford to be loose because nothing read them.
+ *
+ * Each clause is read on its own terms and the first clause to answer a field owns it; a
+ * retraction anywhere in the bubble wins over an assertion of the same field, because the client
+ * saying "not anymore" is the newer statement about themselves.
  */
 export function detectFacts(message: string): DurableFacts {
+  const whole = (message || "").trim();
+  if (!whole) return {};
+  const merged: DurableFacts = {};
+  const retract: Partial<Record<DurableFactField, string>> = {};
+  for (const clause of clausesOf(whole)) {
+    const found = detectInClause(clause);
+    for (const [k, v] of Object.entries(found)) {
+      if (k === "retract") continue;
+      if (v && merged[k as DurableFactField] === undefined) merged[k as DurableFactField] = v as string;
+    }
+    for (const [k, v] of Object.entries(found.retract || {})) {
+      if (v && retract[k as DurableFactField] === undefined) retract[k as DurableFactField] = v as string;
+    }
+  }
+  for (const field of Object.keys(retract) as DurableFactField[]) delete merged[field];
+  if (Object.keys(retract).length) merged.retract = retract;
+  return merged;
+}
+
+function detectInClause(message: string): DurableFacts {
   const raw = (message || "").trim();
   const m = raw.toLowerCase();
   const facts: DurableFacts = {};
@@ -284,6 +371,9 @@ export function detectFacts(message: string): DurableFacts {
   // OVER. Recording it here would train around a knee that is fine, permanently.
   const resolved = /\b(?:no longer|not\s+(?:really\s+)?(?:sore|hurting|painful)|doesn'?t\s+hurt|don'?t\s+hurt|healed|all\s+better|fine\s+now|better\s+now|sorted\s+now)\b|\banymore\b/i.test(m);
   const part = m.match(BODY_PART)?.[0]?.toLowerCase();
+  // AND SAY SO TO THE COLUMN. Suppressing the write left a knee that healed in March still
+  // steering every leg day, because nothing else ever removes it.
+  if (part && resolved) facts.retract = { ...facts.retract, injuries: part };
   if (part && reporting && !resolved) {
     // An INJURY VERB naming a body part is enough on its own — "I hurt my lower back at work" is
     // a report, not a complaint about a hard session.
@@ -304,11 +394,22 @@ export function detectFacts(message: string): DurableFacts {
   // DIETARY RESTRICTION — what they cannot or will not eat. Separate from a preference: this one
   // constrains every meal suggestion we make from now on.
   // Question and future only — see the note above on why mentionsNotDone must not run here.
-  const allergy = !reporting ? undefined : m.match(/\b(?:allergic to|intolerant to|can'?t eat|cannot eat|don'?t eat|i'?m|i am)\s+([a-z ]{3,20}?)\b(?:\.|,|$| and | but )/)?.[1]?.trim();
-  if (allergy && /\b(lactose|gluten|dairy|nuts?|peanuts?|shellfish|eggs?|pork|beef|halaal|halal|vegan|vegetarian|seafood|fish)\b/i.test(allergy)) {
-    facts.dietaryRestrictions = allergy;
-  } else if (reporting && /\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i.test(m) && /\bi'?m|i am\b/i.test(m)) {
-    facts.dietaryRestrictions = m.match(/\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i)![0];
+  //
+  // THE RETRACTION IS CHECKED FIRST, and it is not gated on `reporting`: "am I still vegan?" is a
+  // question, but "I'm not vegan anymore, what should I eat?" is a client correcting their own
+  // record. The asymmetry that justifies the loose guard here is the mirror of the one above —
+  // wrongly REMOVING a restriction costs one suggestion the client can decline, wrongly KEEPING
+  // one starves them of every food we would otherwise offer.
+  const retracted = RESTRICTION_RETRACTED_RE.exec(m);
+  if (retracted) {
+    facts.retract = { ...facts.retract, dietaryRestrictions: (retracted.slice(1).find(Boolean) || "").toLowerCase() };
+  } else {
+    const allergy = !reporting ? undefined : m.match(/\b(?:allergic to|intolerant to|can'?t eat|cannot eat|don'?t eat|i'?m|i am)\s+([a-z ]{3,20}?)\b(?:\.|,|$| and | but )/)?.[1]?.trim();
+    if (allergy && /\b(lactose|gluten|dairy|nuts?|peanuts?|shellfish|eggs?|pork|beef|halaal|halal|vegan|vegetarian|seafood|fish)\b/i.test(allergy)) {
+      facts.dietaryRestrictions = allergy;
+    } else if (reporting && /\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i.test(m) && /\bi'?m|i am\b/i.test(m)) {
+      facts.dietaryRestrictions = m.match(/\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i)![0];
+    }
   }
 
   // LIFE CONTEXT — the thing that makes a month-gone "just say hi" land as a coach. This is the
@@ -344,11 +445,28 @@ export function addFact(existing: string | null | undefined, item: string): stri
   return `${cur}, ${clean}`;
 }
 
+/**
+ * Take one item back out of a comma-separated column.
+ *
+ * MATCHES ON CONTAINMENT, because the column holds what the client said and not a normalised
+ * token — a "vegan" retraction has to clear an entry stored as "vegan now" or "i'm vegan", which
+ * is exactly how the assert branch writes them. Emptying the column returns null, not "", so the
+ * readers' `usable()` and foodConstraints see an absent fact rather than a blank one.
+ */
+export function removeFact(existing: string | null | undefined, item: string): string | null {
+  const clean = (item || "").trim().toLowerCase();
+  const cur = (existing || "").trim();
+  if (!clean || !cur) return existing ?? null;
+  const kept = cur.split(",").map(s => s.trim()).filter(Boolean)
+    .filter(part => !part.toLowerCase().includes(clean));
+  return kept.length ? kept.join(", ") : null;
+}
+
 export interface ClientFactOperation {
-  fact: keyof DurableFacts;
-  operation: "assert";
+  fact: DurableFactField;
+  operation: "assert" | "retract";
   previousValue: string | null;
-  value: string;
+  value: string | null;
   provenance: "client_explicit";
 }
 
@@ -361,12 +479,23 @@ export interface ClientFactOperation {
 export function projectClientFacts(
   current: any,
   facts: DurableFacts,
-): { patch: Record<string, string>; operations: ClientFactOperation[] } {
-  const patch: Record<string, string> = {};
+): { patch: Record<string, string | null>; operations: ClientFactOperation[] } {
+  const patch: Record<string, string | null> = {};
   const operations: ClientFactOperation[] = [];
-  const appendFacts: Array<keyof Pick<DurableFacts,
-    "injuries" | "medicalConditions" | "dietaryRestrictions" | "lifeContext" | "doNotMention"
-  >> = ["injuries", "medicalConditions", "dietaryRestrictions", "lifeContext", "doNotMention"];
+  const appendFacts: DurableFactField[] =
+    ["injuries", "medicalConditions", "dietaryRestrictions", "lifeContext", "doNotMention"];
+
+  // RETRACTIONS FIRST, and they are the only writer that may lower a column. A retraction in the
+  // same message as an assertion of the same fact already won inside detectFacts, so these cannot
+  // race each other here.
+  for (const [field, item] of Object.entries(facts.retract || {}) as Array<[DurableFactField, string]>) {
+    const previous = current?.[field] == null ? null : String(current[field]);
+    if (!previous) continue;
+    const next = removeFact(previous, item);
+    if (next === previous) continue;
+    patch[field] = next;
+    operations.push({ fact: field, operation: "retract", previousValue: previous, value: next, provenance: "client_explicit" });
+  }
 
   for (const fact of appendFacts) {
     const asserted = facts[fact];


### PR DESCRIPTION
Closes #128 item 1 (`detectFacts` per-clause plus retract). Base `main@18d08f3`.

## The two defects, reproduced on main before the change

```
"I'm vegan now, what should I eat?"            → {}
"I can't eat dairy, what can I eat?"           → {}
"my knee is killing me, what should I train?"  → {}
"I'm vegan now"                                → {dietaryRestrictions: "vegan now"}
"I'm not vegan anymore"                        → {dietaryRestrictions: "not vegan anymore"}
"I'm no longer vegetarian"                     → {dietaryRestrictions: "no longer vegetarian"}
"I'm not allergic to nuts anymore"             → {dietaryRestrictions: "nuts anymore"}

foodConstraints({dietaryRestrictions: "not vegan anymore"})
  → vegan:true vegetarian:true noDairy:true noFish:true
  → "Does not eat: vegan, vegan anymore — never suggest these, and never ask them to."
```

**1 — the guard was asked about the wrong span.** `looksLikeQuestion` is true if a `?` appears
anywhere, and the dietary/injury/medical/life facts are gated on it. So the most ordinary thing a
client does on WhatsApp — state a constraint and ask the one useful question in the same breath —
committed nothing at all. Same-turn coaching never saw the fact, and neither did the next turn.

**2 — the detector had only one verb.** A retraction was written into the column verbatim, and
every food owner greps that column for the bare word. The retraction therefore banned *more* than
the assertion ever had.

## What changed (`server/memory.ts`)

- The guards now judge the **clause** they belong to, not the whole bubble. Terminators stay with
  their clause because the `?` is the evidence. The guard is not weakened: a one-clause
  hypothetical, a plan, and a question still record nothing.
- A **retraction** channel (`DurableFacts.retract`) and `removeFact` — a retraction removes the
  fact from the column instead of appending to it. The injury resolution that was already
  detected and merely *suppressed* now removes the joint as well, so a knee that healed in March
  stops steering every leg day.
- Retraction is anchored on a first-person identity or an explicit undoing verb, never a bare
  `not X`: `"I had chicken, not fish"` must not wipe a fish allergy, and `"I'm not eating dairy"`
  is the restriction stated in the negative, not its withdrawal.
- `projectClientFacts` applies retractions first and records `operation: "retract"` in the
  append-only evidence, so the correction has lineage like every other fact change.

No new handler, no new owner, no new store — the existing detector, the existing projection, the
existing `foodConstraints` mouth.

## Proof — behaviour and state, not source strings

**`script/gap-tests.ts`** drives the real sentence through the projection into `foodConstraints`,
the owner every plate/grocery/swap mouth consults:
- the constraint is committed from the mixed bubble and `allows("chicken breast")` is false on the
  same turn;
- `"I'm not vegan anymore"` clears the column and `allows("chicken breast")` is true again;
- an unrelated peanut allergy and an unrelated shoulder injury survive the retraction.

**`script/pg-client-truth-acceptance.ts` §6** (real PostgreSQL, real front door) reads the durable
column *and* `factsLine` — the line the coach is actually handed — back after each turn.

**Negative controls (all in-suite):** hypotheticals/plans/questions still record nothing; a
family member's diabetes is still not this client's chart; `"I had chicken, not fish"`,
`"I'm having chicken not fish"` and `"chicken, no fish"` leave a real fish allergy standing.

## Red on revert (asserted, both mechanisms independently)

Clause split reverted to `return [raw]`:
```
gap-tests: 371/372   ✗ #128/1: a constraint stated in the same bubble as the question still reaches the coach
pg-client-truth-acceptance: RED — 2 check(s) failed
  FAIL  a constraint stated in the same bubble as the question is committed   (null)
```

Retraction detection reverted:
```
gap-tests: 371/372   ✗ #128/1: a client can take a restriction back
pg-client-truth-acceptance: RED — 2 check(s) failed
  FAIL  the retraction clears the column   (vegan now, not vegan anymore)
  FAIL  …and the coach stops being told this person cannot eat meat
        WHAT YOU KNOW ABOUT THIS PERSON: | Does not eat: vegan, vegan now, vegan anymore —
        never suggest these, and never ask them to.
```

## Local verification (remote CI is the gate)

- `npm run check` — clean.
- `npm test` — 36/37 green, `normalizer-replay-tests` still correctly `⊘ COVERED NOTHING` (#163).
- `check-architecture`, `check-file-sizes`, `check-sast`, `check-names`, `check-reach`,
  `check-schema-safety`, `check-prompt-integrity` — all green at their existing budgets.
  **No budget raised.** The new patterns are built with `new RegExp` over shared source strings so
  the restriction vocabulary is one list, read the same way by the assert and the retract branch.
- `pg-client-truth-acceptance` — GREEN, 20 checks.
- Journey Lab — GREEN, 266 checks across 8 sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_