### PR TITLE
#163: the front door is covered — a real Railway recording, and two brakes graded on the product

### DIFF
--- a/script/fixtures/normalizer-corpus.json
+++ b/script/fixtures/normalizer-corpus.json
@@ -1,0 +1,77 @@
+{
+  "recordedAt": "2026-09-06T06:50:34.223Z",
+  "model": "gpt-4o-mini",
+  "promptHash": "a0a5590e7768c4a1",
+  "entries": {
+    "no i moved yesterdays workout to today": {
+      "intent": "OTHER",
+      "confidence": 0.95,
+      "canonical": "",
+      "_input": "No I moved yesterdays workout to today",
+      "_why": "#63: comprehension is correct (moved_to_today) and nothing consumes it — the reply is a food prompt"
+    },
+    "my dinner is the same as the last meal": {
+      "intent": "MEAL_COPY",
+      "confidence": 0.9,
+      "canonical": "dinner same as lunch",
+      "_input": "My dinner is the same as the last meal",
+      "_why": "#63: reported as logged from yesterday; a back-reference whose day resolution is the risk"
+    },
+    "no i'm just fine with this meal": {
+      "intent": "OTHER",
+      "confidence": 0.95,
+      "canonical": "",
+      "_input": "No I'm just fine with this meal",
+      "_why": "#63: a plain decline answered with 'I didn't catch that one' — reproduces offline"
+    },
+    "my steps are 10k today": {
+      "intent": "STEPS",
+      "confidence": 0.9,
+      "canonical": "10000 steps today",
+      "_input": "My steps are 10k today",
+      "_why": "#63: evidence stated, action contradicted it ('get a 20-minute walk in')"
+    },
+    "monday i had pap and chicken, eggs and bread for breakfast, and rice with beef stew for dinner. tuesday was oats, a chicken salad, and pasta with mince. wednesday i had eggs and bacon, a burger and chips, and lamb chops with rice.": {
+      "intent": "FOOD_LOG",
+      "confidence": 0.95,
+      "canonical": "i had pap and chicken, eggs and bread for breakfast and rice with beef stew for dinner yesterday",
+      "_input": "Monday I had pap and chicken, eggs and bread for breakfast, and rice with beef stew for dinner. Tuesday was oats, a chicken salad, and pasta with mince. Wednesday I had eggs and bacon, a burger and chips, and lamb chops with rice.",
+      "_why": "#63 (Bonolo): three days in one batch. multiFact is false for a single-domain note, so the rewrite brake does not engage — this is the input that must not collapse into one day"
+    },
+    "i had a burger and chips last night, i feel like i ruined everything": {
+      "intent": "RANT",
+      "confidence": 0.9,
+      "canonical": "",
+      "_input": "I had a burger and chips last night, I feel like I ruined everything",
+      "_why": "gauntlet: mouth-layer failure, 5 sentences where 3 are the rule"
+    },
+    "work is stressing me out and i ate takeaways again tonight": {
+      "intent": "FOOD_LOG",
+      "confidence": 0.9,
+      "canonical": "i had takeaways for dinner",
+      "_input": "Work is stressing me out and I ate takeaways again tonight",
+      "_why": "gauntlet: 6 sentences where 3 are the rule, and the stress is never acknowledged"
+    },
+    "is today a rest day": {
+      "intent": "QUESTION",
+      "confidence": 0.95,
+      "canonical": "",
+      "_input": "is today a rest day",
+      "_why": "gauntlet: 3 sentences where 2 are the rule"
+    },
+    "i'm doing yesterday's session today": {
+      "intent": "OTHER",
+      "confidence": 0.95,
+      "canonical": "",
+      "_input": "I'm doing yesterday's session today",
+      "_why": "the adjacent shape of moved_to_today — a rewrite must not turn this into a refusal"
+    },
+    "you missed the black coffee yesterday": {
+      "intent": "FOOD_LOG",
+      "confidence": 0.9,
+      "canonical": "i had black coffee for breakfast yesterday",
+      "_input": "you missed the black coffee yesterday",
+      "_why": "a correction naming a past day; the day must survive the rewrite"
+    }
+  }
+}

--- a/script/normalizer-replay-tests.ts
+++ b/script/normalizer-replay-tests.ts
@@ -34,6 +34,9 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { CORPUS, CORPUS_PATH, recordingFingerprint } from "./record-normalizer";
 
+/** Captured before anything can override it — see turn() below. */
+const REAL_LOG = console.log.bind(console);
+
 let passed = 0;
 const failures: string[] = [];
 async function check(name: string, fn: () => Promise<void> | void) {
@@ -68,24 +71,6 @@ async function main() {
       `${missing.length} corpus inputs were never recorded: ${missing.map(m => m.input.slice(0, 40)).join(" | ")}`);
   });
 
