### PR TITLE
The portion the client said, and the join that must not be skipped (#128 item 12)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -2251,6 +2251,62 @@ test("food scan: a combo whose span is its own is untouched (both word orders)",
   assert.ok(scanNames("pap").some(n => /^pap/i.test(n)), "pap alone unaffected");
 });
 
+// THE SIBLING THE FIRST FIX WAS NEVER GRADED ON (#128). The pap case was pinned; the same shape
+// with RICE was not, and "Rice and chicken (home cooked)" carries the alias "rice and chicken",
+// which overlaps "chicken livers" exactly as "pap and chicken" did. Verified correct on current
+// main before this was written — this pins it so it stays that way rather than claiming a fix.
+test("food scan: 'rice and chicken livers' is the same borrowed-word case, in both orders", () => {
+  for (const said of ["rice and chicken livers", "chicken livers and rice"]) {
+    const names = scanNames(said);
+    assert.ok(names.includes("Chicken livers"), `the livers must survive "${said}": ${names.join(", ")}`);
+    assert.ok(names.some(n => /rice/i.test(n)), `the rice must survive "${said}": ${names.join(", ")}`);
+    assert.ok(!names.some(n => /^(?:rice and chicken|chicken and rice)/i.test(n)),
+      `a dish was assembled out of the livers' own word in "${said}": ${names.join(", ")}`);
+    const kcal = adjustFoodsForSegment(scanForSAFoods(said) as any, said)
+      .reduce((s: number, f: any) => s + f.adjustedCalories, 0);
+    assert.ok(kcal < 700, `one plate of rice and livers cannot be ${kcal} kcal — that is the double charge`);
+  }
+  // AND THE CONTROL, which is what stops the rule above being "delete the rice combo": with no
+  // third food borrowing its words, the dish is still the dish.
+  assert.deepEqual(scanNames("rice and chicken"), ["Chicken and rice"]);
+});
+
+// ── #128: THE PORTION THE CLIENT SAID ───────────────────────────────────────────────────────
+//
+// "half a gatsby" is how anyone says it, and the alias was matched as a literal — so the size word
+// was dropped, the generic entry won, and a client who ate HALF was logged the QUARTER portion at
+// 700 kcal instead of 910, under a name they did not say.
+test("food scan: a size the client stated survives the article after it", () => {
+  const portionOf = (said: string) => {
+    const hit = (scanForSAFoods(said) as any[])[0];
+    return hit ? { name: hit.name, kcal: hit.typicalPortionCalories } : null;
+  };
+  const spaced = portionOf("half gatsby");
+  const spoken = portionOf("half a gatsby");
+  assert.ok(spaced && /half/i.test(spaced.name), `"half gatsby" resolves to the half: ${spaced?.name}`);
+  assert.deepEqual(spoken, spaced, `"half a gatsby" must be the same food as "half gatsby"`);
+  assert.deepEqual(portionOf("the full gatsby"), portionOf("full gatsby"), "and the same for a full one");
+
+  // THE CONTROL, and it is the whole risk of this change: an article may be skipped, a JOIN may
+  // never be. If "and"/"with"/"of" were skippable, two foods would start reading as one dish.
+  assert.deepEqual(scanNames("rice and chicken"), ["Chicken and rice"], "a real join still joins");
+  const separate = scanNames("chicken with rice and spinach");
+  assert.ok(separate.length >= 2, `separate foods stay separate: ${separate.join(", ")}`);
+  // A bare mention is unchanged — this adds no new match, it only stops one being lost.
+  assert.deepEqual(portionOf("gatsby"), portionOf("a gatsby"), "an article before the dish changes nothing");
+});
+
+test("food scan: aliasPattern skips an article and nothing else", async () => {
+  const { aliasPattern } = await import("../server/handlers/food-scanner");
+  const re = (alias: string) => new RegExp(`\\b${aliasPattern(alias)}\\b`, "i");
+  assert.ok(re("half gatsby").test("i had half a gatsby"), "the article is skipped");
+  assert.ok(re("half gatsby").test("half gatsby"), "…and its absence still matches");
+  assert.ok(!re("half gatsby").test("half of a gatsby"), "'of' is not an article");
+  assert.ok(!re("pap and chicken").test("pap and the fried chicken"),
+    "a word that is not an article still blocks the match");
+  assert.ok(re("peanut butter on bread").test("peanut butter on the bread"), "works at any position");
+});
+
 test("food scan: every combo in the table still resolves to itself", () => {
   // CONTROL, deliberately exhaustive. The new pass sees every combo, so a rule that is subtly too
   // greedy would show up here rather than in production. These are the phrases the combos exist for.

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -112,6 +112,28 @@ export function escapeRegex(s: string): string {
 }
 
 /**
+ * AN ARTICLE IS NOT A DIFFERENT FOOD (#128).
+ *
+ * Aliases were matched as literals, so one small English word between the size and the dish threw
+ * the client's own portion away:
+ *
+ *   "half gatsby"    → Gatsby (half)   910 kcal, 42g protein
+ *   "half a gatsby"  → Gatsby          700 kcal, 30g protein   ← a QUARTER gatsby
+ *
+ * The second is how anyone actually says it. The entry that matched is the generic one, whose own
+ * portion description reads "quarter gatsby (250g)" — so a client who told us they ate half was
+ * logged a quarter, 210 kcal light, under the name of a portion they did not have. The same shape
+ * waits behind every multi-word alias in the seed; this is the matcher, so this is where it is
+ * fixed rather than in one dish's alias list.
+ *
+ * DELIBERATELY ONLY ARTICLES. "of", "with" and "and" are joins between FOODS — letting an alias
+ * skip those is how a scanner starts reading two dishes as one.
+ */
+export function aliasPattern(alias: string): string {
+  return alias.split(/\s+/).filter(Boolean).map(escapeRegex).join(String.raw`\s+(?:(?:a|an|the)\s+)?`);
+}
+
+/**
  * The serving COUNT implied by a portion description's leading number — used as
  * the divisor when a client states their own count ("3 eggs" → 3/2 portions).
  * Returns 1 when the leading number is a weight/volume, NOT a count: "150g
@@ -285,7 +307,7 @@ function finalizeMatches(matched: SAFood[], lower: string, aliases?: Map<string,
     const spanOf = (name: string): [number, number] | null => {
       const alias = aliases.get(name);
       if (!alias) return null;
-      const m = new RegExp(`\\b(?:na|ne|no|nga|nge|ka|le|ku|se|di|ma)?${escapeRegex(alias)}(?:es|s)?\\b`, "i").exec(lower);
+      const m = new RegExp(`\\b(?:na|ne|no|nga|nge|ka|le|ku|se|di|ma)?${aliasPattern(alias)}(?:es|s)?\\b`, "i").exec(lower);
       return m ? [m.index, m.index + m[0].length] : null;
     };
     const phantomCombos = new Set<string>();
@@ -407,7 +429,7 @@ export function scanForSAFoods(msg: string, opts?: { exactOnly?: boolean }): SAF
       // PLURAL-TOLERANT ("burgers") and PREFIX-TOLERANT: Nguni/Sotho fuse the linking
       // particle onto the noun, so "inkukhu NEPAPA" (chicken AND PAP) used to drop the pap.
       // The leading \b anchors it — an English word can't split into prefix + alias.
-      const re = new RegExp(`\\b(?:na|ne|no|nga|nge|ka|le|ku|se|di|ma)?${escapeRegex(alias)}(?:es|s)?\\b`, "i");
+      const re = new RegExp(`\\b(?:na|ne|no|nga|nge|ka|le|ku|se|di|ma)?${aliasPattern(alias)}(?:es|s)?\\b`, "i");
       if (re.test(lower) && alias.length > longestHit.length) {
         longestHit = alias;
       }


### PR DESCRIPTION
Closes #128 item 12. Base `main@1a5b10e`.

## Two claims in the sentinel's item 12. Traced on current main before writing a line — they did not both hold.

### CLOSED ALREADY, and not redone

> `"rice and chicken livers"` can still match foods.ts `"Rice and chicken (home cooked)"` — not in `COMBO_OVERRIDES`.

It does not, on this SHA:

```
"rice and chicken livers"  → Rice [220kcal] + Chicken livers [258kcal]
"chicken livers and rice"  → Rice [220kcal] + Chicken livers [258kcal]
```

PASS 2b from #146 sees it — the borrowed-word rule is positional, not name-based, so it never needed the dish to be in `COMBO_OVERRIDES`. **No fix authored for a defect that is not there.**

What *was* true is the other half of that finding: *"Tests pin pap only."* The rice sibling was correct by accident and free to regress. It is pinned now, in both word orders, on its **charge** as well as its identity.

### STILL OPEN, and the real defect

The client's own portion word was thrown away by one small English word.

```
"half gatsby"    → Gatsby (half)   910 kcal, 42g protein
"half a gatsby"  → Gatsby          700 kcal, 30g protein   ← a QUARTER gatsby
```

The second is how anybody actually says it. Aliases were matched as literals, so `half gatsby` could not see `half a gatsby`; the generic entry won, and a client who told us they ate **half** was logged the quarter portion — 210 kcal light, under the name of a portion they did not have.

Five Kota entries and five Gatsby entries share these terms, so the qualifier is the only thing standing between the client and a 385 kcal spread on one word. That is the "identity" half of the item: the entries agree with each other on the bare word, and disagree entirely once a size is stated — and the size was the part being dropped.

**Fixed in the matcher, not in one dish's alias list**, because the same shape waits behind every multi-word alias in the seed. Both match sites take the same pattern — the span reader PASS 2b uses, and the PASS 1 matcher — so a dish cannot match on one reading and be measured on another.

## Only articles are skippable, and that restraint is load-bearing

`of`, `with` and `and` are joins between **foods**. The control proves it rather than asserting it: widening the skip set to include them resurrects the sentinel's own reported defect, on demand.

```
✗ a dish was assembled out of the livers' own word in "rice and chicken livers":
  Chicken livers, Rice and chicken (home cooked)
✗ a real join still joins: + 'Rice and chicken (home cooked)'
```

## Red on revert

Restoring the literal alias:
```
✗ food scan: a size the client stated survives the article after it
  "half a gatsby" must be the same food as "half gatsby"
  + kcal: 700,  name: 'Gatsby'
  - kcal: 910,  name: 'Gatsby (half)'
```

## Controls in-suite

- a bare mention is unchanged — `"gatsby"` and `"a gatsby"` resolve identically, so this adds no new match, it only stops one being lost;
- `"of"` is still not an article (`"half of a gatsby"` does not match `half gatsby`);
- a non-article word still blocks (`"pap and the fried chicken"` does not match `pap and chicken`);
- every combo in the table still resolves to itself (the existing exhaustive control);
- separate foods stay separate.

## Local verification (remote CI is the gate)

- `npm run check` — clean.
- `npm test` — 36/37 green, `gap-tests` 380/380, `normalizer-replay-tests` still correctly `⊘ COVERED NOTHING` (#163).
- Journey Lab — GREEN, 266 checks across 8 sections.
- All governors green at existing budgets. **No budget raised.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_