### PR TITLE
The constraint reaches every mouth that names a food (#128 item 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,12 @@ jobs:
       # a fixture that returns the same rows to every query cannot demonstrate a window.
       - name: Daily constraint lifecycle on real PostgreSQL
         run: npx tsx script/pg-daily-constraint-acceptance.ts
+      # THE CONSTRAINT REACHES EVERY MOUTH THAT NAMES A FOOD (#128). Which branch of the Next Meal
+      # menu a client reaches is composed from the day ledger — what is logged, what is left — so
+      # a fixture that answers every query the same way puts every client on one branch. That is
+      # how a menu with zero calls to the constraint owner looked fine.
+      - name: Food constraints reach the plate and grocery mouths on real PostgreSQL
+        run: npx tsx script/pg-food-constraint-mouths-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/pg-food-constraint-mouths-acceptance.ts
+++ b/script/pg-food-constraint-mouths-acceptance.ts
@@ -1,0 +1,168 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the constraint reaches every mouth that names a food (#128).
+ *
+ * THE DEFECT, REPRODUCED ON THIS BRANCH'S PARENT. One client, dietary_restrictions = 'vegan',
+ * asking the plainest question this product answers:
+ *
+ *   "what should I eat"
+ *   → *🍽️ Next Meal Suggestion*
+ *     1. 2 chicken thighs + rice + mixed veg
+ *     2. Beef mince + pap + spinach
+ *     3. Chicken breast + rice + spinach
+ *     4. Tin of pilchards + sweet potato
+ *     5. 3 eggs + brown bread + tomato
+ *
+ * Five plates, five of them impossible. The grocery list, the meal plan and the permission-ask all
+ * consult foodConstraints; this door had ZERO calls to it, and the grocery personalization block
+ * could print "grab eggs" three lines above "🚫 Left off — you told me: eggs".
+ *
+ * WHY POSTGRESQL. The reply is composed from the day ledger — what is logged, what is left — so
+ * which branch of the menu a client reaches depends on real rows. A fixture that answers every
+ * query the same way puts every client on one branch, which is how a menu that never asked about
+ * constraints looked fine.
+ *
+ * EVERY PROHIBITION IS PAIRED WITH ITS CONTROL. "The coach offered no chicken" is trivially
+ * satisfied by a coach that offers nothing at all, so each section has an unconstrained twin that
+ * must still be offered the thing the constrained client is not.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-food-constraint-mouths-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { buildGroceryPersonalization } = await import("../server/grocery-personalize");
+const { foodConstraints } = await import("../server/food-swaps");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+// THE TEST'S OWN VOCABULARY, not the product's. Asserting with `constraints.allows` would grade
+// the filter against itself and pass for any client on any reply.
+const ANIMAL = /\b(chicken|beef|mince|steak|lamb|mutton|biltong|pilchards?|tuna|fish|hake|eggs?|yoghurt|amasi|milk|cheese)\b/i;
+const PORK = /\b(pork|bacon|ham|gammon)\b/i;
+
+async function seed(over: Record<string, any>): Promise<{ id: string; phone: string }> {
+  const phone = `whatsapp:+2795${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, weeklyFoodBudget: "100_300",
+    createdAt: new Date(), lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  // ONE LOGGED MEAL, so the client is on the branch that has calories AND a protein gap left —
+  // the branch that prints the menu. Without it every client lands on the cold-start line.
+  await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     VALUES ($1, now(), 'lunch', 500, 20, $2, 'seed', 'sa_scanner')`,
+    [u.id, JSON.stringify([{ name: "pap", grams: 200 }])]);
+  return { id: u.id, phone };
+}
+
+const ask = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
+    .then(r => String(r || ""));
+
+REAL("\n=== THE PLATE THE COACH NAMES ===");
+
+// ── §1 THE ASK THIS DOOR EXISTS FOR ─────────────────────────────────────────────────────────
+const vegan = await seed({ dietaryRestrictions: "vegan" });
+for (const question of ["what should I eat", "what can I eat", "I'm hungry"]) {
+  const reply = await ask(vegan.phone, question);
+  chk(!ANIMAL.test(reply), `"${question}" offers a vegan client no animal protein`,
+    (reply.match(ANIMAL) || []).join(",") + " | " + reply.slice(0, 200));
+  chk(/\n/.test(reply.trim()) && reply.trim().length > 60,
+    `…and still answers with something — silence is not honouring a constraint`, reply.slice(0, 120));
+}
+
+// ── §2 THE CONTROL: THE SAME DOOR STILL NAMES MEAT WHEN NOTHING IS DECLARED ─────────────────
+//
+// §1 is satisfied by a coach that never names a food again. This is what stops that reading.
+const open = await seed({ dietaryRestrictions: null });
+const openReply = await ask(open.phone, "what should I eat");
+chk(ANIMAL.test(openReply), "an unconstrained client is still offered real protein by name",
+  openReply.slice(0, 200));
+chk(openReply !== await ask(vegan.phone, "what should I eat"),
+  "the two clients genuinely receive different menus");
+
+// ── §3 THE OTHER CONSTRAINTS, ON THE SAME DOOR ──────────────────────────────────────────────
+const halaal = await seed({ dietaryRestrictions: "halaal" });
+const halaalReply = await ask(halaal.phone, "what should I eat");
+chk(!PORK.test(halaalReply), "a halaal client is offered no pork", halaalReply.slice(0, 200));
+chk(/chicken|beef|mince|fish|eggs?/i.test(halaalReply),
+  "…and is still offered the animal protein they DO eat — halaal is not vegan",
+  halaalReply.slice(0, 200));
+
+const noEggs = await seed({ foodDislikes: "eggs" });
+const noEggsReply = await ask(noEggs.phone, "what should I eat");
+chk(!/\beggs?\b/i.test(noEggsReply), "a literal named food from signup is honoured too",
+  noEggsReply.slice(0, 200));
+chk(/chicken|beef|mince|pilchards?/i.test(noEggsReply),
+  "…and nothing else was taken away with it", noEggsReply.slice(0, 200));
+
+// ── §4 THE CALORIE-CEILING BRANCH, WHICH NAMES A SNACK ──────────────────────────────────────
+//
+// A second branch of the same door, reached by a different day. It printed "(eggs, yoghurt,
+// biltong)" unconditionally.
+const full = await seed({ dietaryRestrictions: "vegan", calorieTarget: 600, proteinTarget: 150 });
+const fullReply = await ask(full.phone, "what should I eat");
+chk(!ANIMAL.test(fullReply), "the day-is-done branch names no animal snack either",
+  fullReply.slice(0, 220));
+
+REAL("\n=== THE GROCERY BLOCK ===");
+
+// ── §5 THE HEADER MUST NOT CONTRADICT THE FOOTER ────────────────────────────────────────────
+//
+// buildGroceryPersonalization is pure, so it is graded directly with the profile a real client's
+// meal logs produce: someone who logged chicken for months and has since told us they are vegan.
+const profile = {
+  topFoods: [
+    { name: "chicken", count: 9 }, { name: "pap", count: 8 }, { name: "white bread", count: 6 },
+    { name: "cabbage", count: 4 }, { name: "rice", count: 3 }, { name: "spinach", count: 2 },
+  ],
+  distinctCount: 6,
+};
+const veganBlock = buildGroceryPersonalization(profile, "fat_loss", foodConstraints({ dietaryRestrictions: "vegan" }));
+chk(!ANIMAL.test(veganBlock), "the personalization block names no food this client refuses",
+  veganBlock.replace(/\n/g, " | "));
+chk(/Kept in/.test(veganBlock) && /pap|cabbage|spinach/i.test(veganBlock),
+  "…and still tells them what it kept from their own logs", veganBlock.replace(/\n/g, " | "));
+
+const openBlock = buildGroceryPersonalization(profile, "fat_loss");
+chk(/chicken/i.test(openBlock), "the control block still builds around the chicken they log",
+  openBlock.replace(/\n/g, " | "));
+
+// The protein-gap line was the hardcoded "Eggs and a tin of pilchards".
+const noProtein = { topFoods: [{ name: "pap", count: 9 }, { name: "cabbage", count: 5 },
+  { name: "rice", count: 4 }, { name: "spinach", count: 3 }, { name: "butternut", count: 2 },
+  { name: "tomato", count: 2 }], distinctCount: 6 };
+const veganGap = buildGroceryPersonalization(noProtein, "fat_loss", foodConstraints({ dietaryRestrictions: "vegan" }));
+chk(/Add protein/.test(veganGap) && !ANIMAL.test(veganGap),
+  "the protein-gap line still fires, and names something they can buy",
+  veganGap.replace(/\n/g, " | "));
+chk(/Add protein/.test(buildGroceryPersonalization(noProtein, "fat_loss")),
+  "…and the unconstrained client still gets the same nudge");
+
+await pool.query("DELETE FROM users WHERE id = ANY($1)",
+  [[vegan.id, open.id, halaal.id, noEggs.id, full.id]]);
+REAL(`\npg-food-constraint-mouths-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/server/food-swaps.ts
+++ b/server/food-swaps.ts
@@ -452,7 +452,7 @@ export function answerUnavailable(message: string, c: FoodConstraints = NO_CONST
  *
  * Returns null when nothing survives — an empty suggestion is worse than no suggestion.
  */
-function allowedAlternatives(alt: string, c: FoodConstraints): string | null {
+export function allowedAlternatives(alt: string, c: FoodConstraints): string | null {
   const parts = String(alt || "").split(/\s*,\s*(?:or\s+)?|\s+or\s+/).map(s => s.trim()).filter(Boolean);
   const kept = parts.filter(p => c.allows(p));
   if (kept.length === 0) return null;

--- a/server/grocery-personalize.ts
+++ b/server/grocery-personalize.ts
@@ -20,7 +20,7 @@
  */
 
 import { suggestSwap } from "./food-swaps";
-import { foodConstraints } from "./food-swaps";
+import { foodConstraints, NO_CONSTRAINTS, type FoodConstraints } from "./food-swaps";
 
 export type FoodProfileItem = { name: string; count: number };
 export type FoodProfile = { topFoods: FoodProfileItem[]; distinctCount: number };
@@ -87,7 +87,11 @@ const OWN_LIST_AWARENESS = `📸 _Already have a list, or food in the fridge? Se
  *   • established  → confident "I know your kitchen now" + full adaptation
  * Pure and unit-tested. Kept short on purpose — calm, not a wall of text.
  */
-export function buildGroceryPersonalization(profile: FoodProfile, goalType?: string | null): string {
+export function buildGroceryPersonalization(
+  profile: FoodProfile,
+  goalType?: string | null,
+  c: FoodConstraints = NO_CONSTRAINTS,
+): string {
   const type = loggerType(profile?.distinctCount ?? 0);
 
   // NEW / cold start — no real data yet. Reassure, don't fake knowing them.
@@ -102,8 +106,12 @@ export function buildGroceryPersonalization(profile: FoodProfile, goalType?: str
 
   // 1. Name the GOOD foods they actually eat — proof we watched, and it keeps their
   //    real diet in the plan instead of overriding it with a generic template.
+  // WHAT THEY EAT, MINUS WHAT THEY TOLD US THEY DO NOT (#128). A client's own log is history, not
+  // a standing preference: someone who ate chicken for a year and then told us they are vegan must
+  // not be shown "you already eat chicken, so I built the list around it" above "Left off — vegan".
   const goodFaves = foods
     .filter(f => (["protein", "veg", "wholecarb"] as LoggedFoodClass[]).includes(classOf(f)))
+    .filter(f => c.allows(f.name))
     .slice(0, 3)
     .map(f => f.name);
   if (goodFaves.length) {
@@ -112,7 +120,9 @@ export function buildGroceryPersonalization(profile: FoodProfile, goalType?: str
 
   // 2. First junk we can genuinely swap (reuses the deterministic SA shelf-swap engine).
   for (const f of foods) {
-    const s = suggestSwap(f.name, goalType);
+    // suggestSwap has taken constraints since Cut 9 — "telling a vegan to swap their mayo for
+    // eggs is worse than saying nothing". This caller was simply never passing them.
+    const s = suggestSwap(f.name, goalType, c);
     if (s) {
       lines.push(`🔁 *One swap* — you keep logging ${pretty(f.name)}; grab ${s.swap} instead (${s.reason}).`);
       break;
@@ -124,7 +134,16 @@ export function buildGroceryPersonalization(profile: FoodProfile, goalType?: str
   if (!classesSeen.has("veg")) {
     lines.push(`🥦 *Add veg* — I don't see it in your meals. Spinach, morogo or cabbage: cheap, filling, and it's what's missing.`);
   } else if (!classesSeen.has("protein")) {
-    lines.push(`🥩 *Add protein* — your meals are light on it. Eggs and a tin of pilchards are the cheapest fix in SA.`);
+    // THE HEADER USED TO CONTRADICT THE FOOTER. "Eggs and a tin of pilchards" was hardcoded, so a
+    // client could be told to grab eggs three lines above "🚫 Left off — you told me: eggs".
+    const cheapest = [
+      { text: "Eggs and a tin of pilchards", match: "eggs and pilchards" },
+      { text: "Eggs and sugar beans", match: "eggs and sugar beans" },
+      { text: "Sugar beans and lentils", match: "sugar beans and lentils" },
+    ].find(o => c.allows(o.match));
+    lines.push(cheapest
+      ? `🥩 *Add protein* — your meals are light on it. ${cheapest.text} are the cheapest fix in SA.`
+      : `🥩 *Add protein* — your meals are light on it. Build every plate around a protein you actually eat, before the starch.`);
   }
 
   // Header + footer tuned to how well we know them. Established loggers get quiet
@@ -174,14 +193,14 @@ export async function getGroceryPersonalization(
 ): Promise<string | null> {
   try {
     const profile = await getRecentFoodProfile(userId);
-    const block = buildGroceryPersonalization(profile, goalType);
+    const constraints = foodConstraints({ foodDislikes, dietaryRestrictions });
+    const block = buildGroceryPersonalization(profile, goalType, constraints);
     // ONE OWNER (Cut 9). This read food_dislikes alone, so a client who told us in conversation
     // that they are lactose intolerant — recorded in dietary_restrictions — still got amasi on
     // their shopping list. Which column their constraint landed in depended only on WHEN they
     // said it, and the list honoured one of the two.
-    const c = foodConstraints({ foodDislikes, dietaryRestrictions });
-    if (c.terms.length > 0) {
-      return `${block}\n🚫 *Left off* — you told me: ${c.terms.join(", ")}. Say the word if you want a swap for anything else.`;
+    if (constraints.terms.length > 0) {
+      return `${block}\n🚫 *Left off* — you told me: ${constraints.terms.join(", ")}. Say the word if you want a swap for anything else.`;
     }
     return block;
   } catch (e: any) {

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -3,7 +3,7 @@
 import crypto from "crypto";
 import { turnMutation } from "./chat-log";
 import { sttVocabularyPrompt } from "../foods";
-import { verdictFromLabelLine } from "../food-swaps";
+import { verdictFromLabelLine, foodConstraints } from "../food-swaps";
 import { tmpdir } from "os";
 import { writeFile, unlink } from "fs/promises";
 import { createReadStream } from "fs";
@@ -907,7 +907,7 @@ export async function handleMediaMessage(ctx: {
 Client goal: ${goal.replace("_", " ")}
 Weekly budget: ${budgetLabel[budget] || "R100–R300/week"}
 Daily targets: ${cTarget} kcal, ${pTarget}g protein
-Medical/allergies: ${medicalNotes}
+Medical/allergies: ${medicalNotes}${foodConstraints(user).line ? `\n${foodConstraints(user).line}` : ""}
 
 RULES: Keep items that fit their goal. Replace what doesn't. Add missing essentials. SA products only with rand prices and weekly quantities. Max 20 items.
 

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -39,6 +39,7 @@ import { isDespairNotAQuestion } from "../despair";
 import { SA_FOODS_SEED } from "../foods";
 import { turnEvidence } from "./chat-log";
 import { readHeldConstraints, foodDayClosedWith } from "../held-constraints";
+import { foodConstraints, allowedAlternatives } from "../food-swaps";
 import { getDayLedger, getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
@@ -317,6 +318,17 @@ export async function handleMiscCommands(ctx: {
     const budget = user.weeklyFoodBudget || "100_300";
     const name = user.name?.split(" ")[0] || "";
     const goal = user.goalType || "fat_loss";
+    // WHAT THIS PERSON EATS (#128). This is the door for "what should I eat?", and it was the one
+    // food surface with ZERO calls to the constraint owner: the grocery list, the meal plan and
+    // the permission-ask all consult foodConstraints, and this menu was hand-written animal
+    // protein from top to bottom. A client whose column says "vegan" was handed five plates of
+    // chicken, beef, pilchards and eggs — with "Does not eat: vegan" sitting in the same profile.
+    //
+    // No new recommender. The option sets stay hand-authored in exactly the style they were, with
+    // the alternatives a constrained client can actually eat added beside them; `allows` — the
+    // same predicate the shopping list and the swap engine use — decides which survive.
+    const constraints = foodConstraints(user);
+    const firstAllowed = (options: string[]): string | undefined => options.find(o => constraints.allows(o));
 
     // Determine what's needed
     const needsProtein = protLeft > 20;
@@ -362,8 +374,9 @@ export async function handleMiscCommands(ctx: {
 
     // Calorie target already hit — suggesting more food contradicts the day's assessment
     if (todayCals > 0 && calLeftRaw <= 0) {
+      const snacks = allowedAlternatives("eggs, yoghurt, biltong, hummus, roasted chickpeas", constraints);
       const protNote = protLeft > 20
-        ? `You're about ${protLeft}g short on protein — a small protein snack (eggs, yoghurt, biltong) is a good shout if you're hungry.`
+        ? `You're about ${protLeft}g short on protein — a small protein snack${snacks ? ` (${snacks})` : ""} is a good shout if you're hungry.`
         : "Protein's on track. ✅";
       suggestion += `You've hit your calories for today. ${protNote}\n\nIf you're genuinely hungry, keep it light and protein-first — no need to force more food.`;
       await logChat(user.id, message, suggestion, "MEAL_SUGGESTION");
@@ -372,24 +385,46 @@ export async function handleMiscCommands(ctx: {
 
     if (todayCals === 0) {
       suggestion += `No food logged yet today.\n\n`;
-      if (budget === "under_100") {
-        suggestion += goal === "muscle_gain"
-          ? `Start with: *3 eggs + pap + spinach* (~420 kcal, 24g protein)\nCheap, filling, high protein to start the day.`
-          : `Start with: *2 eggs + oats with water* (~350 kcal, 18g protein)\nLow calorie, high protein start.`;
-      } else {
-        suggestion += goal === "muscle_gain"
-          ? `Start with: *3 eggs + 2 toast + banana* (~550 kcal, 25g protein)\nCarbs + protein for energy and muscle.`
-          : `Start with: *2 eggs + oats + coffee* (~380 kcal, 20g protein)\nBalanced, keeps you full until lunch.`;
-      }
+      const starts = budget === "under_100"
+        ? (goal === "muscle_gain"
+            ? [`*3 eggs + pap + spinach* (~420 kcal, 24g protein)\nCheap, filling, high protein to start the day.`,
+               `*Sugar beans + pap + spinach* (~450 kcal, 22g protein)\nCheap, filling, high protein to start the day.`]
+            : [`*2 eggs + oats with water* (~350 kcal, 18g protein)\nLow calorie, high protein start.`,
+               `*Oats with water + a handful of nuts* (~340 kcal, 12g protein)\nLow calorie, slow-release start.`])
+        : (goal === "muscle_gain"
+            ? [`*3 eggs + 2 toast + banana* (~550 kcal, 25g protein)\nCarbs + protein for energy and muscle.`,
+               `*Soya mince on toast + banana* (~560 kcal, 28g protein)\nCarbs + protein for energy and muscle.`,
+               `*Oats + soya milk + peanuts + banana* (~540 kcal, 22g protein)\nCarbs + protein for energy and muscle.`]
+            : [`*2 eggs + oats + coffee* (~380 kcal, 20g protein)\nBalanced, keeps you full until lunch.`,
+               `*Oats + soya milk + a handful of nuts* (~370 kcal, 14g protein)\nBalanced, keeps you full until lunch.`]);
+      // A CONSTRAINED CLIENT IS NOT LEFT WITH NOTHING. If every plate here is off their list, the
+      // honest answer is the principle rather than a plate we cannot name.
+      suggestion += firstAllowed(starts)
+        ? `Start with: ${firstAllowed(starts)}`
+        : `Start with something you actually eat, protein first — a bean or lentil base with your starch and veg will do the job.`;
     } else if (lowCalBudget && needsProtein) {
       suggestion += `You have ${calLeft} kcal and ${protLeft}g protein left.\n\n`;
       // Pick a suggestion that actually fits within remaining calories
       if (calLeft < 150) {
-        suggestion += `*High-protein, low-cal finish:* 2 boiled eggs (~140 kcal, 12g protein)\nOr: 50g biltong (~130 kcal, 20g protein) — fits your budget.`;
+        const tiny = firstAllowed([
+          "2 boiled eggs (~140 kcal, 12g protein)",
+          "50g biltong (~130 kcal, 20g protein)",
+          "Small tub of plain yoghurt (~120 kcal, 12g protein)",
+          "Half a cup of sugar beans (~120 kcal, 8g protein)",
+        ]);
+        suggestion += tiny
+          ? `*High-protein, low-cal finish:* ${tiny} — fits your budget.`
+          : `*High-protein, low-cal finish:* keep it to a small protein-first portion of something you eat — that is all the room you have left.`;
       } else if (calLeft < 220) {
-        suggestion += `*Best fit:* ${budget === "under_100" ? "2 eggs + spinach (~160 kcal, 14g protein)" : "Tuna salad, no dressing (~190 kcal, 25g protein)"}\nProtein first — just fits your remaining calories.`;
+        const fit = firstAllowed(budget === "under_100"
+          ? ["2 eggs + spinach (~160 kcal, 14g protein)", "Sugar beans + spinach (~180 kcal, 11g protein)"]
+          : ["Tuna salad, no dressing (~190 kcal, 25g protein)", "Chickpea salad, no dressing (~200 kcal, 11g protein)"]);
+        suggestion += `*Best fit:* ${fit || "a small protein-first plate of something you eat"}\nProtein first — just fits your remaining calories.`;
       } else {
-        suggestion += `*Best option:* ${budget === "under_100" ? "Tin of tuna with lemon (~180 kcal, 22g protein)" : "Grilled chicken breast + salad (~250 kcal, 30g protein)"}\nHigh protein, low calories — exactly what you need to finish the day.`;
+        const best = firstAllowed(budget === "under_100"
+          ? ["Tin of tuna with lemon (~180 kcal, 22g protein)", "Sugar beans + tomato and onion (~230 kcal, 13g protein)"]
+          : ["Grilled chicken breast + salad (~250 kcal, 30g protein)", "Tofu + salad (~250 kcal, 20g protein)", "Lentils + salad (~240 kcal, 14g protein)"]);
+        suggestion += `*Best option:* ${best || "a protein-first plate of something you eat"}\nHigh protein, low calories — exactly what you need to finish the day.`;
       }
     } else if (lowCalBudget && !needsProtein) {
       suggestion += `You have ${calLeft} kcal left and protein is sorted.\n\n`;
@@ -420,20 +455,32 @@ export async function handleMiscCommands(ctx: {
       // So the correction is to the option set and the ordering, not to the architecture: fuller
       // plates in the same hand-authored style as the entries already here, and a choice rule that
       // fits the plate to the need.
-      const meals: Array<{ text: string; protein: number; kcal: number }> = budget === "under_100"
+      //
+      // EVERY ENTRY BELOW WAS ANIMAL PROTEIN (#128). The plates a constrained client can eat are
+      // added here in the same style and at the same price point, and `allows` — not a second menu
+      // and not a different door — decides which of them this person is shown.
+      const allMeals: Array<{ text: string; protein: number; kcal: number }> = budget === "under_100"
         ? [
             { text: "Tin of pilchards + 2 eggs + pap (~600 kcal, 42g protein)", protein: 42, kcal: 600 },
             { text: "Sugar beans + 2 eggs + pap + spinach (~620 kcal, 30g protein)", protein: 30, kcal: 620 },
+            { text: "Soya mince + pap + spinach (~600 kcal, 40g protein)", protein: 40, kcal: 600 },
+            { text: "Sugar beans + lentils + pap + spinach (~610 kcal, 26g protein)", protein: 26, kcal: 610 },
             { text: "Tin of pilchards + pap (~350 kcal, 24g protein)", protein: 24, kcal: 350 },
             { text: "2 eggs + pap (~300 kcal, 18g protein)", protein: 18, kcal: 300 },
+            { text: "Sugar beans + pap (~340 kcal, 14g protein)", protein: 14, kcal: 340 },
           ]
         : [
             { text: "2 chicken thighs + rice + mixed veg (~680 kcal, 55g protein)", protein: 55, kcal: 680 },
+            { text: "Soya mince + rice + mixed veg (~620 kcal, 45g protein)", protein: 45, kcal: 620 },
             { text: "Beef mince + pap + spinach (~640 kcal, 40g protein)", protein: 40, kcal: 640 },
             { text: "Chicken breast + rice + spinach (~450 kcal, 35g protein)", protein: 35, kcal: 450 },
+            { text: "Tofu stir-fry + rice (~550 kcal, 30g protein)", protein: 30, kcal: 550 },
+            { text: "Lentil and chickpea curry + rice (~600 kcal, 26g protein)", protein: 26, kcal: 600 },
             { text: "Tin of pilchards + sweet potato (~380 kcal, 24g protein)", protein: 24, kcal: 380 },
             { text: "3 eggs + brown bread + tomato (~400 kcal, 24g protein)", protein: 24, kcal: 400 },
+            { text: "Sugar beans + sweet potato + spinach (~420 kcal, 16g protein)", protein: 16, kcal: 420 },
           ];
+      const meals = allMeals.filter(mm => constraints.allows(mm.text));
       // FIT THE PLATE TO THE NEED, and it takes no arithmetic beyond a comparison.
       //
       // "Biggest protein first" was right while every option was small and becomes wrong the
@@ -446,9 +493,15 @@ export async function handleMiscCommands(ctx: {
       const affordable = meals.filter(mm => mm.kcal <= calLeft);
       const covers = affordable.filter(mm => mm.protein >= protLeft).sort((a, b) => a.kcal - b.kcal);
       const dents = affordable.filter(mm => mm.protein < protLeft).sort((a, b) => b.protein - a.protein);
-      const ordered = [...covers, ...dents];
+      // FIVE, AS BEFORE. Widening the option set so a constrained client has a real menu must not
+      // hand an unconstrained one a wall of nine plates to choose between; the ranking above
+      // already puts the right ones at the top, so the tail is what gets dropped.
+      const ordered = [...covers, ...dents].slice(0, 5);
       if (ordered.length === 0) {
-        suggestion += `You do not have the calories left for a full meal — go protein-only: eggs, biltong, tuna or plain yoghurt, and leave the starch off the plate.`;
+        const only = allowedAlternatives("eggs, biltong, tuna, plain yoghurt, sugar beans, lentils", constraints);
+        suggestion += only
+          ? `You do not have the calories left for a full meal — go protein-only: ${only}, and leave the starch off the plate.`
+          : `You do not have the calories left for a full meal — go protein-only from what you do eat, and leave the starch off the plate.`;
       } else {
         suggestion += `Pick one:\n${ordered.map((mm, i) => `${i + 1}. ${mm.text}`).join("\n")}`;
         if (ordered[0].protein < protLeft) {
@@ -460,11 +513,23 @@ export async function handleMiscCommands(ctx: {
       }
     } else {
       suggestion += `${calLeft} kcal and ${protLeft}g protein to go.\n\n`;
-      if (budget === "under_100") {
-        suggestion += `*Balanced option:* Pap + beans + cabbage (~400 kcal, 14g protein)\n*Protein push:* 2 eggs + pilchards + pap (~500 kcal, 28g protein)`;
-      } else {
-        suggestion += `*Balanced option:* Chicken + sweet potato + vegetables (~500 kcal, 30g protein)\n*Light option:* Greek yoghurt + banana + oats (~350 kcal, 18g protein)`;
-      }
+      const balanced = firstAllowed(budget === "under_100"
+        ? ["Pap + beans + cabbage (~400 kcal, 14g protein)"]
+        : ["Chicken + sweet potato + vegetables (~500 kcal, 30g protein)",
+           "Tofu + sweet potato + vegetables (~480 kcal, 22g protein)",
+           "Lentils + sweet potato + vegetables (~470 kcal, 18g protein)"]);
+      const second = firstAllowed(budget === "under_100"
+        ? ["2 eggs + pilchards + pap (~500 kcal, 28g protein)",
+           "Soya mince + pap + cabbage (~480 kcal, 32g protein)"]
+        : ["Greek yoghurt + banana + oats (~350 kcal, 18g protein)",
+           "Oats + soya milk + peanuts + banana (~360 kcal, 14g protein)"]);
+      const secondLabel = budget === "under_100" ? "Protein push" : "Light option";
+      const twoOptions = [
+        balanced ? `*Balanced option:* ${balanced}` : "",
+        second ? `*${secondLabel}:* ${second}` : "",
+      ].filter(Boolean).join("\n");
+      suggestion += twoOptions
+        || `Build it from what you actually eat: protein first, then your starch, then something green. That is the whole rule with this much room left.`;
     }
 
     await logChat(user.id, message, suggestion, "MEAL_SUGGESTION");


### PR DESCRIPTION
Closes #128 items 3 and 6 (Next Meal Suggestion; grocery personalization). Base `main@d2b3429`.

## The defect, reproduced first on real PostgreSQL

One client, `dietary_restrictions = 'vegan'`, asking the plainest question this product answers:

```
"what should I eat"
→ *🍽️ Next Meal Suggestion*
  1. 2 chicken thighs + rice + mixed veg (~680 kcal, 55g protein)
  2. Beef mince + pap + spinach (~640 kcal, 40g protein)
  3. Chicken breast + rice + spinach (~450 kcal, 35g protein)
  4. Tin of pilchards + sweet potato (~380 kcal, 24g protein)
  5. 3 eggs + brown bread + tomato (~400 kcal, 24g protein)
```

Five plates, five of them impossible, from a profile that also holds `Does not eat: vegan`. The grocery list, the meal plan and the permission-ask all consult `foodConstraints`. This door — the one that owns *"what should I eat?"* — had **zero** calls to it.

## What changed

**`server/handlers/misc-commands.ts` — the Next Meal door.** No new recommender and no second menu. The option sets stay hand-authored in exactly the style they were, with the plates a constrained client can eat added beside them at the same price point, and `allows` — the same predicate the shopping list and the swap engine already use — decides which survive. Five branches named a food and none of them asked: the cold start, the calorie ceiling, the low-headroom finish, the protein menu, and the balanced pair. All five ask now, and each falls back to the principle rather than to silence when nothing on its list is edible.

**Still five options.** Widening the set must not hand an unconstrained client a wall of nine plates; the existing ranking rule already puts the right ones first, so the tail is what gets dropped.

**`server/grocery-personalize.ts`.** `buildGroceryPersonalization` took no constraints at all, so it could print *"grab Eggs and a tin of pilchards"* three lines above *"🚫 Left off — you told me: eggs"*, and *"you already eat Chicken, so I built the list around it"* to someone who has since gone vegan. A client's own log is history, not a standing preference. `suggestSwap` has accepted constraints since Cut 9 — *"telling a vegan to swap their mayo for eggs is worse than saying nothing"* — this caller simply never passed them.

**`server/handlers/media.ts` — the grocery-photo rebuild.** The prompt named `medical_conditions` and `other_medical_notes` and never `dietary_restrictions` or `food_dislikes`, so the photo path rebuilt a vegan client's list out of chicken while the typed path, which goes through `getShoppingList`, would not. It now carries the constraint owner's own sentence.

**`allowedAlternatives` is exported rather than copied** — it is already the owner of "filter a comma-or-list by what this client eats", from #177.

## Proof — `script/pg-food-constraint-mouths-acceptance.ts`, in the PostgreSQL CI job

Which branch of the menu a client reaches is composed from the day ledger — what is logged, what is left — so a fixture that answers every query the same way puts every client on one branch. That is how a menu with no constraint call looked fine.

The test asserts with **its own vocabulary** of animal foods, never with `allows`, which would grade the filter against itself.

**Every prohibition is paired with its control**, because "offered no chicken" is trivially true of a coach that offers nothing:
- an unconstrained twin must still be offered meat **by name**, and must receive a genuinely different menu;
- a halaal client must lose pork and still be offered the animal protein they **do** eat;
- a no-eggs client must lose eggs and **nothing else**;
- the vegan grocery block must still say what it kept from their own logs, and the unconstrained one must still build around the chicken they log;
- the protein-gap line must still fire for both.

## Red on revert (asserted, both mechanisms independently)

The menu stops filtering:
```
FAIL  "what should I eat" offers a vegan client no animal protein
FAIL  "what can I eat" offers a vegan client no animal protein
FAIL  "I'm hungry" offers a vegan client no animal protein
FAIL  the two clients genuinely receive different menus
```

The grocery block stops asking:
```
FAIL  the personalization block names no food this client refuses
      ✅ *Kept in* — you already eat Chicken, Pap and Cabbage…
FAIL  the protein-gap line still fires, and names something they can buy
      🥩 *Add protein* — … Eggs and a tin of pilchards are the cheapest fix in SA.
```

## One change with no executable proof, stated plainly

The `media.ts` prompt line has **no capture seam** — the composed prompt goes straight to the model, and there is no interception point to assert on without inventing one. It is one interpolation through the constraint owner's own `line`, and it is not covered by the acceptance script. `media.ts` also sits exactly on its line budget (1550/1550), so the change carries no explanatory comment; the reasoning is in the commit message instead.

## Local verification (remote CI is the gate)

- `npm run check` — clean.
- `npm test` — 36/37 green, `normalizer-replay-tests` still correctly `⊘ COVERED NOTHING` (#163).
- `check-file-sizes` 236 OK, `check-architecture`, `check-sast`, `check-names`, `check-reach`, `check-schema-safety`, `check-prompt-integrity` — green at existing budgets. **No budget raised.**
- `pg-food-constraint-mouths-acceptance` — GREEN, 18 checks.
- Journey Lab — GREEN, 266 checks across 8 sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_