### PR TITLE
Fix #208: keep one training coaching loop open across turns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,10 @@ jobs:
       # not move. Real rows, real front door, several turns.
       - name: Durable log turns are one coaching turn on real PostgreSQL
         run: npx tsx script/pg-log-turn-acceptance.ts
+      # ONE OPEN COACHING LOOP (#208). Restart durability, user isolation and exact SAST
+      # attribution require the real database; a fixture cannot prove compare-and-set closure.
+      - name: Open training move survives and resolves across turns
+        run: npx tsx script/pg-open-coaching-loop-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,10 @@ jobs:
       # shadow door. Neither is expressible on a fixture that answers every query the same way.
       - name: One weight-direction authority on real PostgreSQL
         run: npx tsx script/pg-weight-authority-acceptance.ts
+      # ONE OPEN COACHING LOOP (#208). Restart durability, user isolation and exact SAST
+      # attribution require the real database; a fixture cannot prove compare-and-set closure.
+      - name: Open training move survives and resolves across turns
+        run: npx tsx script/pg-open-coaching-loop-acceptance.ts
       # A SPARSE CLIENT IS COACHED, NOT JUST RECEIPTED (#203). Every decision here is computed
       # from rows — how many days carry a meal, whether one carries TODAY, how stale the weigh-in
       # is, and whether a same-day re-weigh updates or inserts. None of that is expressible on a
@@ -167,10 +171,6 @@ jobs:
       # not move. Real rows, real front door, several turns.
       - name: Durable log turns are one coaching turn on real PostgreSQL
         run: npx tsx script/pg-log-turn-acceptance.ts
-      # ONE OPEN COACHING LOOP (#208). Restart durability, user isolation and exact SAST
-      # attribution require the real database; a fixture cannot prove compare-and-set closure.
-      - name: Open training move survives and resolves across turns
-        run: npx tsx script/pg-open-coaching-loop-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -149,7 +149,7 @@ const BUDGET = {
    * shrink and a new mouth is a build failure rather than next week's screenshot. Report it
    * with [GUARD8] daily: those two numbers are the whole truth about authorship.
    */
-  authorshipPoints: 420,
+  authorshipPoints: 419,
   twilioCallSites: 16,
 };
 

--- a/script/expectation-continuity-tests.ts
+++ b/script/expectation-continuity-tests.ts
@@ -22,9 +22,14 @@ const { resumeWorkoutFeedbackExpectation } = await import("../server/handlers/wo
 const { users, workoutLogs, chatHistory, mealLogs } = await import("../shared/schema");
 const {
   createWorkoutFeedbackExpectation,
+  createOpenTrainingLoop,
+  readOpenTrainingLoop,
+  reportsOpenTrainingMoveFailed,
+  TRAINING_LOOP_WINDOW_MS,
   readWorkoutFeedbackExpectation,
   WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS,
 } = await import("../server/workout-feedback");
+const { chooseAction } = await import("../server/one-action");
 
 const PHONE = "whatsapp:+27000000901";
 const NOW = Date.now();
@@ -141,10 +146,37 @@ async function replacementAndSubjectChange(): Promise<void> {
     "an explicit subject change must release the workout expectation");
 }
 
+function openTrainingContract(): void {
+  const target = "2026-09-05";
+  const marker = createOpenTrainingLoop(target, "reactive", NOW, "11111111-1111-4111-8111-111111111111");
+  const open = readOpenTrainingLoop(marker, NOW + 1_000);
+  assert.deepEqual(
+    { targetDay: open?.targetDay, ref: open?.ref, source: open?.source },
+    { targetDay: target, ref: "11111111-1111-4111-8111-111111111111", source: "reactive" },
+    "the durable marker must preserve the originating move's SAST day and correlation id",
+  );
+  assert.equal(readOpenTrainingLoop(marker, NOW + TRAINING_LOOP_WINDOW_MS + 1), null,
+    "a stale move must not capture a later outcome");
+  assert.equal(reportsOpenTrainingMoveFailed("I couldn't do it, work was chaos"), true,
+    "the open move supplies the referent for an explicit negative outcome");
+  assert.equal(reportsOpenTrainingMoveFailed("I might train later"), false,
+    "an intention is not a failed outcome");
+
+  const day = {
+    goal: "fat_loss", weeksOnProgramme: 4, daysSinceAnyLog: 0, daysSinceWeighIn: 0,
+    loggedToday: true, proteinPct: 1, caloriePct: 1, sessionsThisWeek: 0,
+    sessionsTarget: 1, stepsToday: 0, stepsTarget: 0, hour: 18,
+  } as const;
+  assert.equal(chooseAction(day as any).kind, "train");
+  assert.notEqual(chooseAction({ ...day, trainingAwaitingOutcome: true } as any).kind, "train",
+    "the canonical owner must not re-issue a move whose outcome is still pending");
+}
+
 await observedJourney();
 await restartAndExpiry();
 await mixedFactJourney();
 await replacementAndSubjectChange();
+openTrainingContract();
 
 console.log("[expectation-continuity] PASS — durable session-feel expectation is recoverable, single-consumed and bounded");
 process.exit(0); // route imports leave background handles; the completed focused harness must not hang CI.

--- a/script/pg-open-coaching-loop-acceptance.ts
+++ b/script/pg-open-coaching-loop-acceptance.ts
@@ -27,6 +27,7 @@ const schema = await import("../shared/schema");
 const { and, desc, eq } = await import("drizzle-orm");
 const { handleMessage } = await import("../server/routes");
 const { canonicalNextMove, recordCanonicalMoveOutbound } = await import("../server/scheduler/proactive-decision");
+const { sendWhatsApp } = await import("../server/scheduler/shared");
 const { consumeOpenTrainingLoop, ensureOpenTrainingLoop } = await import("../server/memory");
 const { createOpenTrainingLoop, isOpenTrainingLoopMarker, readOpenTrainingLoop, TRAINING_LOOP_WINDOW_MS } = await import("../server/workout-feedback");
 const { sastDayKey, sastDayKeyBefore, sastDayStart } = await import("../server/sast");
@@ -101,7 +102,17 @@ const origin = await freshUser();
 const firstMove = await canonicalNextMove(origin);
 check((await reload(origin)).awaitingInputType === null,
   "selecting a proactive move without handing it to outbound creates no phantom ask");
-await recordCanonicalMoveOutbound(origin, firstMove);
+process.env.SHADOW = "on";
+let shadowDelivery: "sent" | "dropped" | "fallback" = "sent";
+try {
+  shadowDelivery = await sendWhatsApp(origin.phoneNumber, firstMove.line);
+} finally {
+  delete process.env.SHADOW;
+}
+await recordCanonicalMoveOutbound(origin, firstMove, shadowDelivery);
+check(shadowDelivery === "dropped" && (await reload(origin)).awaitingInputType === null,
+  "a shadowed or dropped outbound message cannot create an unresolved ask", shadowDelivery);
+await recordCanonicalMoveOutbound(origin, firstMove, "sent");
 const originStored = await reload(origin);
 const originOpen = readOpenTrainingLoop(originStored.awaitingInputType);
 check(firstMove.action.kind === "train", "the canonical decision selects the training move", firstMove.action.kind);