-  // ── THE INVARIANT THAT MATTERS: a rewrite may not destroy what a downstream owner needs ──────
-  //
-  // #63 established the mechanism: a multi-day note is a SINGLE-DOMAIN note, so `multiFact` is
-  // false and the brake that stops the normalizer speaking for a multi-fact message never engages.
-  // The batch logger itself is correct — it answers "Logged 3 days ✅" on the raw text. The risk is
-  // entirely that the raw text never reaches it.
-  await check("a multi-day batch keeps its days through the front door", () => {
-    const batch = CORPUS.find(c => /Monday I had pap/i.test(c.input))!;
-    const rec: any = recorded.entries[batch.input.toLowerCase()];
-    if (!rec) return;                       // already reported by the coverage check above
-    const canon = String(rec.canonical || "");
-    if (!canon) return;                     // no rewrite is the safe outcome — nothing destroyed
-    const days = ["monday", "tuesday", "wednesday"].filter(d => canon.toLowerCase().includes(d));
-    assert.equal(days.length, 3,
-      `the rewrite kept ${days.length}/3 named days — a multi-day note collapsed at the front door, `
-      + `which is how three days of meals land on one: ${canon}`);
-  });
-
   await check("a correction keeps the day it names", () => {
     const rec: any = recorded.entries["you missed the black coffee yesterday"];
     if (!rec?.canonical) return;
@@ -93,19 +78,6 @@ async function main() {
       `the rewrite dropped the day being corrected: ${rec.canonical}`);
   });
 
-  // ── AND THE NUMBERS BRAKE, ASSERTED ON REAL RECORDINGS ──────────────────────────────────────
-  // routes.ts refuses a canonical whose numbers are not in the original. That guard is only as
-  // good as the rewrites it actually sees.
-  await check("no rewrite invents a number the client did not write", () => {
-    for (const [key, rec] of Object.entries<any>(recorded.entries)) {
-      const canon = String(rec.canonical || "");
-      if (!canon) continue;
-      for (const n of canon.match(/\d+/g) || []) {
-        assert.ok(key.includes(n) || /^(1|2)$/.test(n),
-          `the rewrite of "${key.slice(0, 50)}" invented the number ${n}: ${canon}`);
-      }
-    }
-  });
 
   // ── AND THROUGH THE PRODUCTION PATH, WHICH IS THE WHOLE POINT ────────────────────────────────
   //
@@ -139,6 +111,102 @@ async function main() {
         `the pipeline crashed with the normalizer on — this path is only reachable here:\n      ${reply.slice(0, 160)}`);
     });
   }
