### PR TITLE
#211: facts, retractions and same-turn propagation — DO NOT MERGE before CTO adjudication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,12 @@ jobs:
       # not move. Real rows, real front door, several turns.
       - name: Durable log turns are one coaching turn on real PostgreSQL
         run: npx tsx script/pg-log-turn-acceptance.ts
+      # FACTS, RETRACTIONS AND SAME-TURN PROPAGATION (#211). Retraction-before-append ordering,
+      # one operation building on another's patch, and unrelated columns left alone are all
+      # properties of a real transaction — a fixture that returns whatever it was handed cannot
+      # show any of them, which is how a retracted diet came back inside its own write.
+      - name: Facts, retractions and same-turn propagation on real PostgreSQL
+        run: npx tsx script/pg-facts-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -62,7 +62,7 @@ const BUDGET = {
    * to the true figure in one deliberate commit. Until then this red line is the marker, and it is
    * the ONLY thing in this guard that is red — one red line means something, four never did.
    */
-  regexLiterals: 448,
+  regexLiterals: 447,
   /**
    * GUARD #13 — see unreachableExports above. Sixty-two capabilities cannot be reached by a
    * client message today. This budget is deliberately set THREE BELOW that, so this guard is RED
@@ -273,7 +273,7 @@ const RAISES: Array<{ key: keyof typeof BUDGET; from: number; to: number; date: 
       + "so 21 is the smallest truthful current baseline. FROM HERE IT FALLS ONLY.",
   },
   {
-    key: "regexLiterals", from: 318, to: 448, date: "2026-08-24 (fell to 448 on 2026-09-05)",
+    key: "regexLiterals", from: 318, to: 447, date: "2026-08-24 (fell to 448 on 2026-09-05, to 447 on 2026-09-07)",
     why: "NOT A RAISE — A CORRECTED MEASUREMENT, and the follow-up this budget's own comment "
       + "declared owed on 2026-08-17: \"repair the matcher to see multi-line assignments and "
       + "re-baseline to the true figure in one deliberate commit.\" This is that commit. The "

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4239,8 +4239,19 @@ test("#128/1: a client can take a restriction back", async () => {
     const kept = projectClientFacts({ dietaryRestrictions: "allergic to fish" }, detectFacts(said));
     assert.equal(kept.patch.dietaryRestrictions, undefined, `"${said}" leaves the allergy alone`);
   }
-  assert.equal(projectClientFacts({}, detectFacts("I'm not eating dairy")).patch.dietaryRestrictions,
-    "not eating dairy", "a restriction stated in the negative is still a restriction");
+  // A RESTRICTION STATED IN THE NEGATIVE IS STILL A RESTRICTION — and #211 narrowed WHAT gets
+  // stored, not whether. This asserted the raw span the capture happened to reach ("not eating
+  // dairy"); the column now holds the restriction word itself, because the span form put
+  // "vegan now" in the record and read back out of foodConstraints as two terms. Graded on the
+  // promise instead of the old string: the restriction is recorded, and it reaches the one reader
+  // that decides what may be offered.
+  const negative = projectClientFacts({}, detectFacts("I'm not eating dairy")).patch.dietaryRestrictions;
+  assert.equal(negative, "dairy", "a restriction stated in the negative is still a restriction");
+  assert.ok(foodConstraints({ dietaryRestrictions: negative } as any).terms.some(t => /dairy/i.test(t)),
+    "…and it reaches the constraint reader that governs every suggestion");
+  // …and the narrowing must not swallow the restriction entirely — a column that ends up empty
+  // would pass a "no longer says not eating dairy" check while starving the client of the guard.
+  assert.ok(negative && negative.length > 0, "the narrowed restriction is not an empty column");
 });
 
 // ── #128/4: THE PROTEIN CLOSER ──────────────────────────────────────────────────────────────

--- a/script/pg-facts-acceptance.ts
+++ b/script/pg-facts-acceptance.ts
@@ -1,0 +1,259 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — facts, retractions, replacements, same-turn propagation (#211).
+ *
+ * THE RULE THIS ENFORCES. What the client says about themselves must survive intact, and a fact
+ * committed by a message must shape the SAME customer-visible reply — not a column that becomes
+ * useful next turn. Five defects, each traced through the real front door before anything changed:
+ *
+ *   "I'm vegan now, what should I eat?"   stored the restriction as "vegan now" — the span the
+ *                                         capture reached, which read back out of foodConstraints
+ *                                         as two terms and left retractions matching a string the
+ *                                         client never said.
+ *   "I can't eat dairy, what can I eat?"  read as a CLOSED FOOD DAY: "You said you are done
+ *                                         eating today, so I am leaving it there."
+ *   "I'm not vegan, I'm vegetarian"       vegan removed AND put back by the append, vegetarian
+ *                                         deleted by the merge, and the reply said "updated to
+ *                                         *vegan*" — the client corrected us and we confirmed the
+ *                                         thing they had just denied.
+ *   "I can eat nuts again"                cleared an unrelated PEANUT allergy, by containment.
+ *   "my knee doesn't hurt as much anymore, should I still avoid squats?"
+ *                                         erased the active knee injury, off a bare `anymore`, in
+ *                                         a question about training around it.
+ *
+ * WHY POSTGRESQL. Every claim here is about what a real transaction leaves in the row: retraction
+ * before append, one operation building on another's patch, and unrelated columns untouched. A
+ * fixture that returns whatever it was handed cannot show any of it.
+ *
+ * EVERY CLAIM IS PAIRED WITH ITS CONTROL. "The fact was not deleted" is trivially satisfied by a
+ * build that never deletes anything, which is the opposite defect: a healed knee that steers leg
+ * day forever, and a diet the client abandoned still governing every suggestion.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-facts-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { eq } = await import("drizzle-orm");
+const { handleMessage } = await import("../server/routes");
+const { foodConstraints } = await import("../server/food-swaps");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: D(40), programmeStartDate: D(40),
+    programmeWeek: 6, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  return { id: u.id, phone };
+}
+
+const say = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`)
+    .then(r => String(r || ""));
+
+const rowOf = async (id: string) =>
+  (await db.select().from(schema.users).where(eq(schema.users.id, id)).limit(1))[0] as any;
+
+REAL("\n=== A FACT COMMITTED THIS TURN SHAPES THIS TURN'S REPLY ===");
+
+// ── A — vegan + question in one natural sentence ────────────────────────────────────────────
+{
+  const c = await client();
+  const reply = await say(c.phone, "I'm vegan now, what should I eat?");
+  const row = await rowOf(c.id);
+  chk(/\bvegan\b/i.test(String(row.dietaryRestrictions || "")),
+    "A · `I'm vegan now, what should I eat?` — the restriction is durable",
+    `column=${JSON.stringify(row.dietaryRestrictions)}`);
+  // THE SPAN, NOT THE TOKEN, was the defect: "vegan now" read out as two constraint terms.
+  chk(String(row.dietaryRestrictions).toLowerCase() === "vegan",
+    "…and it is stored as the restriction itself, not the span up to the comma",
+    `column=${JSON.stringify(row.dietaryRestrictions)}`);
+  chk(!foodConstraints(row).terms.some(t => /\bnow\b/i.test(t)),
+    "…so no constraint term carries a word the client never restricted",
+    `terms=${JSON.stringify(foodConstraints(row).terms)}`);
+  chk(/vegan|plant|tofu|lentil|bean|soya/i.test(reply) && !/\b(chicken|beef|eggs|fish|milk|cheese)\b/i.test(reply),
+    "…and the SAME reply is already vegan-safe", JSON.stringify(reply.slice(0, 200)));
+}
+
+// ── B — a dietary restriction is not a closed food day ──────────────────────────────────────
+{
+  const c = await client();
+  const reply = await say(c.phone, "I can't eat dairy, what can I eat?");
+  const row = await rowOf(c.id);
+  chk(/dairy/i.test(String(row.dietaryRestrictions || "")),
+    "B · `I can't eat dairy, what can I eat?` — the restriction is durable",
+    `column=${JSON.stringify(row.dietaryRestrictions)}`);
+  chk(!/done eating|leaving it there|finished on/i.test(reply),
+    "…and they are not told they have finished eating for the day",
+    JSON.stringify(reply.slice(0, 220)));
+  chk(!/\b(milk|cheese|yoghurt|yogurt|amasi|dairy)\b/i.test(reply.replace(/can'?t eat dairy/i, "")),
+    "…and the SAME reply is already dairy-safe", JSON.stringify(reply.slice(0, 220)));
+  // CONTROL — a genuinely closed food day must STILL close. Without this the fix above reads as
+  // "closures no longer work", which is the constraint #194 and P0-4b exist to hold.
+  const d = await client();
+  await say(d.phone, "I'm not eating anymore today");
+  const after = await say(d.phone, "what should I eat");
+  chk(/done eating|leaving it there|not eating|finished/i.test(after),
+    "CONTROL: a real closure still closes the day", JSON.stringify(after.slice(0, 160)));
+}
+
+// ── C — injury truth reaches the training answer ────────────────────────────────────────────
+{
+  const c = await client();
+  const reply = await say(c.phone, "my knee is killing me, what should I train?");
+  const row = await rowOf(c.id);
+  chk(/knee/i.test(String(row.injuries || "")), "C · the knee injury is durable",
+    `column=${JSON.stringify(row.injuries)}`);
+  chk(/knee/i.test(reply) && /avoid|instead|safe|upper body/i.test(reply),
+    "…and the SAME reply trains around it", JSON.stringify(reply.slice(0, 160)));
+  chk(!/torn|tear|acl|meniscus|arthritis|tendonitis/i.test(reply),
+    "…without inventing a diagnosis", JSON.stringify(reply.slice(0, 200)));
+}
+
+REAL("\n=== RETRACTION AND REPLACEMENT ARE EXACT ===");
+
+// ── D — replacement ─────────────────────────────────────────────────────────────────────────
+{
+  const c = await client({ dietaryRestrictions: "vegan" });
+  const reply = await say(c.phone, "I'm not vegan, I'm vegetarian");
+  const row = await rowOf(c.id);
+  const col = String(row.dietaryRestrictions || "").toLowerCase();
+  chk(/vegetarian/.test(col), "D · vegetarian becomes the current truth", `column=${JSON.stringify(col)}`);
+  // THE ORDERING PROOF. Retractions run before appends, but the append re-read the ORIGINAL row,
+  // so the retracted item came straight back: "vegan, vegetarian".
+  chk(!/\bvegan\b/.test(col.replace(/vegetarian/g, "")),
+    "…and vegan is gone, not re-added by the append that followed the retraction",
+    `column=${JSON.stringify(col)}`);
+  chk(/vegetarian/i.test(reply) && !/updated to \*vegan\*/i.test(reply),
+    "…and the reply names what they ARE, not what they just denied",
+    JSON.stringify(reply.slice(0, 160)));
+}
+
+// ── E — retraction, exactly once ────────────────────────────────────────────────────────────
+{
+  const c = await client({ dietaryRestrictions: "vegan" });
+  const reply = await say(c.phone, "I'm not vegan anymore");
+  const row = await rowOf(c.id);
+  chk(!row.dietaryRestrictions, "E · vegan is retracted", `column=${JSON.stringify(row.dietaryRestrictions)}`);
+  chk(!/updated to \*vegan\*/i.test(reply) && !/only suggest plant-based/i.test(reply),
+    "…and the reply does not confirm the diet they just dropped",
+    JSON.stringify(reply.slice(0, 160)));
+  chk(reply.trim().length > 0 && !/didn'?t quite catch/i.test(reply),
+    "…and the correction is answered rather than falling through to a non-answer",
+    JSON.stringify(reply.slice(0, 160)));
+}
+
+// ── F — exact removal ───────────────────────────────────────────────────────────────────────
+{
+  const c = await client({ dietaryRestrictions: "peanuts, nuts" });
+  await say(c.phone, "I can eat nuts again");
+  const row = await rowOf(c.id);
+  const col = String(row.dietaryRestrictions || "").toLowerCase();
+  chk(/peanuts/.test(col), "F · retracting `nuts` leaves the unrelated PEANUT restriction intact",
+    `column=${JSON.stringify(col)}`);
+  chk(!/(^|,\s*)nuts(\s*,|$)/.test(col), "…and `nuts` itself is gone", `column=${JSON.stringify(col)}`);
+  // CONTROL — removal must still WORK, and must still clear a legacy span-form row. Without this
+  // the boundary match reads as "retractions stopped removing anything".
+  const legacy = await client({ dietaryRestrictions: "vegan now" });
+  await say(legacy.phone, "I'm not vegan anymore");
+  chk(!(await rowOf(legacy.id)).dietaryRestrictions,
+    "CONTROL: a row written in the old span form is still cleared by its retraction",
+    `column=${JSON.stringify((await rowOf(legacy.id)).dietaryRestrictions)}`);
+}
+
+// ── G — an active injury is not erased by the word `anymore` ────────────────────────────────
+{
+  const c = await client({ injuries: "knee" });
+  const reply = await say(c.phone, "my knee doesn't hurt as much anymore, should I still avoid squats?");
+  const row = await rowOf(c.id);
+  chk(/knee/i.test(String(row.injuries || "")),
+    "G · a hedged improvement inside a question does not amputate the injury",
+    `column=${JSON.stringify(row.injuries)}`);
+  chk(reply.trim().length > 0, "…and the question is still answered", JSON.stringify(reply.slice(0, 120)));
+  // …AND A QUESTION ABOUT A RESOLUTION IS NOT A RESOLUTION. The assert branch has always been
+  // gated on the client REPORTING rather than asking; the retract branch was not, so a question
+  // could not add an injury but could delete one — and this is the sentence that does it, with a
+  // full resolution phrase inside a conditional the client has not claimed.
+  const asked = await client({ injuries: "knee" });
+  await say(asked.phone, "if my knee doesn't hurt anymore should I go back to squats?");
+  chk(/knee/i.test(String((await rowOf(asked.id)).injuries || "")),
+    "…and asking IF it resolves does not resolve it",
+    `column=${JSON.stringify((await rowOf(asked.id)).injuries)}`);
+
+  // CONTROL — a real resolution must STILL clear it, or the guard above is just "never remove".
+  const healed = await client({ injuries: "knee, shoulder" });
+  await say(healed.phone, "my knee doesn't hurt anymore");
+  const h = await rowOf(healed.id);
+  chk(!/knee/i.test(String(h.injuries || "")),
+    "CONTROL: a genuine resolution still clears the joint", `column=${JSON.stringify(h.injuries)}`);
+  chk(/shoulder/i.test(String(h.injuries || "")),
+    "CONTROL: …and takes only that joint with it", `column=${JSON.stringify(h.injuries)}`);
+}
+
+REAL("\n=== ISOLATION, SEPARATORS, AND UNRELATED FACTS ===");
+
+// ── H — mixed intent with no separator, and per-client isolation ────────────────────────────
+{
+  const c = await client();
+  const reply = await say(c.phone, "I am vegan now what should I eat");
+  const row = await rowOf(c.id);
+  chk(String(row.dietaryRestrictions || "").toLowerCase() === "vegan",
+    "H · a fact and a question with no comma still commits the fact",
+    `column=${JSON.stringify(row.dietaryRestrictions)}`);
+  chk(/vegan|plant|tofu|lentil|bean|soya/i.test(reply),
+    "…and the same reply honours it", JSON.stringify(reply.slice(0, 140)));
+
+  // UNRELATED DURABLE FACTS SURVIVE AN UNRELATED RETRACTION, and so does the other client.
+  const other = await client({ dietaryRestrictions: "vegan" });
+  const keeper = await client({ dietaryRestrictions: "halal", injuries: "shoulder", lifeContext: "newborn at home" });
+  await say(keeper.phone, "I'm not vegan anymore");
+  const k = await rowOf(keeper.id);
+  chk(/halal/i.test(String(k.dietaryRestrictions || "")) && /shoulder/i.test(String(k.injuries || ""))
+      && /newborn/i.test(String(k.lifeContext || "")),
+    "…a retraction of something they never had leaves every other fact untouched",
+    JSON.stringify({ diet: k.dietaryRestrictions, inj: k.injuries, life: k.lifeContext }));
+  chk(String((await rowOf(other.id)).dietaryRestrictions || "").toLowerCase() === "vegan",
+    "…and another client's vegan restriction is not touched by it",
+    `column=${JSON.stringify((await rowOf(other.id)).dietaryRestrictions)}`);
+}
+
+REAL(`\n${failed === 0 ? "pg-facts-acceptance: GREEN — all checks passed" : `pg-facts-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  // turn_ledger TOO. Coach Health reads that table for the whole database, so turns this suite
+  // leaves behind are read back as though the lab had produced them — which is exactly how a
+  // clean run of journey-lab reported a #86 regression that belonged to this file's fixtures.
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs", "turn_ledger"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-facts-acceptance.ts
+++ b/script/pg-facts-acceptance.ts
@@ -179,6 +179,22 @@ REAL("\n=== RETRACTION AND REPLACEMENT ARE EXACT ===");
   chk(/peanuts/.test(col), "F · retracting `nuts` leaves the unrelated PEANUT restriction intact",
     `column=${JSON.stringify(col)}`);
   chk(!/(^|,\s*)nuts(\s*,|$)/.test(col), "…and `nuts` itself is gone", `column=${JSON.stringify(col)}`);
+  // …AND THE SAME BUBBLE, WHERE THE BOUNDARY NEVER USED TO GET A CHANCE TO RUN (CTO gate).
+  //
+  // The same-bubble merge decided "is this the same item" with substring containment, one layer
+  // ABOVE removeFact — so a replacement was deleted before projection and the boundary fix could
+  // not save it. The client declared a peanut allergy in the same breath and was left with NO
+  // restriction at all.
+  const swap = await client({ dietaryRestrictions: "nuts" });
+  await say(swap.phone, "I'm not allergic to nuts, I'm allergic to peanuts");
+  const swapped = String((await rowOf(swap.id)).dietaryRestrictions || "").toLowerCase();
+  chk(/peanuts/.test(swapped),
+    "F · a same-message `nuts` → `peanuts` replacement keeps the PEANUT allergy",
+    `column=${JSON.stringify(swapped)}`);
+  chk(swapped.split(",").map(x => x.trim()).every(x => x !== "nuts"),
+    "…and the broader `nuts` restriction is the one that went",
+    `column=${JSON.stringify(swapped)}`);
+
   // CONTROL — removal must still WORK, and must still clear a legacy span-form row. Without this
   // the boundary match reads as "retractions stopped removing anything".
   const legacy = await client({ dietaryRestrictions: "vegan now" });
@@ -215,6 +231,47 @@ REAL("\n=== RETRACTION AND REPLACEMENT ARE EXACT ===");
     "CONTROL: a genuine resolution still clears the joint", `column=${JSON.stringify(h.injuries)}`);
   chk(/shoulder/i.test(String(h.injuries || "")),
     "CONTROL: …and takes only that joint with it", `column=${JSON.stringify(h.injuries)}`);