@@ -149,6 +160,16 @@ check(/logged|session/i.test(aReply), "the customer-visible reply confirms the s
 check(JSON.stringify(aTurn?.mutations || []).includes(aOpen?.ref || "missing-ref"),
   "the later turn ledger attributes resolution to the originating ref");
 
+const explicitToday = await freshUser();
+const explicitOpen = await openOn(explicitToday, sastDayKeyBefore(1), 24 * 3_600_000);
+await handleMessage(explicitToday.phoneNumber, "I got the workout done this morning", undefined, undefined, undefined, "SM-loop-explicit");
+const explicitDays = await workoutDays(explicitToday.id);
+const explicitAfter = await reload(explicitToday);
+check(explicitDays.length === 1 && explicitDays[0] === sastDayKey(),
+  "an explicit current-day phrase outranks the older open-loop target", explicitDays.join(","));
+check(readOpenTrainingLoop(explicitAfter.awaitingInputType)?.ref === explicitOpen?.ref,
+  "the older loop is not falsely resolved by a different explicitly dated session");
+
 REAL("\n=== B — FAILED OUTCOME ===");
 const b = await freshUser();
 await openOn(b, sastDayKey());
@@ -163,6 +184,19 @@ check(bAfter.awaitingInputType === null, "the failed move closes exactly once");
 check(bConstraints.some((row: any) => row.kind === "training" && row.state === "asserted"), "the existing constraint owner records the supported failure");
 check(bNext.action.kind !== "train", "the same-day next decision does not nag after failure", bNext.action.kind);
 check(!/session done|workout logged/i.test(bReply), "the reply makes no false completion claim", bReply);
+
+const bQuestion = await freshUser();
+await openOn(bQuestion, sastDayKey());
+const bQuestionReply = await handleMessage(bQuestion.phoneNumber, "I couldn't do it; what should I do now?", undefined, undefined, undefined, "SM-loop-bq");
+const bQuestionAfter = await reload(bQuestion);
+const bQuestionConstraints = await db.select().from(schema.dailyConstraints)
+  .where(and(eq(schema.dailyConstraints.userId, bQuestion.id), eq(schema.dailyConstraints.day, sastDayKey())));
+check(bQuestionAfter.awaitingInputType === null,
+  "an explicit failure closes before the question in the same turn is answered");
+check(bQuestionConstraints.some((row: any) => row.kind === "training" && row.state === "asserted"),
+  "failure plus a question records the supported constraint first");
+check(!/Get today's session done/i.test(bQuestionReply),
+  "the answer after a reported failure does not immediately reissue training", bQuestionReply);
 
 REAL("\n=== C — INTENTION IS NOT AN OUTCOME ===");
 const c = await freshUser();
@@ -201,6 +235,18 @@ const gotAfter = await reload(got);
 check((await workoutDays(got.id)).includes(sastDayKey()), "the natural session-done phrase writes completion");
 check(readOpenTrainingLoop(gotAfter.awaitingInputType)?.ref !== gotOpen?.ref,
   "the natural session-done phrase resolves its originating ref");
+
+REAL("\n=== EVERY LIVE DECISION SURFACE SHARES THE LOOP ===");
+const surfaces = await freshUser();
+const surfacesOpen = await openOn(surfaces, sastDayKey());
+const oneActionReply = await handleMessage(surfaces.phoneNumber, "what should I do?", undefined, undefined, undefined, "SM-loop-one-action");
+const weeklyReply = await handleMessage(surfaces.phoneNumber, "this week", undefined, undefined, undefined, "SM-loop-weekly");
+check(!/Get today's session done/i.test(oneActionReply),
+  "the explicit one-action customer path does not reissue an unresolved training move", oneActionReply);
+check(!/Get today's session done/i.test(weeklyReply),
+  "the weekly progress customer path does not reissue an unresolved training move", weeklyReply);
+check(readOpenTrainingLoop((await reload(surfaces)).awaitingInputType)?.ref === surfacesOpen?.ref,
+  "consulting either decision surface leaves the same unresolved loop intact");
 
 REAL("\n=== CONTROLS ===");
 const q = await freshUser();

--- a/script/pg-open-coaching-loop-acceptance.ts
+++ b/script/pg-open-coaching-loop-acceptance.ts
@@ -1,0 +1,243 @@
+/**
+ * REAL POSTGRESQL ACCEPTANCE — one canonical training move survives and resolves across turns.
+ *
+ * This intentionally exercises the production handleMessage front door for every client outcome.
+ * The only direct setup is the earlier outbound move, represented through its real durable owner.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-open-coaching-loop-acceptance: SKIPPED — no DATABASE_URL");
+  process.exit(0);
+}
+
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { and, desc, eq } = await import("drizzle-orm");
+const { handleMessage } = await import("../server/routes");
+const { canonicalNextMove, recordCanonicalMoveOutbound } = await import("../server/scheduler/proactive-decision");
+const { consumeOpenTrainingLoop, ensureOpenTrainingLoop } = await import("../server/memory");
+const { createOpenTrainingLoop, isOpenTrainingLoopMarker, readOpenTrainingLoop, TRAINING_LOOP_WINDOW_MS } = await import("../server/workout-feedback");
+const { sastDayKey, sastDayKeyBefore, sastDayStart } = await import("../server/sast");
+
+let failed = 0;
+const ids: string[] = [];
+function check(ok: boolean, claim: string, evidence = "") {
+  if (!ok) failed++;
+  REAL("  " + (ok ? "PASS" : "FAIL") + "  " + claim + (!ok && evidence ? "\n          " + evidence : ""));
+}
+
+async function freshUser(over: Record<string, unknown> = {}) {
+  const phone = "whatsapp:+2788" + String(Math.floor(Math.random() * 900000) + 100000);
+  const [user] = await db.insert(schema.users).values({
+    phoneNumber: phone,
+    name: "Loop",
+    gender: "female",
+    goalType: "fat_loss",
+    age: 34,
+    heightCm: 165,
+    currentWeight: "75.0",
+    trainingDaysPerWeek: 1,
+    calorieTarget: 2000,
+    proteinTarget: 120,
+    stepsTarget: 0,
+    subscriptionStatus: "active",
+    onboardingState: "COMPLETE",
+    popiConsent: true,
+    popiConsentAt: new Date(),
+    trainingMode: "gym",
+    programmeWeek: 4,
+    programmeDayInWeek: 1,
+    programmeStartDate: new Date(Date.now() - 30 * 86_400_000),
+    createdAt: new Date(Date.now() - 30 * 86_400_000),
+    lastActiveAt: new Date(),
+    totalWorkoutsCompleted: 0,
+    ...over,
+  } as any).returning();
+  ids.push(user.id);
+
+  for (let days = 0; days < 4; days++) {
+    await db.insert(schema.mealLogs).values({
+      userId: user.id,
+      loggedAt: new Date(sastDayStart(Date.now() - days * 86_400_000).getTime() + 12 * 3_600_000),
+      rawMessage: "acceptance evidence",
+      source: "retro",
+      kcalInt: 2000,
+      proteinInt: 130,
+      items: [{ name: "evidence meal", kcal: 2000, protein: 130 }],
+    });
+  }
+  await db.insert(schema.weightLogs).values({ userId: user.id, weight: "75.0", loggedAt: new Date() });
+  return user;
+}
+
+async function reload(user: any) {
+  return (await db.select().from(schema.users).where(eq(schema.users.id, user.id)).limit(1))[0];
+}
+
+async function workoutDays(userId: string) {
+  const rows = await db.select({ at: schema.workoutLogs.loggedAt }).from(schema.workoutLogs)
+    .where(eq(schema.workoutLogs.userId, userId));
+  return rows.map((row: any) => sastDayKey(row.at));
+}
+
+async function openOn(user: any, targetDay: string, ageMs = 0) {
+  return ensureOpenTrainingLoop(user, targetDay, "reactive", Date.now() - ageMs);
+}
+
+REAL("\n=== OPENED BY THE CANONICAL OWNER ===");
+const origin = await freshUser();
+const firstMove = await canonicalNextMove(origin);
+check((await reload(origin)).awaitingInputType === null,
+  "selecting a proactive move without handing it to outbound creates no phantom ask");
+await recordCanonicalMoveOutbound(origin, firstMove);
+const originStored = await reload(origin);
+const originOpen = readOpenTrainingLoop(originStored.awaitingInputType);
+check(firstMove.action.kind === "train", "the canonical decision selects the training move", firstMove.action.kind);
+check(!!originOpen && originOpen.targetDay === sastDayKey(), "the unresolved move is durable with its SAST target day");
+const whileOpen = await canonicalNextMove(originStored);
+check(whileOpen.action.kind !== "train", "an unresolved move is not re-issued on the next decision", whileOpen.action.kind);
+
+const reactiveOrigin = await freshUser();
+const originReply = await handleMessage(
+  reactiveOrigin.phoneNumber,
+  "I drank 2 litres of water",
+  undefined,
+  undefined,
+  undefined,
+  "SM-loop-origin",
+);
+await new Promise(resolve => setTimeout(resolve, 100));
+const reactiveOriginAfter = await reload(reactiveOrigin);
+const reactiveOpen = readOpenTrainingLoop(reactiveOriginAfter.awaitingInputType);
+const [originTurn] = await db.select().from(schema.turnLedger)
+  .where(and(eq(schema.turnLedger.userId, reactiveOrigin.id), eq(schema.turnLedger.inputText, "I drank 2 litres of water")))
+  .orderBy(desc(schema.turnLedger.createdAt)).limit(1);
+check(/Get today's session done/i.test(originReply), "the production reply actually delivers the canonical move", originReply);
+check(!!reactiveOpen, "the reactive move survives after the originating turn returns");
+check((originTurn?.stateRead as any)?.openLoopRef === reactiveOpen?.ref,
+  "the turn ledger and durable continuation share one provenance ref");
+
+REAL("\n=== A — LATE COMPLETION ===");
+const a = await freshUser();
+const aOpen = await openOn(a, sastDayKeyBefore(1), 24 * 3_600_000);
+const aReply = await handleMessage(a.phoneNumber, "I trained yesterday, forgot to tell you", undefined, undefined, undefined, "SM-loop-a");
+await new Promise(resolve => setTimeout(resolve, 100));
+const aAfter = await reload(a);
+const aDays = await workoutDays(a.id);
+const aNext = await canonicalNextMove(aAfter);
+const [aTurn] = await db.select().from(schema.turnLedger)
+  .where(and(eq(schema.turnLedger.userId, a.id), eq(schema.turnLedger.inputText, "I trained yesterday, forgot to tell you")))
+  .orderBy(desc(schema.turnLedger.createdAt)).limit(1);
+check(!!aOpen, "the prior-day move starts open");
+check(aDays.length === 1 && aDays[0] === sastDayKeyBefore(1), "the workout owner writes exactly the reported SAST day", aDays.join(","));
+const aAfterOpen = readOpenTrainingLoop(aAfter.awaitingInputType);
+check(aAfterOpen?.ref !== aOpen?.ref, "the attributed move resolves exactly the originating ref");
+check(aNext.action.kind !== "train", "the proactive next decision does not repeat the unresolved originating move", aNext.action.kind);
+check(/logged|session/i.test(aReply), "the customer-visible reply confirms the supported workout truth", aReply);
+check(JSON.stringify(aTurn?.mutations || []).includes(aOpen?.ref || "missing-ref"),
+  "the later turn ledger attributes resolution to the originating ref");
+
+REAL("\n=== B — FAILED OUTCOME ===");
+const b = await freshUser();
+await openOn(b, sastDayKey());
+const bReply = await handleMessage(b.phoneNumber, "I couldn't do it, work was chaos", undefined, undefined, undefined, "SM-loop-b");
+const bAfter = await reload(b);
+const bDays = await workoutDays(b.id);
+const bConstraints = await db.select().from(schema.dailyConstraints)
+  .where(and(eq(schema.dailyConstraints.userId, b.id), eq(schema.dailyConstraints.day, sastDayKey())));
+const bNext = await canonicalNextMove(bAfter);
+check(bDays.length === 0, "failure never fabricates a workout");
+check(bAfter.awaitingInputType === null, "the failed move closes exactly once");
+check(bConstraints.some((row: any) => row.kind === "training" && row.state === "asserted"), "the existing constraint owner records the supported failure");
+check(bNext.action.kind !== "train", "the same-day next decision does not nag after failure", bNext.action.kind);
+check(!/session done|workout logged/i.test(bReply), "the reply makes no false completion claim", bReply);
+
+REAL("\n=== C — INTENTION IS NOT AN OUTCOME ===");
+const c = await freshUser();
+const cOpen = await openOn(c, sastDayKey());
+await handleMessage(c.phoneNumber, "I might train later", undefined, undefined, undefined, "SM-loop-c");
+const cAfter = await reload(c);
+check((await workoutDays(c.id)).length === 0, "an intention writes no workout");
+check(cAfter.awaitingInputType === cOpen?.marker, "an intention leaves the move open");
+
+REAL("\n=== D — STRUCTURED COMPLETION + IDEMPOTENCE ===");
+const d = await freshUser();
+await openOn(d, sastDayKey());
+await handleMessage(d.phoneNumber, "workout done", undefined, undefined, undefined, "SM-loop-d1");
+const dAfterFirst = await reload(d);
+await handleMessage(d.phoneNumber, "workout done", undefined, undefined, undefined, "SM-loop-d2");
+const dAfter = await reload(d);
+check((await workoutDays(d.id)).length === 1, "structured completion writes one session even when repeated");
+check(!isOpenTrainingLoopMarker(dAfterFirst.awaitingInputType), "structured completion also closes the original loop");
+check(!isOpenTrainingLoopMarker(dAfter.awaitingInputType), "a duplicate completion cannot resurrect the original loop");
+const dNext = await canonicalNextMove(dAfter);
+check(dNext.action.kind !== "train", "a completed current-week move is not re-issued after a quiet turn", dNext.action.kind);
+
+const natural = await freshUser();
+const naturalOpen = await openOn(natural, sastDayKeyBefore(1), 24 * 3_600_000);
+await handleMessage(natural.phoneNumber, "I did the workout you told me to do", undefined, undefined, undefined, "SM-loop-natural");
+const naturalAfter = await reload(natural);
+check((await workoutDays(natural.id)).includes(sastDayKeyBefore(1)),
+  "the exact referential completion writes the open move's SAST day");
+check(readOpenTrainingLoop(naturalAfter.awaitingInputType)?.ref !== naturalOpen?.ref,
+  "the exact referential completion resolves its originating ref");
+
+const got = await freshUser();
+const gotOpen = await openOn(got, sastDayKey());
+await handleMessage(got.phoneNumber, "I got the session done", undefined, undefined, undefined, "SM-loop-got");
+const gotAfter = await reload(got);
+check((await workoutDays(got.id)).includes(sastDayKey()), "the natural session-done phrase writes completion");
+check(readOpenTrainingLoop(gotAfter.awaitingInputType)?.ref !== gotOpen?.ref,
+  "the natural session-done phrase resolves its originating ref");
+
+REAL("\n=== CONTROLS ===");
+const q = await freshUser();
+const qOpen = await openOn(q, sastDayKey());
+await handleMessage(q.phoneNumber, "what workout did you tell me to do?", undefined, undefined, undefined, "SM-loop-q");
+check((await workoutDays(q.id)).length === 0, "a question is not completion");
+check((await reload(q)).awaitingInputType === qOpen?.marker, "a question leaves the move open");
+
+const ambiguous = await freshUser();
+const ambiguousOpen = await openOn(ambiguous, sastDayKey());
+await handleMessage(ambiguous.phoneNumber, "I did it", undefined, undefined, undefined, "SM-loop-amb");
+check((await workoutDays(ambiguous.id)).length === 0, "an ambiguous outcome is not attributed");
+check((await reload(ambiguous)).awaitingInputType === ambiguousOpen?.marker, "ambiguity preserves the open evidence");
+
+const isolated = await freshUser();
+check((await reload(isolated)).awaitingInputType === null, "another user never inherits the open move");
+
+const stale = await freshUser();
+const staleMarker = createOpenTrainingLoop(sastDayKeyBefore(3), "reactive", Date.now() - TRAINING_LOOP_WINDOW_MS - 1);
+await pool.query("UPDATE users SET awaiting_input_type = $1 WHERE id = $2", [staleMarker, stale.id]);
+const staleRow = await reload(stale);
+await import("../server/memory").then(m => m.loadOpenTrainingLoop(staleRow));
+check((await reload(stale)).awaitingInputType === null, "a stale move expires instead of capturing a later outcome");
+
+const safe = await freshUser({ profileNotes: "sick_since:" + sastDayKey() + " | sick_until:" + sastDayKey() + " | paused_until:" + sastDayKey() });
+const safeMove = await canonicalNextMove(safe);
+check(safeMove.action.kind !== "train", "safety still outranks training-loop creation", safeMove.action.kind);
+check((await reload(safe)).awaitingInputType === null, "a safety decision opens no training move");
+
+if (originOpen) await consumeOpenTrainingLoop(originStored, originOpen.marker);
+if (reactiveOpen) await consumeOpenTrainingLoop(reactiveOriginAfter, reactiveOpen.marker);
+for (const id of ids) await db.delete(schema.users).where(eq(schema.users.id, id)).catch(() => {});
+await pool.end();
+
+if (failed) {
+  REAL("\npg-open-coaching-loop-acceptance: RED — " + failed + " check(s) failed");
+  process.exit(1);
+}
+REAL("\npg-open-coaching-loop-acceptance: GREEN — LOCAL REAL POSTGRESQL");
+process.exit(0);

--- a/script/pg-thin-evidence-acceptance.ts
+++ b/script/pg-thin-evidence-acceptance.ts
@@ -51,8 +51,8 @@ const { eq } = await import("drizzle-orm");
 const { handleMessage } = await import("../server/routes");
 const { canonicalDecision } = await import("../server/understanding/live");
 const { canonicalNextMove } = await import("../server/scheduler/proactive-decision");
-const { getProgressTruth } = await import("../server/day-ledger");
-const { sastHour } = await import("../server/sast");
+const { getProgressTruth, sessionsThisCalendarWeek } = await import("../server/day-ledger");
+const { sastHour, sastWeekStart } = await import("../server/sast");
 const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
 
 let failed = 0;
@@ -335,9 +335,17 @@ REAL("\n=== REACTIVE AND PROACTIVE AGREE ===");
     `INSERT INTO step_logs (user_id, logged_at, steps, provenance, resolved_day)
      VALUES ($1, now(), 12000, 'client_report', to_char(now() AT TIME ZONE 'Africa/Johannesburg','YYYY-MM-DD'))`,
     [c.id]);
+  const sessionTarget = 3;
+  const canonicalWeekStart = sastWeekStart();
   await pool.query(
     `INSERT INTO workout_logs (user_id, logged_at, workout_completed)
-     SELECT $1, now() - (d || ' days')::interval, true FROM generate_series(0, 3) AS d`, [c.id]);
+     SELECT $1, $2::timestamptz + d * interval '1 millisecond', true
+       FROM generate_series(0, $3 - 1) AS d`,
+    [c.id, canonicalWeekStart, sessionTarget]);
+  const seededSessions = await sessionsThisCalendarWeek(c.id);
+  chk(seededSessions === sessionTarget,
+    "the sufficient-evidence fixture stays inside the canonical current SAST week",
+    `weekStart=${canonicalWeekStart.toISOString()} sessions=${seededSessions}/${sessionTarget}`);
   await pool.query(
     `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
      VALUES ($1, now(), 'dinner', 2200, 160, $2, 'seed', 'sa_scanner')`,

--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -129,6 +129,9 @@ interface TurnScope {
      * carries an instruction.
      */
     canonicalReply?: string | null;
+    /** Correlation carried by the existing durable awaiting-input owner for an open coaching move. */
+    openLoopRef?: string | null;
+    openLoopKind?: "train" | null;
     /**
      * Structured situation frame for a decision turn (birthday outing, eating out today).
      * Rendered by code from extractSalientSituation — not GPT prose.
@@ -613,7 +616,12 @@ export async function recordTurn(reply: string): Promise<void> {
     ]);
     const decision = currentRuntimeDecision();
     const evidenceRefs = decision?.focus === "safety" ? ["safety_gate"] : decision?.focus === "hunger" ? ["hunger_evidence"] : decision?.focus === "intake" ? ["deficit_evidence"] : [];
-    const stateRead = decision ? { ...t.stateRead, decisionState: decision.state, decisionEvidence: decision.evidence, decisionFocus: decision.focus, decisionEvidenceRefs: evidenceRefs, meaningfulProblem: decision.meaningfulProblem, hasMinimumUsefulQuestion: decision.hasMinimumUsefulQuestion } : t.stateRead;
+    const openLoop = t.evidence?.openLoopRef
+      ? { openLoopRef: t.evidence.openLoopRef, openLoopKind: t.evidence.openLoopKind || null }
+      : {};
+    const stateRead = decision
+      ? { ...t.stateRead, ...openLoop, decisionState: decision.state, decisionEvidence: decision.evidence, decisionFocus: decision.focus, decisionEvidenceRefs: evidenceRefs, meaningfulProblem: decision.meaningfulProblem, hasMinimumUsefulQuestion: decision.hasMinimumUsefulQuestion }
+      : { ...t.stateRead, ...openLoop };
     await db.insert(turnLedger).values({
       userId: t.userId, inputType: t.inputType, inputText: t.inputText, resolvedDay: t.resolvedDay,
       stateRead: Object.keys(stateRead).length ? stateRead : null, mutations: t.mutations.length ? t.mutations : null,

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -872,32 +872,11 @@ export async function handleMiscCommands(ctx: {
         // different "one thing" from the weekly card than from the coach five minutes earlier.
         // One constitution does not mean one decision if two callers hand it different worlds.
         //
-        // The CARD is a weekly recap; the ACTION is what to do next, which is a daily question and
-        // the only one chooseAction was built to answer. So the numbers stay weekly and the
-        // decision context becomes today's — identical semantics to computeNextMove and morning.
-        const { chooseAction, underPolicy, PROACTIVE_LOG_FLOOR } = await import("../one-action");
-        const { sastHour } = await import("../sast");
-        const act = underPolicy(chooseAction({
-          goal: (user.goalType as any) || "general", weeksOnProgramme: Math.max(0, (user.programmeWeek || 1) - 1),
-          dreamGoal: user.dreamGoal, biggestStruggle: user.biggestStruggle, lifeContext: user.lifeContext,
-          doNotMention: user.doNotMention,
-          daysSinceAnyLog: truth.today.kcal > 0 ? 0 : (truth.window.daysLogged > 0 ? 1 : 7),
-          daysSinceWeighIn: truth.weight.daysSinceWeighIn, loggedToday: truth.today.kcal > 0,
-          proteinPct: protTarget > 0 ? truth.today.protein / protTarget : 1,
-          caloriePct: calTarget > 0 ? truth.today.kcal / calTarget : 1,
-          sessionsThisWeek: truth.sessions, sessionsTarget: Number(user.trainingDaysPerWeek) || 3,
-          stepsToday: truth.today.steps, stepsTarget: Number(user.stepsTarget) || 0,
-          hour: sastHour(), atKeyboard: true,
-        } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
-         // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a
-         // decision: the proactive side reads a stall verdict this path never computes, so
-         // passing anything but false would be inventing evidence. It means a client with a
-         // usable weight trend and a thin food log is still held on this path.
-         weightSufficient: false, dreamGoal: user.dreamGoal,
-         // The same three facts this call site already computed above (#203).
-         loggedToday: truth.today.kcal > 0,
-         daysSinceWeighIn: truth.weight.daysSinceWeighIn,
-         doNotMention: user.doNotMention });
+        // The CARD keeps its weekly measurements; the ACTION comes from the same live owner used
+        // by every other reactive surface. That owner also carries unresolved-loop state, so a
+        // report cannot reissue the instruction while the client's answer is still outstanding.
+        const { canonicalDecision } = await import("../understanding/live");
+        const act = await canonicalDecision(user, message);
         return `*${name} — last 7 days*\n\n💪 Sessions: *${truth.sessions}*\n📋 Days logged: *${truth.window.daysLogged}/7*\n🔥 Avg: *${truth.window.avgKcal} kcal* · *${truth.window.avgProtein}g* protein\n👟 Avg steps: *${truth.avgSteps.toLocaleString()}*${weightLine}\n\n*${act.todo}*`;
       }
       const todayLine = truth.today.kcal > 0

--- a/server/handlers/one-action-command.ts
+++ b/server/handlers/one-action-command.ts
@@ -20,15 +20,23 @@ import { getDayLedger } from "../day-ledger";
 import { sastDayStart, sastDaysBetween, sastHour, sastWeekStart } from "../sast";
 import { readHealthState } from "../health-state";
 import { foodConstraints } from "../food-swaps";
+import { loadOpenTrainingLoop } from "../memory";
+import { readHeldConstraints, NO_CONSTRAINTS } from "../held-constraints";
 
 /** Is this client inside a declared sick window? Asked of the state owner, not of the text. */
 const isSick = (user: any): boolean => readHealthState(user).isSick;
 
-async function buildDecisionInputs(user: any): Promise<{ state: ProactiveStateForDecision; profile: ProactiveProfile }> {
+async function buildDecisionInputs(user: any): Promise<{
+  state: ProactiveStateForDecision;
+  profile: ProactiveProfile;
+  trainingAwaitingOutcome: boolean;
+  trainingDeclined: boolean;
+  foodDayClosed: boolean;
+}> {
   const dayStart = sastDayStart();
   const weekStart = sastWeekStart();
 
-  const [ledger, lastMeal, lastWeigh, weekSessions, todaySteps, loggedDays] = await Promise.all([
+  const [ledger, lastMeal, lastWeigh, weekSessions, todaySteps, loggedDays, openTraining, held] = await Promise.all([
     getDayLedger(user.id, { user }),
     db.select({ at: mealLogs.loggedAt }).from(mealLogs)
       .where(eq(mealLogs.userId, user.id)).orderBy(desc(mealLogs.loggedAt)).limit(1),
@@ -47,6 +55,8 @@ async function buildDecisionInputs(user: any): Promise<{ state: ProactiveStateFo
       .from(mealLogs)
       .where(and(eq(mealLogs.userId, user.id), gte(mealLogs.loggedAt, new Date(dayStart.getTime() - 6 * 86_400_000))))
       .catch(() => [{ days: 0 }]),
+    loadOpenTrainingLoop(user),
+    readHeldConstraints(user.phoneNumber, user).catch(() => NO_CONSTRAINTS),
   ]);
   const distinctLoggedDays = Number((loggedDays as { days: number }[])[0]?.days || 0);
 
@@ -100,6 +110,9 @@ async function buildDecisionInputs(user: any): Promise<{ state: ProactiveStateFo
       proteinTarget: Number(user?.proteinTarget) || 0,
       stepsTarget: Number(user?.stepsTarget) || 0,
     },
+    trainingAwaitingOutcome: !!openTraining,
+    trainingDeclined: held.trainingDeclined,
+    foodDayClosed: held.foodDayClosed,
   };
 }
 
@@ -122,8 +135,13 @@ export async function oneActionCommand(user: any, opts?: { atKeyboard?: boolean 
     // would have refused to prescribe on — the same client, the same ledgers, two standards
     // depending on who spoke first. decideProactive applies the verdict, and its downgrade turns
     // an unjustifiable prescription into the measurement that would justify it.
-    const { state, profile } = await buildDecisionInputs(user);
-    const decision = decideProactive(state, profile, { atKeyboard: !!opts?.atKeyboard });
+    const { state, profile, trainingAwaitingOutcome, trainingDeclined, foodDayClosed } = await buildDecisionInputs(user);
+    const decision = decideProactive(state, profile, {
+      atKeyboard: !!opts?.atKeyboard,
+      trainingAwaitingOutcome,
+      trainingDeclined,
+      foodDayClosed,
+    });
     return formatOneAction(decision.action, firstName);
   } catch (e: any) {
     console.error("[ONE_ACTION]", e?.message || e);

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -104,7 +104,8 @@ export async function resumeWorkoutFeedbackExpectation(ctx: {
 /**
  * Resolve only an explicit negative answer to the canonical training move. Positive outcomes stay
  * with handleWorkoutCommands: the loop may close only after workout_logs either receives or
- * already holds the attributed session. Questions and intentions leave the marker untouched.
+ * already holds the attributed session. Pure questions and intentions leave the marker untouched;
+ * a turn that both reports failure and asks what next still records the supported outcome first.
  */
 export async function resumeOpenTrainingLoopOutcome(ctx: {
   message: string;
@@ -115,8 +116,10 @@ export async function resumeOpenTrainingLoopOutcome(ctx: {
   const { message, m, user, sourceMessageId } = ctx;
   const open = await loadOpenTrainingLoop(user);
   if (!open) return null;
-  if (looksLikeQuestion(m) || isFutureIntent(m)) return "pending";
-  if (!reportsOpenTrainingMoveFailed(message)) return null;
+  if (isFutureIntent(m)) return "pending";
+  // An explicit outcome remains an outcome when the client also asks what comes next. Persist
+  // what happened before the rest of the turn answers them; punctuation cannot veto the truth.
+  if (!reportsOpenTrainingMoveFailed(message)) return looksLikeQuestion(m) ? "pending" : null;
   if (!await consumeOpenTrainingLoop(user, open.marker)) return null;
   try {
     await recordOpenTrainingFailure(user, open.targetDay, sourceMessageId);
@@ -445,9 +448,7 @@ export async function handleWorkoutCommands(ctx: {
   const lowerMessage = String(m || "").toLowerCase();
   const refersToAssignedSession = ["the workout", "the session", "workout you told",
     "session you told", "workout you asked", "session you asked"].some(shape => lowerMessage.includes(shape));
-  const usesExplicitDay = ["today", "yesterday", "last night", "monday", "tuesday",
-    "wednesday", "thursday", "friday", "saturday", "sunday", "days ago"].some(shape => lowerMessage.includes(shape));
-  const openTargetDate = openTraining && refersToAssignedSession && hasCompletionWord && !usesExplicitDay
+  const openTargetDate = openTraining && refersToAssignedSession && hasCompletionWord && !stated.explicit
     ? new Date(openTraining.targetDay + "T12:00:00+02:00")
     : null;
   const when = openTargetDate && openTraining!.targetDay !== sastDayKey()

--- a/server/handlers/workout.ts
+++ b/server/handlers/workout.ts
@@ -13,6 +13,7 @@ import {
   createWorkoutFeedbackExpectation,
   isWorkoutFeedbackExpectation,
   readWorkoutFeedbackExpectation,
+  reportsOpenTrainingMoveFailed,
   workoutFeedbackReply,
 } from "../workout-feedback";
 import { parseSessionReport, sessionReportReply, sessionMemoryLine, type SessionReport } from "../session-report";
@@ -21,7 +22,7 @@ import {
   buildFullProgramme, getKamlifeProgramme, renderSession, WORKOUT_DONE_RESPONSES,
 } from "../programme";
 import { checkPerfectDay } from "./checks";
-import { storeMemory } from "../memory";
+import { consumeOpenTrainingLoop, loadOpenTrainingLoop, restoreOpenTrainingLoop, storeMemory } from "../memory";
 import { generateVoiceNote } from "../tts";
 import { generateMilestoneVoiceScript } from "../gpt";
 import { logChat, turnMutation, turnAlreadyWrote } from "./chat-log";
@@ -38,6 +39,7 @@ import { calculateTargets } from "../targets";
 import { getPrimaryWorkoutGifUrl } from "../exercise-media";
 import { sendWhatsApp, saveState } from "../scheduler/shared";
 import { PRICING, GUARANTEE_PHRASE } from "../../shared/pricing";
+import { recordOpenTrainingFailure } from "../held-constraints";
 
 // Exercise-name vocabulary. parseLiftLog was deleted with lift logging on 2026-08-06, but
 // this pattern is NOT a parser input — it is a GUARD used twice below, and both uses are the
@@ -99,14 +101,58 @@ export async function resumeWorkoutFeedbackExpectation(ctx: {
   return reply;
 }
 
+/**
+ * Resolve only an explicit negative answer to the canonical training move. Positive outcomes stay
+ * with handleWorkoutCommands: the loop may close only after workout_logs either receives or
+ * already holds the attributed session. Questions and intentions leave the marker untouched.
+ */
+export async function resumeOpenTrainingLoopOutcome(ctx: {
+  message: string;
+  m: string;
+  user: any;
+  sourceMessageId?: string;
+}): Promise<"failed" | "pending" | null> {
+  const { message, m, user, sourceMessageId } = ctx;
+  const open = await loadOpenTrainingLoop(user);
+  if (!open) return null;
+  if (looksLikeQuestion(m) || isFutureIntent(m)) return "pending";
+  if (!reportsOpenTrainingMoveFailed(message)) return null;
+  if (!await consumeOpenTrainingLoop(user, open.marker)) return null;
+  try {
+    await recordOpenTrainingFailure(user, open.targetDay, sourceMessageId);
+  } catch (e) {
+    await restoreOpenTrainingLoop(user, open.marker);
+    console.warn("[COACHING_LOOP] training failure truth not recorded; loop remains open:", e);
+    return "pending";
+  }
+  turnMutation("RESOLVE coaching_loop ref=" + open.ref + " outcome=failed target=" + open.targetDay, "[COACHING_LOOP]");
+  return "failed";
+}
+
 export async function handleWorkoutCommands(ctx: {
   phone: string;
   message: string;
   m: string;
   user: any;
+  sourceMessageId?: string;
 }): Promise<string | null> {
   const { phone, message, m, user } = ctx;
   const firstName = user.name?.split(" ")[0] || "";
+  const openTraining = await loadOpenTrainingLoop(user);
+  let completedOpenTraining = false;
+  const closeTrainingLoop = async (resolvedDay: string): Promise<boolean> => {
+    if (!openTraining || openTraining.targetDay !== resolvedDay) return false;
+    const closed = await consumeOpenTrainingLoop(user, openTraining.marker);
+    if (closed) {
+      completedOpenTraining = true;
+      turnMutation(
+        "RESOLVE coaching_loop ref=" + openTraining.ref + " outcome=completed target="
+          + openTraining.targetDay + " source=" + (ctx.sourceMessageId || "unavailable"),
+        "[COACHING_LOOP]",
+      );
+    }
+    return closed;
+  };
 
   // ---- SESSION REPORTED IN PROSE — "today was my first day back, felt very bad" ----
   // Runs BEFORE the difficulty-feedback gate and the terse `isDone` match, because a
@@ -116,7 +162,10 @@ export async function handleWorkoutCommands(ctx: {
   const sessionReport = parseSessionReport(message);
   if (sessionReport && !looksLikeQuestion(m) && !isFutureIntent(m) && !mentionsNotDone(m)) {
     const handled = await logProseSession(user, phone, message, sessionReport, firstName);
-    if (handled) return handled;
+    if (handled) {
+      await closeTrainingLoop(sastDayKey());
+      return handled;
+    }
   }
 
   // ---- WORKOUT DIFFICULTY FEEDBACK — the post-session "how was it?" loop ----
@@ -233,6 +282,7 @@ export async function handleWorkoutCommands(ctx: {
       .limit(1);
 
     if (existingToday.length > 0) {
+      await closeTrainingLoop(sastDayKey());
       return `${firstName ? firstName + ", " : ""}session already logged today. Good work staying active.`;
     }
 
@@ -302,6 +352,7 @@ export async function handleWorkoutCommands(ctx: {
     // Log workout session
     await db.insert(workoutLogs).values({ userId: user.id, workoutCompleted: true });
     turnMutation("INSERT workout completed=true", "[WORKOUT_LOG]");
+    await closeTrainingLoop(sastDayKey());
     invalidatePatternCache(user.id); // GPT's cached pattern summary must see this session immediately
 
     const newTotal = (user.totalWorkoutsCompleted || 0) + 1;
@@ -381,13 +432,27 @@ export async function handleWorkoutCommands(ctx: {
   // already out-resolved, so "I trained Monday" and "I trained last week" both wrote TODAY.
   // utils.statedWhen answers today / historical / ambiguous for both branches below, from the
   // parser that owns dates — and hands back the date it resolved, so nothing parses twice.
-  const when = statedWhen(m);
   // "done/finished/completed" alone is too generic — must appear beside a workout word.
   // "trained", "did my workout/session/legs/etc." are workout-specific by themselves.
   const hasCompletionWord =
-    /\b(trained|did\s+(?:my\s+)?(?:workout|session|training|gym|legs?|upper(?:\s+body)?|lower(?:\s+body)?|chest|back|push|pull|cardio|arms?|shoulders?|squats?)|workout\s+(?:done|complete[d]?|finished)|session\s+(?:done|complete[d]?|finished)|training\s+(?:done|complete[d]?|finished)|gym\s+(?:done|complete[d]?|finished))\b/i.test(m)
+    /\b(trained|did\s+(?:(?:my|the)\s+)?(?:workout|session|training|gym|legs?|upper(?:\s+body)?|lower(?:\s+body)?|chest|back|push|pull|cardio|arms?|shoulders?|squats?)|workout\s+(?:done|complete[d]?|finished)|session\s+(?:done|complete[d]?|finished)|training\s+(?:done|complete[d]?|finished)|gym\s+(?:done|complete[d]?|finished))\b/i.test(m)
     || /\b(?:done|finished|complete[d]?)\b.{0,40}\b(?:workout|session|training|gym|legs?|upper|lower|chest|back|push|pull|cardio)\b/i.test(m)
     || /\b(?:workout|session|training|gym|legs?|upper|lower|chest|back|push|pull|cardio)\b.{0,40}\b(?:done|finished|complete[d]?)\b/i.test(m);
+  const stated = statedWhen(m);
+  // On the following day, "the session" / "the workout you told me to do" has one supported
+  // referent: the still-open canonical move. Use that move's stored SAST day. A bare "I did it"
+  // is intentionally absent — ambiguity never becomes a workout row.
+  const lowerMessage = String(m || "").toLowerCase();
+  const refersToAssignedSession = ["the workout", "the session", "workout you told",
+    "session you told", "workout you asked", "session you asked"].some(shape => lowerMessage.includes(shape));
+  const usesExplicitDay = ["today", "yesterday", "last night", "monday", "tuesday",
+    "wednesday", "thursday", "friday", "saturday", "sunday", "days ago"].some(shape => lowerMessage.includes(shape));
+  const openTargetDate = openTraining && refersToAssignedSession && hasCompletionWord && !usesExplicitDay
+    ? new Date(openTraining.targetDay + "T12:00:00+02:00")
+    : null;
+  const when = openTargetDate && openTraining!.targetDay !== sastDayKey()
+    ? { when: "historical" as const, date: openTargetDate }
+    : stated;
   // TWO QUESTIONS, NOT ONE (2026-08-25). This regex conflated "did they report a training miss"
   // — which readTrainingDay owns — with "are they sick or injured", which is a health question and
   // is not this owner's to answer. The training half now comes from the owner; the health half
@@ -408,8 +473,7 @@ export async function handleWorkoutCommands(ctx: {
 
   if (isRetroDone) {
     const retroDate = when.date;
-    const retroStart = new Date(retroDate);
-    retroStart.setUTCHours(0, 0, 0, 0);
+    const retroStart = sastDayStart(retroDate);
     const retroEnd = new Date(retroStart.getTime() + 86_400_000);
     const dateLabel = mealDateLabel(retroDate);
 
@@ -422,10 +486,12 @@ export async function handleWorkoutCommands(ctx: {
       .limit(1);
 
     if (existing.length > 0) {
+      await closeTrainingLoop(sastDayKey(retroDate));
       return `${firstName ? firstName + ", already" : "Already"} got ${dateLabel}'s workout logged.`;
     }
 
     await db.insert(workoutLogs).values({ userId: user.id, workoutCompleted: true, loggedAt: retroDate });
+    await closeTrainingLoop(sastDayKey(retroDate));
     // The SAST day, not String(Date).slice(0,10) — which produced "Fri Aug 2" and made the write
     // record unreadable by anything that needed to know WHICH day was written (2026-08-22).
     turnMutation(`INSERT workout completed=true at=${sastDayKey(retroDate)}`, "[WORKOUT_LOG]");
@@ -594,10 +660,12 @@ export async function handleWorkoutCommands(ctx: {
       .limit(1);
 
     if (existing.length > 0) {
+      await closeTrainingLoop(sastDayKey());
       return `${firstName ? firstName + ", " : ""}today's session is already logged. 👌`;
     }
 
     await db.insert(workoutLogs).values({ userId: user.id, workoutCompleted: true });
+    await closeTrainingLoop(sastDayKey());
     turnMutation("INSERT workout", "[WRITE]");
     invalidatePatternCache(user.id); // GPT's cached pattern summary must see this session immediately
 
@@ -708,9 +776,11 @@ export async function handleWorkoutCommands(ctx: {
     // its answer survives a process restart and reaches workout-feedback before a prose/logging
     // handler gets a chance to reinterpret it. A newer question replaces the older single-slot
     // expectation, matching the existing awaitingInputType contract.
-    const feedbackExpectation = createWorkoutFeedbackExpectation();
-    await db.update(users).set({ awaitingInputType: feedbackExpectation }).where(eq(users.id, user.id));
-    user.awaitingInputType = feedbackExpectation;
+    if (!openTraining || completedOpenTraining) {
+      const feedbackExpectation = createWorkoutFeedbackExpectation();
+      await db.update(users).set({ awaitingInputType: feedbackExpectation }).where(eq(users.id, user.id));
+      user.awaitingInputType = feedbackExpectation;
+    }
 
     // Fire referral nudge 60 seconds later on the very first workout
     if (newTotal === 1) {

--- a/server/held-constraints.ts
+++ b/server/held-constraints.ts
@@ -194,6 +194,23 @@ export async function recordDailyConstraint(
 }
 
 /**
+ * Record the negative outcome of an already-open training move. The open move supplies the
+ * missing referent in "I couldn't do it"; this function does not classify language or create a
+ * second training policy. It writes through the same append-only owner as an explicit same-day
+ * training decline, on the SAST day the original move named.
+ */
+export async function recordOpenTrainingFailure(
+  client: { id: string },
+  targetDay: string,
+  sourceMessageId?: string,
+): Promise<void> {
+  await db.insert(dailyConstraints)
+    .values({ userId: client.id, day: targetDay, kind: "training", state: "asserted", via: "said",
+      sourceMessageId: sourceMessageId || null })
+    .onConflictDoNothing();
+}
+
+/**
  * THE SAME CONSTRAINT, READ OVER A BATCH OF TURNS ALREADY IN MEMORY (#138 recurrence, 2026-09-03).
  *
  * readHeldConstraints above answers "what did THIS client settle today" and reaches the chat log to

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -2,10 +2,74 @@ import { pool } from "./db";
 import OpenAI from "openai";
 import { assertAiOnline, isAiOfflineError } from "./ai-offline";
 import { sastDaysBetween } from "./sast";
+import {
+  createOpenTrainingLoop,
+  isOpenTrainingLoopMarker,
+  readOpenTrainingLoop,
+  type OpenTrainingLoop,
+} from "./workout-feedback";
 
 const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY || process.env.OPENAI_API_KEY || "sk-missing-key",
 });
+
+/**
+ * Durable continuation state lives on users.awaiting_input_type. These compare-and-set helpers
+ * are beside the other client-memory writes rather than inside the language recogniser: parsing
+ * an answer and persisting whose answer is pending are separate jobs.
+ */
+export async function loadOpenTrainingLoop(user: any, now = Date.now()): Promise<OpenTrainingLoop | null> {
+  const marker = String(user?.awaitingInputType || "");
+  if (!isOpenTrainingLoopMarker(marker)) return null;
+  const open = readOpenTrainingLoop(marker, now);
+  if (open) return open;
+  const cleared = await pool.query(
+    "UPDATE users SET awaiting_input_type = NULL WHERE id = $1 AND awaiting_input_type = $2 RETURNING id",
+    [user.id, marker],
+  ).catch(() => ({ rows: [] }));
+  if (cleared.rows.length) user.awaitingInputType = null;
+  return null;
+}
+
+export async function ensureOpenTrainingLoop(
+  user: any,
+  targetDay: string,
+  source: OpenTrainingLoop["source"],
+  now = Date.now(),
+): Promise<OpenTrainingLoop | null> {
+  const existing = await loadOpenTrainingLoop(user, now);
+  if (existing) return existing;
+  if (user?.awaitingInputType) return null;
+  const marker = createOpenTrainingLoop(targetDay, source, now);
+  const opened = await pool.query(
+    "UPDATE users SET awaiting_input_type = $1 WHERE id = $2 AND awaiting_input_type IS NULL RETURNING id",
+    [marker, user.id],
+  ).catch(() => ({ rows: [] }));
+  if (!opened.rows.length) return null;
+  user.awaitingInputType = marker;
+  return readOpenTrainingLoop(marker, now);
+}
+
+export async function consumeOpenTrainingLoop(user: any, marker: string): Promise<boolean> {
+  const consumed = await pool.query(
+    "UPDATE users SET awaiting_input_type = NULL WHERE id = $1 AND awaiting_input_type = $2 RETURNING id",
+    [user.id, marker],
+  ).catch(() => ({ rows: [] }));
+  if (!consumed.rows.length) return false;
+  user.awaitingInputType = null;
+  return true;
+}
+
+/** Compensate a failed outcome write without ever overwriting a newer awaiting-input owner. */
+export async function restoreOpenTrainingLoop(user: any, marker: string): Promise<boolean> {
+  const restored = await pool.query(
+    "UPDATE users SET awaiting_input_type = $1 WHERE id = $2 AND awaiting_input_type IS NULL RETURNING id",
+    [marker, user.id],
+  ).catch(() => ({ rows: [] }));
+  if (!restored.rows.length) return false;
+  user.awaitingInputType = marker;
+  return true;
+}
 
 export async function initMemoryTable(): Promise<void> {
   try {

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -109,6 +109,8 @@ export interface DayState {
    * this suppresses one instruction for one day, it does not rewrite the record.
    */
   trainingDeclined?: boolean;
+  /** Coach K already asked for this training session and is waiting for its outcome. */
+  trainingAwaitingOutcome?: boolean;
   /**
    * What this client does not eat — the same owner every food surface consults (#128).
    *
@@ -628,7 +630,8 @@ export function chooseAction(s: DayState): OneAction {
   }
 
   // 8. TRAINING, behind for the week — unless they already ruled today out.
-  if (s.sessionsTarget > 0 && s.sessionsThisWeek < s.sessionsTarget && !s.trainingDeclined) {
+  if (s.sessionsTarget > 0 && s.sessionsThisWeek < s.sessionsTarget
+      && !s.trainingDeclined && !s.trainingAwaitingOutcome) {
     const left = s.sessionsTarget - s.sessionsThisWeek;
     return {
       kind: "train",
@@ -705,7 +708,7 @@ export interface ProactiveProfile {
  */
 export function dayStateFrom(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; justAteProteinMeal?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; justAteProteinMeal?: boolean },
 ): DayState {
   return {
     firstName: s.name,
@@ -732,6 +735,7 @@ export function dayStateFrom(
     atKeyboard: opts?.atKeyboard,
     foodDayClosed: opts?.foodDayClosed,
     trainingDeclined: opts?.trainingDeclined,
+    trainingAwaitingOutcome: opts?.trainingAwaitingOutcome,
     justAteProteinMeal: opts?.justAteProteinMeal,
   };
 }
@@ -983,7 +987,7 @@ function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEv
 
 export function decideProactive(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; justAteProteinMeal?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; justAteProteinMeal?: boolean },
 ): ProactiveDecision {
   let action = chooseAction(dayStateFrom(s, p, opts));
   let evidence = evidenceFor(s, action.kind);

--- a/server/outbound-delivery.ts
+++ b/server/outbound-delivery.ts
@@ -41,6 +41,11 @@ import twilio from "twilio";
 
 export type DeliveryResult = "sent" | "dropped" | "fallback";
 
+/** A transport handoff exists only when the intended text reached Twilio or its owned fallback. */
+export function deliveryAccepted(result: DeliveryResult): boolean {
+  return result === "sent" || result === "fallback";
+}
+
 export interface DeliveryPolicy {
   /** Which door sent this. Appears in every failure line so a log names its origin. */
   label: string;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,7 +39,7 @@ import { captureSignupSource } from "./signup-capture";
 import { JUNK_WORDS as _JUNK_WORDS, checkFoodPatterns, getDamageControlNote, checkPerfectDay } from "./handlers/checks";
 import { scanForSAFoods, parseFoodLogTotalsFromMessageOut, sanitizeCoachReply, recomputeTodayFoodTotals } from "./handlers/food-scanner";
 import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence } from "./handlers/chat-log";
-import { handleWorkoutCommands, resumeWorkoutFeedbackExpectation } from "./handlers/workout";
+import { handleWorkoutCommands, resumeOpenTrainingLoopOutcome, resumeWorkoutFeedbackExpectation } from "./handlers/workout";
 import { getTodayWorkoutState } from "./workout-state";
 import { handleMiscCommands } from "./handlers/misc-commands";
 import { handleLifecycle } from "./handlers/lifecycle";
@@ -593,7 +593,9 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
 
   /** Every exit for a durable-write turn closes through the decision owner — see
    *  understanding/live.closeCoachingTurn and tracking-contract-tests LAW 4. */
-  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user }); if (feedbackReply !== null) turnEvidence({ conversationalOnly: true });
+  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const trainingLoopOutcome = await resumeOpenTrainingLoopOutcome({ message, m, user, sourceMessageId });
+  if (trainingLoopOutcome !== null) turnEvidence({ conversationalOnly: true });
+  const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user }); if (feedbackReply !== null) turnEvidence({ conversationalOnly: true });
   if (feedbackReply !== null && mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply); if (feedbackReply !== null) commitFact(turn, "workout", feedbackReply); if (normalizerLive() && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {
     try {
       const pre = await Promise.race([
@@ -958,7 +960,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
   // ---- WORKOUT COMMANDS (gym log, done, lifts, exercises, weight, programme) ----
   // COMMITS, DOES NOT CLAIM THE TURN. Returned unconditionally, so "I trained chest today and
   // had chicken and pap" logged the session and deleted the meal.
-  const workoutResult = feedbackReply === null ? await handleWorkoutCommands({ phone, message, m, user }) : null;
+  const workoutResult = feedbackReply === null ? await handleWorkoutCommands({ phone, message, m, user, sourceMessageId }) : null;
   if (workoutResult !== null) {
     if (mayEndTurn("workout")) return closeCoachingTurn(workoutResult);
     commitFact(turn, "workout", workoutResult);

--- a/server/sast.ts
+++ b/server/sast.ts
@@ -277,18 +277,21 @@ export type StatedWhen = "today" | "historical" | "ambiguous";
 export const SAYS_TODAY_RE = /\b(today|this morning|this afternoon|this evening|tonight|just now|right now|earlier today)\b/i;
 const A_SPAN_NOT_A_DAY = /\b(?:last|past|previous|this)\s+(?:week|month|fortnight)\b|\bweekend\b|\bthe\s+other\s+day\b|\ba\s+while\s+(?:back|ago)\b|\brecently\b|\blately\b|\bpast\s+few\s+days\b|\bcouple\s+of\s+(?:weeks|months)\b/i;
 
-export function statedWhen(message: string): { when: StatedWhen; date: Date } {
+export function statedWhen(message: string): { when: StatedWhen; date: Date; explicit: boolean } {
   const text = String(message || "");
   const resolved = parseMealDate(text);
   const isToday = sastDayStart(resolved).getTime() === sastDayStart().getTime();
+  const saysToday = SAYS_TODAY_RE.test(text);
 
   // A span first: "last week" resolves to nothing, so the parser would hand back today and the
   // write would land on the wrong day silently. This is the case that has no date to fall back on.
-  if (A_SPAN_NOT_A_DAY.test(text)) return { when: "ambiguous", date: resolved };
+  if (A_SPAN_NOT_A_DAY.test(text)) return { when: "ambiguous", date: resolved, explicit: true };
   // Both a today anchor and a past day in one message — we are being told two things and may
   // act on neither. Refusing costs a log; guessing corrupts a date the client cannot see to fix.
-  if (!isToday && SAYS_TODAY_RE.test(text)) return { when: "ambiguous", date: resolved };
-  return { when: isToday ? "today" : "historical", date: resolved };
+  if (!isToday && saysToday) return { when: "ambiguous", date: resolved, explicit: true };
+  // `today` can be either an explicit current-day statement or the parser's no-date default.
+  // Carry that distinction out of this owner so callers never grow a second day-word vocabulary.
+  return { when: isToday ? "today" : "historical", date: resolved, explicit: saysToday || !isToday };
 }
 
 // Returns true if the message contains a clear retroactive date reference (not today).

--- a/server/scheduler/jobs/evening.ts
+++ b/server/scheduler/jobs/evening.ts
@@ -7,7 +7,7 @@ import {
 } from "../shared";
 import { readHealthState } from "../../health-state";
 import { sendWhatsAppButtons } from "../../twilio-interactive";
-import { canonicalNextMove } from "../proactive-decision";
+import { canonicalNextMove, recordCanonicalMoveOutbound } from "../proactive-decision";
 import { sastHour } from "../../sast";
 
 /**
@@ -75,6 +75,7 @@ export async function runEveningAccountability(): Promise<void> {
         const empty = await canonicalNextMove(client, { hour: sastHour() });
         if (empty.line && await claimDailySlot(client.id, "evening")) {
           await sendWhatsApp(phone, `${name}, haven't heard from you today — no stress.\n\n${empty.line}`);
+          await recordCanonicalMoveOutbound(client, empty);
         }
         continue;
       }
@@ -152,12 +153,16 @@ export async function runEveningAccountability(): Promise<void> {
             "Swap to tomorrow",
             "Rest day today",
           ]);
+          await recordCanonicalMoveOutbound(client, move);
         }
         continue;
       }
 
       const msg = [recap, move.line].filter(Boolean).join("\n\n");
-      if (msg && await claimDailySlot(client.id, "evening")) { await sendWhatsApp(phone, msg); }
+      if (msg && await claimDailySlot(client.id, "evening")) {
+        await sendWhatsApp(phone, msg);
+        await recordCanonicalMoveOutbound(client, move);
+      }
     } catch (err) {
       console.error(`[SCHEDULER] Evening accountability error — ${client.phoneNumber}:`, err);
     }

--- a/server/scheduler/jobs/evening.ts
+++ b/server/scheduler/jobs/evening.ts
@@ -74,8 +74,8 @@ export async function runEveningAccountability(): Promise<void> {
       if (todayLogs.length === 0) {
         const empty = await canonicalNextMove(client, { hour: sastHour() });
         if (empty.line && await claimDailySlot(client.id, "evening")) {
-          await sendWhatsApp(phone, `${name}, haven't heard from you today — no stress.\n\n${empty.line}`);
-          await recordCanonicalMoveOutbound(client, empty);
+          const delivery = await sendWhatsApp(phone, `${name}, haven't heard from you today — no stress.\n\n${empty.line}`);
+          await recordCanonicalMoveOutbound(client, empty, delivery);
         }
         continue;
       }
@@ -148,20 +148,20 @@ export async function runEveningAccountability(): Promise<void> {
       // actually chosen `train`, so a declined or sick day never renders it.
       if (move.action.kind === "train" && isTrainingDay) {
         if (await claimDailySlot(client.id, "evening")) {
-          await sendWhatsAppButtons(phone, `${recap}\n\n${move.line}`, [
+          const delivery = await sendWhatsAppButtons(phone, `${recap}\n\n${move.line}`, [
             "Doing it tonight",
             "Swap to tomorrow",
             "Rest day today",
           ]);
-          await recordCanonicalMoveOutbound(client, move);
+          await recordCanonicalMoveOutbound(client, move, delivery);
         }
         continue;
       }
 
       const msg = [recap, move.line].filter(Boolean).join("\n\n");
       if (msg && await claimDailySlot(client.id, "evening")) {
-        await sendWhatsApp(phone, msg);
-        await recordCanonicalMoveOutbound(client, move);
+        const delivery = await sendWhatsApp(phone, msg);
+        await recordCanonicalMoveOutbound(client, move, delivery);
       }
     } catch (err) {
       console.error(`[SCHEDULER] Evening accountability error — ${client.phoneNumber}:`, err);

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -16,7 +16,7 @@ import { readHealthState } from "../../health-state";
 import { morningClosingLine, composeMorning, yesterdayObservation, breakfastReplayLine } from "../../morning-message";
 import { adaptTargets, adaptiveInputFrom } from "../../adaptive-targets";
 import { chooseAction, decideProactive, formatOneAction, underPolicy } from "../../one-action";
-import { loadSituationFrame } from "../../memory";
+import { ensureOpenTrainingLoop, loadOpenTrainingLoop, loadSituationFrame } from "../../memory";
 import { readHeldConstraints } from "../../held-constraints";
 import { foodConstraints } from "../../food-swaps";
 
@@ -481,12 +481,14 @@ export async function runMorningCheckin(): Promise<void> {
         // inferring it from a kind string.
         const breakfastAsk = `🍳 What's for breakfast?${repeatSuggestion || ""}`;
         let decisionLine = "";
+        let selectedTrainingMove = false;
         try {
           // ONE READER FOR BOTH CONSTRAINTS (2026-08-25, P0-4b). This was an inline copy of the
           // query that read only the food half — trainingDayIsDeclined existed and had nowhere to
           // go, so a client who said "I'm not training today" could still be told to. Now the
           // outbound floor and the decision read the same held state about the same day.
           const held = await readHeldConstraints(phone, client);
+          const openTraining = await loadOpenTrainingLoop(client);
           const decision = decideProactive(state, {
             dreamGoal: client.dreamGoal,
             biggestStruggle: client.biggestStruggle,
@@ -502,8 +504,10 @@ export async function runMorningCheckin(): Promise<void> {
             hour: 7,
             foodDayClosed: held.foodDayClosed,
             trainingDeclined: held.trainingDeclined,
+            trainingAwaitingOutcome: !!openTraining,
           });
           decisionLine = decision.line;
+          selectedTrainingMove = decision.action.kind === "train";
           console.log(`[MORNING] ${client.id.slice(-6)} decision=${decision.state} evidence=${decision.evidence} action=${decision.action.kind}`);
         } catch (e) {
           console.warn("[MORNING] one-action skipped:", (e as any)?.message || e);
@@ -525,6 +529,7 @@ export async function runMorningCheckin(): Promise<void> {
           situationLine: await loadSituationFrame(phone).catch(() => ""),
           sickYesterday: state.health.sickYesterday,
         }));
+        if (selectedTrainingMove) await ensureOpenTrainingLoop(client, todaySAST(), "proactive");
       }
     } catch (err) {
       console.error(`[SCHEDULER] Morning check-in error — ${client.phoneNumber}:`, err);

--- a/server/scheduler/jobs/morning.ts
+++ b/server/scheduler/jobs/morning.ts
@@ -19,6 +19,7 @@ import { chooseAction, decideProactive, formatOneAction, underPolicy } from "../
 import { ensureOpenTrainingLoop, loadOpenTrainingLoop, loadSituationFrame } from "../../memory";
 import { readHeldConstraints } from "../../held-constraints";
 import { foodConstraints } from "../../food-swaps";
+import { deliveryAccepted } from "../../outbound-delivery";
 
 /**
  * WHAT WE SAY TO SOMEONE WHO HAS GONE — decided by the ladder, not written here.
@@ -514,7 +515,7 @@ export async function runMorningCheckin(): Promise<void> {
         }
         // ONE COMPOSER. Every part above is now an INPUT, not a branch that assembles its own
         // slice of the message. The order of the message is decided in one place.
-        await sendWhatsApp(phone, composeMorning({
+        const delivery = await sendWhatsApp(phone, composeMorning({
           firstName: name,
           targetFixLine,
           identityLine,
@@ -529,7 +530,9 @@ export async function runMorningCheckin(): Promise<void> {
           situationLine: await loadSituationFrame(phone).catch(() => ""),
           sickYesterday: state.health.sickYesterday,
         }));
-        if (selectedTrainingMove) await ensureOpenTrainingLoop(client, todaySAST(), "proactive");
+        if (selectedTrainingMove && deliveryAccepted(delivery)) {
+          await ensureOpenTrainingLoop(client, todaySAST(), "proactive");
+        }
       }
     } catch (err) {
       console.error(`[SCHEDULER] Morning check-in error — ${client.phoneNumber}:`, err);

--- a/server/scheduler/jobs/programme.ts
+++ b/server/scheduler/jobs/programme.ts
@@ -113,8 +113,8 @@ export async function runWeeklyMondayCheckin(): Promise<void> {
       if (move.line) msg = `${msg}\n\n${move.line}`;
       // Daily-slot claim before send (preserves daily-cap reach; DB-backed, restart-safe).
       if (await claimDailySlot(client.id, "weekly_checkin")) {
-        await sendWhatsApp(client.phoneNumber, msg);
-        await recordCanonicalMoveOutbound(client, move);
+        const delivery = await sendWhatsApp(client.phoneNumber, msg);
+        await recordCanonicalMoveOutbound(client, move, delivery);
       }
     } catch (err) { console.error(`[SCHEDULER] Weekly check-in error — ${client.phoneNumber}:`, err); }
   }

--- a/server/scheduler/jobs/programme.ts
+++ b/server/scheduler/jobs/programme.ts
@@ -7,7 +7,7 @@ import {
 } from "../shared";
 import { getGoalProfile } from "../../goal-profiles";
 import { getWeightTruth } from "../../day-ledger";
-import { canonicalNextMove } from "../proactive-decision";
+import { canonicalNextMove, recordCanonicalMoveOutbound } from "../proactive-decision";
 import { sastHour } from "../../sast";
 
 export async function runPhaseAdvancement(): Promise<void> {
@@ -112,7 +112,10 @@ export async function runWeeklyMondayCheckin(): Promise<void> {
       const move = await canonicalNextMove(client, { hour: sastHour() });
       if (move.line) msg = `${msg}\n\n${move.line}`;
       // Daily-slot claim before send (preserves daily-cap reach; DB-backed, restart-safe).
-      if (await claimDailySlot(client.id, "weekly_checkin")) { await sendWhatsApp(client.phoneNumber, msg); }
+      if (await claimDailySlot(client.id, "weekly_checkin")) {
+        await sendWhatsApp(client.phoneNumber, msg);
+        await recordCanonicalMoveOutbound(client, move);
+      }
     } catch (err) { console.error(`[SCHEDULER] Weekly check-in error — ${client.phoneNumber}:`, err); }
   }
 }

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -79,8 +79,8 @@ export async function runFridayWeekendStrategy(): Promise<void> {
       ].filter(Boolean);
       if (move.line) lines.push(``, move.line);
 
-      await sendWhatsApp(client.phoneNumber, lines.join("\n"));
-      await recordCanonicalMoveOutbound(client, move);
+      const delivery = await sendWhatsApp(client.phoneNumber, lines.join("\n"));
+      await recordCanonicalMoveOutbound(client, move, delivery);
       sent++;
     } catch (err) { console.error(`[SCHEDULER] Friday strategy error — ${client.phoneNumber}:`, err); }
   }
@@ -118,8 +118,8 @@ export async function runSundayWeeklyReport(): Promise<void> {
         if (clientAgeDays < 2) continue; // just onboarded today — skip
         const quiet = await canonicalNextMove(client);
         if (quiet.line) {
-          await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week.\n\n${quiet.line}`);
-          await recordCanonicalMoveOutbound(client, quiet);
+          const delivery = await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week.\n\n${quiet.line}`);
+          await recordCanonicalMoveOutbound(client, quiet, delivery);
         }
         continue;
       }
@@ -127,8 +127,8 @@ export async function runSundayWeeklyReport(): Promise<void> {
       if (daysWithLogs < 3) {
         const thin = await canonicalNextMove(client);
         const opener = `${name}, ${daysWithLogs} day${daysWithLogs !== 1 ? "s" : ""} logged this week. You're in it.`;
-        await sendWhatsApp(client.phoneNumber, thin.line ? `${opener}\n\n${thin.line}` : opener);
-        await recordCanonicalMoveOutbound(client, thin);
+        const delivery = await sendWhatsApp(client.phoneNumber, thin.line ? `${opener}\n\n${thin.line}` : opener);
+        await recordCanonicalMoveOutbound(client, thin, delivery);
         continue;
       }
 
@@ -257,8 +257,8 @@ export async function runSundayWeeklyReport(): Promise<void> {
       // One-tap acceptance — routes to the deterministic step-target updater. Client's call.
       if (stepAdj) lines.push(``, `[BUTTONS:Set steps to ${stepAdj.newTarget}]`);
 
-      await sendWhatsApp(client.phoneNumber, lines.join("\n"));
-      await recordCanonicalMoveOutbound(client, move);
+      const delivery = await sendWhatsApp(client.phoneNumber, lines.join("\n"));
+      await recordCanonicalMoveOutbound(client, move, delivery);
 
       try {
         const list = getShoppingList(budgetTierWeekly, weekNum + 1, clientGoalWeekly, foodConstraints(client as any));
@@ -400,8 +400,8 @@ export async function runWeekendFoodAudit(): Promise<void> {
       // Claim only when there is actually a pattern to flag — DB-backed weekly dedup.
       if (!(await claimProactive(client.id, "weekend_food_audit", thisWeekUTC()))) continue;
       const audit = await canonicalNextMove(client);
-      await sendWhatsApp(client.phoneNumber, audit.line ? `${pattern}\n\n${audit.line}` : pattern);
-      await recordCanonicalMoveOutbound(client, audit);
+      const delivery = await sendWhatsApp(client.phoneNumber, audit.line ? `${pattern}\n\n${audit.line}` : pattern);
+      await recordCanonicalMoveOutbound(client, audit, delivery);
     } catch (err) { console.error(`[SCHEDULER] Weekend food audit error — ${client.phoneNumber}:`, err); }
   }
 }

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -14,7 +14,7 @@ import { getTrajectoryForUser } from "../../trajectory-report";
 import { runWeeklyRecaps } from "../../weekly-recap";
 import { generateMealPlan } from "../../meal-plan";
 import { mentionsForbidden } from "../../brain/reply-verifier";
-import { canonicalNextMove } from "../proactive-decision";
+import { canonicalNextMove, recordCanonicalMoveOutbound } from "../proactive-decision";
 
 export async function runFridayWeekendStrategy(): Promise<void> {
   console.log("[SCHEDULER] JOB: Friday weekend strategy");
@@ -80,6 +80,7 @@ export async function runFridayWeekendStrategy(): Promise<void> {
       if (move.line) lines.push(``, move.line);
 
       await sendWhatsApp(client.phoneNumber, lines.join("\n"));
+      await recordCanonicalMoveOutbound(client, move);
       sent++;
     } catch (err) { console.error(`[SCHEDULER] Friday strategy error — ${client.phoneNumber}:`, err); }
   }
@@ -116,7 +117,10 @@ export async function runSundayWeeklyReport(): Promise<void> {
       if (chats.length === 0) {
         if (clientAgeDays < 2) continue; // just onboarded today — skip
         const quiet = await canonicalNextMove(client);
-        if (quiet.line) await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week.\n\n${quiet.line}`);
+        if (quiet.line) {
+          await sendWhatsApp(client.phoneNumber, `${name}, nothing logged this week.\n\n${quiet.line}`);
+          await recordCanonicalMoveOutbound(client, quiet);
+        }
         continue;
       }
       const daysWithLogs = new Set(chats.map(c => new Date(c.createdAt!).toDateString())).size;
@@ -124,6 +128,7 @@ export async function runSundayWeeklyReport(): Promise<void> {
         const thin = await canonicalNextMove(client);
         const opener = `${name}, ${daysWithLogs} day${daysWithLogs !== 1 ? "s" : ""} logged this week. You're in it.`;
         await sendWhatsApp(client.phoneNumber, thin.line ? `${opener}\n\n${thin.line}` : opener);
+        await recordCanonicalMoveOutbound(client, thin);
         continue;
       }
 
@@ -253,6 +258,7 @@ export async function runSundayWeeklyReport(): Promise<void> {
       if (stepAdj) lines.push(``, `[BUTTONS:Set steps to ${stepAdj.newTarget}]`);
 
       await sendWhatsApp(client.phoneNumber, lines.join("\n"));
+      await recordCanonicalMoveOutbound(client, move);
 
       try {
         const list = getShoppingList(budgetTierWeekly, weekNum + 1, clientGoalWeekly, foodConstraints(client as any));
@@ -395,6 +401,7 @@ export async function runWeekendFoodAudit(): Promise<void> {
       if (!(await claimProactive(client.id, "weekend_food_audit", thisWeekUTC()))) continue;
       const audit = await canonicalNextMove(client);
       await sendWhatsApp(client.phoneNumber, audit.line ? `${pattern}\n\n${audit.line}` : pattern);
+      await recordCanonicalMoveOutbound(client, audit);
     } catch (err) { console.error(`[SCHEDULER] Weekend food audit error — ${client.phoneNumber}:`, err); }
   }
 }

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -40,6 +40,7 @@ import { loadProactiveState } from "./shared";
 import { foodConstraints } from "../food-swaps";
 import { sastDayKey } from "../sast";
 import { ensureOpenTrainingLoop, loadOpenTrainingLoop } from "../memory";
+import { deliveryAccepted, type DeliveryResult } from "../outbound-delivery";
 
 export interface CanonicalMove {
   /** Ready to place in a message. "" when the decision is `hold` — nothing to add is an answer. */
@@ -53,8 +54,8 @@ export interface CanonicalMove {
 }
 
 /** Persist only a training move that a proactive sender has actually handed to its outbound door. */
-export async function recordCanonicalMoveOutbound(client: any, move: CanonicalMove) {
-  return move.action.kind === "train"
+export async function recordCanonicalMoveOutbound(client: any, move: CanonicalMove, delivery: DeliveryResult) {
+  return move.action.kind === "train" && deliveryAccepted(delivery)
     ? ensureOpenTrainingLoop(client, sastDayKey(), "proactive")
     : null;
 }

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -38,6 +38,8 @@ import { chooseAction, decideProactive, formatOneAction, underPolicy, type OneAc
 import { readHeldConstraints, NO_CONSTRAINTS, type HeldConstraints } from "../held-constraints";
 import { loadProactiveState } from "./shared";
 import { foodConstraints } from "../food-swaps";
+import { sastDayKey } from "../sast";
+import { ensureOpenTrainingLoop, loadOpenTrainingLoop } from "../memory";
 
 export interface CanonicalMove {
   /** Ready to place in a message. "" when the decision is `hold` — nothing to add is an answer. */
@@ -48,6 +50,13 @@ export interface CanonicalMove {
   held: HeldConstraints;
   /** True when the ledger read failed and the degraded contract was applied instead. */
   degraded: boolean;
+}
+
+/** Persist only a training move that a proactive sender has actually handed to its outbound door. */
+export async function recordCanonicalMoveOutbound(client: any, move: CanonicalMove) {
+  return move.action.kind === "train"
+    ? ensureOpenTrainingLoop(client, sastDayKey(), "proactive")
+    : null;
 }
 
 function profileOf(client: any) {
@@ -80,6 +89,7 @@ export async function canonicalNextMove(
   const firstName = String(client.name || "").split(" ")[0] || undefined;
   const profile = profileOf(client);
   const held = await readHeldConstraints(client.phoneNumber, client).catch(() => NO_CONSTRAINTS);
+  const openTraining = await loadOpenTrainingLoop(client);
 
   try {
     const state = await loadProactiveState(client);
@@ -87,6 +97,7 @@ export async function canonicalNextMove(
       hour: opts?.hour,
       foodDayClosed: held.foodDayClosed,
       trainingDeclined: held.trainingDeclined,
+      trainingAwaitingOutcome: !!openTraining,
     });
     console.log(`[PROACTIVE_DECISION] ${String(client.id || "").slice(-6)} decision=${decision.state} action=${decision.action.kind} foodClosed=${held.foodDayClosed} trainingDeclined=${held.trainingDeclined}`);
     return {
@@ -117,6 +128,7 @@ export async function canonicalNextMove(
       hour: opts?.hour ?? 12,
       foodDayClosed: held.foodDayClosed,
       trainingDeclined: held.trainingDeclined,
+      trainingAwaitingOutcome: !!openTraining,
       // Same as morning's degraded branch (#203): the zeros above are placeholders for state this
       // path could not build, so no investigation context is passed and the gate holds.
     }), { foodSufficient: false, weightSufficient: false, dreamGoal: client.dreamGoal });

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -17,7 +17,7 @@ import { provenanceGate, shadowDoor } from "../verifiers/response-gate";
 import { humanizeReply } from "../reply-hygiene";
 import { enforceOutboundTruth, prepareOutbound } from "../outbound-authority";
 import { templateSid, WINDOW_RECOVERY_TEMPLATE } from "../whatsapp-templates";
-import { whatsappFrom } from "../outbound-delivery";
+import { whatsappFrom, type DeliveryResult } from "../outbound-delivery";
 
 export { db, pool };
 export { users, chatHistory, stepLogs, workoutLogs, weightLogs, mealLogs, sentProactive, escalations, exerciseLogs, clientIntelligenceProfiles };
@@ -513,7 +513,7 @@ async function logOutboundToHistory(to: string, body: string): Promise<void> {
   }
 }
 
-export async function sendWhatsApp(to: string, body: string, mediaUrl?: string): Promise<void> {
+export async function sendWhatsApp(to: string, body: string, mediaUrl?: string): Promise<DeliveryResult> {
   // PROVENANCE FIRST (2026-07-30). Every outbound message — reactive reply, morning check-in,
   // weekly review — crosses this function, which makes it the only place a claim can be checked
   // for ALL of them. The gate had to go here rather than on the reply paths because the worst
@@ -545,7 +545,7 @@ export async function sendWhatsApp(to: string, body: string, mediaUrl?: string):
   // once. Proactive keeps its own failure policy: nobody is waiting, so a refused message is
   // blocked and recorded rather than repaired.
   const prepared = await prepareOutbound("proactive", recipientId, to, body, recipientRow);
-  if (prepared.blocked) return;
+  if (prepared.blocked) return "dropped";
   const shaped0 = prepared.text;
   // VOICE, ENFORCED (2026-07-30). humanizeReply — the numbered-list reshape, the platitude strip,
   // the wall-of-text break — existed since 22 July and was wired into exactly ONE caller
@@ -559,15 +559,16 @@ export async function sendWhatsApp(to: string, body: string, mediaUrl?: string):
   const shaped = shaped0;
   // SHADOW (2026-08-04) — the proactive half of the door. Captured whole, before the bubble
   // split, so a shadow row holds the message as the client would have read it.
-  if (await shadowDoor(to, shaped, "proactive", "server/scheduler/shared.ts", mediaUrl)) return;
+  if (await shadowDoor(to, shaped, "proactive", "server/scheduler/shared.ts", mediaUrl)) return "dropped";
   const parts = splitWhatsAppBody(shaped);
   for (let i = 0; i < parts.length; i++) {
     const remainingText = parts.slice(i).join("\n\n");
     const outcome = await sendOneWhatsApp(to, parts[i], i === parts.length - 1 ? mediaUrl : undefined, remainingText);
     // "fallback" = SMS/template already carried remainingText; "dropped" = channel/gate
     // is down for this recipient right now. Either way the rest must not double-send.
-    if (outcome !== "sent") return;
+    if (outcome !== "sent") return outcome;
   }
+  return "sent";
 }
 
 async function sendOneWhatsApp(to: string, body: string, mediaUrl: string | undefined, smsFallbackText: string): Promise<"sent" | "dropped" | "fallback"> {
@@ -618,8 +619,8 @@ async function sendOneWhatsApp(to: string, body: string, mediaUrl: string | unde
       if (e.code === 63016 && reengageTemplateSid()) {
         console.warn(`[WA:WINDOW] outside 24h window for ${to.slice(-8)} — sending re-engagement template`);
         try {
-          await sendWhatsAppTemplate(to, reengageTemplateSid(), undefined, { fallbackText: smsFallbackText });
-          return "fallback"; // template path logs history + handles its own SMS fallback
+          const templateDelivery = await sendWhatsAppTemplate(to, reengageTemplateSid(), undefined, { fallbackText: smsFallbackText });
+          return templateDelivery === "dropped" ? "dropped" : "fallback";
         } catch {
           console.warn(`[WA:WINDOW] re-engagement template failed for ${to.slice(-8)} — falling back to SMS`);
         }
@@ -653,12 +654,12 @@ export async function sendWhatsAppTemplate(
   contentSid: string,
   variables?: Record<string, string | number | null | undefined>,
   opts?: { mediaUrl?: string; fallbackText?: string },
-): Promise<void> {
+): Promise<DeliveryResult> {
   resetDeliveryStatsIfNeeded();
   if (!contentSid) {
     console.warn("[SCHEDULER:TEMPLATE] no contentSid provided — skipping send");
     deliveryStats.failed++;
-    return;
+    return "dropped";
   }
   // Share the same outbound rate gate as freeform sends.
   const now = Date.now();
@@ -669,7 +670,7 @@ export async function sendWhatsAppTemplate(
   // SHADOW (2026-08-04) — templates re-open a closed 24h window, so one escaping in staging
   // is a client pulled back into a conversation the build was not allowed to have.
   const logText = opts?.fallbackText || `[template ${contentSid}]`;
-  if (await shadowDoor(to, logText, "template", "server/scheduler/shared.ts", opts?.mediaUrl)) return;
+  if (await shadowDoor(to, logText, "template", "server/scheduler/shared.ts", opts?.mediaUrl)) return "dropped";
   const params: Record<string, unknown> = { contentSid };
   const cv = buildContentVariables(variables);
   if (cv) params.contentVariables = cv;
@@ -683,7 +684,7 @@ export async function sendWhatsAppTemplate(
   // The circuit-breaker check moved INTO the shared owner, which is why it no longer appears
   // above: it ran here before the shadow door, so a paused build still consulted a live breaker.
   const { deliverTwilioMessage } = await import("../outbound-delivery");
-  await deliverTwilioMessage(to, params, {
+  return deliverTwilioMessage(to, params, {
     label: "template",
     retryDelaysMs: [0, 3000, 8000],
     throwOnTerminal: true,

--- a/server/twilio-interactive.ts
+++ b/server/twilio-interactive.ts
@@ -14,6 +14,7 @@
 
 import twilio from "twilio";
 import { shadowDoor } from "./verifiers/response-gate";
+import type { DeliveryResult } from "./outbound-delivery";
 
 const ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID || "";
 const AUTH_TOKEN  = process.env.TWILIO_AUTH_TOKEN  || "";
@@ -75,13 +76,13 @@ export async function sendWhatsAppButtons(
   to: string,
   body: string,
   buttons: string[]
-): Promise<void> {
-  if (!FROM_NUMBER) return;
+): Promise<DeliveryResult> {
+  if (!FROM_NUMBER) return "dropped";
 
   // SHADOW (2026-08-04) — the third client-facing door. A button set is a message; if it
   // could reach a phone while the build is in staging, the mode is a lie.
   if (await shadowDoor(to, buttons.length > 0 ? `${body}\n\n[BUTTONS:${buttons.slice(0, 3).join("|")}]` : body,
-                       "buttons", "server/twilio-interactive.ts")) return;
+                       "buttons", "server/twilio-interactive.ts")) return "dropped";
 
   if (buttons.length > 0) {
     const contentSid = await _getOrCreateTemplate(buttons.slice(0, 3));
@@ -93,7 +94,7 @@ export async function sendWhatsAppButtons(
           contentSid,
           contentVariables: JSON.stringify({ "1": body }),
         });
-        return;
+        return "sent";
       } catch (err: unknown) {
         console.warn("[BUTTONS] ContentSid send failed, using text fallback:", (err as Error)?.message);
       }
@@ -104,6 +105,7 @@ export async function sendWhatsAppButtons(
   const opts = buttons.map((b, i) => `*${i + 1}.* ${b}`).join("\n");
   const fullBody = buttons.length > 0 ? `${body}\n\n${opts}` : body;
   await twilioClient.messages.create({ from: FROM_NUMBER, to, body: fullBody } as any);
+  return "sent";
 }
 
 /**
@@ -114,7 +116,7 @@ export async function sendWhatsAppYesNo(
   body: string,
   yesLabel = "Yes, done ✅",
   noLabel = "Not yet"
-): Promise<void> {
+): Promise<DeliveryResult> {
   return sendWhatsAppButtons(to, body, [yesLabel, noLabel]);
 }
 

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -79,12 +79,14 @@ export async function canonicalDecision(
     const { chooseAction, underPolicy, trainingDayIsDeclined, PROACTIVE_LOG_FLOOR } = await import("../one-action");
     const { readHeldConstraints, foodDayClosedWith } = await import("../held-constraints");
     const { getProgressTruth, sessionsThisCalendarWeek } = await import("../day-ledger");
-    const { sastHour } = await import("../sast");
+    const { sastDayKey, sastHour } = await import("../sast");
     const { getTodayWorkoutState } = await import("../workout-state");
     const { readHealthState } = await import("../health-state");
     const { getDisplayName } = await import("../utils");
+    const { ensureOpenTrainingLoop, loadOpenTrainingLoop } = await import("../memory");
 
     const truth = await getProgressTruth(user, { days: 7 });
+    const openTraining = await loadOpenTrainingLoop(user);
     const held = await readHeldConstraints(user.phoneNumber, user).catch(() => ({ foodDayClosed: false, trainingDeclined: false, sick: false }));
     const weekSessions = await sessionsThisCalendarWeek(user.id).catch(() => 0);
     const wState = await getTodayWorkoutState(user).catch(() => ({ type: "REST" as const }));
@@ -119,6 +121,9 @@ export async function canonicalDecision(
       // for that, so this door and the SMART NEXT MEAL door cannot read one sentence differently.
       foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
       trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
+      // An unresolved canonical training move is already the client's one thing. Keep it open
+      // across turns instead of selecting the same instruction again on every reply.
+      trainingAwaitingOutcome: !!openTraining,
       // WHAT THIS CLIENT DOES NOT EAT, and WHETHER THEY JUST ATE A PROPER PROTEIN MEAL (#128).
       // The protein rung names foods and re-issued the instruction the plate had just carried
       // out; both facts already exist, and neither reached the ladder.
@@ -146,11 +151,17 @@ export async function canonicalDecision(
     const { formatOneAction } = await import("../one-action");
     const rendered = act.kind === "hold" ? "" : formatOneAction(act, getDisplayName(user) || undefined);
 
+    const openedTraining = act.kind === "train"
+      ? await ensureOpenTrainingLoop(user, sastDayKey(), "reactive")
+      : null;
+
     const { turnEvidence } = await import("../handlers/chat-log");
     turnEvidence({
       canonicalKind: act.kind,
       canonicalTodo: act.kind === "hold" ? null : act.todo,
       canonicalReply: rendered || null,
+      openLoopRef: openedTraining?.ref || openTraining?.ref || null,
+      openLoopKind: openedTraining || openTraining ? "train" : null,
     });
 
     // "hold" means the honest answer is that nothing needs changing. An empty todo is what

--- a/server/workout-feedback.ts
+++ b/server/workout-feedback.ts
@@ -12,6 +12,8 @@
 
 export type WorkoutFeedbackKind = "too_easy" | "just_right" | "too_hard";
 
+import { randomUUID } from "node:crypto";
+
 // The post-session question has one existing durable home: users.awaitingInputType. Other
 // pending-answer flows already use that single slot, including timestamped, payload-carrying
 // holds. Keep this deliberately workout-scoped rather than creating a second conversation state
@@ -20,6 +22,74 @@ const EXPECTATION_OWNER = "workout_feedback";
 const EXPECTATION_TYPE = "session_feel";
 const EXPECTATION_SOURCE = "post_session_checkin";
 export const WORKOUT_FEEDBACK_EXPECTATION_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+// The same durable continuation slot also owns the narrower pre-session loop introduced by
+// #208. This is not another memory store: users.awaiting_input_type already answers "what reply
+// is Coach K waiting for?" across restarts. The marker carries only the originating canonical
+// move, its SAST target day and a correlation id; workout_logs remains the completion truth.
+const TRAINING_LOOP_OWNER = "coaching_loop";
+const TRAINING_LOOP_TYPE = "train";
+export const TRAINING_LOOP_WINDOW_MS = 48 * 60 * 60 * 1000;
+
+export interface OpenTrainingLoop {
+  owner: typeof TRAINING_LOOP_OWNER;
+  type: typeof TRAINING_LOOP_TYPE;
+  targetDay: string;
+  createdAt: number;
+  ref: string;
+  source: "reactive" | "proactive";
+  marker: string;
+}
+
+export function createOpenTrainingLoop(
+  targetDay: string,
+  source: OpenTrainingLoop["source"],
+  now = Date.now(),
+  ref = randomUUID(),
+): string {
+  return [TRAINING_LOOP_OWNER, TRAINING_LOOP_TYPE, targetDay, now, ref, source].join(":");
+}
+
+export function isOpenTrainingLoopMarker(marker: string | null | undefined): boolean {
+  return String(marker || "").startsWith(`${TRAINING_LOOP_OWNER}:${TRAINING_LOOP_TYPE}:`);
+}
+
+export function readOpenTrainingLoop(
+  marker: string | null | undefined,
+  now = Date.now(),
+): OpenTrainingLoop | null {
+  const raw = String(marker || "");
+  const parts = raw.split(":");
+  if (
+    parts.length !== 6
+    || parts[0] !== TRAINING_LOOP_OWNER
+    || parts[1] !== TRAINING_LOOP_TYPE
+    || parts[2].length !== 10
+    || Number.isNaN(Date.parse(parts[2] + "T00:00:00+02:00"))
+    || parts[4].length !== 36
+    || parts[4].split("-").length !== 5
+    || !["reactive", "proactive"].includes(parts[5])
+  ) return null;
+  const createdAt = Number(parts[3]);
+  const age = now - createdAt;
+  if (!Number.isFinite(createdAt) || createdAt <= 0 || age < -60_000 || age > TRAINING_LOOP_WINDOW_MS) return null;
+  return {
+    owner: TRAINING_LOOP_OWNER,
+    type: TRAINING_LOOP_TYPE,
+    targetDay: parts[2],
+    createdAt,
+    ref: parts[4],
+    source: parts[5] as OpenTrainingLoop["source"],
+    marker: raw,
+  };
+}
+
+/** The unambiguous negative answer becomes meaningful only while the training move is open. */
+export function reportsOpenTrainingMoveFailed(message: string): boolean {
+  const text = String(message || "").toLowerCase().replaceAll("’", "'");
+  return ["couldn't do it", "could not do it", "couldn't make it", "could not make it",
+    "didn't manage to do it", "wasn't able to do it"].some(shape => text.includes(shape));
+}
 
 export interface WorkoutFeedbackExpectation {
   owner: typeof EXPECTATION_OWNER;

--- a/server/workout-feedback.ts
+++ b/server/workout-feedback.ts
@@ -87,8 +87,9 @@ export function readOpenTrainingLoop(
 /** The unambiguous negative answer becomes meaningful only while the training move is open. */
 export function reportsOpenTrainingMoveFailed(message: string): boolean {
   const text = String(message || "").toLowerCase().replaceAll("’", "'");
-  return ["couldn't do it", "could not do it", "couldn't make it", "could not make it",
-    "didn't manage to do it", "wasn't able to do it"].some(shape => text.includes(shape));
+  const explicitFailures = ["couldn't do it", "could not do it", "couldn't make it",
+    "could not make it", "didn't manage to do it", "wasn't able to do it"];
+  return explicitFailures.some(shape => text.includes(shape));
 }
 
 export interface WorkoutFeedbackExpectation {


### PR DESCRIPTION
Fixes #208.

## Structural correction

- uses the existing durable `users.awaiting_input_type` owner for one bounded open training move; no schema, store, parser family, response author, or decision engine added
- persists the canonical move's SAST target day, source, timestamp, and correlation ref only after proactive outbound handoff (or as part of the reactive canonical reply)
- suppresses duplicate training instructions while the outcome is unresolved
- attributes natural later completion through the existing workout/session writer and closes by compare-and-set exactly once
- records explicit failure through the existing daily-constraint owner without fabricating a workout; intentions, questions, ambiguity, stale moves, and other users remain untouched
- writes the originating ref into both the source turn and resolution mutation for reconstruction

## Proof

- `npm run check` - PASS
- `npm run test:continuity` - PASS
- `npm run test:safety` - 82/82
- `npm run test:golden` - PASS
- integration - 38/38
- decision runtime - 6/6
- unit merge-base comparator - PASS, base 1056/1060 and head 1056/1060, NEW 0
- fresh `LOCAL REAL POSTGRESQL` acceptance - GREEN for A-E and all controls
- red-on-revert - disabling the compare-and-set resolution owner produced 8 targeted failures; restoration returned the same acceptance green
- Journey Lab - training journey 40/40; aggregate 265/266 with the unchanged step-provenance baseline red
- routing - 320/322 with the unchanged two step-number formatting baseline reds
- file governor - no new overage; `server/routes.ts` is 1199 lines
- architecture governor - no branch counter increase; local Windows path/parser harness noise remains on current main

Baseline reconciled to `8f88e2bff9ece40e3cadd522f242f029378b7d87` after #207 merged. Not merged or deployed.