+
+  // ── THE INVARIANT THAT MATTERS, GRADED ON THE PRODUCT AND NOT ON THE MODEL'S STRING ─────────
+  //
+  // The first real recording (2026-09-06, Railway) settled a question the string form of these two
+  // checks could not even ask. gpt-4o-mini DOES collapse the three-day batch — it returned
+  // "…for breakfast and rice with beef stew for dinner yesterday", losing Tuesday and Wednesday and
+  // renaming Monday. Graded as a string that is a failure. Graded through the front door it is not
+  // a failure at all, because routes.ts refuses the rewrite before any handler sees it:
+  //
+  //   [NORMALIZER] multi-DAY note is never rewritten; raw text proceeds
+  //   [MEAL_LOG] INSERT meal … at=Mon Aug 31
+  //   [MEAL_LOG] INSERT meal … at=Tue Sep 01
+  //   [MEAL_LOG] INSERT meal … at=Wed Sep 02
+  //
+  // Three days in, three days written. The old assertion demanded that the MODEL behave, which is
+  // neither something this product controls nor what #63 was ever about: #63 is that the raw text
+  // must reach the batch logger. So these now drive the real turn and read the durable writes and
+  // the front door's own instrumentation. That is strictly stronger — a model that happened to
+  // echo the three day names would satisfy the old check while the brake was broken — and it is
+  // the same discipline the rest of this repo applies: static shape produces candidates, the
+  // runtime trace decides.
+  const { mealLogs } = await import("../shared/schema");
+  const { sastDayKey } = await import("../server/sast");
+
+  /** Run one real turn and capture what it wrote and whether the front door applied a rewrite. */
+  async function turn(input: string): Promise<{ days: string[]; appliedRewrite: boolean }> {
+    const g = globalThis as any;
+    g.__KAMLIFE_STUB_USER = { ...USER };
+    g.__KAMLIFE_STUB_WRITES = [];
+    // The applied-rewrite line is only printed when the canonical SURVIVES every brake
+    // (routes.ts:709). Every refusal prints a differently-shaped line, so this reads the product's
+    // own instrumentation rather than re-deriving the decision.
+    // ONE TURN AT A TIME, AND THE RESTORE TARGET IS CAPTURED ONCE. The first cut ran these
+    // concurrently through Promise.all: the overrides nested, the last restore put back another
+    // OVERRIDE rather than the real function, and the suite's own summary vanished into it.
+    // Concurrent turns would also share __KAMLIFE_STUB_WRITES and the stub user, so sequential is
+    // the only honest shape here regardless of the logging.
+    const APPLIED = /^\[NORMALIZER\] [A-Z_]+\(\d+%\)/;
+    let applied = false;
+    console.log = (...a: unknown[]) => { if (APPLIED.test(String(a[0] ?? ""))) applied = true; };
+    try { await handleMessage(USER.phoneNumber, input); }
+    finally { console.log = REAL_LOG; }
+    const days = (g.__KAMLIFE_STUB_WRITES as Array<{ table: unknown; values: any }>)
+      .filter(w => w.table === mealLogs && w.values?.loggedAt)
+      .map(w => sastDayKey(new Date(w.values.loggedAt)));
+    delete g.__KAMLIFE_STUB_WRITES;
+    return { days: [...new Set(days)], appliedRewrite: applied };
+  }
+
+  await check("a multi-day batch still lands on three days through the front door", async () => {
+    const batch = CORPUS.find(c => /Monday I had pap/i.test(c.input))!;
+    if (!(batch.input.toLowerCase() in recorded.entries)) return;   // reported by the coverage check
+    const { days, appliedRewrite } = await turn(batch.input);
+    assert.equal(days.length, 3,
+      `three days of meals landed on ${days.length} day(s): ${days.join(", ")} — this is the ~7,700 `
+      + `kcal-on-one-day failure from #63, and it means the raw text never reached the batch logger`);
+    assert.equal(appliedRewrite, false,
+      "the front door applied a rewrite to a multi-day note — the brake that protects the batch "
+      + "logger is not firing, whatever the model happened to return this time");
+  });
+
+  // ── AND THE NUMBERS BRAKE, GRADED ON WHETHER IT FIRED ───────────────────────────────────────
+  //
+  // routes.ts refuses any canonical carrying a digit the client did not write. The first real
+  // recording produced one: "my steps are 10k today" → "10000 steps today". That expansion is
+  // reasonable and the brake still refuses it, because a brake that reasons about which inventions
+  // are benign is not a brake. The old check called that a failure of the MODEL; what matters is
+  // that the GUARD held and the deterministic step parser read "10k" off the raw text anyway.
+  await check("a canonical carrying an unwritten number never reaches a handler", async () => {
+    // The brake's own test, in the brake's own terms (routes.ts): separators stripped, digit-for-
+    // digit containment. Word-number compounds are the brake's other allowance and none of the
+    // recorded inputs use one, so this is deliberately the narrow form.
+    const inventing = Object.entries<any>(recorded.entries).filter(([key, rec]) => {
+      const stripped = key.replace(/[.,\s]/g, "");
+      return String(rec.canonical || "").match(/\d+/g)?.some(d => !stripped.includes(d));
+    });
+    for (const [key] of inventing) {
+      const rec: any = recorded.entries[key];
+      const { appliedRewrite } = await turn(String(rec._input || key));
+      assert.equal(appliedRewrite, false,
+        `the front door applied "${rec.canonical}" to "${key.slice(0, 46)}" — it carries a number `
+        + `the client never wrote, and the hallucination brake let it through`);
+    }
+    // NOT VACUOUS. If nothing in the corpus invents a number the loop above asserts nothing, and a
+    // brake that refused EVERY rewrite would also pass it. Both are ruled out here.
+    assert.ok(inventing.length > 0,
+      "no recorded canonical carries an unwritten number, so this check graded nothing — re-record, "
+      + "or retire it deliberately rather than letting it pass empty");
+    let anyApplied = false;
+    for (const c of CORPUS.filter(c => recorded.entries[c.input.toLowerCase()]?.canonical)) {
+      if ((await turn(c.input)).appliedRewrite) { anyApplied = true; break; }
+    }
+    assert.ok(anyApplied,
+      "the front door applied NO rewrite from the whole corpus — the brakes cannot be graded "
+      + "against a normalizer that is off");
+  });
 
   console.log(`\nnormalizer-replay: ${passed}/${passed + failures.length} passed `
     + `(${Object.keys(recorded.entries).length} recorded normalizations)`);


### PR DESCRIPTION
Closes #163.

**BASE `origin/main`: `e53fb02e12fea00312e489f531573251edfb351a`**
**HEAD: `35927af0a9c3d28dd0bff875484dd2d3730268a5`**

`normalizer-replay-tests` has reported `COVERED NOTHING` since it was written. It does not any more.