+}
+
+REAL("\n=== DERIVED STATE FOLLOWS THE CANONICAL COLUMN ===");
+
+// ── A PARTIAL RETRACTION MUST NOT LEAVE A LIVE MOUTH ON THE OLD DIET (CTO gate) ─────────────
+//
+// profileNotes carries the `diet:` flag that utils._getPool reads to choose the protein pool a
+// client is OFFERED. Only the announcer ever wrote it, and only when the column emptied — so a
+// retraction that left ANOTHER diet standing kept the old flag alive, and the canonical column
+// said vegetarian while the suggestion mouth still served the vegan pool.
+{
+  const { proteinOptions } = await import("../server/utils");
+  const c = await client({ dietaryRestrictions: "vegan, vegetarian", profileNotes: "diet:vegan" });
+  await say(c.phone, "I'm not vegan anymore");
+  const row = await rowOf(c.id);
+  const col = String(row.dietaryRestrictions || "").toLowerCase();
+  chk(/vegetarian/.test(col) && !/\bvegan\b/.test(col.replace(/vegetarian/g, "")),
+    "a partial retraction leaves the OTHER diet as canonical truth", `column=${JSON.stringify(col)}`);
+  chk(!/diet:vegan\b/i.test(String(row.profileNotes || "")),
+    "…and the derived diet flag no longer says vegan", `notes=${JSON.stringify(row.profileNotes)}`);
+  chk(/diet:vegetarian/i.test(String(row.profileNotes || "")),
+    "…it says what the column says", `notes=${JSON.stringify(row.profileNotes)}`);
+  // THE LIVE MOUTH, not just the flag: the pool a client is actually offered.
+  const pool = proteinOptions(row as any);
+  chk(!/tofu|soya|lentil/i.test(pool) || /egg|cottage cheese/i.test(pool),
+    "…and the protein pool they are offered is no longer the vegan one", `pool=${JSON.stringify(pool)}`);
+
+  // CONTROL — a client who IS still vegan keeps the vegan flag and the vegan pool, so the
+  // reconciliation is convergence and not "the flag is always cleared".
+  const stays = await client({ dietaryRestrictions: "vegan, peanuts", profileNotes: "diet:vegan" });
+  await say(stays.phone, "I can eat peanuts again");
+  const sr = await rowOf(stays.id);
+  chk(/diet:vegan/i.test(String(sr.profileNotes || "")),
+    "CONTROL: an unrelated retraction leaves a still-true vegan flag alone",
+    `notes=${JSON.stringify(sr.profileNotes)} column=${JSON.stringify(sr.dietaryRestrictions)}`);
+  // CONTROL — notes that are not the diet flag are not collateral.
+  const keepsNotes = await client({ dietaryRestrictions: "vegan", profileNotes: "fish allergy diet:vegan" });
+  await say(keepsNotes.phone, "I'm not vegan anymore");
+  chk(/fish allergy/i.test(String((await rowOf(keepsNotes.id)).profileNotes || "")),
+    "CONTROL: an unrelated profile note survives the diet-flag reconciliation",
+    `notes=${JSON.stringify((await rowOf(keepsNotes.id)).profileNotes)}`);
 }
 
 REAL("\n=== ISOLATION, SEPARATORS, AND UNRELATED FACTS ===");

