### PR TITLE
#207: a durable log turn is one coach speaking — DO NOT MERGE before CTO adjudication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,12 @@ jobs:
       # fixture that answers every query the same way.
       - name: Thin-evidence coaching on real PostgreSQL
         run: npx tsx script/pg-thin-evidence-acceptance.ts
+      # ONE COACH SPEAKING (#207). The repetition defect this closes is invisible to a fixture
+      # that sends one message per client: it only appears across CONSECUTIVE durable writes by
+      # the same person, where the decision is recomputed from day state that the new event did
+      # not move. Real rows, real front door, several turns.
+      - name: Durable log turns are one coaching turn on real PostgreSQL
+        run: npx tsx script/pg-log-turn-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/pg-log-turn-acceptance.ts
+++ b/script/pg-log-turn-acceptance.ts
@@ -1,0 +1,276 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — a durable log turn is ONE coach speaking (#207).
+ *
+ * THE FOUNDER COMPLAINT THIS CLOSES. Coach K read like a receipt printer: an acknowledgement
+ * written by a handler that knew the client's words and nothing else, then a move appended across
+ * a blank line by a ladder that knew day state and nothing about the event. Two subsystems, one
+ * bubble. Traced through the real front door before anything changed — one client, one day:
+ *
+ *     "two eggs and toast for breakfast"  ->  "Got it — Eggs toast. 👌"
+ *                                             "Start tomorrow with protein — eggs … at breakfast."
+ *     "walked 9000 steps"                 ->  the same instruction, stapled to a step count
+ *     "87.4kg this morning"               ->  the same instruction, a third time
+ *
+ * WHY POSTGRESQL, AND WHY A MULTI-TURN CLIENT. Every claim here is about what a SEQUENCE of
+ * durable writes does to the next decision: how many days carry a meal, what today's totals
+ * became after this write, whether the instruction has already gone out in this conversation.
+ * A fresh fixture per assertion cannot express any of it — the repetition defect is invisible to
+ * a suite that only ever sends one message per client, which is exactly how it survived.
+ *
+ * chooseAction remains the sole owner of WHAT the client should do. Nothing in this cut selects,
+ * ranks or invents an action; the move arrives decided and is phrased beside the event.
+ *
+ * EVERY CLAIM IS PAIRED WITH ITS CONTROL. "The coach said less" is trivially satisfied by a coach
+ * that stops coaching, which is the opposite defect and the one #203 exists to prevent.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-log-turn-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+let captured: string[] = [];
+console.log = console.warn = console.error =
+  (...a: any[]) => { captured.push(a.map(x => typeof x === "string" ? x : JSON.stringify(x)).join(" ")); };
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(over: Record<string, any> = {}, seed: { meals?: number[]; weights?: number[]; steps?: number[]; workouts?: number[] } = {}) {
+  const phone = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: D(40), programmeStartDate: D(40),
+    programmeWeek: 6, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  if (seed.meals?.length) await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     SELECT $1, now() - (d || ' days')::interval, 'lunch', 600, 40, $2, 'seed', 'sa_scanner'
+       FROM unnest($3::int[]) AS d`,
+    [u.id, JSON.stringify([{ name: "pap", grams: 200 }]), seed.meals]);
+  if (seed.weights?.length) await pool.query(
+    `INSERT INTO weight_logs (user_id, weight, logged_at)
+     SELECT $1, 88.0 + d * 0.3, now() - (d || ' days')::interval FROM unnest($2::int[]) AS d`,
+    [u.id, seed.weights]);
+  if (seed.steps?.length) await pool.query(
+    `INSERT INTO step_logs (user_id, logged_at, steps, provenance, resolved_day)
+     SELECT $1, now() - (d || ' days')::interval, 9000, 'client_report',
+            to_char((now() - (d || ' days')::interval) AT TIME ZONE 'Africa/Johannesburg','YYYY-MM-DD')
+       FROM unnest($2::int[]) AS d`, [u.id, seed.steps]);
+  if (seed.workouts?.length) await pool.query(
+    `INSERT INTO workout_logs (user_id, logged_at, workout_completed)
+     SELECT $1, now() - (d || ' days')::interval, true FROM unnest($2::int[]) AS d`,
+    [u.id, seed.workouts]);
+  return { id: u.id, phone };
+}
+
+/** One turn through the real front door, with the move the close actually delivered. */
+async function say(phone: string, text: string): Promise<{ reply: string; move: string }> {
+  captured = [];
+  const reply = String(await handleMessage(
+    phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
+  const marker = captured.filter(l => l.includes("[COACH_TURN] MOVE=")).pop() || "";
+  const move = marker ? (marker.split("[COACH_TURN] MOVE=")[1] || "").replace(/\s*\([^)]*\)\s*$/, "").trim() : "";
+  return { reply, move };
+}
+
+/** An EVIDENCED client: six days of food, steps, two weigh-ins. A real prescription is available,
+ *  so nothing receipt-shaped here can be blamed on thin evidence. */
+const EV = { meals: [1, 2, 3, 4, 5, 6], weights: [0, 6], steps: [1, 2, 3], workouts: [3] };
+
+REAL("\n=== ONE COACH SPEAKING, NOT ACK + STAPLED RUNG ===");
+
+// ── §1 THE DAY THAT PRODUCED THE COMPLAINT ──────────────────────────────────────────────────
+{
+  _resetOutboundDedupe();
+  const c = await client({}, EV);
+  const breakfast = await say(c.phone, "two eggs and toast for breakfast");
+  const steps = await say(c.phone, "walked 9000 steps");
+  const weight = await say(c.phone, "87.4kg this morning");
+
+  chk(!!breakfast.move,
+    "the first durable event of the day carries the canonical move",
+    `reply=${JSON.stringify(breakfast.reply)}`);
+  // ONE AUTHOR: the move is inside the acknowledgement's paragraph, not a block after it.
+  chk(breakfast.reply.trim().split(/\n\s*\n/).length === 1,
+    "…and it is one paragraph from one author, not a receipt with a block stapled after it",
+    JSON.stringify(breakfast.reply));
+  // THE ACKNOWLEDGEMENT NAMES THE FACT THE MOVE TURNS ON. Being told to start tomorrow with
+  // protein, seconds after logging breakfast, reads as a coach who never looked at the plate.
+  chk(/\b24g protein\b/.test(breakfast.reply),
+    "…and the breakfast it is coaching about is named, with the protein this turn actually wrote",
+    JSON.stringify(breakfast.reply));
+
+  chk(steps.move === "",
+    "the same instruction is not re-issued when a step report arrives moments later",
+    `move=${JSON.stringify(steps.move)} reply=${JSON.stringify(steps.reply)}`);
+  chk(!steps.reply.includes("Start tomorrow with protein"),
+    "…and the customer does not read the breakfast instruction stapled to their step count",
+    JSON.stringify(steps.reply));
+  chk(steps.reply.trim().length > 0,
+    "…and the step report is still acknowledged rather than met with silence",
+    JSON.stringify(steps.reply));
+
+  chk(!weight.reply.includes("Start tomorrow with protein"),
+    "…nor a third time on the weigh-in two turns later",
+    JSON.stringify(weight.reply));
+}
+
+// ── §2 A SPARSE CLIENT IS ASKED ONCE, NOT EVERY TURN (#203 and #207 together) ────────────────
+{
+  _resetOutboundDedupe();
+  const c = await client({}, { meals: [1], weights: [0, 4] });
+  const steps = await say(c.phone, "walked 8000 steps today");
+  const weight = await say(c.phone, "87.4kg this morning");
+
+  chk(/tell me what you ate today/i.test(steps.reply),
+    "a sparse client is still asked the one measurement that would unlock coaching (#203 holds)",
+    JSON.stringify(steps.reply));
+  chk(!/tell me what you ate today/i.test(weight.reply),
+    "…and is not asked the identical question again on the very next durable event",
+    JSON.stringify(weight.reply));
+  chk(weight.reply.trim().length > 0,
+    "…while the weigh-in is still acknowledged",
+    JSON.stringify(weight.reply));
+}
+
+REAL("\n=== CANONICAL TRUTH REACHES THE ACKNOWLEDGEMENT ===");
+
+// ── §3 AN ADVERSE EVENT IS NOT BLINDLY CELEBRATED ───────────────────────────────────────────
+//
+// 2 445 kcal against a 1 200 kcal target used to read "Got it — Chips, Pap and Beef stew. 👌",
+// purely because the acknowledgement author was starved of the comparison. NO NEW RUNG was added
+// to chooseAction for being over budget on a cut — that policy gap is real and is reported
+// separately. This asserts only that canonical truth reaches the mouth.
+{
+  _resetOutboundDedupe();
+  const c = await client({ calorieTarget: 1200 }, EV);
+  const { reply } = await say(c.phone, "I had a huge plate of pap and beef stew and chips for dinner");
+  chk(/over your calories for today/i.test(reply),
+    "a plate that puts the day over its canonical target says so",
+    JSON.stringify(reply));
+  chk(!/👌/.test(reply),
+    "…and is not given the acknowledgement emoji that means 'nice one'",
+    JSON.stringify(reply));
+  // CONTROL — the same sentence on a normal target is NOT scolded. Without this, a build that
+  // simply deleted the cheerful acknowledgement everywhere would pass the two checks above.
+  _resetOutboundDedupe();
+  const ok = await client({}, EV);
+  const fine = await say(ok.phone, "I had rice and chicken for lunch");
+  chk(!/over your calories/i.test(fine.reply),
+    "CONTROL: a meal inside the day's calories is never told it went over",
+    JSON.stringify(fine.reply));
+  chk(/👌/.test(fine.reply),
+    "CONTROL: …and still gets the ordinary acknowledgement",
+    JSON.stringify(fine.reply));
+}
+
+// ── §4 A PLATE WE JUST TOLD THEM TO CHANGE IS NOT A PLATE TO REPEAT ──────────────────────────
+//
+// One message said "go bean or chicken bunny over mutton — leaner" and, four blocks later,
+// "that's one proper protein down — start tomorrow the same way". justAteProteinMeal is grams
+// alone, and a bunny chow clears PROPER_PROTEIN_G. The dish's OWN verdict — the existing
+// authoritative evaluation, unchanged — now says this turn already asked for a change.
+{
+  _resetOutboundDedupe();
+  const c = await client({}, EV);
+  const { reply } = await say(c.phone,
+    "I was so stressed at work today I ended up eating a bunny chow and two cokes");
+  chk(/leaner|order it smart|not one for you/i.test(reply),
+    "the turn still gives the plate the smart-order coaching it always gave",
+    JSON.stringify(reply));
+  chk(!/start tomorrow the same way|one proper protein down/i.test(reply),
+    "…and cannot also call that plate a win to repeat tomorrow",
+    JSON.stringify(reply));
+  // CONTROL — a plate nobody asked them to change still earns the protein closer, so the fix is
+  // about the verdict and not about deleting the sentence.
+  _resetOutboundDedupe();
+  const good = await client({}, EV);
+  const win = await say(good.phone, "grilled chicken breast with broccoli and sweet potato for lunch");
+  chk(/one proper protein down/i.test(win.reply),
+    "CONTROL: a plate we did NOT ask them to change still earns the protein closer",
+    JSON.stringify(win.reply));
+}
+
+REAL("\n=== CONTROLS — WHAT MUST NOT CHANGE ===");
+
+// ── §5 EXISTING OWNERSHIP AND CONSTRAINTS ───────────────────────────────────────────────────
+{
+  // A reply that already owns NEXT keeps exactly one, and is not recomposed: the workout card is
+  // not a bare receipt, so the close leaves it alone.
+  _resetOutboundDedupe();
+  const c = await client({}, EV);
+  const w = await say(c.phone, "did my workout today");
+  chk(w.move === "",
+    "a reply that already owns NEXT is not given a second one",
+    `move=${JSON.stringify(w.move)}`);
+  chk((w.reply.match(/\?/g) || []).length <= 2 && w.reply.includes("How did it feel"),
+    "…and the handler's own question survives untouched",
+    JSON.stringify(w.reply));
+
+  // doNotMention stays authoritative through whatever composes the turn.
+  _resetOutboundDedupe();
+  const q = await client({ doNotMention: "weight" }, EV);
+  const dn = await say(q.phone, "I had rice and chicken for lunch");
+  chk(!/\b(weigh|scale|kg)\b/i.test(dn.reply),
+    "a client who ruled out the scale reads no weight word in a composed turn",
+    JSON.stringify(dn.reply));
+
+  // A closed food day is never answered with an instruction to eat.
+  _resetOutboundDedupe();
+  const f = await client({}, EV);
+  await say(f.phone, "I'm not eating anything else today");
+  const after = await say(f.phone, "walked 9000 steps");
+  chk(!/eat|meal|breakfast/i.test(after.move || ""),
+    "a closed food day is never answered with an instruction to eat",
+    `move=${JSON.stringify(after.move)}`);
+
+  // NUMERIC ATTRIBUTION. The only figures a composed turn may add are ones the turn itself wrote.
+  _resetOutboundDedupe();
+  const n = await client({}, EV);
+  const meal = await say(n.phone, "I had rice and chicken for lunch");
+  const grams = [...meal.reply.matchAll(/(\d+)g protein/g)].map(m => Number(m[1]));
+  const [row] = (await pool.query(
+    `SELECT protein_int FROM meal_logs WHERE user_id = $1 ORDER BY logged_at DESC LIMIT 1`, [n.id])).rows;
+  chk(grams.length > 0 && grams.every(g => g === Number(row.protein_int)),
+    "every gram figure in a composed turn is the protein this turn actually wrote",
+    `said=${JSON.stringify(grams)} row=${row?.protein_int}`);
+  chk(!/average|per day|this week|7 days/i.test(meal.reply),
+    "…and no total, average or window the client never asked for came with it",
+    JSON.stringify(meal.reply));
+}
+
+REAL(`\n${failed === 0 ? "pg-log-turn-acceptance: GREEN — all checks passed" : `pg-log-turn-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-log-turn-day.ts
+++ b/script/pg-log-turn-day.ts
@@ -68,14 +68,14 @@ async function turn(phone: string, text: string) {
   const reply = String(await handleMessage(
     phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
   const writes = captured.filter(l => MUT.test(l)).map(l => l.trim().replace(/user=\S+ /, ""));
-  const appended = captured.some(l => l.includes("[COACH_TURN]"));
-  const move = appended ? reply.split("\n\n").slice(-1)[0] : "";
-  const prose = appended ? reply.split("\n\n").slice(0, -1).join("\n\n") : reply;
+  // The close now leaves its own marker saying WHICH shape it used, so this reports what happened
+  // rather than inferring it from a blank line the composed turn no longer contains.
+  const marker = captured.find(l => l.includes("[COACH_TURN]")) || "(no close)";
   REAL(`\n  ▸ ${JSON.stringify(text)}`);
   REAL(`      wrote  ${writes.join(" ; ") || "(nothing durable)"}`);
-  REAL(`      ack    ${JSON.stringify(prose)}`);
-  REAL(`      move   ${move ? JSON.stringify(move) : "(no append)"}`);
-  return move;
+  REAL(`      close  ${marker.replace(/^\s*\[COACH_TURN\]\s*/, "").trim()}`);
+  REAL(`      REPLY  ${JSON.stringify(reply)}`);
+  return reply;
 }
 
 REAL("=".repeat(94));
@@ -95,7 +95,7 @@ moves.push(await turn(a.phone, "pap and beef stew for dinner"));
 
 const nonEmpty = moves.filter(Boolean);
 const distinct = new Set(nonEmpty);
-REAL(`\n  moves appended: ${nonEmpty.length}   distinct: ${distinct.size}`);
+REAL(`\n  replies: ${nonEmpty.length}   distinct: ${distinct.size}`);
 for (const m of distinct) REAL(`    ${nonEmpty.filter(x => x === m).length}× ${JSON.stringify(m)}`);
 
 REAL("\n" + "─".repeat(94));
@@ -106,7 +106,7 @@ bm.push(await turn(b.phone, "walked 8000 steps today"));
 bm.push(await turn(b.phone, "87.4kg this morning"));
 bm.push(await turn(b.phone, "did my workout"));
 const bne = bm.filter(Boolean);
-REAL(`\n  moves appended: ${bne.length}   distinct: ${new Set(bne).size}`);
+REAL(`\n  replies: ${bne.length}   distinct: ${new Set(bne).size}`);
 for (const m of new Set(bne)) REAL(`    ${bne.filter(x => x === m).length}× ${JSON.stringify(m)}`);
 
 REAL(`\n${"=".repeat(94)}`);

--- a/script/pg-log-turn-day.ts
+++ b/script/pg-log-turn-day.ts
@@ -1,0 +1,120 @@
+/**
+ * DIAGNOSTIC TRACE 2 — a whole day of log turns, one client (#207).
+ *
+ * Trace 1 took one turn per client. The founder's complaint is about how a DAY reads: several
+ * durable logs in a row, each acknowledged and each stapled with a move chosen from day state.
+ * chooseAction is a pure function of that state, so this asks the question trace 1 could not:
+ * does the same client get the same stapled sentence turn after turn?
+ */
+if (!process.env.DATABASE_URL) { console.log("SKIPPED — no DATABASE_URL."); process.exit(0); }
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+let captured: string[] = [];
+console.log = console.warn = console.error =
+  (...a: any[]) => { captured.push(a.map(x => typeof x === "string" ? x : JSON.stringify(x)).join(" ")); };
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(over: Record<string, any> = {}, seed: { meals?: number[]; weights?: number[]; steps?: number[]; workouts?: number[] } = {}) {
+  const phone = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: D(40), programmeStartDate: D(40),
+    programmeWeek: 6, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  if (seed.meals?.length) await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     SELECT $1, now() - (d || ' days')::interval, 'lunch', 600, 40, $2, 'seed', 'sa_scanner'
+       FROM unnest($3::int[]) AS d`,
+    [u.id, JSON.stringify([{ name: "pap", grams: 200 }]), seed.meals]);
+  if (seed.weights?.length) await pool.query(
+    `INSERT INTO weight_logs (user_id, weight, logged_at)
+     SELECT $1, 88.0 + d * 0.3, now() - (d || ' days')::interval FROM unnest($2::int[]) AS d`,
+    [u.id, seed.weights]);
+  if (seed.steps?.length) await pool.query(
+    `INSERT INTO step_logs (user_id, logged_at, steps, provenance, resolved_day)
+     SELECT $1, now() - (d || ' days')::interval, 9000, 'client_report',
+            to_char((now() - (d || ' days')::interval) AT TIME ZONE 'Africa/Johannesburg','YYYY-MM-DD')
+       FROM unnest($2::int[]) AS d`, [u.id, seed.steps]);
+  if (seed.workouts?.length) await pool.query(
+    `INSERT INTO workout_logs (user_id, logged_at, workout_completed)
+     SELECT $1, now() - (d || ' days')::interval, true FROM unnest($2::int[]) AS d`,
+    [u.id, seed.workouts]);
+  return { id: u.id, phone };
+}
+
+const MUT = /\b(INSERT|UPDATE) (meal|steps|weight|workout|water)\b/i;
+
+async function turn(phone: string, text: string) {
+  captured = [];
+  const reply = String(await handleMessage(
+    phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
+  const writes = captured.filter(l => MUT.test(l)).map(l => l.trim().replace(/user=\S+ /, ""));
+  const appended = captured.some(l => l.includes("[COACH_TURN]"));
+  const move = appended ? reply.split("\n\n").slice(-1)[0] : "";
+  const prose = appended ? reply.split("\n\n").slice(0, -1).join("\n\n") : reply;
+  REAL(`\n  ▸ ${JSON.stringify(text)}`);
+  REAL(`      wrote  ${writes.join(" ; ") || "(nothing durable)"}`);
+  REAL(`      ack    ${JSON.stringify(prose)}`);
+  REAL(`      move   ${move ? JSON.stringify(move) : "(no append)"}`);
+  return move;
+}
+
+REAL("=".repeat(94));
+REAL("#207 — ONE CLIENT, ONE DAY, SEVERAL DURABLE LOGS");
+REAL("=".repeat(94));
+
+const ev = { meals: [1, 2, 3, 4, 5, 6], weights: [0, 6], steps: [1, 2, 3], workouts: [3] };
+
+REAL("\nA · A normal day: breakfast, steps, lunch, weigh-in, dinner");
+const a = await client({}, ev);
+const moves: string[] = [];
+moves.push(await turn(a.phone, "two eggs and toast for breakfast"));
+moves.push(await turn(a.phone, "walked 9000 steps"));
+moves.push(await turn(a.phone, "chicken and rice for lunch"));
+moves.push(await turn(a.phone, "87.4kg this morning"));
+moves.push(await turn(a.phone, "pap and beef stew for dinner"));
+
+const nonEmpty = moves.filter(Boolean);
+const distinct = new Set(nonEmpty);
+REAL(`\n  moves appended: ${nonEmpty.length}   distinct: ${distinct.size}`);
+for (const m of distinct) REAL(`    ${nonEmpty.filter(x => x === m).length}× ${JSON.stringify(m)}`);
+
+REAL("\n" + "─".repeat(94));
+REAL("\nB · A sparse client reporting three things in a row");
+const b = await client({}, { meals: [1], weights: [0, 4] });
+const bm: string[] = [];
+bm.push(await turn(b.phone, "walked 8000 steps today"));
+bm.push(await turn(b.phone, "87.4kg this morning"));
+bm.push(await turn(b.phone, "did my workout"));
+const bne = bm.filter(Boolean);
+REAL(`\n  moves appended: ${bne.length}   distinct: ${new Set(bne).size}`);
+for (const m of new Set(bne)) REAL(`    ${bne.filter(x => x === m).length}× ${JSON.stringify(m)}`);
+
+REAL(`\n${"=".repeat(94)}`);
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(0);

--- a/script/pg-log-turn-trace.ts
+++ b/script/pg-log-turn-trace.ts
@@ -78,19 +78,16 @@ async function trace(label: string, phone: string, text: string) {
   const reply = String(await handleMessage(
     phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
   const writes = captured.filter(l => MUT.test(l)).map(l => l.trim());
-  const appended = captured.find(l => l.includes("[COACH_TURN]")) || "";
-  // The append shape is a constant in reply-hygiene: `${prose}\n\n${move}.`
-  const stapled = appended ? reply.split("\n\n").slice(-1)[0] : "";
-  const prose = appended ? reply.split("\n\n").slice(0, -1).join("\n\n") : reply;
+  // The close states which shape it used, so this reports what happened rather than inferring it
+  // from a blank line the composed turn no longer contains.
+  const closed = captured.find(l => l.includes("[COACH_TURN]")) || "";
 
   REAL(`\n${"─".repeat(94)}\n${label}`);
   REAL(`  client words     ${JSON.stringify(text)}`);
   REAL(`  durable writes   ${writes.length ? writes.join("\n                   ") : "(none)"}`);
-  REAL(`  coach-turn       ${appended ? appended.trim() : "(withNextMove changed nothing — no append)"}`);
-  REAL(`  handler prose    ${JSON.stringify(prose)}`);
-  REAL(`  stapled move     ${stapled ? JSON.stringify(stapled) : "(none)"}`);
+  REAL(`  close            ${closed ? closed.replace(/^\s*\[COACH_TURN\]\s*/, "").trim() : "(no close — nothing durable, or the reply already owns NEXT)"}`);
   REAL(`  FINAL REPLY      ${JSON.stringify(reply)}`);
-  return { reply, prose, stapled, writes, appended };
+  return { reply, writes, closed };
 }
 
 REAL("=".repeat(94));

--- a/script/pg-log-turn-trace.ts
+++ b/script/pg-log-turn-trace.ts
@@ -1,0 +1,150 @@
+/**
+ * DIAGNOSTIC TRACE — where does a durable log turn stop being one coaching turn? (#207)
+ *
+ * Not an acceptance. This prints, for each scenario the issue names:
+ *
+ *   client words -> durable truth written -> canonical decision -> handler prose
+ *                -> withNextMove -> final customer reply
+ *
+ * Handler prose is recovered honestly rather than guessed: closeCoachingTurn logs
+ * `[COACH_TURN] appended one next move after <domains>` when and only when withNextMove changed
+ * the string, and the append shape is a known constant (`\n\n${move}.`), so the prose is the
+ * final reply with that exact tail removed. Every durable write is read off the turn's own
+ * mutation record, which chat-log prints with its domain prefix.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-log-turn-trace: SKIPPED — no DATABASE_URL.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+let captured: string[] = [];
+const cap = (...a: any[]) => { captured.push(a.map(x => typeof x === "string" ? x : JSON.stringify(x)).join(" ")); };
+console.log = console.warn = console.error = cap;
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(over: Record<string, any> = {}, seed: { meals?: number[]; weights?: number[]; steps?: number[]; workouts?: number[] } = {}) {
+  const phone = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: D(40), programmeStartDate: D(40),
+    programmeWeek: 6, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  if (seed.meals?.length) await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     SELECT $1, now() - (d || ' days')::interval, 'lunch', 600, 40, $2, 'seed', 'sa_scanner'
+       FROM unnest($3::int[]) AS d`,
+    [u.id, JSON.stringify([{ name: "pap", grams: 200 }]), seed.meals]);
+  if (seed.weights?.length) await pool.query(
+    `INSERT INTO weight_logs (user_id, weight, logged_at)
+     SELECT $1, 88.0 + d * 0.3, now() - (d || ' days')::interval FROM unnest($2::int[]) AS d`,
+    [u.id, seed.weights]);
+  if (seed.steps?.length) await pool.query(
+    `INSERT INTO step_logs (user_id, logged_at, steps, provenance, resolved_day)
+     SELECT $1, now() - (d || ' days')::interval, 9000, 'client_report',
+            to_char((now() - (d || ' days')::interval) AT TIME ZONE 'Africa/Johannesburg','YYYY-MM-DD')
+       FROM unnest($2::int[]) AS d`, [u.id, seed.steps]);
+  if (seed.workouts?.length) await pool.query(
+    `INSERT INTO workout_logs (user_id, logged_at, workout_completed)
+     SELECT $1, now() - (d || ' days')::interval, true FROM unnest($2::int[]) AS d`,
+    [u.id, seed.workouts]);
+  return { id: u.id, phone };
+}
+
+/** THE MARKERS. A durable write is whatever chat-log recorded; the append is what closeCoachingTurn said. */
+const MUT = /\b(INSERT|UPDATE) (meal|steps|weight|workout|water)\b/i;
+
+async function trace(label: string, phone: string, text: string) {
+  captured = [];
+  const reply = String(await handleMessage(
+    phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
+  const writes = captured.filter(l => MUT.test(l)).map(l => l.trim());
+  const appended = captured.find(l => l.includes("[COACH_TURN]")) || "";
+  // The append shape is a constant in reply-hygiene: `${prose}\n\n${move}.`
+  const stapled = appended ? reply.split("\n\n").slice(-1)[0] : "";
+  const prose = appended ? reply.split("\n\n").slice(0, -1).join("\n\n") : reply;
+
+  REAL(`\n${"─".repeat(94)}\n${label}`);
+  REAL(`  client words     ${JSON.stringify(text)}`);
+  REAL(`  durable writes   ${writes.length ? writes.join("\n                   ") : "(none)"}`);
+  REAL(`  coach-turn       ${appended ? appended.trim() : "(withNextMove changed nothing — no append)"}`);
+  REAL(`  handler prose    ${JSON.stringify(prose)}`);
+  REAL(`  stapled move     ${stapled ? JSON.stringify(stapled) : "(none)"}`);
+  REAL(`  FINAL REPLY      ${JSON.stringify(reply)}`);
+  return { reply, prose, stapled, writes, appended };
+}
+
+REAL("=".repeat(94));
+REAL("#207 — DOES A DURABLE LOG TURN READ AS ONE COACH SPEAKING?");
+REAL("=".repeat(94));
+
+// An EVIDENCED client: six days of food, steps, two weigh-ins, sessions behind. The ladder has a
+// real prescription available, so anything receipt-shaped here is not a thin-evidence artefact.
+const ev = { meals: [1, 2, 3, 4, 5, 6], weights: [0, 6], steps: [1, 2, 3], workouts: [3] };
+
+const c1 = await client({}, ev);
+await trace("1 · NORMAL FOOD LOG", c1.phone, "I had rice and chicken for lunch");
+
+const c2 = await client({}, ev);
+await trace("2 · CLEARLY GOOD MEAL", c2.phone, "grilled chicken breast with broccoli and sweet potato for lunch");
+
+const c3 = await client({}, ev);
+await trace("3 · POOR MEAL + LIFE CONTEXT", c3.phone,
+  "I was so stressed at work today I ended up eating a bunny chow and two cokes");
+
+const c4 = await client({}, ev);
+await trace("4 · STEPS LOG", c4.phone, "I walked 9000 steps today");
+
+const c5 = await client({}, ev);
+await trace("5 · WEIGHT LOG", c5.phone, "87.4kg this morning");
+
+const c6 = await client({}, ev);
+await trace("6 · WORKOUT COMPLETION", c6.phone, "did my workout today");
+
+// 7 — the sparse client #205 legitimately questions.
+const c7 = await client({}, { meals: [1], weights: [0, 4] });
+await trace("7 · SPARSE CLIENT (#205 asks one measurement)", c7.phone, "I walked 8000 steps today");
+
+// 8 — CONTROL: the reply already owns NEXT. A workout completion whose card carries the next
+// session is the real case; if it does not, this control says so rather than pretending.
+const c8 = await client({}, ev);
+await trace("8 · CONTROL — reply already owns NEXT", c8.phone, "finished my session, what's tomorrow?");
+
+// 9 — CONTROL: doNotMention must stay authoritative through whatever composes the turn.
+const c9 = await client({ doNotMention: "weight" }, ev);
+await trace("9 · CONTROL — doNotMention: weight", c9.phone, "I had rice and chicken for lunch");
+
+// 10 — CONTROL: numbers must remain attributable. A closed food day must not be answered with an
+// instruction to eat, and no portion may appear that the ledger did not produce.
+const c10 = await client({ calorieTarget: 1200 }, ev);
+await trace("10 · CONTROL — closed food day / numeric attribution", c10.phone,
+  "I had a huge plate of pap and beef stew and chips for dinner");
+
+REAL(`\n${"=".repeat(94)}`);
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(0);

--- a/script/pg-thin-evidence-acceptance.ts
+++ b/script/pg-thin-evidence-acceptance.ts
@@ -53,6 +53,7 @@ const { canonicalDecision } = await import("../server/understanding/live");
 const { canonicalNextMove } = await import("../server/scheduler/proactive-decision");
 const { getProgressTruth } = await import("../server/day-ledger");
 const { sastHour } = await import("../server/sast");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
 
 let failed = 0;
 const chk = (ok: boolean, msg: string, evidence = "") => {
@@ -118,13 +119,36 @@ for (const [said, what] of [
 
 // A SECOND WEIGH-IN ON THE SAME DAY IS THE SAME EVENT. It UPDATEs rather than inserts, and that
 // verb is the only difference — the client cannot see it and must not be coached differently for it.
+//
+// REGRADED BY #207, NOT WEAKENED. This used to assert that both weigh-ins carry the ask, back to
+// back. That is now two claims tangled together: the verb-blindness this cut proved, and the
+// separate rule #207 added — the identical instruction is not re-issued to the same client
+// seconds later, whatever event arrives. Asserting the tangle would have made this suite demand
+// the very repetition the founder complained about. Each half is asserted directly instead, which
+// is strictly more than the original: the first check proves the verb changes nothing, and the
+// second proves the UPDATE still reaches the decision owner rather than standing down silently.
 {
   const c = await client({}, { meals: [3], weights: WEIGHED });
   const first = await say(c.phone, "88.1kg this morning");
-  const second = await say(c.phone, "87.4kg this morning");
-  chk(ASKS.test(first) && ASKS.test(second),
+  // THE VERB, ISOLATED. A fresh window is exactly the state the first weigh-in met, so anything
+  // the second is denied is denied by the UPDATE and by nothing else.
+  _resetOutboundDedupe();
+  const secondFresh = await say(c.phone, "87.4kg this morning");
+  chk(ASKS.test(first) && ASKS.test(secondFresh),
     "the second weigh-in of a day is coached exactly like the first",
-    `first=${JSON.stringify(first.slice(0, 90))} second=${JSON.stringify(second.slice(0, 90))}`);
+    `first=${JSON.stringify(first.slice(0, 90))} second=${JSON.stringify(secondFresh.slice(0, 90))}`);
+
+  // AND BACK TO BACK, the UPDATE is still recognised as a durable write — the turn is answered
+  // with the client's own figure — while the question they were asked seconds ago is not repeated.
+  const c2 = await client({}, { meals: [3], weights: WEIGHED });
+  const a = await say(c2.phone, "88.1kg this morning");
+  const b = await say(c2.phone, "87.4kg this morning");
+  chk(ASKS.test(a) && /87\.4/.test(b),
+    "…and back to back the second is still answered with their figure",
+    `first=${JSON.stringify(a.slice(0, 90))} second=${JSON.stringify(b.slice(0, 90))}`);
+  chk(!ASKS.test(b),
+    "…without asking them the identical question twice in a row (#207)",
+    JSON.stringify(b.slice(0, 140)));
 }
 
 // ── §2 THE CATCH-UP MESSAGE ─────────────────────────────────────────────────────────────────

--- a/script/tracking-contract-tests.ts
+++ b/script/tracking-contract-tests.ts
@@ -198,10 +198,23 @@ const MUST_WRITE: [string, string][] = [
   const { invalidatePatternCache } = await import("../server/cache");
   const { checkGptRateLimit } = await import("../server/utils");
   const { _resetDumpWindow } = await import("../server/card-policy");
+  // THE OUTBOUND DEDUPE IS PROCESS STATE TOO (#207) — the same class as the ledger note below and
+  // reset here for the same reason. closeCoachingTurn now consults isDuplicateOutbound before
+  // reissuing a next move, so the coach cannot staple the identical instruction onto three
+  // durable events in a row. Every graded turn in this file is a SEPARATE conversation, not the
+  // same client ninety seconds later; without this reset one scenario inherits the previous
+  // scenario's delivered move and Law 4 grades a suppression production would never perform.
+  //
+  // THE SUPPRESSION ITSELF IS STILL GRADED, deliberately, on consecutive turns of ONE
+  // conversation — see "the same next move is not stapled onto every durable event" below.
+  // _resetOutboundDedupe is this module's own existing test/ops hook, so no production code
+  // exists solely to be testable.
+  const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
   const freshTurn = () => {
     invalidatePatternCache(USER.id);
     checkGptRateLimit(USER.id, 1_000_000, 0);
     _resetDumpWindow();
+    _resetOutboundDedupe();
   };
   const NAME = new Map<any, string>([
     [schema.stepLogs, "steps"], [schema.weightLogs, "weight"],
@@ -2386,15 +2399,43 @@ const MUST_WRITE: [string, string][] = [
     // The decision reads state that INCLUDES this turn's write — the production ordering.
     if (opts?.seeWrites !== false) g.__KAMLIFE_STUB_REFLECT_WRITES = 1;
     g.__KAMLIFE_STUB_WRITES = [];
-    const reply = String(await handleMessage(USER.phoneNumber, message).catch(() => ""));
+    // WHAT THE CLOSE ACTUALLY DELIVERED, captured from its own marker (#207). See closingMove.
+    const said: string[] = [];
+    const realLog = console.log;
+    console.log = (...a: any[]) => { said.push(a.map(x => typeof x === "string" ? x : String(x)).join(" ")); realLog(...a); };
+    let reply = "";
+    try {
+      reply = String(await handleMessage(USER.phoneNumber, message).catch(() => ""));
+    } finally { console.log = realLog; }
     delete g.__KAMLIFE_STUB_REFLECT_WRITES;
+    const marker = said.filter(l => l.includes("[COACH_TURN] MOVE=")).pop() || "";
+    LAST_MOVE = marker ? (marker.split("[COACH_TURN] MOVE=")[1] || "").replace(/\s*\([^)]*\)\s*$/, "").trim() : "";
     return reply;
   }
-  /** A move is a separate closing block that is not a question — what withNextMove appends. */
+  /**
+   * THE MOVE THIS TURN DELIVERED — regraded on behaviour (#207), not restored.
+   *
+   * This used to be "the last blank-line-separated block", because withNextMove appended the move
+   * across a blank line and that LAYOUT was the move. #207 composes the durable-log turn through
+   * one author, so the instruction now arrives in the same paragraph as the acknowledgement: the
+   * shape reader saw no move at all on replies that plainly carry one, and Law 4 went red for a
+   * reply that is strictly better than the one it was written against.
+   *
+   * Putting the block-splitter back would preserve a layout rather than the promise. Law 4
+   * promises that a durable write DELIVERS the canonical next move, so that is what is read —
+   * off the close's own marker, which names the move it issued and is empty when it issued none.
+   * Strictly stronger than the splitter, which accepted any trailing block regardless of whether
+   * the decision owner had chosen anything; and it reads the same fact on both shapes, so the
+   * appended path this cut deliberately leaves alone is graded exactly as before.
+   *
+   * Cross-checked against the customer-visible string: a move the close claims to have delivered
+   * must actually appear in the reply, so a marker that lies cannot pass this.
+   */
+  let LAST_MOVE = "";
   const closingMove = (reply: string) => {
-    const blocks = reply.trim().split(/\n\s*\n/);
-    const last = (blocks[blocks.length - 1] || "").trim();
-    return blocks.length > 1 && !last.includes("?") && !/\[(?:BUTTONS|MEDIA)/i.test(last) ? last : "";
+    const move = LAST_MOVE.trim().replace(/[.\s]*$/, "");
+    if (!move) return "";
+    return reply.includes(move) ? move : "";
   };
 
   // A bare receipt must gain exactly one move — on EVERY tracked fact that writes durably.
@@ -2418,6 +2459,71 @@ const MUST_WRITE: [string, string][] = [
     // …and the move must have read the write. Telling a client who just logged 8 000 steps to
     // walk is the defect this ordering exists to prevent.
     if (/\bwalk\b/i.test(move)) failures.push(`The move ignored the row this turn wrote — 8 000 steps logged, and the coach said: "${move}"`);
+  }
+
+  /**
+   * THE SAME NEXT MOVE IS NOT STAPLED ONTO EVERY DURABLE EVENT (#207).
+   *
+   * Traced through the real front door on real PostgreSQL — script/pg-log-turn-day.ts — one
+   * client, one ordinary day:
+   *
+   *     "two eggs and toast for breakfast"  ->  "Start tomorrow with protein — eggs … at breakfast."
+   *     "walked 9000 steps"                 ->  the same sentence again
+   *     "87.4kg this morning"               ->  the same sentence a third time
+   *
+   * chooseAction is a pure function of day state, and a step report moves none of the state the
+   * protein rung reads — so the identical instruction was re-issued for no reason but the arrival
+   * of a new event. That is the nagging app this product defines itself against, and it is the
+   * rule reply-hygiene already states for whole replies: "saying the same words twice in ten
+   * minutes is never the right outcome". The stapled move escaped that rule only because the
+   * acknowledgement wrapped around it differed.
+   *
+   * GRADED ON CONSECUTIVE TURNS OF ONE CONVERSATION, which is the only place the defect exists —
+   * freshTurn() clears the window between unrelated scenarios precisely so this one can own it.
+   */
+  {
+    freshTurn();
+    const first = await coachingTurn("walked 8000 steps today");
+    const firstMove = closingMove(first);
+    // The window is NOT reset between these two: this is the same client, seconds apart.
+    const second = String(await handleMessage(USER.phoneNumber, "2 litres of water").catch(() => ""));
+    if (!firstMove) {
+      failures.push(`The repeat control is vacuous: the first durable event carried no move to repeat`);
+    } else if (second.includes(firstMove)) {
+      failures.push(`The same next move was stapled onto a second durable event seconds later: "${second.replace(/\n/g, " ⏎ ")}"`);
+    }
+    // POSITIVE CONTROL — the suppression must be about the MOVE, not about the second event.
+    // The identical water turn, in a fresh window, still earns its instruction; without this a
+    // build that simply stopped coaching the second event of any conversation would pass.
+    freshTurn();
+    const alone = await coachingTurn("2 litres of water");
+    if (!closingMove(alone)) {
+      failures.push(`The suppression is not about repetition: the same water turn earned no move even in a fresh window: "${alone.replace(/\n/g, " ⏎ ")}"`);
+    }
+  }
+
+  /**
+   * A DURABLE LOG TURN IS SPOKEN BY ONE COACH, NOT TWO (#207).
+   *
+   * The acknowledgement was written by a handler that knew the client's words and nothing else,
+   * and the move was appended across a blank line by a ladder that knew day state and nothing
+   * about the event. The customer read two subsystems. When the reply is nothing but the bare
+   * receipt, the same author now composes both halves — so the move must arrive INSIDE the
+   * acknowledgement's paragraph, not as a separate block after it.
+   *
+   * This grades the shape ONLY where the cut claims it: a bare receipt. Every richer reply keeps
+   * the appended path, and the assertions above still grade those.
+   */
+  {
+    freshTurn();
+    const reply = await coachingTurn("walked 8000 steps today");
+    const move = closingMove(reply);
+    const blocks = reply.trim().split(/\n\s*\n/);
+    if (!move) {
+      failures.push(`The one-author control is vacuous: the bare step receipt carried no move`);
+    } else if (blocks.length > 1 && (blocks[blocks.length - 1] || "").trim().startsWith(move)) {
+      failures.push(`A bare receipt still had its move stapled on as a separate block: "${reply.replace(/\n/g, " ⏎ ")}"`);
+    }
   }
 
   /**

--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -145,6 +145,24 @@ interface TurnScope {
     /** The CoachAction the meaning engine emitted this turn, when it emitted one. Structured
      *  provenance — checked BEFORE the prose backstop. */
     structuredAction?: string | null;
+    /**
+     * THE BARE RECEIPT THIS TURN'S OWN AUTHOR WROTE (#207), and the facts it wrote it from.
+     *
+     * closeCoachingTurn needs one thing that is otherwise unknowable at the end of a turn: is the
+     * reply in hand nothing but neverSilentLine's fallback line? If it is, the same author can be
+     * asked again — this time holding the canonical decision — and compose ONE coherent turn
+     * instead of having a move stapled after a blank line. If the handler wrote anything richer
+     * (a workout card, street-food advice) the string will not match and the existing append path
+     * runs untouched. `line` is COMPARED, never re-parsed.
+     */
+    receipt?: { line: string; kind: string; label?: string; amount?: string; carryingShame?: boolean } | null;
+    /**
+     * THIS TURN ALREADY TOLD THE CLIENT TO CHANGE THE PLATE (#207). Set by the existing street-dish
+     * evaluation when its verdict is anything but a clean win. Without it one message could say
+     * "go bean or chicken bunny over mutton — leaner" and, four blocks later, "that's one proper
+     * protein down — start tomorrow the same way": change this, and repeat this.
+     */
+    plateNeedsChange?: boolean;
   };
 }
 
@@ -575,6 +593,14 @@ export function turnEvidence(facts: NonNullable<TurnScope["evidence"]>): void {
   const t = turnStore.getStore();
   if (!t) return;
   t.evidence = { ...(t.evidence || {}), ...facts };
+}
+
+/** WHAT THIS TURN RECORDED FOR THE DURABLE-LOG CLOSE (#207). Read once, by closeCoachingTurn. */
+export function turnReceipt(): NonNullable<TurnScope["evidence"]>["receipt"] {
+  return turnStore.getStore()?.evidence?.receipt ?? null;
+}
+export function turnPlateNeedsChange(): boolean {
+  return !!turnStore.getStore()?.evidence?.plateNeedsChange;
 }
 
 export async function recordTurn(reply: string): Promise<void> {

--- a/server/handlers/food-commands.ts
+++ b/server/handlers/food-commands.ts
@@ -15,7 +15,7 @@ import { askCoachK } from "../gpt";
 import { getShoppingList, formatShoppingList } from "../shopping-lists";
 import { getGroceryPersonalization } from "../grocery-personalize";
 import { scanForSAFoods } from "./food-scanner";
-import { logChat, withTimeout } from "./chat-log";
+import { logChat, withTimeout, turnEvidence } from "./chat-log";
 import { tryLogWater } from "./water";
 import { generateMealPlan } from "../meal-plan";
 import { answerSwapAsk } from "../food-swaps";
@@ -67,6 +67,12 @@ export async function handleFoodCommands(ctx: { phone: string; message: string; 
     const streetHit = matchStreetDish(m);
     const g = streetHit ? formatStreetDish(streetHit, user.goalType || "fat_loss")
       : isStreetContext(m) ? streetGuide(user.goalType || "fat_loss") : null;
+    // WE JUST TOLD THEM TO ORDER IT DIFFERENTLY (#207). The dish's own verdict is the existing
+    // authoritative evaluation; anything short of a clean win means this turn's advice was
+    // "change it". Recorded so the decision owner cannot, later in the same message, celebrate
+    // the same plate as one proper protein down and tell them to repeat it tomorrow. This is a
+    // fact about what we SAID, not a new nutrition rule — the verdict is unchanged.
+    if (g && streetHit && streetHit.verdict !== "win") turnEvidence({ plateNeedsChange: true });
     if (g) { await logChat(user.id, message, g, "STREET_FOOD_GUIDE"); return g; }
   }
 

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -17,7 +17,7 @@ import { db } from "../db";
 import { mealLogs, chatHistory, users } from "../../shared/schema";
 import { eq, and, gte, sql, desc, inArray, isNotNull } from "drizzle-orm";
 import { sastDayStart, sastToday } from "../utils";
-import { turnMutation } from "./chat-log";
+import { turnMutation, turnEvidence } from "./chat-log";
 import { isBareReaction, isDiagnosticQuestion, bareReactionFallback } from "../reaction-guard";
 
 // ── Per-user in-memory cache for recomputeTodayFoodTotals ──────────────────
@@ -1009,7 +1009,12 @@ export async function buildFoodLogReply(p: {
     ? `${bareNames.slice(0, -1).join(", ")} and ${bareNames[bareNames.length - 1]}`
     : bareNames[0] || "";
   const label = hidden > 0 ? `${bareNames.join(", ")} and ${hidden} more` : joined;
-  const line = neverSilentLine("meal", { label, carryingShame: carriesFeelingClause(p.userMessage || "") });
+  const carryingShame = carriesFeelingClause(p.userMessage || "");
+  const line = neverSilentLine("meal", { label, carryingShame });
+  // The receipt, recorded for the durable-log close (#207) — see steps.ts. Recorded BEFORE the
+  // retro clause below, because a reply carrying "logged for yesterday" is no longer the bare
+  // line and must keep the existing append path rather than being recomposed.
+  turnEvidence({ receipt: { line, kind: "meal", label, carryingShame } });
   // The retro day is a FACT the client needs — logging to the wrong day is the one error they
   // cannot see. It rides as a clause, not as a second sentence.
   return p.isRetro ? line.replace(/\.\s*👌$/, " — logged for yesterday. 👌") : line;

--- a/server/handlers/steps.ts
+++ b/server/handlers/steps.ts
@@ -1,5 +1,5 @@
 import { db } from "../db";
-import { turnMutation } from "./chat-log";
+import { turnMutation, turnEvidence } from "./chat-log";
 import { users, stepLogs } from "../../shared/schema";
 import { eq, desc, and, gte, lt } from "drizzle-orm";
 import { neverSilentLine } from "../reply-hygiene";
@@ -150,7 +150,13 @@ export function getStepResponse(steps: number, target: number, weightKg = 75, st
   // not answer — one line, their number, nothing else. The parameters stay because callers pass
   // them and the signature is not the point; the VOICE was the point, and it has one owner.
   void target; void weightKg; void streak; void weeklyAvg; void user; void isWorkoutDay;
-  return neverSilentLine("steps", { amount: steps.toLocaleString("en-ZA") });
+  // THE RECEIPT, RECORDED SO THE TURN CAN CLOSE AS ONE COACH (#207). closeCoachingTurn compares
+  // the reply it holds against this exact string: if nothing richer was written, the same author
+  // is asked again with the canonical decision in hand and composes one line instead of two.
+  const amount = steps.toLocaleString("en-ZA");
+  const line = neverSilentLine("steps", { amount });
+  turnEvidence({ receipt: { line, kind: "steps", amount } });
+  return line;
 }
 
 

--- a/server/handlers/water.ts
+++ b/server/handlers/water.ts
@@ -7,7 +7,7 @@ import { db } from "../db";
 import { users } from "../../shared/schema";
 import { neverSilentLine } from "../reply-hygiene";
 import { eq, sql } from "drizzle-orm";
-import { logChat, turnMutation } from "./chat-log";
+import { logChat, turnMutation, turnEvidence } from "./chat-log";
 import { sastToday, mentionsNotDone, reportedInSomeClause, digitizeSpokenAmounts } from "../utils";
 import { waterTargetLitres } from "../targets";
 import { scanForSAFoods } from "./food-scanner";
@@ -143,7 +143,10 @@ export async function tryLogWater(ctx: {
     // client actually saw most were the running totals: "2L added. Running total: 0L / 2.7L
     // target. 2.7L left." Three numbers, two of them targets the client never asked about, on
     // the day they drank some water. The coach writes the sentence now; this is the net.
-    const waterReply = neverSilentLine("water", { amount: `${litres}L` });
+    const waterAmount = `${litres}L`;
+    const waterReply = neverSilentLine("water", { amount: waterAmount });
+    // The receipt, recorded for the durable-log close (#207) — see steps.ts.
+    turnEvidence({ receipt: { line: waterReply, kind: "water", amount: waterAmount } });
     await logChat(user.id, message, waterReply, "WATER_LOG");
     return `${waterReply}`;
   }

--- a/server/handlers/weight.ts
+++ b/server/handlers/weight.ts
@@ -1,5 +1,5 @@
 import { db } from "../db";
-import { turnMutation } from "./chat-log";
+import { turnMutation, turnEvidence } from "./chat-log";
 import { users, weightLogs, escalations } from "../../shared/schema";
 import { neverSilentLine } from "../reply-hygiene";
 import { trendCalorieAdjust } from "../adaptive-targets";
@@ -519,5 +519,11 @@ export async function handleWeightLog(
   // it must reach the person whether or not the engine wrote anything. Everything else that
   // used to be concatenated here is now the coach's job, or the card's.
   void changeNote; void trendLine; void targetsLine; void weightAddOn;
-  return `${neverSilentLine("weight", { amount: `${newKg}kg` })}${underweightFlipNote}`;
+  // THE RECEIPT, RECORDED FOR THE DURABLE-LOG CLOSE (#207) — see steps.ts. The safety note is
+  // deliberately NOT part of it: a turn carrying duty-of-care prose is not a bare receipt, so the
+  // string will not match and the existing append path runs, exactly as it does today.
+  const amount = `${newKg}kg`;
+  const line = neverSilentLine("weight", { amount });
+  turnEvidence({ receipt: { line, kind: "weight", amount } });
+  return `${line}${underweightFlipNote}`;
 }

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -774,6 +774,28 @@ const INVESTIGATIVE: ReadonlySet<ActionKind> = new Set<ActionKind>(["come_back",
 const PRESCRIPTIVE: ReadonlySet<ActionKind> = new Set<ActionKind>(["protein", "walk", "train", "eat_more", "rest"]);
 
 /**
+ * WHICH TRACKED FACT EACH ACTION IS ABOUT (#207) — the domain names durableDomains already uses.
+ *
+ * closeCoachingTurn refuses to re-issue an instruction the client was given moments ago, and the
+ * first version of that decided "moments ago" from the instruction's TEXT alone. That inference is
+ * wrong, and an existing acceptance control caught it: chooseAction can emit the same sentence
+ * from genuinely different state. A client who logged a banana, was told to make their next meal
+ * a protein one, and then logged rice and spinach has EATEN AGAIN — they earned that instruction
+ * a second time, and swallowing it leaves them coached for one meal out of two.
+ *
+ * So the question is not "did we say this" but "did this event move the ground the move stands
+ * on". A meal re-earns a food instruction; a step report does not. Kinds with no domain
+ * (`come_back`, `rest`, `hold`) turn on no single tracked fact and are never re-earned this way.
+ *
+ * It lives beside the kinds because it is a fact ABOUT the kinds, and putting it at the call site
+ * is how a second, drifting copy of this table gets written.
+ */
+export const ACTION_DOMAIN: Readonly<Partial<Record<ActionKind, string>>> = {
+  protein: "food", eat_more: "food", log: "food",
+  weigh: "weight", walk: "steps", train: "workout",
+};
+
+/**
  * THE POLICY BOUNDARY, EXPORTED (2026-08-21).
  *
  * `chooseAction` is the one decision function, but a single function name does not make a single

--- a/server/reply-hygiene.ts
+++ b/server/reply-hygiene.ts
@@ -395,22 +395,84 @@ export function firstSentence(text: string): string {
 export type LoggedKind = "steps" | "water" | "weight" | "meal" | "workout" | "sleep";
 
 /**
+ * WHAT THE TURN ALREADY KNOWS (#207) — supplied BY THE CALLER. This module still reads nothing:
+ * no database, no ledger reconstruction, no history interpretation. Every field below is a value
+ * an existing owner produced earlier in the same turn and simply did not pass on.
+ *
+ * It exists because a durable log turn used to be authored twice: this function wrote an
+ * acknowledgement knowing only the client's own words, withNextMove stapled on a move chosen
+ * from day state, and neither half could see the other. The customer read two subsystems.
+ * Traced on real PostgreSQL — script/pg-log-turn-day.ts — one client, one day:
+ *
+ *     "two eggs and toast for breakfast"  ->  "Start tomorrow with protein — eggs … at breakfast."
+ *     "walked 9000 steps"                 ->  the same sentence again
+ *     "87.4kg this morning"               ->  the same sentence a third time
+ *
+ * NONE OF THIS CHOOSES ANYTHING. `move` arrives already decided by chooseAction; this phrases it
+ * beside the event instead of after a blank line. There is no ladder here and no second policy.
+ */
+export interface DurableTurnContext {
+  /** The move chooseAction/canonicalNextMove already selected. Phrased here, NEVER chosen here. */
+  move?: string | null;
+  /** That action's canonical kind, so the acknowledgement can name the fact the move turns on. */
+  moveKind?: string | null;
+  /** Protein this turn's own write recorded, off the turn's mutation record. Not re-derived. */
+  wroteProtein?: number | null;
+  /** Canonical day totals THIS TURN already read, from getProgressTruth. Never re-queried. */
+  day?: { kcal: number; kcalTarget: number } | null;
+  /** The same turn's own meal evaluation already told the client to change this plate. */
+  plateNeedsChange?: boolean;
+}
+
+/**
  * @param label the client's OWN words for the thing, when there are any ("pap and chicken").
  *        Never a database name, never a portion in brackets — that is voice rule 18.
  * @param amount the figure THEY gave, already formatted. Never recomputed, never rounded.
+ *
+ * With NO DurableTurnContext this returns exactly what it has always returned, byte for byte —
+ * every existing caller is unaffected, and the never-silent net still works when nothing else in
+ * the turn has anything to add.
  */
-export function neverSilentLine(kind: LoggedKind, opts: { label?: string; amount?: string; carryingShame?: boolean } = {}): string {
+export function neverSilentLine(
+  kind: LoggedKind,
+  opts: { label?: string; amount?: string; carryingShame?: boolean } & DurableTurnContext = {},
+): string {
   const label = (opts.label || "").trim().slice(0, 60);
   const amount = (opts.amount || "").trim();
+  const move = (opts.move || "").trim().replace(/[.\s]*$/, "");
+  // OVER THE DAY'S CALORIES, ON CANONICAL TOTALS THE CALLER ALREADY HELD. A 2 445 kcal plate
+  // against a 1 200 kcal target used to read "Got it — Chips, Pap and Beef stew. 👌", because
+  // this function was starved of the one fact that made the plate adverse. Stated plainly, and
+  // no figure is printed: the comparison is canonical, the number would be a second claim.
+  const overForTheDay = !!opts.day && opts.day.kcalTarget > 0 && opts.day.kcal > opts.day.kcalTarget;
+
   // CHEAT, NO SHAME (voice rule 9) — and deterministic on purpose. Someone who writes "I feel
   // like I ruined everything" needs the second half of this sentence whether or not the model
   // answered that turn, and the model is exactly what is missing when this function runs. The
   // words already existed in food-context as a guilt note and never reached the log path.
-  if (kind === "meal" && opts.carryingShame) {
-    return label
-      ? `Got it — ${label}. One meal doesn't break a week. 👌`
-      : `Got it. One meal doesn't break a week. 👌`;
-  }
+  // It outranks the over-target sentence: a person already carrying shame does not need both.
+  const head = (kind === "meal" && opts.carryingShame)
+    ? (label ? `Got it — ${label}. One meal doesn't break a week. 👌` : `Got it. One meal doesn't break a week. 👌`)
+    : kind === "meal" && overForTheDay
+      // No 👌 — that emoji is the whole "blind celebration" the trace caught.
+      ? (label ? `Got it — ${label}. That puts you over your calories for today.`
+               : `Got it. That puts you over your calories for today.`)
+    : kind === "meal" && label && opts.moveKind === "protein" && (opts.wroteProtein ?? 0) > 0
+      // THE FACT THE MOVE TURNS ON, NAMED IN THE SAME BREATH. Logging eggs at breakfast and being
+      // told "start tomorrow with protein at breakfast" reads as a coach who did not look at the
+      // plate. The gram figure is this turn's own write — not a total, not an average, not a
+      // target — so the instruction arrives with its reason attached.
+      //
+      // THE 👌 STAYS. Naming the number is not a reason to go cold: an in-budget plate must still
+      // read as an ordinary, warm acknowledgement, and dropping the emoji here made the adverse
+      // case above indistinguishable from the normal one. The acceptance control caught it.
+      ? `Got it — ${label}: ${opts.wroteProtein}g protein. 👌`
+    : kindLine(kind, label, amount);
+
+  return move ? `${head} ${move}.` : head;
+}
+
+function kindLine(kind: LoggedKind, label: string, amount: string): string {
   switch (kind) {
     case "steps":   return amount ? `${amount} steps — nice one. 👌` : `Steps logged. 👌`;
     case "water":   return amount ? `${amount} of water — good. 👌` : `Water logged. 👌`;

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -63,7 +63,9 @@ import { assembleDeficitEvidence, hasRelevantDeficitEvidence, weightTrendUsable,
  *
  * rather than the model deciding in prose and a verifier trying to work out what it decided.
  */
-export async function canonicalDecision(user: any, message?: string, opts?: { justAteProteinMeal?: boolean }): Promise<{ todo: string; kind: string; reply: string }> {
+export async function canonicalDecision(
+  user: any, message?: string, opts?: { justAteProteinMeal?: boolean },
+): Promise<{ todo: string; kind: string; reply: string; day: { kcal: number; kcalTarget: number } | null }> {
   try {
     // ONE CONSTITUTION (2026-08-21). This called theNextMove(), a SECOND ranked ladder —
     // training → protein → calories → steps → scale — that produced "the one thing to do" from
@@ -153,8 +155,17 @@ export async function canonicalDecision(user: any, message?: string, opts?: { ju
 
     // "hold" means the honest answer is that nothing needs changing. An empty todo is what
     // tellDontAsk expects in that case, and it is what the old ladder returned too.
-    return { todo: act.kind === "hold" ? "" : act.todo, kind: act.kind, reply: rendered };
-  } catch { return { todo: "", kind: "hold", reply: "" }; }
+    //
+    // `day` CARRIES OUT WHAT THIS FUNCTION ALREADY READ (#207) and used to throw away. The
+    // durable-turn author needs to know whether the plate it is acknowledging put the client over
+    // for the day — a 2 445 kcal dinner against a 1 200 kcal target read "Got it 👌" purely
+    // because that fact stopped at this boundary. No extra query: these are the same two numbers
+    // the caloriePct above is computed from.
+    return {
+      todo: act.kind === "hold" ? "" : act.todo, kind: act.kind, reply: rendered,
+      day: { kcal: truth.today.kcal, kcalTarget: calTarget },
+    };
+  } catch { return { todo: "", kind: "hold", reply: "", day: null }; }
 }
 
 /** The string form, for the callers that only append it. */
@@ -623,35 +634,108 @@ export async function runMeaningEngineLive(ctx: {
 }
 
 /**
- * CLOSE A COACHING TURN: a durable write is followed by ONE next move (2026-08-26, issue #63).
+ * CLOSE A COACHING TURN: a durable write becomes ONE coaching turn (2026-08-26 #63; #207).
  *
  * Lives here, beside canonicalDecision, because it is the decision owner's own last step — the
  * decision APPLIED to a turn that just wrote. routes.ts keeps a one-line closure over it so every
  * exit calls the same thing; the router is not where this reasoning belongs.
  *
  * Only a turn that DURABLY WROTE earns a move, and the turn's own mutation record answers that —
- * not what was composed. A question or a chat turn is not a coaching moment. Whether the reply
- * already owns the client's next action is asked ONCE, inside withNextMove, which is the policy
- * owner; asking it here too would cost what this repo keeps paying for, two copies of one rule.
+ * not what was composed. A question or a chat turn is not a coaching moment.
  *
- * Rationale, measurements and both-ways grading: script/tracking-contract-tests.ts, LAW 4.
+ * WHAT #207 CHANGED, AND WHY. This used to do exactly one thing: hand the reply and the todo to
+ * withNextMove, which concatenated them across a blank line. That is two authors — a handler that
+ * knows the client's words and nothing else, and a ladder that knows day state and nothing about
+ * the event — and the customer read both. Traced on real PostgreSQL, one client, one day:
+ *
+ *     "two eggs and toast for breakfast"  ->  "Got it — Eggs toast. 👌"
+ *                                             "Start tomorrow with protein — eggs … at breakfast."
+ *     "walked 9000 steps"                 ->  the same instruction, stapled to a step count
+ *     "87.4kg this morning"               ->  the same instruction, a third time
+ *
+ * Three fixes, all through owners that already exist:
+ *
+ *   1. THE SAME MOVE IS NOT REISSUED. isDuplicateOutbound is this product's stated rule that
+ *      "saying the same words twice in ten minutes is never the right outcome". The stapled move
+ *      escaped it only because the acknowledgement around it differed, so it is consulted here on
+ *      the move itself, in the same window, through the same map. No second history engine.
+ *   2. THE TURN HAS ONE AUTHOR. When the reply in hand is nothing but the bare receipt this
+ *      turn's own author wrote — compared as an exact string, recorded by the handler that wrote
+ *      it — that author is asked again, this time holding the decision and the canonical day
+ *      facts, and composes ONE line. Anything richer keeps the existing append path untouched.
+ *   3. A PLATE WE JUST TOLD THEM TO CHANGE IS NOT A WIN. justAteProteinMeal is grams alone, and a
+ *      bunny chow clears the bar, so one message said "go bean or chicken over mutton — leaner"
+ *      and then "that's one proper protein down — start tomorrow the same way".
+ *
+ * chooseAction remains the sole owner of WHAT the client should do. Nothing here selects, ranks
+ * or invents an action; the move arrives decided and is phrased beside the event.
+ *
+ * Rationale, measurements and both-ways grading: script/tracking-contract-tests.ts, LAW 4, and
+ * script/pg-log-turn-acceptance.ts.
  */
 export async function closeCoachingTurn(user: any, message: string, reply: string | null): Promise<string> {
   const out = String(reply ?? "");
-  const { turnMutations } = await import("../handlers/chat-log");
+  const { turnMutations, turnReceipt, turnPlateNeedsChange } = await import("../handlers/chat-log");
   const { durableDomains, proteinWrittenIn } = await import("./messy-intake");
-  const { withNextMove } = await import("../reply-hygiene");
+  const { withNextMove, ownsNextAction, neverSilentLine, isDuplicateOutbound } = await import("../reply-hygiene");
   const { PROPER_PROTEIN_G } = await import("../macro-card-attach");
   const mutations = turnMutations();
   const wrote = durableDomains(mutations);
   if (!out || wrote.length === 0) return out;
   // THE PLATE THIS TURN JUST WROTE, off the same record `wrote` was read from. PROPER_PROTEIN_G
   // is the card's number, named once, so "did they just eat a proper protein meal" cannot mean
-  // one thing on the picture and another in the text.
+  // one thing on the picture and another in the text — AND NOT A PLATE THIS TURN ALREADY TOLD
+  // THEM TO CHANGE (#207), which is the existing street-dish verdict, not a new nutrition rule.
+  const protein = proteinWrittenIn(mutations);
+  const plateNeedsChange = turnPlateNeedsChange();
   const decided = await canonicalDecision(user, message, {
-    justAteProteinMeal: proteinWrittenIn(mutations) >= PROPER_PROTEIN_G,
+    justAteProteinMeal: protein >= PROPER_PROTEIN_G && !plateNeedsChange,
   }).catch(() => ({ todo: "" } as any));
-  const next = withNextMove(out, String(decided?.todo || ""));
-  if (next !== out) console.log(`[COACH_TURN] appended one next move after ${wrote.join("+")}`);
+
+  const move = String(decided?.todo || "").trim();
+  // ASKED ONLY WHEN IT WOULD ACTUALLY GO OUT, so a move the reply already owns is never recorded
+  // as delivered. The key is namespaced off the client's id AND the move: the same map, the same
+  // ten minutes, a slot per instruction. Keying on the client alone holds only the LAST thing
+  // said, which the day trace caught — breakfast got the protein instruction, lunch replaced it
+  // with a different one, and the weigh-in two minutes later reissued the first verbatim.
+  //
+  // AND AN EVENT IN THE MOVE'S OWN DOMAIN RE-EARNS IT. Suppressing on the text alone was wrong:
+  // a client told to make their next meal a protein one, who then logs a second low-protein meal,
+  // has eaten again and needs telling again. `wrote` is this turn's durable domains and
+  // ACTION_DOMAIN says which one the move turns on — a meal re-earns a food move, a step count
+  // does not. An existing acceptance control caught this; it is not a hypothetical.
+  const { ACTION_DOMAIN } = await import("../one-action");
+  const movesGround = ACTION_DOMAIN[decided?.kind as keyof typeof ACTION_DOMAIN];
+  const reEarned = !!movesGround && wrote.includes(movesGround);
+  const wouldDeliver = !!move && !ownsNextAction(out.trim());
+  // THE SLOT IS ALWAYS CONSULTED, and the verdict is ignored only when the move was re-earned.
+  // Short-circuiting on `reEarned` instead looks equivalent and is not: isDuplicateOutbound
+  // records on a MISS, so skipping the call on the very first delivery left the slot empty and
+  // the next event re-issued the instruction anyway. The acceptance caught that too.
+  //
+  // It records on a miss and does not refresh on a hit, so the window runs from the first
+  // delivery rather than the latest — an instruction re-earned three times becomes sayable again
+  // ten minutes after it was first given, which is the behaviour that module already documents.
+  const seenInWindow = wouldDeliver && isDuplicateOutbound(`${user?.id}::next::${move}`, move);
+  const alreadyDelivered = seenInWindow && !reEarned;
+  const moveToUse = alreadyDelivered ? "" : move;
+  if (alreadyDelivered) console.log(`[COACH_TURN] MOVE=  (already delivered this window, not reissued after ${wrote.join("+")})`);
+
+  const receipt = turnReceipt();
+  if (receipt && out.trim() === String(receipt.line || "").trim()) {
+    const one = neverSilentLine(receipt.kind as any, {
+      label: receipt.label, amount: receipt.amount, carryingShame: receipt.carryingShame,
+      move: moveToUse || null, moveKind: decided?.kind || null,
+      wroteProtein: protein || null, day: decided?.day ?? null, plateNeedsChange,
+    });
+    // The move is NAMED in the marker, not merely counted. One author now composes the whole
+    // turn, so "did this reply carry an instruction" can no longer be answered by looking for a
+    // trailing block — in the log, or in a test. What we told them is the fact worth recording.
+    console.log(`[COACH_TURN] MOVE=${moveToUse} (one author closed ${wrote.join("+")})`);
+    return one;
+  }
+
+  const next = withNextMove(out, moveToUse);
+  console.log(`[COACH_TURN] MOVE=${next !== out ? moveToUse : ""} (appended after ${wrote.join("+")})`);
   return next;
 }


### PR DESCRIPTION
**`FIXED + PROVEN`** for #207, under the bounded canonical-truth contract. Baseline `origin/main@84601ba` (the SHA the issue names), from evidence commit `3018e28`. Branch HEAD `fe40bd9`.

**Held at CTO adjudication — not merged, not deployed.**

The architecture is unchanged: `canonical write/state → chooseAction → the existing durable-turn author → one reply`. `chooseAction` remains the sole owner of WHAT the client should do. Nothing here selects, ranks or infers an action, and `neverSilentLine` still reads nothing — every fact it now holds is one an owner produced earlier in the same turn and simply did not pass on.

## BEFORE → AFTER, the same multi-turn client and day

| turn | before | after |
|---|---|---|
| `two eggs and toast for breakfast` | `Got it — Eggs toast. 👌`<br>`Start tomorrow with protein — eggs, amasi, or tin fish at breakfast.` | `Got it — Eggs toast: 24g protein. 👌 Start tomorrow with protein — eggs, amasi, or tin fish at breakfast.` |
| `walked 9000 steps` | `9 000 steps — nice one. 👌`<br>**`Start tomorrow with protein — eggs, amasi, or tin fish at breakfast.`** | `9 000 steps — nice one. 👌` |
| `chicken and rice for lunch` | `Got it — Chicken and rice. 👌`<br>`That's one proper protein down…` | `Got it — Chicken and rice: 56g protein. 👌 That's one proper protein down — start tomorrow the same way.` |
| `87.4kg this morning` | `87.4kg — noted. 👌`<br>**`Start tomorrow with protein — eggs, amasi, or tin fish at breakfast.`** | `87.4kg — noted. 👌` |
| `pap and beef stew for dinner` | `Got it — Pap and Beef stew. 👌` | `Got it — Pap and Beef stew. 👌` |

Three deliveries of one instruction became one. Sparse client, same shape: `Tell me what you ate today` once on the step report, not again on the weigh-in ninety seconds later — and the weigh-in is still answered.

```
"a huge plate of pap and beef stew and chips"   (2 445 kcal, 1 200 kcal target)
  before  "Got it — Chips, Pap and Beef stew. 👌 ⏎⏎ Get a 20-minute walk in today."
  after   "Got it — Chips, Pap and Beef stew. That puts you over your calories for
           today. Get a 20-minute walk in today."

bunny chow, after being told "go bean or chicken over mutton — leaner"
  before  "…That's one proper protein down — start tomorrow the same way."
  after   "…Start tomorrow with protein — eggs, amasi, or tin fish at breakfast."
```

## Three fixes, all through owners that already exist

**1. The turn has one author.** When the reply is nothing but the bare receipt this turn's own author wrote — compared as an exact string, recorded by the handler that wrote it — that author is asked again holding the decision and the canonical day facts, and composes ONE line. Anything richer keeps the existing append path untouched, so `withNextMove` still closes every other path exactly as before. Not a mouth rewrite.

The acknowledgement now names the fact the move turns on. The gram figure is this turn's own write — not a total, not an average, not a target.

**2. The same move is not reissued.** `isDuplicateOutbound` is this product's stated rule that *"saying the same words twice in ten minutes is never the right outcome"*. The stapled move escaped it only because the acknowledgement around it differed, so it is consulted on the move itself, in the same window, through the same map. No second history engine.

**And an event in the move's own domain re-earns it.** Suppressing on the text alone was wrong, and an existing acceptance control caught it: a client told to make their next meal a protein one, who then logs a second low-protein meal, has eaten again and needs telling again. `ACTION_DOMAIN` says which tracked fact each action turns on — a meal re-earns a food move, a step count does not.

**3. A plate we just told them to change is not a win.** The dish's own verdict — the existing evaluation, unchanged, **no new nutrition policy** — now records that this turn already asked for a change.

## The 2 445 kcal case

Canonical truth reaches the acknowledgement, and **no rung was added** to `chooseAction` for being over budget on a cut. That policy gap is real, is not this cut's authority, and is filed as an unresolved finding below.

## Controls — what must not change, each asserted

- a reply that already owns NEXT keeps exactly one, and the workout card is never recomposed;
- `doNotMention: weight` survives composition — no weight word reaches the client;
- a closed food day is never answered with an instruction to eat;
- every gram figure in a composed turn is checked against the `meal_logs` row this turn wrote;
- no total, average or window arrives that the client never asked for;
- an in-budget meal is never told it went over, and still gets the ordinary warm acknowledgement;
- a plate we did NOT ask them to change still earns the protein closer;
- a sparse client is still asked the one measurement that would unlock coaching (#203 holds);
- the same turn in a fresh window still earns its move — the suppression is about repetition, not about the second event.

## Two assertions regraded, neither weakened

**Law 4's `closingMove`** read "the last blank-line-separated block", because the append across a blank line *was* the move. One author composes the durable-log turn now, so a layout reader saw no move on replies that plainly carry one. It reads the delivered move off the close's own marker instead — strictly stronger, since the splitter accepted any trailing block whether or not the decision owner had chosen anything, and it reads the same fact on both shapes. Cross-checked against the customer-visible string, so a marker that lies cannot pass.

**#203's same-day re-weigh check** asserted both weigh-ins carry the ask, back to back. That tangled two claims: the verb-blindness #203 proved, and the rule this cut adds. Asserting the tangle would make the suite demand the very repetition the founder complained about. Each half is asserted directly now, which is more than the original: a fresh window proves the UPDATE changes nothing, and back to back proves it still reaches the decision owner and answers with their figure.

## Red on revert — all three mechanisms, independently

```
repetition rule removed   4 acceptance checks fail, 1 tracking violation
                          "9 000 steps — nice one. 👌 Start tomorrow with protein…"
                          "87.4kg — noted. 👌 Tell me what you ate today…"

one-author close removed  5 acceptance checks fail, 1 tracking violation
                          "Got it — Eggs toast. 👌 ⏎⏎ Start tomorrow with protein…"
                          "Got it — Chips, Pap and Beef stew. 👌"   (2 445 kcal)

plate verdict removed     the bunny chow says change this AND repeat this
```

## Unresolved finding, for the next adjudication

**There is no rung for being over budget on a cut.** The ladder is `come_back · rest · weigh · eat_more(bulk) · protein · log · walk · train · hold`. A client who eats twice their day's calories has no action that responds to it; this cut makes the acknowledgement honest about it, and nothing more. Separately, the bunny-chow turn still ships five separately-authored blocks and tells a client who has already eaten to *"snap a photo when you get it"* — a claim-precedence defect in the street-guide path, out of scope here.

## Verification

- `npm run check` — clean.
- `npm test` — **37/37 green**.
- Journey Lab — GREEN, **266 checks** across 8 sections.
- All **eleven** PostgreSQL acceptance suites GREEN, including the new `pg-log-turn-acceptance` (24 checks), wired into the `pg-acceptance` job.
- No governor raised, no assertion weakened, no exclusion, no `continue-on-error`, no second response author, no new ladder, no policy moved into prompt copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_