```
before   suites: 36/37 green, 1 covered nothing
         ⊘ normalizer-replay-tests — no recording at script/fixtures/normalizer-corpus.json
           — the production front door is NOT covered

after    suites: 37/37 green
         ✓ normalizer-replay-tests
         normalizer-replay: 14/14 passed (10 recorded normalizations)
         ✓ the production front door was exercised, not skipped
```

## The recording

| | |
|---|---|
| Where it ran | **Inside Railway**, using the credential already present there |
| Genuine recordings | **10 / 10** |
| Distinct intents | 6 — `FOOD_LOG`, `MEAL_COPY`, `OTHER`, `QUESTION`, `RANT`, `STEPS` |
| Fallback sentinels (`OTHER`/0/no canonical) | **0** |
| Fingerprint | `gpt-4o-mini` / `a0a5590e7768c4a1` |
| Fingerprint vs current `main` | **MATCH** — computed from `server/gpt.ts` at BASE; not stale |
| Front-door cases replayed | **10** (14 checks total) |

No credential was read, printed, copied or committed. Only the non-secret corpus crossed into the repository, through the `--stdout` marker path #185 built for exactly this hand-off. The diff was scanned for credential-shaped strings before pushing; it contains none. Two files changed, **no product code**.

## Two checks were grading the model's string instead of the product

The first real recording is what made this visible — it could not be seen before, because there was nothing to grade.

### 1. The multi-day batch

gpt-4o-mini really does collapse it. It returned `"…for breakfast and rice with beef stew for dinner yesterday"` — losing Tuesday and Wednesday, and renaming Monday. As a string assertion that is a failure. **Through the front door it is not**, because `routes.ts` refuses the rewrite before any handler sees it:

```
[NORMALIZER] multi-DAY note is never rewritten; raw text proceeds
[MEAL_LOG] INSERT meal … at=Mon Aug 31
[MEAL_LOG] INSERT meal … at=Tue Sep 01
[MEAL_LOG] INSERT meal … at=Wed Sep 02
```

Three days in, three days written. The old check demanded that the **model** behave — which this product does not control, and which is not what #63 was about. #63 is that the raw text must reach the batch logger. The check now reads the durable writes.

### 2. The numbers brake

`"my steps are 10k today"` → `"10000 steps today"`. The expansion is reasonable and the brake still refuses it, because a brake that reasons about which inventions are benign is not a brake — and the deterministic step parser then reads `10k` off the raw text and logs 10000 anyway. The old check called that a model failure. The check now asserts what matters: **a canonical carrying a number the client never wrote must not reach a handler.**

Per the issue's guardrail I looked hard for a product defect here first. There isn't one: both brakes fire, and the customer-visible outcome is correct in both cases. So no product behaviour was changed and nothing was handed to CTO as a defect.

## Strictly stronger — proven by removing the mechanisms

The old string checks would have passed all three of these, because the model's output is identical in every run:

```
multi-day brake disabled   ✗ a multi-day batch still lands on three days through the front door
                             three days of meals landed on 1 day(s): 2026-09-05 — this is the
                             ~7,700 kcal-on-one-day failure from #63

numbers brake disabled     ✗ a canonical carrying an unwritten number never reaches a handler
                             the front door applied "10000 steps today" to "my steps are 10k today"

one recording removed      ✗ every corpus input has a recording
                             1 corpus inputs were never recorded (STRICT)
```

Each restored to **14/14** immediately after. The corruption was confirmed applied before each run (`entries now: 9 (was 10)`, and the brake edits asserted their target existed).

## Neither new check can pass empty

The numbers check asserts that **at least one** recorded canonical carries an unwritten number — otherwise it graded nothing — **and** that the front door applies at least one rewrite from the corpus, otherwise the brakes are being graded against a normalizer that is off.

## A harness bug the controls caught first

The turns ran concurrently through `Promise.all`, so the `console.log` overrides nested and the last restore put back another **override** rather than the real function — the suite's own summary vanished into it. Turns are sequential now, and they must be regardless: they share the stub's write log and the stub user.

## Voice / STT boundary — reported, not overclaimed

The voice path transcribes with Whisper (`server/handlers/media.ts`) and re-enters `handleMessage` as text, so this corpus covers the **text** normalizer only. The earlier speech-to-text transformation is **not** covered by it and no coverage is claimed. Recorded as separate evidence debt, per the issue's instruction not to build a second framework here.

## Verification

- `npm run check` — clean.
- `npm test` — **37/37 green, no abstention** (was 36/37 + 1 covered nothing).
- `normalizer-replay-tests` — 14/14, 10 recorded normalizations, 10 front-door turns.
- Journey Lab — GREEN, 266 checks across 8 sections.
- All nine PostgreSQL acceptance suites — GREEN.
- No budget raised, no assertion weakened, no `continue-on-error`, no product behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_