### PR TITLE
The protein closer, and the plate it just watched land (#128 item 4)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4187,6 +4187,91 @@ test("#128/1: a client can take a restriction back", async () => {
     "not eating dairy", "a restriction stated in the negative is still a restriction");
 });
 
+// ── #128/4: THE PROTEIN CLOSER ──────────────────────────────────────────────────────────────
+//
+// Both owners of "the next move" name foods. Graded on the sentence each one returns, with an
+// unconstrained twin beside every claim: a coach that stopped naming food altogether would
+// satisfy the prohibition and fail the client.
+
+test("#128/4: the card's protein line asks what this person eats", async () => {
+  const { nextMoveLine } = await import("../server/macro-card-attach");
+  const { foodConstraints, NO_CONSTRAINTS } = await import("../server/food-swaps");
+  const ANIMAL = /\b(chicken|fish|eggs?|yoghurt|amasi|biltong|mince|beef)\b/i;
+  const rows = (prot: number) => [
+    { label: "Calories", current: 900, target: 2800, unit: "" },
+    { label: "Protein", current: prot, target: 195, unit: "g" },
+    { label: "Fat", current: 40, target: 80, unit: "g" },
+  ];
+  const vegan = foodConstraints({ dietaryRestrictions: "vegan" });
+
+  // Each protein band that names a food, at an hour that is neither early nor a close-out.
+  for (const prot of [160, 175, 188]) {
+    const open = nextMoveLine(rows(prot), false, 14, false, false, false, NO_CONSTRAINTS);
+    const bound = nextMoveLine(rows(prot), false, 14, false, false, false, vegan);
+    assert.ok(!ANIMAL.test(bound), `${195 - prot}g owed: the vegan card names no animal food — "${bound}"`);
+    assert.ok(bound.trim().length > 10, `${195 - prot}g owed: …and still gives an instruction — "${bound}"`);
+    // THE CONTROL. Without it, "names no animal food" is equally true of a card that says nothing.
+    assert.ok(ANIMAL.test(open), `${195 - prot}g owed: the unconstrained card still names one — "${open}"`);
+  }
+  // A CLIENT WHO DECLARED NOTHING READS THE LINE THEY HAVE ALWAYS READ. The founder's list is
+  // tried first, so this wording is untouched by the change.
+  assert.equal(nextMoveLine(rows(160), false, 14, false, false, false, NO_CONSTRAINTS),
+    "Make your next meal a proper protein — chicken, fish, or eggs");
+  // A partial exclusion takes one food, not the sentence.
+  const noEggs = nextMoveLine(rows(160), false, 14, false, false, false, foodConstraints({ foodDislikes: "eggs" }));
+  assert.ok(/chicken/.test(noEggs) && !/\beggs?\b/i.test(noEggs), `no-eggs client keeps chicken — "${noEggs}"`);
+});
+
+test("#128/4: the action ladder's protein rung asks too, and does not re-issue the plate", async () => {
+  const { chooseAction } = await import("../server/one-action");
+  const { foodConstraints } = await import("../server/food-swaps");
+  const ANIMAL = /\b(chicken|fish|eggs?|yoghurt|amasi|biltong|mince|beef|pilchards?)\b/i;
+  const base: any = {
+    goal: "fat_loss", weeksOnProgramme: 3, daysSinceAnyLog: 0, daysSinceWeighIn: 1,
+    loggedToday: true, proteinPct: 0.31, caloriePct: 0.4, sessionsThisWeek: 2, sessionsTarget: 3,
+    stepsToday: 9000, stepsTarget: 8000, hour: 14, atKeyboard: true,
+  };
+  const vegan = foodConstraints({ dietaryRestrictions: "vegan" });
+
+  // Every phrasing this rung has — the three struggles and the after-20:00 close-out.
+  for (const s of [{ biggestStruggle: "no time" }, { biggestStruggle: "no money" }, { hour: 21 }]) {
+    const open = chooseAction({ ...base, ...s });
+    const bound = chooseAction({ ...base, ...s, constraints: vegan });
+    assert.equal(bound.kind, "protein", "the lever is unchanged — this is not a stand-down");
+    assert.ok(!ANIMAL.test(bound.todo), `the vegan instruction names no animal food — "${bound.todo}"`);
+    assert.ok(ANIMAL.test(open.todo), `…and the unconstrained one still does — "${open.todo}"`);
+  }
+
+  // THE PLATE THEY JUST ATE IS NOT THE PLATE THEY MUST GO AND MAKE. 61g against 195g leaves the
+  // day under 60%, so the rung still fires; what it says has to move forward from the meal.
+  const after = chooseAction({ ...base, justAteProteinMeal: true });
+  assert.equal(after.kind, "protein", "protein is still the lever");
+  assert.ok(!/make (?:your next meal|lunch) a (?:proper )?protein/i.test(after.todo),
+    `it must not re-issue the instruction just carried out — "${after.todo}"`);
+  assert.match(after.todo, /one proper protein down/i, "it acknowledges the plate that landed");
+  // CONTROL: the same client who did NOT just eat one still gets the instruction.
+  assert.match(chooseAction({ ...base }).todo, /protein/i);
+  assert.ok(/make your next meal a proper protein meal/i.test(chooseAction({ ...base }).todo),
+    "the unchanged case is unchanged");
+});
+
+test("#128/4: one number answers 'did they just eat a proper protein meal', on both owners", async () => {
+  const { proteinWrittenIn } = await import("../server/understanding/messy-intake");
+  const { PROPER_PROTEIN_G } = await import("../server/macro-card-attach");
+  // The write door's own stamp, read rather than re-derived.
+  assert.equal(proteinWrittenIn(["INSERT meal kcal=610 prot=61 label=lunch at=2026-09-06"]), 61);
+  assert.equal(proteinWrittenIn(["INSERT steps 9000", "INSERT meal kcal=200 prot=12 label=snack"]), 12);
+  assert.equal(proteinWrittenIn(["INSERT workout push"]), 0, "no meal written is no protein written");
+  // TWO PLATES IN ONE BUBBLE ARE TWO PLATES. The biggest decides, never the sum — otherwise two
+  // small snacks would read as a proper protein meal that nobody ate.
+  assert.equal(proteinWrittenIn([
+    "INSERT meal kcal=200 prot=20 label=snack", "INSERT meal kcal=610 prot=61 label=lunch",
+  ]), 61);
+  assert.ok(20 + 20 >= PROPER_PROTEIN_G && proteinWrittenIn([
+    "INSERT meal kcal=200 prot=20 label=snack", "INSERT meal kcal=200 prot=20 label=snack",
+  ]) < PROPER_PROTEIN_G, "two 20g snacks are not one 40g meal");
+});
+
 // ── CUT 8: DON'T-MENTION IS BOUND TO THE MOUTH ──────────────────────────────────────────────
 
 test("cut8: the reply path honours do_not_mention, above the meaningful-message gate", () => {

--- a/script/pg-food-constraint-mouths-acceptance.ts
+++ b/script/pg-food-constraint-mouths-acceptance.ts
@@ -81,6 +81,21 @@ const ask = (phone: string, text: string) =>
   handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
     .then(r => String(r || ""));
 
+// A WEIGH-IN TODAY, so the ladder can REACH the protein rung. `weigh` outranks `protein`, and a
+// client who has never stood on a scale is correctly asked for the measurement instead — which
+// would have made §6 below pass without the protein rung ever running.
+const weighed = (id: string) => pool.query(
+  `INSERT INTO weight_logs (user_id, weight, logged_at) VALUES ($1, 84.5, now())`, [id]);
+
+// …AND ENOUGH LOGGED DAYS FOR THE DECISION TO BE ALLOWED TO PRESCRIBE AT ALL. underPolicy
+// downgrades an unevidenced instruction to `hold` below PROACTIVE_LOG_FLOOR distinct days, which
+// is correct and which would have made every check in this section pass on an empty move.
+const loggingSince = (id: string) => pool.query(
+  `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+   SELECT $1, now() - (d || ' days')::interval, 'lunch', 500, 20, $2, 'seed', 'sa_scanner'
+     FROM generate_series(1, 6) AS d`,
+  [id, JSON.stringify([{ name: "pap", grams: 200 }])]);
+
 REAL("\n=== THE PLATE THE COACH NAMES ===");
 
 // ── §1 THE ASK THIS DOOR EXISTS FOR ─────────────────────────────────────────────────────────
@@ -161,8 +176,67 @@ chk(/Add protein/.test(veganGap) && !ANIMAL.test(veganGap),
 chk(/Add protein/.test(buildGroceryPersonalization(noProtein, "fat_loss")),
   "…and the unconstrained client still gets the same nudge");
 
+REAL("\n=== THE MOVE APPENDED TO A MEAL THE CLIENT JUST LOGGED ===");
+
+// ── §6 THE PLATE THEY JUST ATE IS NOT THE PLATE THEY MUST GO AND MAKE (#128/4) ──────────────
+//
+// closeCoachingTurn appends the canonical next move to a turn that durably wrote. The ladder had
+// no answer to "did they just eat a proper protein meal", so a 61g plate against a 195g target —
+// still under 60% of the DAY — was answered with "Make your next meal a proper protein meal" in
+// the same turn the card said "That's one proper protein down". Only a real write produces the
+// mutation record this reads, which is why it is graded here rather than on a fixture.
+//
+// THE SECOND LOG IS THE GRADED ONE. A client's FIRST ever meal gets the first-log celebration in
+// place of a next move, so grading turn one would have measured the welcome and called it a
+// coaching decision — which is how the control below caught this harness before it caught the
+// product.
+const eater = await seed({ dietaryRestrictions: null, proteinTarget: 195, calorieTarget: 2800 });
+await weighed(eater.id); await loggingSince(eater.id);
+await ask(eater.phone, "I had a banana");
+const afterPlate = await ask(eater.phone, "I had a chicken breast and rice");
+chk(!/make (?:your next meal|lunch) a (?:proper )?protein/i.test(afterPlate),
+  "a client who just logged a proper protein meal is not told to go and make one",
+  afterPlate.slice(0, 300));
+// NON-VACUOUS: a move WAS appended, and it moves forward from the plate rather than restating it.
+// Without this, a turn that appended nothing at all would satisfy the check above.
+chk(/one proper protein down/i.test(afterPlate),
+  "…the move acknowledges the plate that landed, so this is not an empty turn",
+  afterPlate.slice(0, 300));
+
+// THE CONTROL, and it is the point: a small plate must still earn the instruction, or §6 is
+// satisfied by a coach that stopped prescribing protein at all.
+const nibbler = await seed({ dietaryRestrictions: null, proteinTarget: 195, calorieTarget: 2800 });
+await weighed(nibbler.id); await loggingSince(nibbler.id);
+await ask(nibbler.phone, "I had a banana");
+const afterSnack = await ask(nibbler.phone, "I had an apple");
+chk(/protein/i.test(afterSnack),
+  "…while a client who logged an apple still gets the protein move", afterSnack.slice(0, 300));
+
+// ── §7 AND WHAT IT NAMES IS STILL THEIR FOOD ────────────────────────────────────────────────
+//
+// biggestStruggle IS LOAD-BEARING HERE. The rung's default phrasing names no food at all, so a
+// client without one would pass this section without the naming branch ever running — the first
+// cut of this check did exactly that and stayed green with the constraint removed. "No time" is
+// the branch that says "tin fish, eggs or amasi".
+const STRUGGLE = "I have no time, I work late";
+const veganEater = await seed({ dietaryRestrictions: "vegan", proteinTarget: 195, calorieTarget: 2800, biggestStruggle: STRUGGLE });
+await weighed(veganEater.id); await loggingSince(veganEater.id);
+await ask(veganEater.phone, "I had a banana");
+const veganAfter = await ask(veganEater.phone, "I had rice and spinach");
+chk(!ANIMAL.test(veganAfter), "the move appended for a vegan client names no animal protein",
+  veganAfter.slice(0, 300));
+chk(veganAfter.trim().length > 20, "…and the turn still answered", veganAfter.slice(0, 120));
+
+// THE CONTROL: the same turn, the same struggle, nothing declared — the coach still names one.
+const openEater = await seed({ dietaryRestrictions: null, proteinTarget: 195, calorieTarget: 2800, biggestStruggle: STRUGGLE });
+await weighed(openEater.id); await loggingSince(openEater.id);
+await ask(openEater.phone, "I had a banana");
+const openAfter = await ask(openEater.phone, "I had rice and spinach");
+chk(ANIMAL.test(openAfter), "…and an unconstrained client on the same branch is still named one",
+  openAfter.slice(0, 300));
+
 await pool.query("DELETE FROM users WHERE id = ANY($1)",
-  [[vegan.id, open.id, halaal.id, noEggs.id, full.id]]);
+  [[vegan.id, open.id, halaal.id, noEggs.id, full.id, eater.id, nibbler.id, veganEater.id, openEater.id]]);
 REAL(`\npg-food-constraint-mouths-acceptance: ${failed === 0 ? "GREEN — all checks passed" : `RED — ${failed} check(s) failed`}`);
 await pool.end();
 process.exit(failed === 0 ? 0 : 1);

--- a/server/handlers/one-action-command.ts
+++ b/server/handlers/one-action-command.ts
@@ -19,6 +19,7 @@ import { sql } from "drizzle-orm";
 import { getDayLedger } from "../day-ledger";
 import { sastDayStart, sastDaysBetween, sastHour, sastWeekStart } from "../sast";
 import { readHealthState } from "../health-state";
+import { foodConstraints } from "../food-swaps";
 
 /** Is this client inside a declared sick window? Asked of the state owner, not of the text. */
 const isSick = (user: any): boolean => readHealthState(user).isSick;
@@ -88,6 +89,9 @@ async function buildDecisionInputs(user: any): Promise<{ state: ProactiveStateFo
       },
     },
     profile: {
+      // WHAT THIS CLIENT DOES NOT EAT (#128) — through the constraint owner, from the same two
+      // columns every other food surface merges.
+      constraints: foodConstraints(user || {}),
       dreamGoal: user?.dreamGoal,
       biggestStruggle: user?.biggestStruggle,
       weeksOnProgramme: user?.createdAt ? Math.floor(sastDaysBetween(new Date(user.createdAt)) / 7) : 0,

--- a/server/macro-card-attach.ts
+++ b/server/macro-card-attach.ts
@@ -21,6 +21,7 @@ import { waterTargetLitres } from "./targets";
 import { getNumbersMode, stripNumbersFromProse } from "./numbers-mode";
 import { cardWillAttach, cardSuppressedByDump, noteCardSent } from "./card-policy";
 import { sastHour } from "./sast";
+import { foodConstraints, allowedAlternatives, NO_CONSTRAINTS, type FoodConstraints } from "./food-swaps";
 
 // Shared: the public base URL (forced to https:// — see below) or "" when a card can't be
 // served. APP_URL was stored WITHOUT a scheme, so the first live marker leaked as a text link
@@ -187,8 +188,23 @@ export function biggestEventProtein(events: Array<{ protein: number }>): number 
   return events.reduce((max, e) => Math.max(max, Math.round(e?.protein || 0)), 0);
 }
 
-export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false, justAteProteinMeal = false): string {
+export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), isPastDay = false, foodDayClosed = false, justAteProteinMeal = false, c: FoodConstraints = NO_CONSTRAINTS): string {
   const r = (label: string) => rows.find(x => x.label === label);
+  // THE CARD NAMES FOOD, SO IT HAS TO ASK WHAT THIS PERSON EATS (#128). Four of the lines below
+  // are shopping lists in miniature — "chicken, fish or eggs", "eggs, tin fish or a shake" — and
+  // none of them consulted the constraint owner, so a vegan client photographing their lunch got
+  // a picture telling them to eat chicken. `allowedAlternatives` is the same filter #177 gave the
+  // shopping list and the swap engine; when it can keep nothing, the instruction stands without
+  // the menu rather than naming a food they refuse or saying nothing at all.
+  //
+  // TWO TIERS, SO NOBODY'S WORDING CHANGES WHO DID NOT ASK FOR IT. The founder's list is tried
+  // first and comes back untouched for a client who declared nothing — the line they read today
+  // is the line they read tomorrow. The plant tier is consulted ONLY when the first list has
+  // nothing left in it, which is exactly the client this is for.
+  const eat = (primary: string, ifNoneOfThose: string, withNames: (kept: string) => string, unnamed: string): string => {
+    const kept = allowedAlternatives(primary, c) || allowedAlternatives(ifNoneOfThose, c);
+    return kept ? withNames(kept) : unnamed;
+  };
   if (isPastDay) return "Yesterday's log — today's plate is a separate day";
   const ratio = (x?: Row) => (x && x.target > 0 ? x.current / x.target : 0);
   const cal = r("Calories"), prot = r("Protein"), fat = r("Fat");
@@ -277,7 +293,9 @@ export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), is
   // is a different, smaller action, not a repeat of the meal.
   if (protLeft >= 60) {
     return justAteProteinMeal ? "That's one proper protein down — same again at your next two meals"
-      : earlyDay ? "Chicken or eggs at lunch AND supper"
+      : earlyDay ? eat("chicken, eggs", "sugar beans, lentils",
+          kept => `${kept[0].toUpperCase()}${kept.slice(1)} at lunch AND supper`,
+          "A real protein at lunch AND supper")
       : "Get a real protein into your next two meals";
   }
   if (protLeft >= 35) {
@@ -287,12 +305,21 @@ export function nextMoveLine(rows: Row[], isBulk: boolean, hour = sastHour(), is
     // the gap, and this branch runs anywhere from 35g to 59g owed. At 59g owed another minimum
     // qualifying meal still leaves 24g, so "you're there" was a promise the data does not carry.
     // Acknowledge the protein, carry the lever forward, claim nothing about arriving.
+    const meal = earlyDay ? "lunch" : "your next meal";
     return justAteProteinMeal ? "Good protein in — keep that going at your next meal"
-      : earlyDay ? "Make lunch a proper protein — chicken, fish or eggs"
-      : "Make your next meal a proper protein — chicken, fish or eggs";
+      : eat("chicken, fish, eggs", "sugar beans, lentils",
+          kept => `Make ${meal} a proper protein — ${kept}`,
+          `Make ${meal} a proper protein`);
   }
-  if (protLeft >= 18) return "Add eggs, tin fish or a shake today";
-  if (protLeft > 0) return "One yoghurt or a boiled egg and you're done";
+  if (protLeft >= 18) {
+    return eat("eggs, tin fish, a shake", "sugar beans, lentils",
+      kept => `Add ${kept} today`, "Add a protein-first portion today");
+  }
+  if (protLeft > 0) {
+    return eat("one yoghurt, a boiled egg", "a handful of nuts, some hummus",
+      kept => `${kept[0].toUpperCase()}${kept.slice(1)} and you're done`,
+      "One protein-first portion and you're done");
+  }
 
   if (calLeft > 400) return "Eat a proper meal — you're short on food today";
   return "Nothing left to do — today is done properly";
@@ -500,6 +527,8 @@ export function mealCard(opts: {
   isPastDay?: boolean;
   /** They said they are done eating today. The card's next move must agree with the decision's. */
   foodDayClosed?: boolean;
+  /** What this client does not eat. The card names foods, so it has to know (#128). */
+  constraints?: FoodConstraints;
   /** Protein in the meal this card is confirming. Absent on the on-demand "Today" card, which
    *  is answering a question rather than acknowledging a plate. */
   mealProtein?: number;
@@ -523,7 +552,8 @@ export function mealCard(opts: {
     unit: opts.usesNumbers ? (opts.isPastDay ? "protein yesterday" : "protein today") : (opts.isPastDay ? "yesterday" : "so far today"),
     line: `${opts.firstName ? opts.firstName + ": " : ""}${opts.mealName} logged.`,
     sub: nextMoveLine(opts.rows, opts.isBulk, opts.hour, !!opts.isPastDay, !!opts.foodDayClosed,
-      !opts.isPastDay && (opts.mealProtein ?? 0) >= PROPER_PROTEIN_G),
+      !opts.isPastDay && (opts.mealProtein ?? 0) >= PROPER_PROTEIN_G,
+      opts.constraints ?? NO_CONSTRAINTS),
   };
 }
 
@@ -574,6 +604,7 @@ export async function macroCardMarker(opts: { user: any; mealName: string; mealP
       mealName: opts.mealName || "Meal",
       rows: today.rows,
       foodDayClosed: isPastDay ? false : await dayClosedFor(opts.user),
+      constraints: foodConstraints(opts.user || {}),
       isBulk: today.isBulk,
       usesNumbers: getNumbersMode(opts.user) !== "low" && getGoalProfile(opts.user?.goalType).usesMacros,
       isPastDay,
@@ -615,6 +646,7 @@ export async function dailyMacroCardMarker(user: any): Promise<string> {
       mealName: "Today",
       rows: today.rows,
       foodDayClosed: await dayClosedFor(user),
+      constraints: foodConstraints(user || {}),
       isBulk: today.isBulk,
       usesNumbers: getNumbersMode(user) !== "low" && getGoalProfile(user?.goalType).usesMacros,
     });

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -32,6 +32,9 @@ import { selectDecisionState, type DecisionEvidence } from "./understanding/stat
 // Pure, and it has to be: the verifier owns "may this reach a client" and carries no database or
 // model, so the decision can ask it what the client asked us not to say (Cut 8).
 import { mentionsForbidden } from "./brain/reply-verifier";
+// Pure as well, and already the owner of "what may this client be offered" for every plate,
+// grocery list and swap in the product (Cut 9, #177, #128).
+import { allowedAlternatives, NO_CONSTRAINTS, type FoodConstraints } from "./food-swaps";
 
 export interface DayState {
   firstName?: string;
@@ -106,6 +109,29 @@ export interface DayState {
    * this suppresses one instruction for one day, it does not rewrite the record.
    */
   trainingDeclined?: boolean;
+  /**
+   * What this client does not eat — the same owner every food surface consults (#128).
+   *
+   * The protein and eat_more rungs NAME FOODS: "eggs, amasi or tin fish", "eggs, bread and peanut
+   * butter". A vegan client behind on protein was told to eat eggs by the one line the coach
+   * calls its highest-leverage action, and the outbound floor cannot save it — this line goes out
+   * in a proactive brief that never passes the reactive mouth gate. Same reasoning as
+   * `doNotMention` above: a fact the decision holds, so the decision can choose differently
+   * rather than have its sentence filtered afterwards.
+   */
+  constraints?: FoodConstraints;
+  /**
+   * The plate that just landed WAS a proper protein meal — the card's own `PROPER_PROTEIN_G`
+   * test, on the ladder that had no answer to it.
+   *
+   * macro-card-attach already refuses to tell a man holding an empty plate to go and make the
+   * plate. This ladder did not: after a 61g meal against a 195g target the day is still under
+   * 60%, so rung 5 fired and said "Make your next meal a proper protein meal" in the same turn
+   * the card said "That's one proper protein down". Two owners of the next move, one of which
+   * had read the meal. The rung does not stand down — protein is still the lever — it moves
+   * FORWARD from what they did, exactly as the card does.
+   */
+  justAteProteinMeal?: boolean;
 }
 
 export type ActionKind =
@@ -522,11 +548,25 @@ export function chooseAction(s: DayState): OneAction {
 
   // 4. UNDER-FUELLED ON A BULK. Nothing else works if they aren't eating.
   // Closed food day wins: they told us the next meal is not happening.
+  // WHAT THEY MAY BE OFFERED, ASKED ONCE FOR THE WHOLE LADDER (#128). Two tiers, so a client who
+  // declared nothing reads the line they have always read: the founder's own list is tried first
+  // and comes back untouched, and the plant tier is consulted only when nothing in it survives.
+  // When even that is empty the instruction stands WITHOUT the menu — never a food they refuse,
+  // and never silence, because the action is the point and the examples are the garnish.
+  const c = s.constraints ?? NO_CONSTRAINTS;
+  const eat = (primary: string, ifNoneOfThose: string, withNames: (kept: string) => string, unnamed: string): string => {
+    const kept = allowedAlternatives(primary, c) || allowedAlternatives(ifNoneOfThose, c);
+    return kept ? withNames(kept) : unnamed;
+  };
+
   if (isBulk && s.loggedToday && s.caloriePct < 0.6 && s.hour >= LATE && !s.foodDayClosed) {
     return {
       kind: "eat_more",
+      // A RECIPE, NOT A LIST OF ALTERNATIVES, so it is kept or dropped whole rather than filtered
+      // into "beans does it".
       todo: struggle === "money"
-        ? "Add one more proper meal today — eggs, bread and peanut butter does it."
+        ? (plate => plate ? `Add one more proper meal today — ${plate} does it.` : "Add one more proper meal today.")(
+            ["eggs, bread and peanut butter", "beans, bread and peanuts"].find(x => c.allows(x)))
         : "Add one more proper meal today.",
       why: why("You can't build on food you didn't eat.", s.dreamGoal),
     };
@@ -541,14 +581,27 @@ export function chooseAction(s: DayState): OneAction {
     // one must not lose what the deleted one knew — "make your next meal a protein one" sent at
     // nine at night is an instruction nobody can act on.
     const closingTheDay = s.hour >= 20;
+    // …AND IT DOES NOT RE-ISSUE THE INSTRUCTION THEY HAVE JUST CARRIED OUT. The card's wording,
+    // because it is the card's finding: the plate that landed cleared PROPER_PROTEIN_G, the day
+    // is still short, so the move goes forward from what they did.
     return {
       kind: "protein",
-      todo: closingTheDay
-        ? "Start tomorrow with protein — eggs, amasi or tin fish at breakfast."
+      todo: s.justAteProteinMeal
+        ? (closingTheDay
+            ? "That's one proper protein down — start tomorrow the same way."
+            : "That's one proper protein down — same again at your next meal.")
+        : closingTheDay
+        ? eat("eggs, amasi or tin fish", "sugar beans, lentils or peanuts",
+            kept => `Start tomorrow with protein — ${kept} at breakfast.`,
+            "Start tomorrow with protein at breakfast.")
         : struggle === "time"
-        ? "Make your next meal a protein one — tin fish, eggs or amasi. Two minutes."
+        ? eat("tin fish, eggs or amasi", "tinned beans, lentils or peanuts",
+            kept => `Make your next meal a protein one — ${kept}. Two minutes.`,
+            "Make your next meal a protein one. Two minutes.")
         : struggle === "money"
-        ? "Get protein into your next meal — eggs, pilchards or sugar beans."
+        ? eat("eggs, pilchards or sugar beans", "sugar beans, lentils or peanuts",
+            kept => `Get protein into your next meal — ${kept}.`,
+            "Get protein into your next meal.")
         : "Make your next meal a proper protein meal.",
       why: why(
         isBulk ? "Protein is the part your body actually builds with."
@@ -628,6 +681,14 @@ export interface ProactiveProfile {
   doNotMention?: string | null;
   /** users.life_context — a durable fact (Cut 7), carried so the come_back rungs can name it. */
   lifeContext?: string | null;
+  /**
+   * What this client does not eat (#128). REQUIRED, deliberately: the protein and eat_more rungs
+   * name foods, and a profile that forgets to carry this produces a coach that offers a vegan
+   * client eggs — silently, in a proactive brief that never passes the reactive mouth gate. An
+   * optional field would have made the omission invisible; a required one makes the compiler
+   * enumerate every assembly site. Pass NO_CONSTRAINTS where a client genuinely has none.
+   */
+  constraints: FoodConstraints;
   weeksOnProgramme: number;
   sessionsTarget: number;
   calorieTarget: number;
@@ -644,7 +705,7 @@ export interface ProactiveProfile {
  */
 export function dayStateFrom(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; justAteProteinMeal?: boolean },
 ): DayState {
   return {
     firstName: s.name,
@@ -666,10 +727,12 @@ export function dayStateFrom(
     sick: s.health.sick,
     lifeContext: p.lifeContext,
     doNotMention: p.doNotMention,
+    constraints: p.constraints ?? NO_CONSTRAINTS,
     hour: opts?.hour ?? s.today.hour,
     atKeyboard: opts?.atKeyboard,
     foodDayClosed: opts?.foodDayClosed,
     trainingDeclined: opts?.trainingDeclined,
+    justAteProteinMeal: opts?.justAteProteinMeal,
   };
 }
 
@@ -832,7 +895,7 @@ function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEv
 
 export function decideProactive(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; justAteProteinMeal?: boolean },
 ): ProactiveDecision {
   let action = chooseAction(dayStateFrom(s, p, opts));
   let evidence = evidenceFor(s, action.kind);

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -18,6 +18,7 @@ import { adaptTargets, adaptiveInputFrom } from "../../adaptive-targets";
 import { chooseAction, decideProactive, formatOneAction, underPolicy } from "../../one-action";
 import { loadSituationFrame } from "../../memory";
 import { readHeldConstraints } from "../../held-constraints";
+import { foodConstraints } from "../../food-swaps";
 
 /**
  * WHAT WE SAY TO SOMEONE WHO HAS GONE — decided by the ladder, not written here.
@@ -39,6 +40,7 @@ async function silenceAsk(client: any, daysSilent: number): Promise<string> {
     biggestStruggle: client.biggestStruggle,
     lifeContext: client.lifeContext,
     doNotMention: client.doNotMention,
+    constraints: foodConstraints(client || {}),
     weeksOnProgramme: Math.max(0, (client.programmeWeek || 1) - 1),
     sessionsTarget: Number(client.trainingDaysPerWeek) || 3,
     calorieTarget: Number(client.calorieTarget) || 0,
@@ -487,6 +489,7 @@ export async function runMorningCheckin(): Promise<void> {
             biggestStruggle: client.biggestStruggle,
             lifeContext: client.lifeContext,
             doNotMention: client.doNotMention,
+            constraints: foodConstraints(client || {}),
             weeksOnProgramme: Math.floor(progDays / 7),
             sessionsTarget: isTodayTrainingDay ? (Number(client.trainingDaysPerWeek) || 3) : 0,
             calorieTarget: Number(client.calorieTarget) || 0,

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -37,6 +37,7 @@
 import { chooseAction, decideProactive, formatOneAction, underPolicy, type OneAction } from "../one-action";
 import { readHeldConstraints, NO_CONSTRAINTS, type HeldConstraints } from "../held-constraints";
 import { loadProactiveState } from "./shared";
+import { foodConstraints } from "../food-swaps";
 
 export interface CanonicalMove {
   /** Ready to place in a message. "" when the decision is `hold` — nothing to add is an answer. */
@@ -55,6 +56,7 @@ function profileOf(client: any) {
     biggestStruggle: client.biggestStruggle,
     lifeContext: client.lifeContext,
     doNotMention: client.doNotMention,
+    constraints: foodConstraints(client || {}),
     weeksOnProgramme: Math.max(0, (client.programmeWeek || 1) - 1),
     sessionsTarget: Number(client.trainingDaysPerWeek) || 3,
     calorieTarget: Number(client.calorieTarget) || 0,
@@ -105,6 +107,7 @@ export async function canonicalNextMove(
       biggestStruggle: client.biggestStruggle,
       lifeContext: client.lifeContext,
       doNotMention: client.doNotMention,
+      constraints: foodConstraints(client || {}),
       weeksOnProgramme: profile.weeksOnProgramme,
       daysSinceAnyLog: 0, daysSinceWeighIn: 0, loggedToday: false,
       proteinPct: 1, caloriePct: 1,

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -28,7 +28,7 @@ import { runMeaningEngine, writeReplyAfterTools } from "./meaning-engine";
 import { planCorrection, isMealDateMove } from "../food-identity-correction";
 import { isRetroactiveMeal } from "../utils";
 import { tellDontAsk } from "../reply-hygiene";
-import { localiseSuggestion } from "../food-swaps";
+import { localiseSuggestion, foodConstraints } from "../food-swaps";
 import { matchRestaurant } from "../restaurants";
 import { symptomPersistence } from "../quality-signals";
 import { reportsHunger, asksAboutWeightProgress } from "../unlogged-notice";
@@ -63,7 +63,7 @@ import { assembleDeficitEvidence, hasRelevantDeficitEvidence, weightTrendUsable,
  *
  * rather than the model deciding in prose and a verifier trying to work out what it decided.
  */
-export async function canonicalDecision(user: any, message?: string): Promise<{ todo: string; kind: string; reply: string }> {
+export async function canonicalDecision(user: any, message?: string, opts?: { justAteProteinMeal?: boolean }): Promise<{ todo: string; kind: string; reply: string }> {
   try {
     // ONE CONSTITUTION (2026-08-21). This called theNextMove(), a SECOND ranked ladder —
     // training → protein → calories → steps → scale — that produced "the one thing to do" from
@@ -117,6 +117,11 @@ export async function canonicalDecision(user: any, message?: string): Promise<{ 
       // for that, so this door and the SMART NEXT MEAL door cannot read one sentence differently.
       foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
       trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
+      // WHAT THIS CLIENT DOES NOT EAT, and WHETHER THEY JUST ATE A PROPER PROTEIN MEAL (#128).
+      // The protein rung names foods and re-issued the instruction the plate had just carried
+      // out; both facts already exist, and neither reached the ladder.
+      constraints: foodConstraints(user || {}),
+      justAteProteinMeal: !!opts?.justAteProteinMeal,
     } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
          // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a
          // decision: the proactive side reads a stall verdict this path never computes, so
@@ -628,11 +633,18 @@ export async function runMeaningEngineLive(ctx: {
 export async function closeCoachingTurn(user: any, message: string, reply: string | null): Promise<string> {
   const out = String(reply ?? "");
   const { turnMutations } = await import("../handlers/chat-log");
-  const { durableDomains } = await import("./messy-intake");
+  const { durableDomains, proteinWrittenIn } = await import("./messy-intake");
   const { withNextMove } = await import("../reply-hygiene");
-  const wrote = durableDomains(turnMutations());
+  const { PROPER_PROTEIN_G } = await import("../macro-card-attach");
+  const mutations = turnMutations();
+  const wrote = durableDomains(mutations);
   if (!out || wrote.length === 0) return out;
-  const decided = await canonicalDecision(user, message).catch(() => ({ todo: "" } as any));
+  // THE PLATE THIS TURN JUST WROTE, off the same record `wrote` was read from. PROPER_PROTEIN_G
+  // is the card's number, named once, so "did they just eat a proper protein meal" cannot mean
+  // one thing on the picture and another in the text.
+  const decided = await canonicalDecision(user, message, {
+    justAteProteinMeal: proteinWrittenIn(mutations) >= PROPER_PROTEIN_G,
+  }).catch(() => ({ todo: "" } as any));
   const next = withNextMove(out, String(decided?.todo || ""));
   if (next !== out) console.log(`[COACH_TURN] appended one next move after ${wrote.join("+")}`);
   return next;

--- a/server/understanding/messy-intake.ts
+++ b/server/understanding/messy-intake.ts
@@ -488,6 +488,26 @@ export function durableDomains(writes: string[]): string[] {
   return DURABLE_WRITE.filter(([, re]) => re.test(all)).map(([d]) => d);
 }
 
+/**
+ * HOW MUCH PROTEIN THIS TURN ACTUALLY WROTE — read off the same record durableDomains reads.
+ *
+ * The card knows the plate it is confirming and stands its instruction down accordingly; the
+ * action ladder did not, so after a 61g meal against a 195g target the client read "That's one
+ * proper protein down" on the picture and "Make your next meal a proper protein meal" in the
+ * text of the SAME turn. The fact was already stamped — the write door records
+ * `INSERT meal kcal=… prot=…` — so this is a read of an existing record, not a second ledger
+ * query and not a new fact. The BIGGEST single write, because two logs in one bubble are two
+ * plates and neither is the sum.
+ */
+export function proteinWrittenIn(writes: string[]): number {
+  let most = 0;
+  for (const w of writes || []) {
+    const m = String(w).match(/INSERT meal\b[^|]*?\bprot=(\d+)/i);
+    if (m) most = Math.max(most, Number(m[1]) || 0);
+  }
+  return most;
+}
+
 export function resolveTurn(
   ledger: TurnLedger,
   opts: { hasFeeling: boolean; alsoAsksCoach: boolean; durableWrites?: string[] },


### PR DESCRIPTION
Closes #128 item 4. Base `main@c0e9d3c`.

## Two owners of the next move, one of which had read the meal

Reproduced end to end on real PostgreSQL, one client, one turn:

```
Got it — Rice and Chicken breast. 👌

Make your next meal a proper protein meal.
```

61g of protein against a 195g target leaves the **day** under 60%, so rung 5 fired and told a man holding an empty plate to go and make the plate. The card has refused to do that since #148 — `macro-card-attach` says it in the founder's own case, *"a human coach never tells a man who just ate a meal to go and eat a meal"* — and the action ladder had no field to put the fact in.

It does now, and **it does not stand down**: protein is still the lever, the move goes forward from what they did, in the card's own words.

### Where the fact comes from

The write door already stamps `INSERT meal kcal=… prot=…` on the turn, and `closeCoachingTurn` already reads that record to decide whether a move is earned at all. `proteinWrittenIn` reads the same line — no second ledger query, no new fact — and `PROPER_PROTEIN_G` is the card's number, named once, so *"did they just eat a proper protein meal"* cannot mean one thing on the picture and another in the text. The **biggest** single write decides, never the sum: two 20g snacks in one bubble are two snacks, not one 40g meal.

## And the closer names food

Every phrasing of the protein rung is a shopping list in miniature — "eggs, amasi or tin fish", "tin fish, eggs or amasi", "eggs, pilchards or sugar beans" — and so are four lines of the card. None of them asked the constraint owner, so the one line this coach calls its highest-leverage action told a vegan client to eat eggs. The outbound floor cannot cover for it: this line also goes out in a **proactive brief that never passes the reactive mouth gate**.

**Two tiers, so nobody's wording changes who did not ask for it.** The founder's list is tried first and comes back untouched for a client who declared nothing — the line they read today is the line they read tomorrow, and the unit test that pins `eggs|tin fish|amasi` passes unaltered. The plant tier is consulted only when the first list has nothing left in it. When even that is empty the instruction stands **without** the menu: never a food they refuse, never silence.

**`constraints` is a required field on `ProactiveProfile`, deliberately.** An optional one would have let a sender forget it and produce a coach that offers a vegan client eggs, silently, on a schedule. Required, the compiler enumerated all four assembly sites; all four now carry it.

## Proof

**`script/gap-tests.ts`** grades both owners on the sentence each returns — every protein band, every struggle phrasing, and the after-20:00 close-out — each with an **unconstrained twin that must still be named a food**, because a coach that stopped naming food would otherwise satisfy every prohibition here. Plus: a partial exclusion takes one food, not the sentence; and the unconstrained wording is asserted verbatim so this change cannot quietly rewrite it.

**`script/pg-food-constraint-mouths-acceptance.ts`** grades the move the client actually receives, through the real front door — the only place the mutation record exists.

### The control found three harness defects before it found the product

- a first-ever log gets the welcome celebration instead of a move;
- `underPolicy` correctly downgrades an unevidenced prescription below `PROACTIVE_LOG_FLOOR`, so every check would have passed on an empty move;
- the rung's **default** phrasing names no food at all, so a client with no `biggestStruggle` would have passed the naming section without the naming branch ever running.

All three are seeded around now, and each is written down where it was found.

## Red on revert — four mechanisms, independently

The ladder hears neither fact:
```
FAIL  a client who just logged a proper protein meal is not told to go and make one
      Got it — Rice and Chicken breast. 👌
      Make your next meal a proper protein meal.
```

The ladder loses the constraint:
```
FAIL  the move appended for a vegan client names no animal protein
      Got it — Rice and Spinach. 👌
      Make your next meal a protein one — tin fish, eggs, or amasi. Two minutes.
```

The card stops filtering:
```
✗ 35g owed: the vegan card names no animal food —
  "Make your next meal a proper protein — chicken, fish, eggs"
```

The rung stops hearing the plate:
```
✗ it must not re-issue the instruction just carried out —
  "Make your next meal a proper protein meal."
```

## Local verification (remote CI is the gate)

- `npm run check` — clean.
- `npm test` — 36/37 green, `normalizer-replay-tests` still correctly `⊘ COVERED NOTHING` (#163). `gap-tests` 377/377.
- `check-file-sizes`, `check-architecture`, `check-sast`, `check-names`, `check-reach`, `check-schema-safety`, `check-prompt-integrity` — green at existing budgets. **No budget raised.**
- `pg-food-constraint-mouths-acceptance` and `pg-proactive-authority-acceptance` — GREEN.
- Journey Lab — GREEN, 266 checks across 8 sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_