--- a/script/pg-facts-trace.ts
+++ b/script/pg-facts-trace.ts
@@ -1,0 +1,139 @@
+/**
+ * DIAGNOSTIC TRACE — facts, retractions, replacements, same-turn propagation (#211).
+ *
+ * Not an acceptance. For each journey the issue names it prints:
+ *
+ *   client words -> fact extracted -> durable truth -> canonical belief -> reply owner -> reply
+ *
+ * Real front door, real PostgreSQL. `detectFacts` is called separately on the same words purely to
+ * show what the extractor SAW; the durable truth is re-read from the users row after the turn, and
+ * the canonical belief is read through the owners the reply itself uses (foodConstraints,
+ * readHealthState) rather than by re-deriving anything here.
+ */
+if (!process.env.DATABASE_URL) { console.log("SKIPPED — no DATABASE_URL."); process.exit(0); }
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+let captured: string[] = [];
+console.log = console.warn = console.error =
+  (...a: any[]) => { captured.push(a.map(x => typeof x === "string" ? x : JSON.stringify(x)).join(" ")); };
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { eq } = await import("drizzle-orm");
+const { handleMessage } = await import("../server/routes");
+const { detectFacts } = await import("../server/memory");
+const { foodConstraints } = await import("../server/food-swaps");
+const { readHealthState } = await import("../server/health-state");
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: D(40), programmeStartDate: D(40),
+    programmeWeek: 6, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  return { id: u.id, phone };
+}
+
+const FACT_COLS = ["dietaryRestrictions", "injuries", "medicalConditions", "lifeContext", "doNotMention", "workSchedule"] as const;
+
+async function turn(label: string, c: { id: string; phone: string }, text: string) {
+  captured = [];
+  const saw = detectFacts(text);
+  const reply = String(await handleMessage(
+    c.phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 9)}`) || "");
+  const [row] = await db.select().from(schema.users).where(eq(schema.users.id, c.id)).limit(1);
+  const durable: Record<string, any> = {};
+  for (const k of FACT_COLS) if (row[k as keyof typeof row]) durable[k] = row[k as keyof typeof row];
+  const cons = foodConstraints(row as any);
+  const health = readHealthState(row as any);
+  const owner = (captured.find(l => /\[(FOOD_|PLATE_|STREET_|GOAL_|WORKOUT|PAIN|INJURY|SAFETY|MISC|ENGINE_|GPT)/i.test(l)) || "").trim();
+
+  REAL(`\n${"─".repeat(96)}\n${label}`);
+  REAL(`  client words     ${JSON.stringify(text)}`);
+  REAL(`  fact extracted   ${JSON.stringify({ ...saw, retract: saw.retract && Object.keys(saw.retract).length ? saw.retract : undefined })}`);
+  REAL(`  durable truth    ${JSON.stringify(durable)}`);
+  REAL(`  canonical belief constraints=[${cons.terms.join(", ")}]  sick=${health.isSick}`);
+  REAL(`  reply owner      ${owner || "(no owner marker logged)"}`);
+  REAL(`  FINAL REPLY      ${JSON.stringify(reply)}`);
+  return { reply, row, cons, health, saw };
+}
+
+REAL("=".repeat(96));
+REAL("#211 — FACTS, RETRACTIONS, AND SAME-TURN PROPAGATION");
+REAL("=".repeat(96));
+
+REAL("\n### A/B/C — FACT + QUESTION IN ONE NATURAL SENTENCE");
+{
+  const a = await client();
+  const ra = await turn("A · vegan + question", a, "I'm vegan now, what should I eat?");
+  REAL(`  >> vegan-safe this turn? constraints carry vegan = ${ra.cons.terms.some(t => /vegan/i.test(t))}`);
+
+  const b = await client();
+  const rb = await turn("B · dairy + question", b, "I can't eat dairy, what can I eat?");
+  REAL(`  >> dairy-safe this turn? constraints carry dairy = ${rb.cons.terms.some(t => /dairy|milk/i.test(t))}`);
+
+  const c = await client();
+  const rc = await turn("C · knee + training question", c, "my knee is killing me, what should I train?");
+  REAL(`  >> injury recorded this turn? injuries = ${JSON.stringify(rc.row.injuries)}`);
+}
+
+REAL("\n### D/E — RETRACTION AND REPLACEMENT");
+{
+  const d = await client({ dietaryRestrictions: "vegan" });
+  await turn("D · replacement", d, "I'm not vegan, I'm vegetarian");
+
+  const e = await client({ dietaryRestrictions: "vegan" });
+  await turn("E · retraction", e, "I'm not vegan anymore");
+}
+
+REAL("\n### F — EXACT REMOVAL");
+{
+  const f = await client({ dietaryRestrictions: "peanuts, nuts" });
+  await turn("F · retract nuts, keep peanuts", f, "I can eat nuts again");
+}
+
+REAL("\n### G — INJURY `anymore` NEGATIVE CONTROL");
+{
+  const g = await client({ injuries: "knee" });
+  await turn("G · a question containing `anymore` must not erase the injury", g,
+    "my knee doesn't hurt as much anymore, should I still avoid squats?");
+}
+
+REAL("\n### H — MIXED INTENT, NO CLEAN SEPARATOR + ISOLATION");
+{
+  const h = await client();
+  await turn("H1 · fact and question, no comma", h, "I am vegan now what should I eat");
+
+  const h2 = await client({ dietaryRestrictions: "halal", injuries: "shoulder", lifeContext: "newborn at home" });
+  await turn("H2 · unrelated durable facts must survive an unrelated retraction", h2, "I'm not vegan anymore");
+}
+
+REAL(`\n${"=".repeat(96)}`);
+for (const id of ids) {
+  // turn_ledger TOO. Coach Health reads that table for the whole database, so turns this suite
+  // leaves behind are read back as though the lab had produced them — which is exactly how a
+  // clean run of journey-lab reported a #86 regression that belonged to this file's fixtures.
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs", "turn_ledger"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(0);

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -480,10 +480,38 @@ export async function handleEarlyCommands(ctx: {
     /\b(i (don.?t|no longer|stopped|gave up) eat(ing)?)\b.*\b(meat|pork|chicken|beef|fish|pilchards|animal)\b/i.test(m) ||
     /\b(change|update)\b.*\b(diet(ary)?|food preference|eating)\b.*\b(halal|vegetarian|veggie|vegan|plant.?based)\b/i.test(m)
   ) {
+    // WHAT THE FRONT DOOR COMMITTED THIS TURN, NOT WHAT THIS REGEX RE-READS OFF THE MESSAGE (#211).
+    //
+    // These tests ran on the raw words, and the trigger above matches "i'm … vegan" with anything
+    // in between — so a RETRACTION announced an assertion, and `vegan` was tested before
+    // `vegetarian` so a replacement announced the thing being replaced:
+    //
+    //     "I'm not vegan anymore"        -> "got it — updated to *vegan*"
+    //     "I'm not vegan, I'm vegetarian" -> "got it — updated to *vegan*"
+    //
+    // recordClientFacts has already run at the door, before any routing, and `user` is the row it
+    // committed. Reading the canonical column instead makes this mouth render the one durable
+    // truth rather than hold a second opinion about it: a retraction leaves the column without a
+    // diet and this branch stands down, and a replacement names what the client actually is.
+    // WHAT THIS TURN ACTUALLY DID TO THE RECORD. detectFacts is the one extractor and is asked,
+    // not re-implemented. Without this the branch announced on every MENTION rather than on a
+    // change, so a halal client saying "I'm not vegan anymore" read "updated to *halal*" — a
+    // change that never happened, about a diet they did not just state.
+    const { detectFacts: _detect } = await import("../memory");
+    const _factsThisTurn = _detect(message);
+    const _takenBack = _factsThisTurn.retract?.dietaryRestrictions;
+    const _assertedThisTurn = _factsThisTurn.dietaryRestrictions;
+    const _dietTruth = String(user.dietaryRestrictions || "").toLowerCase();
     let _newDietFlag: string | null = null;
-    if (/\bvegan\b/i.test(m) || /\bplant.?based\b/i.test(m)) _newDietFlag = "diet:vegan";
-    else if (/\b(vegetarian|veggie)\b/i.test(m) || /\b(don.?t|no longer|stopped|gave up)\s+eat(ing)?\b.*\b(meat|chicken|beef|fish|pilchards|animal)\b/i.test(m.toLowerCase())) _newDietFlag = "diet:vegetarian";
-    else if (/\b(halal|muslim|islam|haram)\b/i.test(m)) _newDietFlag = "diet:halal";
+    if (!_assertedThisTurn) _newDietFlag = null;
+    else
+    if (/\bvegan\b/.test(_dietTruth) || /\bplant.?based\b/.test(_dietTruth)) _newDietFlag = "diet:vegan";
+    else if (/\b(vegetarian|veggie)\b/.test(_dietTruth)) _newDietFlag = "diet:vegetarian";
+    else if (/\b(halaal|halal)\b/.test(_dietTruth)) _newDietFlag = "diet:halal";
+    // The column is the authority on WHAT they are; it does not carry "I stopped eating meat", so
+    // that phrasing is still read off the message — and only when the column has not answered.
+    else if (/\b(don.?t|no longer|stopped|gave up)\s+eat(ing)?\b.*\b(meat|chicken|beef|fish|pilchards|animal)\b/i.test(m)) _newDietFlag = "diet:vegetarian";
+    else if (!_dietTruth && /\b(muslim|islam|haram)\b/i.test(m)) _newDietFlag = "diet:halal";
 
     if (_newDietFlag) {
       const _existingNotes = (user.profileNotes || "").replace(/\bdiet:\w+\b/g, "").trim();
@@ -504,6 +532,29 @@ export async function handleEarlyCommands(ctx: {
       const _dietReply = `${firstName ? firstName + ", g" : "G"}ot it — updated to *${_dietLabel}*. ${_dietNote}\n\nYour protein sources from now on: *${_dietProteins}*.\n\nType *meal plan* to get an updated eating plan.`;
       await logChat(user.id, message, _dietReply, "DIET_PREFERENCE_UPDATE");
       return _dietReply;
+    }
+
+    // AND A RETRACTION IS AN ANSWER TOO (#211). The trigger above fires on "I'm not vegan
+    // anymore" — the client is talking about their diet — but the column correctly holds nothing
+    // afterwards, so with the announcement suppressed the turn fell to the GPT fallback and the
+    // client read "Sorry Kam, I didn't quite catch that" after correcting their own record.
+    //
+    // detectFacts is the one extractor and is asked, not re-implemented; the stale `diet:` flag is
+    // cleared in the same breath so the meal-plan reader cannot keep building vegan plans off a
+    // restriction the canonical column no longer has.
+    // Confirmed only when the record now carries NO diet at all — something was genuinely taken
+    // off, or they never had one, and either way the sentence is true. A client who still holds a
+    // different restriction (halal) has had nothing changed by this, so the branch stands down and
+    // the rest of the pipeline answers them.
+    if (_takenBack && !_dietTruth) {
+      const _cleared = (user.profileNotes || "").replace(/\bdiet:\w+\b/g, "").trim();
+      if (_cleared !== (user.profileNotes || "").trim()) {
+        await db.update(users).set({ profileNotes: _cleared || null }).where(eq(users.phoneNumber, phone));
+        user.profileNotes = _cleared || null;
+      }
+      const _offReply = `${firstName ? firstName + ", g" : "G"}ot it — you're not ${_takenBack} anymore. I've taken that off your record.\n\nEverything I suggest from here is back to the full list.`;
+      await logChat(user.id, message, _offReply, "DIET_PREFERENCE_RETRACTED");
+      return _offReply;
     }
   }
 

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -421,7 +421,9 @@ export function detectFacts(message: string): DurableFacts {
     const asserted = merged[field] == null ? "" : String(merged[field]).toLowerCase();
     const taken = String(retract[field] || "").toLowerCase();
     if (!asserted) continue;
-    if (!taken || asserted === taken || asserted.includes(taken) || taken.includes(asserted)) {
+    // SAMENESS IS DECIDED BY THE ONE PREDICATE, not by substring containment. `namesFact` is what
+    // removeFact uses, so "peanuts" and "nuts" are different items in both places.
+    if (!taken || asserted === taken || namesFact(asserted, taken) || namesFact(taken, asserted)) {
       delete merged[field];
     }
   }
@@ -581,10 +583,30 @@ export function removeFact(existing: string | null | undefined, item: string): s
   const clean = (item || "").trim().toLowerCase();
   const cur = (existing || "").trim();
   if (!clean || !cur) return existing ?? null;
-  const whole = new RegExp(String.raw`\b${clean.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\b`, "i");
   const kept = cur.split(",").map(s => s.trim()).filter(Boolean)
-    .filter(part => !whole.test(part));
+    .filter(part => !namesFact(part, clean));
   return kept.length ? kept.join(", ") : null;
+}
+
+/**
+ * DOES `text` NAME `item`, AS A WHOLE WORD?
+ *
+ * THE ONE ANSWER, because two places ask it and they must not disagree. removeFact asks it of a
+ * stored column; the same-bubble merge in detectFacts asks it of an assertion and a retraction
+ * standing side by side. The merge originally decided sameness with `a.includes(b)`, which
+ * recreated the exact defect the boundary here exists to prevent — one layer earlier, where the
+ * boundary never got a chance to run:
+ *
+ *     "I'm not allergic to nuts, I'm allergic to peanuts"
+ *       retract nuts, assert peanuts  ->  "peanuts".includes("nuts")  ->  assertion deleted
+ *       result: the column emptied, and a client who had just declared a PEANUT allergy was
+ *       left with no restriction at all.
+ */
+export function namesFact(text: string | null | undefined, item: string): boolean {
+  const clean = (item || "").trim().toLowerCase();
+  const t = String(text || "").trim();
+  if (!clean || !t) return false;
+  return new RegExp(String.raw`\b${clean.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\b`, "i").test(t);
 }
 
 export interface ClientFactOperation {
@@ -643,6 +665,34 @@ export function projectClientFacts(
     if (!next || next === previous) continue;
     patch[fact] = next;
     operations.push({ fact, operation: "assert", previousValue: previous, value: next, provenance: "client_explicit" });
+  }
+
+  // THE DERIVED DIET FLAG FOLLOWS THE CANONICAL COLUMN (#211 gate).
+  //
+  // profileNotes carries `diet:vegan` / `diet:vegetarian` / `diet:halal`, and utils._getPool reads
+  // it to choose the protein pool a client is OFFERED. Nothing but the announcer ever wrote it, so
+  // a retraction that left another diet standing kept the old flag alive:
+  //
+  //     column "vegan, vegetarian" + "I'm not vegan anymore"
+  //       canonical -> "vegetarian"
+  //       profileNotes still "diet:vegan"  ->  the suggestion mouth still offers the VEGAN pool
+  //
+  // A successful canonical retraction leaving a live customer-facing mouth on the old diet is the
+  // whole reason derived state has to be reconciled where the canonical value changes, rather than
+  // in the one handler that happened to write it. This is a PROJECTION of the column, not a second
+  // opinion about it: it is computed from the value this same patch just produced, and it never
+  // decides anything the column does not already say.
+  if (Object.prototype.hasOwnProperty.call(patch, "dietaryRestrictions")) {
+    const next = String(patch.dietaryRestrictions || "").toLowerCase();
+    const flag = /\bvegan\b/.test(next) ? "diet:vegan"
+      : /\b(vegetarian|veggie)\b/.test(next) ? "diet:vegetarian"
+      : /\bhalaal?\b/.test(next) ? "diet:halal" : "";
+    const notes = current?.profileNotes == null ? "" : String(current.profileNotes);
+    if (/\bdiet:\w+\b/i.test(notes) || flag) {
+      const rebuilt = [notes.replace(/\bdiet:\w+\b/gi, "").replace(/\s+/g, " ").trim(), flag]
+        .filter(Boolean).join(" ").trim();
+      if (rebuilt !== notes.trim()) patch.profileNotes = rebuilt || null;
+    }
   }
 
   if (facts.workSchedule && facts.workSchedule !== current?.workSchedule) {

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -342,6 +342,10 @@ const RESTRICTION_WORD = String.raw`lactose intolerant|gluten.?free|dairy.?free|
  * to a stopping verb, or carry "anymore" itself. "I'm not eating dairy" is deliberately NOT here:
  * that is the restriction, stated in the negative, and belongs to the assert branch.
  */
+/** The restriction word itself, off the one list above — what a column should store. */
+const RESTRICTION_TOKEN_RE = new RegExp(String.raw`\b(?:${RESTRICTION_WORD})\b`, "i");
+
+
 const RESTRICTION_RETRACTED_RE = new RegExp(
   String.raw`\b(?:i'?m|i\s+am|im)\s+(?:not|no\s+longer)\s+(?:really\s+|strictly\s+|a\s+)*`
   + String.raw`(?:allergic\s+to\s+|intolerant\s+(?:to|of)\s+)?(${RESTRICTION_WORD})\b`
@@ -399,7 +403,28 @@ export function detectFacts(message: string): DurableFacts {
       if (v && retract[k as DurableFactField] === undefined) retract[k as DurableFactField] = v as string;
     }
   }
-  for (const field of Object.keys(retract) as DurableFactField[]) delete merged[field];
+  // A RETRACTION BEATS AN ASSERTION OF THE SAME ITEM — NOT OF THE WHOLE FIELD (#211).
+  //
+  // This deleted any assertion of a field that carried a retraction anywhere in the bubble, which
+  // is right when the client says the same thing twice and wrong for the commonest correction
+  // there is:
+  //
+  //     "I'm not vegan, I'm vegetarian"
+  //       clause 1  retract dietaryRestrictions:vegan
+  //       clause 2  assert  dietaryRestrictions:vegetarian   <- deleted here
+  //       result    no dietary truth at all
+  //
+  // The client corrected their own record and came out with less truth than either half of the
+  // sentence contained. A retraction and an assertion naming DIFFERENT items of one field is a
+  // replacement, and both halves are what they said.
+  for (const field of Object.keys(retract) as DurableFactField[]) {
+    const asserted = merged[field] == null ? "" : String(merged[field]).toLowerCase();
+    const taken = String(retract[field] || "").toLowerCase();
+    if (!asserted) continue;
+    if (!taken || asserted === taken || asserted.includes(taken) || taken.includes(asserted)) {
+      delete merged[field];
+    }
+  }
   if (Object.keys(retract).length) merged.retract = retract;
   return merged;
 }
@@ -433,11 +458,31 @@ function detectInClause(message: string): DurableFacts {
   // "that workout hurt" does not, and must not amputate their leg day.
   // "my knee doesn't hurt anymore", "the back is healed" — the client is telling us the injury is
   // OVER. Recording it here would train around a knee that is fine, permanently.
-  const resolved = /\b(?:no longer|not\s+(?:really\s+)?(?:sore|hurting|painful)|doesn'?t\s+hurt|don'?t\s+hurt|healed|all\s+better|fine\s+now|better\s+now|sorted\s+now)\b|\banymore\b/i.test(m);
+  // "anymore" IS A TIME MARKER, NOT A RESOLUTION CLAIM (#211). A bare `\banymore\b` alternative
+  // stood here, so ANY sentence naming a body part and containing that word amputated the injury:
+  //
+  //     "my knee doesn't hurt as much anymore, should I still avoid squats?"
+  //       -> retract injuries:knee, and the client is asking how to train around it
+  //
+  // It now has to attach to a phrase that actually claims the injury is over. And a HEDGED
+  // improvement is not resolution: "doesn't hurt as much" / "a bit less sore" is a knee getting
+  // better, which is the state in which training around it still matters most.
+  const HEDGE = String.raw`(?:as\s+much|as\s+bad|much|a\s+bit|a\s+little|so\s+much|quite\s+so|less)`;
+  const resolved = new RegExp(
+    String.raw`\b(?:no longer|not\s+(?:really\s+)?(?:sore|hurting|painful)|doesn'?t\s+hurt|don'?t\s+hurt`
+    + String.raw`|healed|all\s+better|fine\s+now|better\s+now|sorted\s+now)\b(?!\s+${HEDGE}\b)`
+    + String.raw`|\b(?:gone|over|better|healed|sorted|fine)\s+(?:now\s+)?any\s?more\b`
+    + String.raw`|\bno\s+(?:more\s+)?(?:pain|niggle)\b`, "i").test(m);
   const part = m.match(BODY_PART)?.[0]?.toLowerCase();
   // AND SAY SO TO THE COLUMN. Suppressing the write left a knee that healed in March still
   // steering every leg day, because nothing else ever removes it.
-  if (part && resolved) facts.retract = { ...facts.retract, injuries: part };
+  //
+  // THE SAME `reporting` GATE THE ASSERT BRANCH BELOW ALREADY USES (#211). Only the assert side
+  // carried it, so a QUESTION could not add an injury but could delete one — the asymmetry ran in
+  // the unsafe direction. For food the module argues the opposite way on purpose, and says why:
+  // wrongly keeping a restriction starves the client. For an injury the costs are reversed —
+  // wrongly keeping one costs a conservative session, wrongly clearing one trains a hurt joint.
+  if (part && resolved && reporting) facts.retract = { ...facts.retract, injuries: part };
   if (part && reporting && !resolved) {
     // An INJURY VERB naming a body part is enough on its own — "I hurt my lower back at work" is
     // a report, not a complaint about a hard session.
@@ -470,7 +515,12 @@ function detectInClause(message: string): DurableFacts {
   } else {
     const allergy = !reporting ? undefined : m.match(/\b(?:allergic to|intolerant to|can'?t eat|cannot eat|don'?t eat|i'?m|i am)\s+([a-z ]{3,20}?)\b(?:\.|,|$| and | but )/)?.[1]?.trim();
     if (allergy && /\b(lactose|gluten|dairy|nuts?|peanuts?|shellfish|eggs?|pork|beef|halaal|halal|vegan|vegetarian|seafood|fish)\b/i.test(allergy)) {
-      facts.dietaryRestrictions = allergy;
+      // THE TOKEN, NOT THE SPAN THE CAPTURE HAPPENED TO REACH (#211). The lazy group above runs to
+      // the next comma, so "I'm vegan now, what should I eat?" stored the restriction as
+      // "vegan now" — which then read out through foodConstraints as TWO terms, "vegan" and
+      // "vegan now", and left a retraction matching on a string the client never said. Narrowed to
+      // the restriction word itself, from the one list this module already keeps.
+      facts.dietaryRestrictions = allergy.match(RESTRICTION_TOKEN_RE)?.[0].toLowerCase() || allergy;
     } else if (reporting && /\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i.test(m) && /\bi'?m|i am\b/i.test(m)) {
       facts.dietaryRestrictions = m.match(/\b(lactose intolerant|gluten free|dairy free|vegan|vegetarian|halaal|halal|kosher)\b/i)![0];
     }
@@ -512,17 +562,28 @@ export function addFact(existing: string | null | undefined, item: string): stri
 /**
  * Take one item back out of a comma-separated column.
  *
- * MATCHES ON CONTAINMENT, because the column holds what the client said and not a normalised
- * token — a "vegan" retraction has to clear an entry stored as "vegan now" or "i'm vegan", which
- * is exactly how the assert branch writes them. Emptying the column returns null, not "", so the
- * readers' `usable()` and foodConstraints see an absent fact rather than a blank one.
+ * MATCHES ON A WHOLE WORD (#211). This matched on CONTAINMENT, for a stated reason — the column
+ * holds what the client said rather than a normalised token, so a "vegan" retraction had to clear
+ * an entry the assert branch had written as "vegan now". The cost of that was exact removal, and
+ * it was not hypothetical: a client restricted on "peanuts, nuts" who said "I can eat nuts again"
+ * had BOTH cleared, because "peanuts".includes("nuts"). A peanut allergy silently deleted by an
+ * unrelated sentence is the most dangerous write in this module.
+ *
+ * A word boundary keeps the reason and drops the cost. "vegan now" still contains the WORD
+ * "vegan", so the entry the comment was written for is still cleared; "peanuts" does not contain
+ * the word "nuts", so it survives. The assert branch now stores the token anyway (see below), but
+ * this stays boundary-matched for rows written before that.
+ *
+ * Emptying the column returns null, not "", so the readers' `usable()` and foodConstraints see an
+ * absent fact rather than a blank one.
  */
 export function removeFact(existing: string | null | undefined, item: string): string | null {
   const clean = (item || "").trim().toLowerCase();
   const cur = (existing || "").trim();
   if (!clean || !cur) return existing ?? null;
+  const whole = new RegExp(String.raw`\b${clean.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\b`, "i");
   const kept = cur.split(",").map(s => s.trim()).filter(Boolean)
-    .filter(part => !part.toLowerCase().includes(clean));
+    .filter(part => !whole.test(part));
   return kept.length ? kept.join(", ") : null;
 }
 
@@ -564,7 +625,20 @@ export function projectClientFacts(
   for (const fact of appendFacts) {
     const asserted = facts[fact];
     if (!asserted) continue;
-    const previous = current?.[fact] == null ? null : String(current[fact]);
+    // BUILD ON WHAT THE RETRACTION ABOVE JUST PRODUCED, NOT ON THE ROW IT STARTED FROM (#211).
+    //
+    // Retractions run first, deliberately — but the append then re-read `current`, so a
+    // replacement put the retracted item straight back and the retraction patch was overwritten
+    // by the wider one:
+    //
+    //     "I'm not vegan, I'm vegetarian"   column "vegan"
+    //       retract -> patch "vegan" => null
+    //       assert  -> addFact(current "vegan", "vegetarian") => "vegan, vegetarian"
+    //
+    // The client is left MORE restricted than before they corrected us. `patch` is this
+    // transaction's own newer truth and is what the next operation must see.
+    const base = Object.prototype.hasOwnProperty.call(patch, fact) ? patch[fact] : current?.[fact];
+    const previous = base == null ? null : String(base);
     const next = addFact(previous, asserted);
     if (!next || next === previous) continue;
     patch[fact] = next;

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -410,7 +410,18 @@ export function trainingDayIsDeclined(text: string): boolean {
 export function foodDayIsClosed(text: string): boolean {
   const t = String(text || "");
   if (!t.trim()) return false;
-  if (/\b(?:won'?t|will not|not (?:going to|gonna)|can'?t|cannot)\s+(?:be able to\s+)?eat(?:\s+anymore)?\b/i.test(t)) return true;
+  // AND THIS CESSATION MUST APPLY TO EATING ITSELF TOO (#211) — the rule the composed clause below
+  // already states, which this earlier, simpler clause never got. "I can't eat" with a FOOD after
+  // it is a restriction, not a closed day, and the plainest way a client states one went straight
+  // through here:
+  //
+  //     "I can't eat dairy, what can I eat?"
+  //       -> food day CLOSED -> "You said you are done eating today, so I am leaving it there."
+  //
+  // They were asking what they CAN eat and were told they had finished eating. So the verb must be
+  // followed by the end of the clause or by a marker that scopes it in TIME; a food after it means
+  // they named what they avoid, and the dietary owner in memory.ts records exactly that.
+  if (/\b(?:won'?t|will not|not (?:going to|gonna)|can'?t|cannot)\s+(?:be able to\s+)?eat\b(?:\s+(?:any\s?more|again|tonight|today|now|this\s+(?:evening|afternoon|morning)))*\s*(?:[.!?,;]|$)/i.test(t)) return true;
   if (/\bno more food\b/i.test(t)) return true;
   // A STATED CESSATION OF EATING, COMPOSED RATHER THAN LISTED (2026-08-24).
   //


### PR DESCRIPTION
**`FIXED + PROVEN`** for #211 / 2A. Baseline `origin/main@9156d471` (the SHA the start note names). Branch HEAD `3c44f02`.

**Held at CTO adjudication — not merged, not deployed.** No `#208` open-loop state touched, no `#213` question-selection authority touched, no food identity work.

Reproduced through the real front door on real PostgreSQL before changing anything. **Five defects**, each fixed at its own first divergence, all through owners that already existed.

## Acceptance A–H — before → after

| | client words | before | after |
|---|---|---|---|
| **A** | `I'm vegan now, what should I eat?` | column stored `"vegan now"`; constraints read out as **two** terms `[vegan, vegan now]` | column `vegan`; one term; reply vegan-safe |
| **B** | `I can't eat dairy, what can I eat?` | *"You said you are done eating today, so I am leaving it there. You finished on 0 kcal."* | a real, dairy-safe meal suggestion |
| **C** | `my knee is killing me, what should I train?` | already correct | **GREEN on current main — no code written** |
| **D** | `I'm not vegan, I'm vegetarian` | column `vegan, vegetarian`; reply *"updated to **vegan**"* | column `vegetarian`; reply *"updated to **vegetarian**"* |
| **E** | `I'm not vegan anymore` | reply *"updated to **vegan**. I'll only suggest plant-based proteins"* | *"you're not vegan anymore. I've taken that off your record."* |
| **F** | `I can eat nuts again` on `peanuts, nuts` | **both cleared** | `peanuts` intact |
| **G** | `my knee doesn't hurt as much anymore, should I still avoid squats?` | knee injury **erased** | injury intact, question answered |
| **H** | `I am vegan now what should I eat` (no separator) | already correct | GREEN; isolation and unrelated-fact preservation asserted |

## The five first divergences

**1 · The span, not the token.** The lazy capture runs to the next comma, so the restriction was stored as `"vegan now"` — which read out of `foodConstraints` as two terms and left every retraction matching a string the client never said. Narrowed to the restriction word, off the one list the module already keeps.

**2 · A restriction is not a closed day.** `foodDayIsClosed` claimed `"I can't eat dairy"`. The composed clause directly below it already carried the rule — *the cessation must apply to eating ITSELF; an adverb or a food after the verb means they described how they eat* — and this earlier, simpler clause never got it. Now scoped the same way, checked both directions.

**3 · Exact removal.** `removeFact` matched on **containment**, for a stated reason (spans like `"vegan now"` had to be reachable). The cost was a **peanut allergy deleted by a sentence about nuts** — the most dangerous write in the module. A word boundary keeps the reason and drops the cost, and legacy span rows are still cleared (controlled).

**4 · A retraction beats the same *item*, not the whole *field*.** The merge deleted any assertion of a field carrying a retraction anywhere in the bubble, so `"I'm not vegan, I'm vegetarian"` ended with **no dietary truth at all**. Underneath it, a second bug: retractions run before appends by design, but the append re-read the *original* row, so the retracted item came straight back and overwrote the retraction's own patch — the client corrected us and ended up **more** restricted.

**5 · `anymore` is a time marker, not a resolution claim.** A bare `\banymore\b` alternative meant any sentence naming a body part and containing that word amputated the injury. It now has to attach to a phrase claiming the injury is over; a hedged improvement is not resolution; and the retract branch carries the same `reporting` gate the assert branch always had — a question could not *add* an injury but could *delete* one, and that asymmetry ran in the unsafe direction.

## And the mouth speaks the one truth

`DIET_PREFERENCE_UPDATE` held a second opinion about diet — it re-read the raw message, tested `vegan` before `vegetarian`, and its trigger matches `i'm … vegan` with anything in between. `recordClientFacts` has already run at the door before any routing, so this mouth now renders the canonical column, announces only when the turn actually changed the record, confirms a retraction, and clears the stale `diet:` flag in `profileNotes` so the meal-plan reader cannot keep building vegan plans off a restriction that is gone.

## Red on revert — seven mechanisms, independently

```
removeFact boundary   -> the peanut allergy is deleted again
reporting gate        -> asking IF a knee resolves resolves it
resolution regex      -> a hedged improvement amputates the injury
merge rule            -> vegetarian is deleted by the vegan retraction
append ordering       -> "vegan, vegetarian"
token narrowing       -> "vegan now" stored, read out as two terms
closure scoping       -> a dairy restriction closes the food day
announcer             -> the coach confirms the diet they just dropped
```

The `reporting` gate did **not** bite on the first attempt — the resolution-regex fix alone covered the hedged sentence. Rather than keep unproven code I added the control that needs it (`"if my knee doesn't hurt anymore should I go back to squats?"` — a full resolution phrase inside a conditional the client has not claimed), and it bites now.

## Controls — all asserted

A real closure still closes the day · a genuine resolution still clears the joint and takes **only** that joint · a legacy span row is still cleared by its retraction · another client's restriction is untouched · unrelated durable facts survive a retraction of something they never had · no diagnosis is invented.

## One assertion regraded, not weakened

`gap-tests` asserted the column held `"not eating dairy"` — the raw span. It holds `"dairy"` now. The promise is that *a restriction stated in the negative is still a restriction*, so that is what is graded: recorded, non-empty, and reaching `foodConstraints`.

## A finding, not fixed here

`"I'm vegan now, what should I eat?"` is claimed by the diet announcer rather than the meal-plan owner, so it answers with the vegan protein list and *"Type meal plan"* instead of a Next Meal Suggestion. The reply is vegan-safe and the fact lands, so acceptance A holds — but this is a genuine claim-precedence tension between a fact-statement and a plate-ask. It behaves identically on current main. Left alone deliberately: routing/question-selection is `#213`'s lane.

*(It surfaced as a false Journey Lab failure first — my acceptance script was not cleaning `turn_ledger`, and Coach Health reads that table for the whole database. Fixed in the script; the product was never involved.)*

## Verification

- `npm run check` — clean.
- `npm test` — **37/37 green**.
- Journey Lab — GREEN, **266 checks** across 8 sections.
- All **twelve** PostgreSQL acceptance suites GREEN, including the new `pg-facts-acceptance` (30 checks), wired into the `pg-acceptance` job.
- **No governor raised** — `regexLiterals` *fell* to 447 and is locked in. No assertion weakened, no exclusion, no `continue-on-error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_