### PR TITLE
Three checks were green on the clock rather than on the code

### DIFF
--- a/script/journey-lab.ts
+++ b/script/journey-lab.ts
@@ -30,7 +30,7 @@ console.log = console.warn = console.error = (...a: any[]) => { LOG.push(a.map(S
 
 const { pool } = await import("../server/db");
 const { handleMessage } = await import("../server/routes");
-const { sastDayKey } = await import("../server/sast");
+const { sastDayKey, effectiveMealLoggedAt } = await import("../server/sast");
 // The instrument's own definition of "no door claimed this", not a copy of it. See admin-turns.ts.
 const { FALLBACK_REPLY, buildCoachHealthBrief } = await import("../server/routes/admin-turns");
 
@@ -362,10 +362,24 @@ await journey("3 · COMEBACK — genuine absence vs present-but-sparse, on ident
 
   // ABSENCE MUST NOT BREAK THE ORDINARY WORK. The next three turns are the reason someone comes
   // back at all — if the return path swallows a food log, the comeback cost them their day.
-  const a2 = await say(absent.id, absent.phone, "I had chicken and rice for lunch");
+  const FOOD = "I had chicken and rice for lunch";
+  const a2 = await say(absent.id, absent.phone, FOOD);
   const am = await meals(absent.id);
   ok(am.length === 1, `the returning client's food log landed (${am.length} rows)`);
-  ok(!!am[0] && dayOf(am[0]) === sastDayKey(new Date()), `it landed on today`);
+  // THE DAY THE PRODUCT RESOLVES, NOT THE DAY THE WALL CLOCK SHOWS.
+  //
+  // This asserted `today` outright and was red every night between 00:00 and 04:59 SAST —
+  // including 04:00, which is when the nightly CI cron runs. Nothing was broken: sast.ts says in
+  // as many words that "only 00:00–04:59 is ambiguous", and at 03:17 a client saying they had
+  // LUNCH is telling us about the day that just ended. The product was right and the check was
+  // asserting the wrong thing four hours out of every twenty-four.
+  //
+  // Asked through effectiveMealLoggedAt, the same owner the write door uses, so the harness cannot
+  // hold a second opinion about which day a meal belongs to. It still fails if the comeback path
+  // files this log on any other day, on no day, or not at all.
+  const expectedDay = sastDayKey(effectiveMealLoggedAt(new Date(), FOOD, "lunch"));
+  ok(!!am[0] && dayOf(am[0]) === expectedDay, `it landed on the day the words resolve to`,
+     `row ${am[0] && dayOf(am[0])} vs ${expectedDay}`);
   ok(!!am[0] && String(am[0].meal_label || "").toLowerCase() === "lunch",
      `the stated slot was honoured`, `label=${am[0]?.meal_label}`);
   ok(mutated(a2, /INSERT meal/i), `the turn ledger carries the returning client's write`, mutationsOf(a2));

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -82,13 +82,24 @@ function serialise<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 const sastDayKeyOf = (d: Date) => new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg", year: "numeric", month: "2-digit", day: "2-digit" }).format(d);
-/** Midday on the most recent past Saturday — for fixtures that correct a named weekday. */
-function lastSaturday(): Date {
+/**
+ * Midday on a past weekday the client can NAME — for fixtures that correct a named day.
+ *
+ * WHY NOT "LAST SATURDAY". The Saturday version was already computed rather than hard-coded, so
+ * that the fixture would not depend on which weekday the suite runs. It still did: on a SUNDAY the
+ * most recent past Saturday IS yesterday, the coach correctly answers "yesterday's breakfast"
+ * because that is the truer thing to call it, and the check demanding the word "Saturday" went red
+ * once a week on the calendar rather than on the code.
+ *
+ * Three days back is never today and never yesterday, on any day of the week, so the day has a
+ * name the coach must use. The name is returned with the date so the assertion asks for the day
+ * this fixture actually seeded.
+ */
+function namedPastDay(): { at: Date; name: string } {
   const d = new Date();
   d.setHours(12, 0, 0, 0);
-  const back = (d.getDay() - 6 + 7) % 7 || 7;   // never today: "from Saturday" means a past one
-  d.setDate(d.getDate() - back);
-  return d;
+  d.setDate(d.getDate() - 3);
+  return { at: d, name: new Intl.DateTimeFormat("en-ZA", { weekday: "long", timeZone: "Africa/Johannesburg" }).format(d) };
 }
 const NOW = Date.now();
 const USER = {
@@ -2037,6 +2048,7 @@ async function main() {
     const { mealLogs } = await import("../shared/schema");
     const { sastDayStart } = await import("../server/utils");
     const g = globalThis as any;
+    const named = namedPastDay();
     const replies = await serialise(async () => {
       // One row per day the check corrects — see 2b. A single yesterday row made the today case
       // vacuous under a stub that could not filter.
@@ -2047,15 +2059,15 @@ async function main() {
         id: "parity-day-row-2-today", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
         carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: new Date(NOW - 3600_000),
       }, {
-        // …and the named day the check corrects. Computed, not hard-coded, so the fixture does not
-        // depend on which weekday the suite happens to run.
-        id: "parity-day-row-2-sat", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
-        carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: lastSaturday(),
+        // …and the named day the check corrects — three days back, so it is never today and never
+        // yesterday, whichever day of the week the suite runs on. See namedPastDay.
+        id: "parity-day-row-2-named", mealLabel: "breakfast", kcalInt: 500, proteinInt: 40,
+        carbsInt: 50, fatInt: 20, items: [{ name: "Oats" }], loggedAt: named.at,
       }]]]);
       const out = {
         today: await say("You missed the black coffee"),
         yesterday: await say("You missed the black coffee yesterday"),
-        saturday: await say("You missed the black coffee from Saturday"),
+        named: await say(`You missed the black coffee from ${named.name}`),
         span: await say("you missed the black coffee last week"),
       };
       delete g.__KAMLIFE_STUB_ROWS;
@@ -2065,8 +2077,8 @@ async function main() {
     assert.match(replies.yesterday, /yesterday'?s breakfast/i,
       `a past-day correction did not name the day: ${replies.yesterday}`);
     assert.ok(!/_Today:/.test(replies.yesterday), "a past-day correction quoted today's total");
-    assert.match(replies.saturday, /saturday'?s breakfast/i,
-      `a named-day correction did not name the day: ${replies.saturday}`);
+    assert.match(replies.named, new RegExp(`${named.name}'?s breakfast`, "i"),
+      `a named-day correction did not name the day: ${replies.named}`);
     // …AND THE MEAL THEY NAMED. With dinner logged after breakfast, "at breakfast" must not
     // attach to dinner — the date defect one axis over, found reviewing this cut.
     const slotted = await serialise(async () => {
@@ -3447,21 +3459,41 @@ async function main() {
   // alone would pass even if no caller used it. This is the string on the handset.
   check("header outcome . the workout the client is sent does not contradict itself", async () => {
     const g = globalThis as any;
-    // The parity user trains 3x/week, so "today" is a rest day on most calendar days and the
-    // session is never composed. Six days puts today inside the programme whenever this runs.
-    const reply = await serialise(async () => {
+    // TWO CALLERS, AND NEITHER OF THEM IS THE CALENDAR.
+    //
+    // This asked for "workout" with trainingDaysPerWeek raised to 6, on the reasoning that six
+    // days puts today inside the programme whenever the suite runs. It does not: SCHEDULE_MAP
+    // tops out at Mon–Sat, so NOBODY trains on a Sunday, and every Sunday this check received
+    // "*Sunday — Rest Day.*", found no header, and went red on the day of the week rather than on
+    // the code. A suite that is green six days in seven is not a gate, and its redness on the
+    // seventh teaches everyone to ignore it.
+    //
+    // renderSession has exactly two callers — the `workout` command and the moved-into-today
+    // path — and programme.ts says in as many words that having both end at one function is the
+    // property worth having. The moved path composes on a rest day BY DESIGN ("a client saying
+    // they moved a session into today has already decided they are training"), so asking both
+    // reaches a composed session on any day of the week, and grades both mouths instead of one.
+    const replies = await serialise(async () => {
       g.__KAMLIFE_STUB_USER = { ...USER, trainingDaysPerWeek: 6 };
-      try { return String(await handleMessage(USER.phoneNumber, "workout") ?? ""); }
-      catch (e: any) { return `__THREW__ ${e?.message || e}`; }
+      const ask = async (text: string) => {
+        try { return String(await handleMessage(USER.phoneNumber, text) ?? ""); }
+        catch (e: any) { return `__THREW__ ${e?.message || e}`; }
+      };
+      try { return [await ask("workout"), await ask("no I moved yesterdays workout to today")]; }
       finally { g.__KAMLIFE_STUB_USER = { ...USER }; }
     });
-    const header = reply.split("\n").find(l => /\*Week \d/.test(l)) || "";
-    assert.ok(header, `no week header in the workout reply: ${reply.slice(0, 200)}`);
-    assert.ok(!/— Session \d+\*\s*$/.test(header.trim()),
-      `Week and Session are still printed as one clock: ${header}`);
-    if (/Session/.test(header)) {
-      assert.match(header, /Session \d+ overall/,
-        `a session number without its clock named: ${header}`);
+    const headers = replies.flatMap(r => r.split("\n").filter(l => /\*Week \d/.test(l)));
+    // NOT VACUOUS: at least one of the two must have actually composed a session, so a build that
+    // stops delivering sessions altogether fails here rather than passing with an empty list.
+    assert.ok(headers.length, `neither the workout command nor a moved session composed a week `
+      + `header: ${replies.map(r => r.slice(0, 120)).join(" || ")}`);
+    for (const header of headers) {
+      assert.ok(!/— Session \d+\*\s*$/.test(header.trim()),
+        `Week and Session are still printed as one clock: ${header}`);
+      if (/Session \d/.test(header)) {
+        assert.match(header, /Session \d+ overall/,
+          `a session number without its clock named: ${header}`);
+      }
     }
   });
 


### PR DESCRIPTION
Base `main@add2d6a`. **Blocks every other merge right now** — all three are red on `main`, with no code change. Two moved with the day of the week; one moves with the hour, and its window contains the nightly CI cron.

```
✗ header outcome . the workout the client is sent does not contradict itself
  no week header in the workout reply: *Sunday — Rest Day.*

✗ 2c . the client is told which day was changed
  a named-day correction did not name the day:
  You're right — added Coffee (black) to yesterday's breakfast.

✗ 3 · COMEBACK · it landed on today
```

Reproduced on `origin/main` with a clean tree before touching anything. **None of the three is a product defect.**

## Why this is worth a PR rather than a re-run

A check that passes because of *when* it ran is not a gate. Some days it blocks every unrelated merge; the rest of the time it teaches everyone that its redness means "try again later". That is #128 section D — verification that can be green while the thing it names is untested, and red while the thing it names is fine.

## header outcome — red every Sunday

The check raised `trainingDaysPerWeek` to 6 on the stated reasoning that *"six days puts today inside the programme whenever this runs"*. It does not: `SCHEDULE_MAP` tops out at Mon–Sat, so **nobody** trains on a Sunday. The client correctly receives a rest-day reply and no session header is composed to grade.

`renderSession` has exactly two callers, and `programme.ts` says in as many words that both ending at one function is the property worth having. The moved-into-today path composes on a rest day **by design** — *"a client saying they moved a session into today has already decided they are training"*. The check now asks for both and grades every week header either one returns: calendar-independent, two mouths instead of one, and **not vacuous** — at least one of the two must actually compose a session.

## 2c — red every Sunday

`lastSaturday()` was already computed rather than hard-coded, precisely so the fixture would not depend on the weekday. It still did: on a Sunday the most recent past Saturday **is** yesterday, so the coach says "yesterday's breakfast" — the truer thing to call it — and the assertion demanding "Saturday" fails on the calendar.

The named day is now three days back: never today, never yesterday, on any day of the week. The assertion asks for the day the fixture actually seeded.

## COMEBACK — red four hours out of every twenty-four

00:00–04:59 SAST, which contains the 02:00 UTC nightly run (04:00 SAST). Nothing was broken: `sast.ts` says in as many words that *"only 00:00–04:59 is ambiguous"*, and at 03:17 a client reporting **lunch** is telling us about the day that just ended. The product was right; the check was asserting the wrong thing.

It now asks `effectiveMealLoggedAt` — the same owner the write door uses — so the harness cannot hold a second opinion about which day a meal belongs to.

## Nothing weakened — each repaired check still fails for the reason it exists

`sessionHeaderLine` reverted to the string that shipped:
```
✗ header outcome . Week and Session are still printed as one clock: *Week 1 — Session 25*
✗ header . Week and Session still read as one clock: *Week 1 — Session 25*
```

The day naming removed entirely:
```
✗ 2c . a past-day correction did not name the day: ... to your breakfast.
```

Every past day collapsed to "yesterday" — the regression the Sunday collision was masking:
```
✗ 2c . a named-day correction did not name the day: ... to yesterday's breakfast.
```

Meals filed three days back:
```
RED in journeys 1, 2, 3 and 6
```

The write door stops consulting the ambiguous-hours owner — the control that matters, because it shows the repaired check reads the *resolved* day and is not tautological:
```
✗ 3 · COMEBACK · it landed on the day the words resolve to
  row 2026-09-06 vs 2026-09-05
```

## Verification

- `npm run check` — clean.
- `production-parity` — **142/142**, and `journey-lab` — **266/266**, at 03:00 SAST on a Sunday.
- `npm test` — 36/37 green, `normalizer-replay-tests` still correctly `⊘ COVERED NOTHING` (#163).
- No product file changed. No budget raised, no assertion deleted, no `continue-on-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa