### PR TITLE
#213: choose the highest-value missing fact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,10 @@ jobs:
       # fixture that answers every query the same way.
       - name: Thin-evidence coaching on real PostgreSQL
         run: npx tsx script/pg-thin-evidence-acceptance.ts
+      # INFORMATION VALUE (#213). Weekend coverage, stalled trend, the durable open loop and the
+      # later backdated answer are all real rows; this grades the one canonical INVESTIGATE owner.
+      - name: Highest-value investigation on real PostgreSQL
+        run: npx tsx script/pg-information-value-acceptance.ts
       # ONE COACH SPEAKING (#207). The repetition defect this closes is invisible to a fixture
       # that sends one message per client: it only appears across CONSECUTIVE durable writes by
       # the same person, where the decision is recomputed from day state that the new event did

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -114,7 +114,7 @@ const BUDGET = {
    *
    * LOWER THIS as each of those lands. Never raise it.
    */
-  directWeightReads: 13,
+  directWeightReads: 11,
   /**
    * GUARD #16 — see handRolledDayBuckets above. SQL that decides which SAST day a ledger row
    * belongs to, written somewhere other than the owner.

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3478,6 +3478,32 @@ test("information value: a known stall asks for the missing weekend before chang
     "canonical weekend evidence closes this missing fact; silence never fabricates an answer");
 });
 
+test("information value: stall duration is elapsed time, not a count of scale readings", async () => {
+  const { stalledWeeksFrom } = await import("../server/day-ledger-core");
+  const at = (days: number) => new Date(Date.UTC(2026, 8, 7) - days * 86_400_000);
+  assert.equal(stalledWeeksFrom([
+    { kg: 88.0, at: at(5) }, { kg: 88.1, at: at(2) }, { kg: 88.0, at: at(0) },
+  ]), 0, "three readings across five days cannot manufacture a two-week stall");
+  assert.equal(stalledWeeksFrom([
+    { kg: 88.0, at: at(21) }, { kg: 88.1, at: at(14) },
+    { kg: 88.0, at: at(7) }, { kg: 88.1, at: at(0) },
+  ]), 3, "weekly chronology establishes three elapsed stalled weeks");
+});
+
+test("information value: weekend-stall investigation exists only for a weight goal", async () => {
+  const { decideProactive } = await import("../server/one-action");
+  const stalled = decisionState({
+    goalType: "general",
+    food: { loggedDays7d: 3, weekendLoggedDays7d: 0, daysSinceAnyLog: 0 },
+    weight: { daysSinceWeighIn: 1, trendUsable: true, stalledWeeks: 3 },
+    today: { kcal: 900, protein: 35, steps: 9000, logged: true, hour: 14 },
+    evidence: { foodSufficient: false, weightSufficient: true },
+  });
+  const move = decideProactive(stalled, decisionProfile as any, { hour: 14 });
+  assert.notEqual(move.action.investigation?.missingFact, "weekend_food",
+    "a general-wellness client is not interrogated to explain a scale outcome they are not pursuing");
+});
+
 test("information value: open loop, holds and do-not-mention retain precedence", async () => {
   const { decideProactive } = await import("../server/one-action");
   const stalled = decisionState({
@@ -3513,7 +3539,7 @@ test("information value: reactive and proactive doors use the same missing-fact 
   const opts = {
     foodSufficient: false, weightSufficient: true, loggedToday: true,
     daysSinceWeighIn: 1, hour: 14, loggedDays7d: 3, weekendLoggedDays7d: 0,
-    stalledWeeks: 3,
+    stalledWeeks: 3, weightIsGoal: true,
   };
   const proactive = decideProactive(state, decisionProfile as any, { hour: 14 }).action;
   const reactive = underPolicy(chooseAction(dayStateFrom(state, decisionProfile as any, { hour: 14 })), opts);

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -3455,6 +3455,85 @@ test("verdict: the downgrade asks for what is missing, never for what they just 
   assert.equal(nothingToAsk.line, "");
 });
 
+test("information value: a known stall asks for the missing weekend before changing food", async () => {
+  const { decideProactive } = await import("../server/one-action");
+  const state = decisionState({
+    food: { loggedDays7d: 3, weekendLoggedDays7d: 0, daysSinceAnyLog: 0 },
+    weight: { daysSinceWeighIn: 1, trendUsable: true, stalledWeeks: 3 },
+    today: { kcal: 900, protein: 35, steps: 9000, logged: true, hour: 14 },
+    evidence: { foodSufficient: false, weightSufficient: true },
+  });
+  const d = decideProactive(state, decisionProfile as any, { hour: 14 });
+  assert.equal(d.state, "INVESTIGATE");
+  assert.equal(d.action.kind, "log");
+  assert.equal(d.action.investigation?.missingFact, "weekend_food");
+  assert.match(d.action.todo, /weekend/i);
+  assert.equal((d.action.todo.match(/\?/g) || []).length, 1, "one turn asks one question");
+
+  const answered = decideProactive(decisionState({
+    ...state,
+    food: { ...state.food, weekendLoggedDays7d: 1 },
+  }), decisionProfile as any, { hour: 14 });
+  assert.notEqual(answered.action.investigation?.missingFact, "weekend_food",
+    "canonical weekend evidence closes this missing fact; silence never fabricates an answer");
+});
+
+test("information value: open loop, holds and do-not-mention retain precedence", async () => {
+  const { decideProactive } = await import("../server/one-action");
+  const stalled = decisionState({
+    food: { loggedDays7d: 3, weekendLoggedDays7d: 0, daysSinceAnyLog: 0 },
+    weight: { daysSinceWeighIn: 1, trendUsable: true, stalledWeeks: 3 },
+    today: { kcal: 1900, protein: 150, steps: 9000, logged: true, hour: 14 },
+    evidence: { foodSufficient: false, weightSufficient: true },
+  });
+  const open = decideProactive(stalled, decisionProfile as any, { trainingAwaitingOutcome: true, hour: 14 });
+  assert.notEqual(open.action.investigation?.missingFact, "weekend_food",
+    "an unresolved coaching outcome is already the one material question");
+
+  const forbidden = decideProactive(stalled,
+    { ...decisionProfile, doNotMention: "food and meals" } as any, { hour: 14 });
+  assert.notEqual(forbidden.action.investigation?.missingFact, "weekend_food");
+
+  const closed = decideProactive(stalled, decisionProfile as any, { foodDayClosed: true, hour: 14 });
+  assert.notEqual(closed.action.investigation?.missingFact, "weekend_food",
+    "a declared day hold is not replaced by a context question");
+
+  const sick = decideProactive({ ...stalled, health: { sick: true } }, decisionProfile as any, { hour: 14 });
+  assert.equal(sick.action.kind, "rest", "illness remains higher than information collection");
+});
+
+test("information value: reactive and proactive doors use the same missing-fact authority", async () => {
+  const { decideProactive, underPolicy, chooseAction, dayStateFrom } = await import("../server/one-action");
+  const state = decisionState({
+    food: { loggedDays7d: 3, weekendLoggedDays7d: 0, daysSinceAnyLog: 0 },
+    weight: { daysSinceWeighIn: 1, trendUsable: true, stalledWeeks: 3 },
+    today: { kcal: 900, protein: 35, steps: 9000, logged: true, hour: 14 },
+    evidence: { foodSufficient: false, weightSufficient: true },
+  });
+  const opts = {
+    foodSufficient: false, weightSufficient: true, loggedToday: true,
+    daysSinceWeighIn: 1, hour: 14, loggedDays7d: 3, weekendLoggedDays7d: 0,
+    stalledWeeks: 3,
+  };
+  const proactive = decideProactive(state, decisionProfile as any, { hour: 14 }).action;
+  const reactive = underPolicy(chooseAction(dayStateFrom(state, decisionProfile as any, { hour: 14 })), opts);
+  assert.equal(reactive.investigation?.missingFact, proactive.investigation?.missingFact);
+  assert.equal(reactive.todo, proactive.todo);
+});
+
+test("information value: an afternoon weight investigation is actionable", async () => {
+  const { decideProactive } = await import("../server/one-action");
+  const d = decideProactive(decisionState({
+    food: { loggedDays7d: 3, weekendLoggedDays7d: 1, daysSinceAnyLog: 0 },
+    weight: { daysSinceWeighIn: 3, trendUsable: false, stalledWeeks: 0 },
+    today: { kcal: 900, protein: 35, steps: 9000, logged: true, hour: 14 },
+    evidence: { foodSufficient: false, weightSufficient: false },
+  }), decisionProfile as any, { hour: 14 });
+  assert.equal(d.action.investigation?.missingFact, "weight_current");
+  assert.match(d.action.todo, /tomorrow morning/i);
+  assert.doesNotMatch(d.action.todo, /\bthis morning\b/i);
+});
+
 test("verdict: the reactive path is held to the same standard", () => {
   const cmd = readFileSync("server/handlers/one-action-command.ts", "utf-8");
   const code = cmd.split("\n").filter(l => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");

--- a/script/pg-information-value-acceptance.ts
+++ b/script/pg-information-value-acceptance.ts
@@ -1,0 +1,200 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the existing INVESTIGATE owner asks for the fact most likely to
+ * change its decision (#213). Rows matter here: weekend coverage, trend usability, stall length,
+ * open-loop durability and the later backdated answer cannot be proven by a fixture.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-information-value-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { eq } = await import("drizzle-orm");
+const { handleMessage } = await import("../server/routes");
+const { canonicalDecision } = await import("../server/understanding/live");
+const { canonicalNextMove } = await import("../server/scheduler/proactive-decision");
+const { getProgressTruth } = await import("../server/day-ledger");
+const { weekendLoggedDays } = await import("../server/day-ledger-core");
+const { ensureOpenTrainingLoop } = await import("../server/memory");
+const { sastDayKey } = await import("../server/sast");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+
+let failed = 0;
+const check = (ok: boolean, claim: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${claim}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+const ids: string[] = [];
+const ago = (days: number) => new Date(Date.now() - days * 86_400_000);
+const isWeekend = (at: Date) => weekendLoggedDays([{ day: sastDayKey(at) }]) === 1;
+
+async function freshUser(over: Record<string, unknown> = {}) {
+  const phoneNumber = `whatsapp:+2786${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [user] = await db.insert(schema.users).values({
+    phoneNumber, name: "Kam", onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "88.0", heightCm: 178, gender: "male", age: 35,
+    totalWorkoutsCompleted: 8, createdAt: ago(50), programmeStartDate: ago(50),
+    programmeWeek: 7, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(user.id);
+  return user;
+}
+
+async function seedMeals(userId: string, offsets: number[]) {
+  for (const offset of offsets) {
+    await pool.query(
+      `INSERT INTO meal_logs
+         (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+       VALUES ($1, $2, 'lunch', 650, 45, $3, 'seed', 'sa_scanner')`,
+      [userId, ago(offset), JSON.stringify([{ name: "pap", grams: 200, origin: "db" }])],
+    );
+  }
+}
+
+async function seedWeights(userId: string, points: Array<{ days: number; kg: number }>) {
+  for (const point of points) {
+    await pool.query(
+      "INSERT INTO weight_logs (user_id, weight, logged_at) VALUES ($1, $2, $3)",
+      [userId, point.kg, ago(point.days)],
+    );
+  }
+}
+
+const reload = async (id: string) =>
+  (await db.select().from(schema.users).where(eq(schema.users.id, id)).limit(1))[0];
+const say = async (phone: string, text: string) => String(await handleMessage(
+  phone, text, undefined, undefined, undefined, `SM-iv-${Math.random().toString(36).slice(2, 9)}`,
+) || "");
+const weekdayOffsets = Array.from({ length: 7 }, (_, i) => i).filter(i => !isWeekend(ago(i))).slice(0, 3);
+const stalled = [
+  { days: 0, kg: 88.0 }, { days: 7, kg: 88.1 },
+  { days: 14, kg: 88.0 }, { days: 21, kg: 88.1 },
+];
+
+REAL("\n=== A + D — STALL WITH A BOUNDED CONTEXT UNKNOWN ===");
+const a = await freshUser();
+await seedMeals(a.id, weekdayOffsets);
+await seedWeights(a.id, stalled);
+const before = await getProgressTruth(a, { days: 7 });
+check(before.window.daysLogged >= 2 && weekendLoggedDays(before.window.perDay) === 0,
+  "fixture has thin weekday food evidence and no weekend invention",
+  `days=${before.window.daysLogged} weekend=${weekendLoggedDays(before.window.perDay)}`);
+
+const beforeCount = Number((await pool.query("SELECT COUNT(*)::int AS n FROM meal_logs WHERE user_id=$1", [a.id])).rows[0].n);
+const silentDecision = await canonicalDecision(a, "how am I doing?");
+const afterCount = Number((await pool.query("SELECT COUNT(*)::int AS n FROM meal_logs WHERE user_id=$1", [a.id])).rows[0].n);
+check(beforeCount === afterCount, "choosing a missing fact stores no fabricated behaviour from silence");
+check(silentDecision.kind === "log" && /weekend/i.test(silentDecision.todo),
+  "reactive canonical decision chooses the weekend fact, not a generic measurement",
+  `kind=${silentDecision.kind} todo=${JSON.stringify(silentDecision.todo)}`);
+
+const proactive = await canonicalNextMove(a, { hour: 14 });
+check(proactive.action.investigation?.missingFact === "weekend_food",
+  "proactive decision selects the same explicit missing fact",
+  JSON.stringify(proactive.action));
+check(proactive.action.todo === silentDecision.todo,
+  "reactive and proactive doors ask the same one question",
+  `reactive=${JSON.stringify(silentDecision.todo)} proactive=${JSON.stringify(proactive.action.todo)}`);
+
+_resetOutboundDedupe();
+const liveReply = await say(a.phoneNumber, "Dinner is rice, mince and mixed veggies");
+check(/what did eating look like over the weekend\?/i.test(liveReply),
+  "the real customer front door delivers the authorized weekend question",
+  JSON.stringify(liveReply.slice(-220)));
+
+_resetOutboundDedupe();
+const answerReply = await say(a.phoneNumber, "Saturday I had pap and chicken. Sunday I had eggs and toast.");
+const answeredTruth = await getProgressTruth(await reload(a.id), { days: 7 });
+check(weekendLoggedDays(answeredTruth.window.perDay) > 0,
+  "the answer becomes canonical backdated weekend evidence",
+  JSON.stringify(answeredTruth.window.perDay));
+const afterAnswer = await canonicalDecision(await reload(a.id), "how am I doing now?");
+check(!/weekend/i.test(answerReply) && afterAnswer.todo !== silentDecision.todo,
+  "the answered fact is not asked again and the next decision changes or reconfirms",
+  `reply=${JSON.stringify(answerReply.slice(-180))} next=${JSON.stringify(afterAnswer.todo)}`);
+
+REAL("\n=== B — AN OPEN COACHING LOOP OUTRANKS A NEW QUESTION ===");
+const b = await freshUser();
+await seedMeals(b.id, weekdayOffsets);
+await seedWeights(b.id, stalled);
+await ensureOpenTrainingLoop(b, sastDayKey(), "reactive");
+_resetOutboundDedupe();
+const openReply = await say(b.phoneNumber, "I walked 8000 steps today");
+const openDecision = await canonicalDecision(await reload(b.id), "I walked 8000 steps today");
+check(!/what did eating look like over the weekend/i.test(openReply)
+    && !/weekend/i.test(openDecision.todo),
+  "an unresolved #208 outcome is not displaced by a competing investigation",
+  `reply=${JSON.stringify(openReply.slice(-180))} decision=${JSON.stringify(openDecision.todo)}`);
+
+REAL("\n=== C — STALE WEIGHT REMAINS THE RIGHT SIMPLE ASK ===");
+const c = await freshUser();
+await seedMeals(c.id, [0, 1, 2, 3, 4]);
+await seedWeights(c.id, [{ days: 11, kg: 88.0 }, { days: 18, kg: 89.0 }]);
+const stale = await canonicalNextMove(c, { hour: 14 });
+check(stale.action.investigation?.missingFact === "weight_current",
+  "adequate food plus stale weight keeps the existing measurement owner",
+  JSON.stringify(stale.action));
+check(/tomorrow morning/i.test(stale.action.todo) && !/\bthis morning\b/i.test(stale.action.todo),
+  "the 13:39 SAST control is actionable after the morning has elapsed",
+  JSON.stringify(stale.action.todo));
+
+REAL("\n=== E + CONTROLS — DO NOT INTERROGATE OR LEAK STATE ===");
+const e = await freshUser();
+await seedMeals(e.id, weekdayOffsets);
+await seedWeights(e.id, [
+  { days: 0, kg: 88.0 }, { days: 7, kg: 89.0 }, { days: 14, kg: 90.0 },
+]);
+const safe = await canonicalNextMove(e, { hour: 14 });
+check(safe.action.investigation?.missingFact !== "weekend_food",
+  "without a stall, a merely available question is not asked",
+  JSON.stringify(safe.action));
+
+const forbidden = await freshUser({ doNotMention: "food and meals" });
+await seedMeals(forbidden.id, weekdayOffsets);
+await seedWeights(forbidden.id, stalled);
+const forbiddenMove = await canonicalNextMove(forbidden, { hour: 14 });
+check(forbiddenMove.action.investigation?.missingFact !== "weekend_food",
+  "doNotMention still blocks the context question",
+  JSON.stringify(forbiddenMove.action));
+
+const ill = await freshUser({
+  profileNotes: `sick_since:${sastDayKey()} | sick_until:${sastDayKey()} | paused_until:${sastDayKey()}`,
+});
+await seedMeals(ill.id, weekdayOffsets);
+await seedWeights(ill.id, stalled);
+const illMove = await canonicalNextMove(ill, { hour: 14 });
+check(illMove.action.kind === "rest" && !illMove.action.investigation,
+  "illness retains precedence over information collection",
+  JSON.stringify(illMove.action));
+
+const isolated = await freshUser();
+await seedMeals(isolated.id, weekdayOffsets);
+await seedWeights(isolated.id, stalled);
+const isolatedMove = await canonicalNextMove(isolated, { hour: 14 });
+check(isolatedMove.action.investigation?.missingFact === "weekend_food",
+  "one client's answer never fills another client's missing fact",
+  JSON.stringify(isolatedMove.action));
+
+for (const id of ids) await db.delete(schema.users).where(eq(schema.users.id, id)).catch(() => {});
+await pool.end();
+if (failed) {
+  REAL(`\npg-information-value-acceptance: RED — ${failed} check(s) failed`);
+  process.exit(1);
+}
+REAL("\npg-information-value-acceptance: GREEN — LOCAL REAL POSTGRESQL");
+process.exit(0);

--- a/script/pg-information-value-acceptance.ts
+++ b/script/pg-information-value-acceptance.ts
@@ -25,10 +25,11 @@ const schema = await import("../shared/schema");
 const { eq } = await import("drizzle-orm");
 const { handleMessage } = await import("../server/routes");
 const { canonicalDecision } = await import("../server/understanding/live");
-const { canonicalNextMove } = await import("../server/scheduler/proactive-decision");
+const { canonicalNextMove, recordCanonicalMoveOutbound } = await import("../server/scheduler/proactive-decision");
+const { loadProactiveState } = await import("../server/scheduler/shared");
 const { getProgressTruth } = await import("../server/day-ledger");
 const { weekendLoggedDays } = await import("../server/day-ledger-core");
-const { ensureOpenTrainingLoop } = await import("../server/memory");
+const { ensureOpenTrainingLoop, weekendInvestigationAnswered } = await import("../server/memory");
 const { sastDayKey } = await import("../server/sast");
 const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
 
@@ -116,6 +117,23 @@ const liveReply = await say(a.phoneNumber, "Dinner is rice, mince and mixed vegg
 check(/what did eating look like over the weekend\?/i.test(liveReply),
   "the real customer front door delivers the authorized weekend question",
   JSON.stringify(liveReply.slice(-220)));
+const openedA = await reload(a.id);
+check(/investigate_weekend_food_open:/i.test(String(openedA.profileNotes || "")),
+  "the reactive question becomes durable only after it is included in the handed-off reply",
+  JSON.stringify(openedA.profileNotes));
+
+const nonMealCount = Number((await pool.query("SELECT COUNT(*)::int AS n FROM meal_logs WHERE user_id=$1", [a.id])).rows[0].n);
+await say(a.phoneNumber, "I was travelling and didn't track");
+const nonMealAnswered = await reload(a.id);
+const nonMealAfterCount = Number((await pool.query("SELECT COUNT(*)::int AS n FROM meal_logs WHERE user_id=$1", [a.id])).rows[0].n);
+const afterNonMealAnswer = await canonicalDecision(nonMealAnswered, "how am I doing now?");
+check(nonMealAfterCount === nonMealCount,
+  "a truthful no-tracking answer closes the unknown without inventing database-shaped backfill");
+check(weekendInvestigationAnswered(nonMealAnswered)
+    && /investigate_weekend_food_answered:\d{4}-\d{2}-\d{2}:untracked/i.test(String(nonMealAnswered.profileNotes || ""))
+    && afterNonMealAnswer.investigation?.missingFact !== "weekend_food",
+  "'I was travelling and didn't track' durably closes the open question",
+  `notes=${JSON.stringify(nonMealAnswered.profileNotes)} next=${JSON.stringify(afterNonMealAnswer.todo)}`);
 
 _resetOutboundDedupe();
 const answerReply = await say(a.phoneNumber, "Saturday I had pap and chicken. Sunday I had eggs and toast.");
@@ -127,6 +145,29 @@ const afterAnswer = await canonicalDecision(await reload(a.id), "how am I doing 
 check(!/weekend/i.test(answerReply) && afterAnswer.todo !== silentDecision.todo,
   "the answered fact is not asked again and the next decision changes or reconfirms",
   `reply=${JSON.stringify(answerReply.slice(-180))} next=${JSON.stringify(afterAnswer.todo)}`);
+
+const normal = await freshUser();
+await seedMeals(normal.id, weekdayOffsets);
+await seedWeights(normal.id, stalled);
+_resetOutboundDedupe();
+await say(normal.phoneNumber, "Dinner is rice, mince and mixed veggies");
+await say(normal.phoneNumber, "It was normal");
+const normalAnswered = await reload(normal.id);
+check(weekendInvestigationAnswered(normalAnswered)
+    && /investigate_weekend_food_answered:\d{4}-\d{2}-\d{2}:usual/i.test(String(normalAnswered.profileNotes || "")),
+  "'it was normal' is accepted as the bounded answer to the question actually open",
+  JSON.stringify(normalAnswered.profileNotes));
+
+const handoff = await freshUser();
+await seedMeals(handoff.id, weekdayOffsets);
+await seedWeights(handoff.id, stalled);
+const handoffMove = await canonicalNextMove(handoff, { hour: 14 });
+await recordCanonicalMoveOutbound(handoff, handoffMove, "dropped");
+check(!/investigate_weekend_food_open:/i.test(String((await reload(handoff.id)).profileNotes || "")),
+  "selecting or dropping a proactive question creates no phantom open investigation");
+await recordCanonicalMoveOutbound(handoff, handoffMove, "sent");
+check(/investigate_weekend_food_open:/i.test(String((await reload(handoff.id)).profileNotes || "")),
+  "an accepted proactive handoff opens the same durable investigation");
 
 REAL("\n=== B — AN OPEN COACHING LOOP OUTRANKS A NEW QUESTION ===");
 const b = await freshUser();
@@ -163,6 +204,44 @@ const safe = await canonicalNextMove(e, { hour: 14 });
 check(safe.action.investigation?.missingFact !== "weekend_food",
   "without a stall, a merely available question is not asked",
   JSON.stringify(safe.action));
+
+const frequent = await freshUser();
+await seedMeals(frequent.id, weekdayOffsets);
+await seedWeights(frequent.id, [
+  { days: 0, kg: 88.0 }, { days: 2, kg: 88.1 }, { days: 5, kg: 88.0 },
+]);
+const frequentState = await loadProactiveState(frequent);
+const frequentReactive = await canonicalDecision(frequent, "how am I doing?");
+const frequentProactive = await canonicalNextMove(frequent, { hour: 14 });
+check(frequentState.weight.stalledWeeks === 0
+    && frequentReactive.investigation?.missingFact !== "weekend_food"
+    && frequentProactive.action.investigation?.missingFact !== "weekend_food",
+  "0/2/5-day flat readings are zero elapsed stalled weeks through both decision doors",
+  `weeks=${frequentState.weight.stalledWeeks} reactive=${JSON.stringify(frequentReactive.todo)} proactive=${JSON.stringify(frequentProactive.action.todo)}`);
+
+const oneWindow = await freshUser({
+  profileNotes: `sick_since:${sastDayKey(ago(40))} | sick_until:${sastDayKey(ago(35))}`,
+});
+await seedMeals(oneWindow.id, weekdayOffsets);
+await seedWeights(oneWindow.id, [
+  { days: 0, kg: 88.0 }, { days: 8, kg: 88.1 }, { days: 16, kg: 88.0 }, { days: 40, kg: 88.1 },
+]);
+const windowReactive = await canonicalDecision(oneWindow, "how am I doing?");
+const windowProactive = await canonicalNextMove(oneWindow, { hour: 14 });
+check(windowReactive.investigation?.missingFact === "weekend_food"
+    && windowProactive.action.investigation?.missingFact === "weekend_food",
+  "reactive and proactive decisions share the canonical 28-day weight window",
+  `reactive=${JSON.stringify(windowReactive.todo)} proactive=${JSON.stringify(windowProactive.action.todo)}`);
+
+const wellness = await freshUser({ goalType: "general" });
+await seedMeals(wellness.id, weekdayOffsets);
+await seedWeights(wellness.id, stalled);
+const wellnessReactive = await canonicalDecision(wellness, "how am I doing?");
+const wellnessProactive = await canonicalNextMove(wellness, { hour: 14 });
+check(wellnessReactive.investigation?.missingFact !== "weekend_food"
+    && wellnessProactive.action.investigation?.missingFact !== "weekend_food",
+  "a non-weight goal cannot trigger weekend-stall investigation through either door",
+  `reactive=${JSON.stringify(wellnessReactive.todo)} proactive=${JSON.stringify(wellnessProactive.action.todo)}`);
 
 const forbidden = await freshUser({ doNotMention: "food and meals" });
 await seedMeals(forbidden.id, weekdayOffsets);

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -2586,9 +2586,11 @@ async function main() {
         [chatHistory, [{ id: 1, createdAt: today, intent: "FOOD_LOG", messageIn: "chicken and rice" }]],
         [mealLogs, [meal]],
         [workoutLogs, []],                                  // zero sessions this week
+        // getWeightTruth is the shared owner and orders oldest -> newest; the stub does not apply
+        // orderBy, so its seeded rows must have the chronology the real PostgreSQL query returns.
         [weightLogs, [
-          { id: 2, weight: "82.0", w: "82.0", at: new Date(NOW - 86_400_000), loggedAt: new Date(NOW - 86_400_000) },
           { id: 1, weight: "83.4", w: "83.4", at: new Date(NOW - 20 * 86_400_000), loggedAt: new Date(NOW - 20 * 86_400_000) },
+          { id: 2, weight: "82.0", w: "82.0", at: new Date(NOW - 86_400_000), loggedAt: new Date(NOW - 86_400_000) },
         ]],
         [stepLogs, [{ avg: 9000, steps: 9000, at: today, loggedAt: today }]],
         // WHAT THEY RULED OUT TODAY IS A ROW NOW (#194), not a sentence re-derived from the last

--- a/server/day-ledger-core.ts
+++ b/server/day-ledger-core.ts
@@ -137,6 +137,26 @@ export function weightChangeKg(weighIns: Array<{ weight: unknown }>): number | n
   return Math.round((kgs[kgs.length - 1] - kgs[0]) * 10) / 10;
 }
 
+/** Weeks of no meaningful movement (<0.3kg), with readings ordered newest first. */
+export function stalledWeeksFrom(weights: number[]): number {
+  if (weights.length < 3) return 0;
+  const newest = weights[0];
+  let weeks = 0;
+  for (const weight of weights.slice(1)) {
+    if (Math.abs(newest - weight) >= 0.3) break;
+    weeks++;
+  }
+  return weeks;
+}
+
+/** Logged weekend days in an already-canonical SAST window. */
+export function weekendLoggedDays(perDay: Array<{ day: string }>): number {
+  return perDay.filter(({ day }) => {
+    const weekday = new Date(`${day}T12:00:00Z`).getUTCDay();
+    return weekday === 0 || weekday === 6;
+  }).length;
+}
+
 // ── FOOD PROVENANCE — how much of this window do we actually KNOW? ──────────────────────────
 // Moved here from report-card.ts in Cut 11: pure derivation over ledger rows, which is what
 // this module is for, and the canonical progress object is now its main consumer. Known /

--- a/server/day-ledger-core.ts
+++ b/server/day-ledger-core.ts
@@ -137,16 +137,22 @@ export function weightChangeKg(weighIns: Array<{ weight: unknown }>): number | n
   return Math.round((kgs[kgs.length - 1] - kgs[0]) * 10) / 10;
 }
 
-/** Weeks of no meaningful movement (<0.3kg), with readings ordered newest first. */
-export function stalledWeeksFrom(weights: number[]): number {
-  if (weights.length < 3) return 0;
-  const newest = weights[0];
-  let weeks = 0;
-  for (const weight of weights.slice(1)) {
-    if (Math.abs(newest - weight) >= 0.3) break;
-    weeks++;
+/**
+ * Whole elapsed weeks with no meaningful movement (<0.3kg), over canonical chronological points.
+ * A reading is not a week: three flat readings in five days are still zero stalled weeks.
+ */
+export function stalledWeeksFrom(points: Array<{ kg: number; at: Date }>): number {
+  const ordered = points
+    .filter(p => Number.isFinite(p.kg) && Number.isFinite(p.at?.getTime()))
+    .slice().sort((a, b) => a.at.getTime() - b.at.getTime());
+  if (ordered.length < 2) return 0;
+  const newest = ordered[ordered.length - 1];
+  let earliest = newest;
+  for (let i = ordered.length - 2; i >= 0; i--) {
+    if (Math.abs(newest.kg - ordered[i].kg) >= 0.3) break;
+    earliest = ordered[i];
   }
-  return weeks;
+  return Math.floor((newest.at.getTime() - earliest.at.getTime()) / (7 * 86_400_000));
 }
 
 /** Logged weekend days in an already-canonical SAST window. */

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -13,6 +13,7 @@ import {
 type WeekendAnswer = "untracked" | "usual" | "reported";
 type WeekendInvestigation = { state: "open" | "answered"; day: string; outcome?: WeekendAnswer };
 const WEEKEND_ANSWER = { UNTRACKED: "untracked", USUAL: "usual", REPORTED: "reported" } as const;
+const WEEKEND_ANSWER_TERMS = ["weekend", "saturday", "sunday"] as const;
 const WEEKEND_INVESTIGATION_DB_RE = "\\s*\\|?\\s*investigate_weekend_food_(open|answered):[0-9]{4}-[0-9]{2}-[0-9]{2}(:((untracked|usual|reported)))?";
 
 function readWeekendInvestigation(user: any, now = Date.now()): WeekendInvestigation | null {
@@ -58,7 +59,7 @@ function weekendAnswerFrom(message: string): WeekendAnswer | null {
     .some(signal => words.includes(signal))) return WEEKEND_ANSWER.UNTRACKED;
   if (["normal", "usual", "same as usual", "nothing different", "nothing unusual"]
     .some(signal => words.includes(signal))) return WEEKEND_ANSWER.USUAL;
-  return ["weekend", "saturday", "sunday"].some(signal => words.includes(signal)) ? WEEKEND_ANSWER.REPORTED : null;
+  return WEEKEND_ANSWER_TERMS.some(signal => words.includes(signal)) ? WEEKEND_ANSWER.REPORTED : null;
 }
 
 /** Close the open question with a bounded durable answer; an answer need not invent meal rows. */

--- a/server/memory.ts
+++ b/server/memory.ts
@@ -1,13 +1,84 @@
 import { pool } from "./db";
 import OpenAI from "openai";
 import { assertAiOnline, isAiOfflineError } from "./ai-offline";
-import { sastDaysBetween } from "./sast";
+import { sastDayKey, sastDaysBetween } from "./sast";
+import { looksLikeQuestion } from "./utils";
 import {
   createOpenTrainingLoop,
   isOpenTrainingLoopMarker,
   readOpenTrainingLoop,
   type OpenTrainingLoop,
 } from "./workout-feedback";
+
+type WeekendAnswer = "untracked" | "usual" | "reported";
+type WeekendInvestigation = { state: "open" | "answered"; day: string; outcome?: WeekendAnswer };
+const WEEKEND_ANSWER = { UNTRACKED: "untracked", USUAL: "usual", REPORTED: "reported" } as const;
+const WEEKEND_INVESTIGATION_DB_RE = "\\s*\\|?\\s*investigate_weekend_food_(open|answered):[0-9]{4}-[0-9]{2}-[0-9]{2}(:((untracked|usual|reported)))?";
+
+function readWeekendInvestigation(user: any, now = Date.now()): WeekendInvestigation | null {
+  for (const token of String(user?.profileNotes || "").split("|").map(part => part.trim())) {
+    const state = token.startsWith("investigate_weekend_food_open:") ? "open"
+      : token.startsWith("investigate_weekend_food_answered:") ? "answered" : null;
+    if (!state) continue;
+    const [day, outcome] = token.slice(`investigate_weekend_food_${state}:`.length).split(":");
+    if (day.length !== 10 || !Number.isFinite(new Date(`${day}T12:00:00+02:00`).getTime())) continue;
+    const age = sastDaysBetween(new Date(`${day}T12:00:00+02:00`), now);
+    if (age >= 0 && age <= 7) return { state, day, outcome: outcome as WeekendAnswer | undefined };
+  }
+  return null;
+}
+
+/** The weekend unknown has already been answered for this decision window, even without meal rows. */
+export function weekendInvestigationAnswered(user: any, now = Date.now()): boolean {
+  return readWeekendInvestigation(user, now)?.state === "answered";
+}
+
+/** Persist the question only at an outbound handoff boundary. profileNotes is the existing fact owner. */
+export async function ensureOpenWeekendInvestigation(user: any, now = Date.now()): Promise<boolean> {
+  const current = readWeekendInvestigation(user, now);
+  if (current) return current.state === "open";
+  const token = `investigate_weekend_food_open:${sastDayKey(now)}`;
+  const updated = await pool.query(
+    `UPDATE users
+        SET profile_notes = concat_ws(' | ', NULLIF(btrim(regexp_replace(COALESCE(profile_notes, ''), $1, '', 'gi'), ' |'), ''), $2::text)
+      WHERE id = $3
+      RETURNING profile_notes`,
+    [WEEKEND_INVESTIGATION_DB_RE, token, user.id],
+  ).catch(() => ({ rows: [] }));
+  if (!updated.rows.length) return false;
+  user.profileNotes = updated.rows[0].profile_notes;
+  return true;
+}
+
+function weekendAnswerFrom(message: string): WeekendAnswer | null {
+  const text = String(message || "").trim();
+  if (!text || looksLikeQuestion(text)) return null;
+  const words = text.toLowerCase().replaceAll("’", "'");
+  if (["travel", "didn't track", "did not track", "didn't log", "did not log", "not tracked", "not logged", "can't remember", "cannot remember"]
+    .some(signal => words.includes(signal))) return WEEKEND_ANSWER.UNTRACKED;
+  if (["normal", "usual", "same as usual", "nothing different", "nothing unusual"]
+    .some(signal => words.includes(signal))) return WEEKEND_ANSWER.USUAL;
+  return ["weekend", "saturday", "sunday"].some(signal => words.includes(signal)) ? WEEKEND_ANSWER.REPORTED : null;
+}
+
+/** Close the open question with a bounded durable answer; an answer need not invent meal rows. */
+export async function resumeOpenWeekendInvestigation(user: any, message: string, now = Date.now()): Promise<boolean> {
+  const current = readWeekendInvestigation(user, now);
+  const outcome = weekendAnswerFrom(message);
+  if (current?.state !== "open" || !outcome) return false;
+  const openToken = `investigate_weekend_food_open:${current.day}`;
+  const answeredToken = `investigate_weekend_food_answered:${current.day}:${outcome}`;
+  const updated = await pool.query(
+    `UPDATE users
+        SET profile_notes = concat_ws(' | ', NULLIF(btrim(regexp_replace(COALESCE(profile_notes, ''), $1, '', 'gi'), ' |'), ''), $2::text)
+      WHERE id = $3 AND position($4 in COALESCE(profile_notes, '')) > 0
+      RETURNING profile_notes`,
+    [WEEKEND_INVESTIGATION_DB_RE, answeredToken, user.id, openToken],
+  ).catch(() => ({ rows: [] }));
+  if (!updated.rows.length) return false;
+  user.profileNotes = updated.rows[0].profile_notes;
+  return true;
+}
 
 const openai = new OpenAI({
   apiKey: process.env.AI_INTEGRATIONS_OPENAI_API_KEY || process.env.OPENAI_API_KEY || "sk-missing-key",
@@ -295,7 +366,7 @@ export async function retrieveMemories(phone: string, query: string): Promise<st
 import { db } from "./db";
 import { clientTruthCommits, users } from "../shared/schema";
 import { and, eq, sql } from "drizzle-orm";
-import { looksLikeQuestion, isFutureIntent } from "./utils";
+import { isFutureIntent } from "./utils";
 import { foodConstraints } from "./food-swaps";
 
 export type DurableFactField =

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -146,6 +146,11 @@ export interface OneAction {
   todo: string;
   /** Why it matters — in their language, tied to the dream when we have one. */
   why: string;
+  /** The explicit fact this INVESTIGATE action is asking for, and why it can change the decision. */
+  investigation?: {
+    missingFact: "food_today" | "weight_current" | "weekend_food";
+    whyItMatters: string;
+  };
 }
 
 // ── WHAT GETS IN THEIR WAY ───────────────────────────────────────────────────────────────────
@@ -224,6 +229,7 @@ function askToLog(dream?: string | null): OneAction {
     kind: "log",
     todo: "Tell me what you ate today — one line is enough.",
     why: why("I can't coach a day I can't see.", dream),
+    investigation: { missingFact: "food_today", whyItMatters: "Today's food is absent." },
   };
 }
 
@@ -235,16 +241,29 @@ function holdAction(dream?: string | null): OneAction {
   };
 }
 
-function askToWeigh(dream?: string | null, neverWeighed = false): OneAction {
+function askToWeigh(dream?: string | null, neverWeighed = false, hour = 8): OneAction {
   return {
     kind: "weigh",
-    todo: "Stand on a scale this morning, before you eat.",
+    todo: `Stand on a scale ${hour >= 12 ? "tomorrow morning" : "this morning"}, before you eat.`,
     why: why(
       neverWeighed
         ? "It's one number and it's the only way either of us sees this working."
-        : "It's been a while — one number today and I can show you what's actually happening.",
+        : `It's been a while — one number ${hour >= 12 ? "tomorrow morning" : "today"} and I can show you what's actually happening.`,
       dream,
     ),
+    investigation: { missingFact: "weight_current", whyItMatters: "The weight evidence is missing or stale." },
+  };
+}
+
+function askAboutWeekend(dream?: string | null): OneAction {
+  return {
+    kind: "log",
+    todo: "What did eating look like over the weekend?",
+    why: why("That will tell me whether the plan needs changing or just carrying on.", dream),
+    investigation: {
+      missingFact: "weekend_food",
+      whyItMatters: "The stalled trend is known, but the weekend food evidence that could explain it is not.",
+    },
   };
 }
 
@@ -556,7 +575,7 @@ export function chooseAction(s: DayState): OneAction {
   const neverWeighed = s.daysSinceWeighIn === null;
   const scaleIsOffLimits = mentionsForbidden("weight scale weigh", s.doNotMention);
   if (!scaleIsOffLimits && ((neverWeighed && s.weeksOnProgramme >= 1) || (s.daysSinceWeighIn !== null && s.daysSinceWeighIn >= 10))) {
-    return askToWeigh(s.dreamGoal, neverWeighed);
+    return askToWeigh(s.dreamGoal, neverWeighed, s.hour);
   }
 
   // 4. UNDER-FUELLED ON A BULK. Nothing else works if they aren't eating.
@@ -680,10 +699,10 @@ export interface ProactiveStateForDecision {
   name: string;
   goalType: string;
   health: { sick: boolean };
-  food: { loggedDays7d: number | null; daysSinceAnyLog: number | null };
+  food: { loggedDays7d: number | null; weekendLoggedDays7d?: number | null; daysSinceAnyLog: number | null };
   workout: { sessionsLast7d: number; sessionsThisWeek?: number };
   steps: { avg7d: number | null };
-  weight: { daysSinceWeighIn: number | null; trendUsable: boolean };
+  weight: { daysSinceWeighIn: number | null; trendUsable: boolean; stalledWeeks?: number };
   today: { kcal: number; protein: number; steps: number; logged: boolean; hour: number };
   evidence: { foodSufficient: boolean; weightSufficient: boolean };
 }
@@ -912,8 +931,20 @@ export function underPolicy(
     foodSufficient: boolean; weightSufficient: boolean; dreamGoal?: string | null;
     /** From the same DayState the caller just built. Omitted = there is nothing worth asking. */
     loggedToday?: boolean; daysSinceWeighIn?: number | null; doNotMention?: string | null;
+    hour?: number; loggedDays7d?: number | null; weekendLoggedDays7d?: number | null;
+    stalledWeeks?: number; trainingAwaitingOutcome?: boolean;
+    foodDayClosed?: boolean; trainingDeclined?: boolean;
   },
 ): OneAction {
+  const asksUsefulWeekendFact = action.kind !== "rest" && action.kind !== "weigh"
+    && action.kind !== "come_back" && !opts.trainingAwaitingOutcome
+    && !opts.foodDayClosed && !opts.trainingDeclined
+    && opts.weightSufficient && (opts.stalledWeeks ?? 0) >= 2
+    && !opts.foodSufficient && (opts.loggedDays7d ?? 0) >= 2
+    && opts.weekendLoggedDays7d === 0
+    && !mentionsForbidden("food meal eat weekend", opts.doNotMention);
+  if (asksUsefulWeekendFact) return askAboutWeekend(opts.dreamGoal);
+
   const verdict = evidenceFromKind(action.kind)
     ?? evidenceFromLedger(opts.foodSufficient, opts.weightSufficient);
   if (verdict === "sufficient") return action;
@@ -936,7 +967,8 @@ export function underPolicy(
     foodSufficient: opts.foodSufficient, weightSufficient: opts.weightSufficient,
     loggedToday: opts.loggedToday ?? true,
     daysSinceWeighIn: opts.daysSinceWeighIn === undefined ? 0 : opts.daysSinceWeighIn,
-    doNotMention: opts.doNotMention, dreamGoal: opts.dreamGoal,
+    doNotMention: opts.doNotMention, dreamGoal: opts.dreamGoal, hour: opts.hour ?? 8,
+    trainingAwaitingOutcome: opts.trainingAwaitingOutcome,
   });
 }
 
@@ -958,13 +990,15 @@ export function underPolicy(
 function investigateInstead(ctx: {
   foodSufficient: boolean; weightSufficient: boolean; loggedToday: boolean;
   daysSinceWeighIn: number | null; doNotMention?: string | null; dreamGoal?: string | null;
+  hour: number; trainingAwaitingOutcome?: boolean;
 }): OneAction {
+  if (ctx.trainingAwaitingOutcome) return holdAction(ctx.dreamGoal);
   const canAskForFood = !ctx.foodSufficient && !ctx.loggedToday;
   const staleWeight = ctx.daysSinceWeighIn === null || ctx.daysSinceWeighIn >= 3;
   const canAskForWeight = !ctx.weightSufficient && staleWeight
     && !mentionsForbidden("weight scale weigh", ctx.doNotMention);
   return canAskForFood ? askToLog(ctx.dreamGoal)
-    : canAskForWeight ? askToWeigh(ctx.dreamGoal, ctx.daysSinceWeighIn === null)
+    : canAskForWeight ? askToWeigh(ctx.dreamGoal, ctx.daysSinceWeighIn === null, ctx.hour)
     : holdAction(ctx.dreamGoal);
 }
 
@@ -1029,14 +1063,18 @@ export function decideProactive(
   // rows produced an investigative ask when the client messaged us and CONTINUE/silence when we
   // messaged them. Convergence that only runs one way is not convergence. A hold under SUFFICIENT
   // evidence is still an earned verdict here, exactly as it is there.
-  if ((PRESCRIPTIVE.has(action.kind) || action.kind === "hold") && evidence === "insufficient") {
-    action = investigateInstead({
-      foodSufficient: s.evidence.foodSufficient, weightSufficient: s.evidence.weightSufficient,
-      loggedToday: s.today.logged, daysSinceWeighIn: s.weight.daysSinceWeighIn,
-      doNotMention: p.doNotMention, dreamGoal: p.dreamGoal,
-    });
-    evidence = evidenceFor(s, action.kind);
-  }
+  action = underPolicy(action, {
+    foodSufficient: s.evidence.foodSufficient, weightSufficient: s.evidence.weightSufficient,
+    loggedToday: s.today.logged, daysSinceWeighIn: s.weight.daysSinceWeighIn,
+    doNotMention: p.doNotMention, dreamGoal: p.dreamGoal, hour: opts?.hour ?? s.today.hour,
+    loggedDays7d: s.food.loggedDays7d,
+    weekendLoggedDays7d: s.food.weekendLoggedDays7d,
+    stalledWeeks: s.weight.stalledWeeks,
+    trainingAwaitingOutcome: opts?.trainingAwaitingOutcome,
+    foodDayClosed: opts?.foodDayClosed,
+    trainingDeclined: opts?.trainingDeclined,
+  });
+  evidence = evidenceFor(s, action.kind);
 
   const investigating = INVESTIGATIVE.has(action.kind);
   const state = selectDecisionState({

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -27,7 +27,7 @@
  * Pure — no DB, no model. Unit-tested.
  */
 
-import type { GoalKey } from "./goal-profiles";
+import { getGoalProfile, type GoalKey } from "./goal-profiles";
 import { selectDecisionState, type DecisionEvidence } from "./understanding/state";
 // Pure, and it has to be: the verifier owns "may this reach a client" and carries no database or
 // model, so the decision can ask it what the client asked us not to say (Cut 8).
@@ -738,7 +738,7 @@ export interface ProactiveProfile {
  */
 export function dayStateFrom(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; justAteProteinMeal?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; weekendInvestigationAnswered?: boolean; justAteProteinMeal?: boolean },
 ): DayState {
   return {
     firstName: s.name,
@@ -933,12 +933,14 @@ export function underPolicy(
     loggedToday?: boolean; daysSinceWeighIn?: number | null; doNotMention?: string | null;
     hour?: number; loggedDays7d?: number | null; weekendLoggedDays7d?: number | null;
     stalledWeeks?: number; trainingAwaitingOutcome?: boolean;
-    foodDayClosed?: boolean; trainingDeclined?: boolean;
+    foodDayClosed?: boolean; trainingDeclined?: boolean; weekendInvestigationAnswered?: boolean;
+    weightIsGoal?: boolean;
   },
 ): OneAction {
   const asksUsefulWeekendFact = action.kind !== "rest" && action.kind !== "weigh"
     && action.kind !== "come_back" && !opts.trainingAwaitingOutcome
     && !opts.foodDayClosed && !opts.trainingDeclined
+    && opts.weightIsGoal === true && !opts.weekendInvestigationAnswered
     && opts.weightSufficient && (opts.stalledWeeks ?? 0) >= 2
     && !opts.foodSufficient && (opts.loggedDays7d ?? 0) >= 2
     && opts.weekendLoggedDays7d === 0
@@ -1032,7 +1034,7 @@ function evidenceFor(s: ProactiveStateForDecision, kind: ActionKind): DecisionEv
 
 export function decideProactive(
   s: ProactiveStateForDecision, p: ProactiveProfile,
-  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; justAteProteinMeal?: boolean },
+  opts?: { atKeyboard?: boolean; hour?: number; foodDayClosed?: boolean; trainingDeclined?: boolean; trainingAwaitingOutcome?: boolean; weekendInvestigationAnswered?: boolean; justAteProteinMeal?: boolean },
 ): ProactiveDecision {
   let action = chooseAction(dayStateFrom(s, p, opts));
   let evidence = evidenceFor(s, action.kind);
@@ -1073,6 +1075,8 @@ export function decideProactive(
     trainingAwaitingOutcome: opts?.trainingAwaitingOutcome,
     foodDayClosed: opts?.foodDayClosed,
     trainingDeclined: opts?.trainingDeclined,
+    weekendInvestigationAnswered: opts?.weekendInvestigationAnswered,
+    weightIsGoal: getGoalProfile(s.goalType).weightIsGoal,
   });
   evidence = evidenceFor(s, action.kind);
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,7 +17,7 @@ import { handleOnboarding, getMenuText, getOnboardingMealPlan } from "./onboardi
 import { saysNotWorking } from "./despair";
 import { getShoppingList, formatShoppingList } from "./shopping-lists";
 import { nutritionAgent, programmingAgent, mindsetAgent, adminAgent, routeToAgent } from "./agents";
-import { recordClientFacts, bindClientTruth } from "./memory";
+import { recordClientFacts, bindClientTruth, resumeOpenWeekendInvestigation } from "./memory";
 import { generateVoiceNote, getVoiceFilePath, voiceFileExists } from "./tts";
 import { sendWhatsApp } from "./scheduler";
 import { recordConversion } from "./ab";
@@ -593,7 +593,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
 
   /** Every exit for a durable-write turn closes through the decision owner — see
    *  understanding/live.closeCoachingTurn and tracking-contract-tests LAW 4. */
-  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const trainingLoopOutcome = await resumeOpenTrainingLoopOutcome({ message, m, user, sourceMessageId });
+  const closeCoachingTurn = (reply: string | null) => closeCoachingTurnFor(user, message, reply); const trainingLoopOutcome = await resumeOpenTrainingLoopOutcome({ message, m, user, sourceMessageId }); await resumeOpenWeekendInvestigation(user, message);
   if (trainingLoopOutcome !== null) turnEvidence({ conversationalOnly: true });
   const feedbackReply = await resumeWorkoutFeedbackExpectation({ phone, message, m, user }); if (feedbackReply !== null) turnEvidence({ conversationalOnly: true });
   if (feedbackReply !== null && mayEndTurn("workout-feedback")) return closeCoachingTurn(feedbackReply); if (feedbackReply !== null) commitFact(turn, "workout", feedbackReply); if (normalizerLive() && !mediaUrl && user.onboardingState === "COMPLETE" && !user.awaitingInputType) {

--- a/server/scheduler/proactive-decision.ts
+++ b/server/scheduler/proactive-decision.ts
@@ -39,7 +39,7 @@ import { readHeldConstraints, NO_CONSTRAINTS, type HeldConstraints } from "../he
 import { loadProactiveState } from "./shared";
 import { foodConstraints } from "../food-swaps";
 import { sastDayKey } from "../sast";
-import { ensureOpenTrainingLoop, loadOpenTrainingLoop } from "../memory";
+import { ensureOpenTrainingLoop, ensureOpenWeekendInvestigation, loadOpenTrainingLoop, weekendInvestigationAnswered } from "../memory";
 import { deliveryAccepted, type DeliveryResult } from "../outbound-delivery";
 
 export interface CanonicalMove {
@@ -53,11 +53,14 @@ export interface CanonicalMove {
   degraded: boolean;
 }
 
-/** Persist only a training move that a proactive sender has actually handed to its outbound door. */
+/** Persist a follow-up only after a proactive sender has actually handed its move to outbound. */
 export async function recordCanonicalMoveOutbound(client: any, move: CanonicalMove, delivery: DeliveryResult) {
-  return move.action.kind === "train" && deliveryAccepted(delivery)
-    ? ensureOpenTrainingLoop(client, sastDayKey(), "proactive")
-    : null;
+  if (!deliveryAccepted(delivery)) return null;
+  if (move.action.kind === "train") return ensureOpenTrainingLoop(client, sastDayKey(), "proactive");
+  if (move.action.investigation?.missingFact === "weekend_food") {
+    return ensureOpenWeekendInvestigation(client);
+  }
+  return null;
 }
 
 function profileOf(client: any) {
@@ -99,6 +102,7 @@ export async function canonicalNextMove(
       foodDayClosed: held.foodDayClosed,
       trainingDeclined: held.trainingDeclined,
       trainingAwaitingOutcome: !!openTraining,
+      weekendInvestigationAnswered: weekendInvestigationAnswered(client),
     });
     console.log(`[PROACTIVE_DECISION] ${String(client.id || "").slice(-6)} decision=${decision.state} action=${decision.action.kind} foodClosed=${held.foodDayClosed} trainingDeclined=${held.trainingDeclined}`);
     return {

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -877,8 +877,7 @@ export interface ProactiveState {
   workout: { sessionsLast7d: number; sessionsThisWeek: number; daysSinceLastSession: number | null };
   steps: { avg7d: number | null };
   weight: { weeklyKgChange: number | null; trendUsable: boolean; stalledWeeks: number;
-    /** Unbounded, unlike weeklyKgChange's 28-day window — "never weighed" and "weighed in March"
-     *  are different clients and the decision owner treats them differently. */
+    /** From the same canonical 28-day weight truth as direction and stall. */
     daysSinceWeighIn: number | null };
   /** TODAY, not the 7-day picture. The one-action decision turns on these. */
   today: { kcal: number; protein: number; steps: number; logged: boolean; hour: number };
@@ -900,7 +899,7 @@ export { PROACTIVE_LOG_FLOOR };
  * than throwing — a scheduled job must not die for one client's missing row.
  */
 export async function loadProactiveState(client: any): Promise<ProactiveState> {
-  const { weightTrendUsable } = await import("../adaptive-targets");
+  const { weightDirectionSpeakable } = await import("../adaptive-targets");
   const { contactState } = await import("../understanding/reentry");
   const { getProgressTruth } = await import("../day-ledger");
   const { stalledWeeksFrom, weekendLoggedDays } = await import("../day-ledger-core");
@@ -918,11 +917,8 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
   const { sastDayStart, sastDaysBetween, sastHour, sastWeekStart } = await import("../sast");
   const dayStart0 = sastDayStart();
 
-  const [progress, wRows, stepAgg, workoutRows, lastMeal, lastWeigh, todaySteps] = await Promise.all([
-    getProgressTruth(client, { days: 7 }).catch(() => null),
-    db.select({ w: weightLogs.weight, at: weightLogs.loggedAt }).from(weightLogs)
-      .where(and(eq(weightLogs.userId, client.id), gte(weightLogs.loggedAt, since(28))))
-      .orderBy(desc(weightLogs.loggedAt)).limit(12).catch(() => [] as any[]),
+  const [progress, stepAgg, workoutRows, lastMeal, todaySteps] = await Promise.all([
+    getProgressTruth(client, { days: 7, weightWindowDays: 28 }).catch(() => null),
     db.select({ avg: sql<number>`COALESCE(AVG(${stepLogs.steps}),0)::int` }).from(stepLogs)
       .where(and(eq(stepLogs.userId, client.id), gte(stepLogs.loggedAt, since(7)))).catch(() => [] as any[]),
     // THE WORKOUT LEDGER, not chat_history saying "done". A client typing the word is not a
@@ -930,35 +926,24 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
     db.select({ at: workoutLogs.loggedAt }).from(workoutLogs)
       .where(and(eq(workoutLogs.userId, client.id), gte(workoutLogs.loggedAt, since(7))))
       .orderBy(desc(workoutLogs.loggedAt)).catch(() => [] as any[]),
-    // UNBOUNDED, deliberately. The 28-day windows above answer "what is happening now"; these two
-    // answer "has this ever happened", and a client who last weighed in March is a different
-    // person from one who never has. Bounding them would collapse both into null.
+    // UNBOUNDED, deliberately. The windows above answer "what is happening now"; this answers
+    // whether food logging has ever happened, so never and long ago do not collapse together.
     db.select({ at: mealLogs.loggedAt }).from(mealLogs)
       .where(eq(mealLogs.userId, client.id)).orderBy(desc(mealLogs.loggedAt)).limit(1)
-      .catch(() => [] as any[]),
-    db.select({ at: weightLogs.loggedAt }).from(weightLogs)
-      .where(eq(weightLogs.userId, client.id)).orderBy(desc(weightLogs.loggedAt)).limit(1)
       .catch(() => [] as any[]),
     db.select({ steps: stepLogs.steps }).from(stepLogs)
       .where(and(eq(stepLogs.userId, client.id), gte(stepLogs.loggedAt, dayStart0)))
       .orderBy(desc(stepLogs.loggedAt)).limit(1).catch(() => [] as any[]),
   ]);
 
-  const weights = (wRows as any[]).map(r => parseFloat(String(r.w))).filter(n => Number.isFinite(n));
+  const weightPoints = progress?.weight.points ?? [];
   let weeklyKgChange: number | null = null;
   let trendUsable = false;
-  if (weights.length >= 2) {
-    const newestAt = new Date((wRows as any[])[0].at as Date).getTime();
-    const oldestAt = new Date((wRows as any[])[wRows.length - 1].at as Date).getTime();
-    const verdict = weightTrendUsable({
-      count: weights.length, newestAt, oldestAt, now: Date.now(),
-      sickSince: sickSince ? new Date(sickSince).getTime() : undefined,
-      sickUntil: sickUntil ? new Date(sickUntil).getTime() : undefined,
-    });
-    trendUsable = verdict.usable;
-    if (verdict.usable) {
-      const spanDays = Math.max(1, (newestAt - oldestAt) / 86_400_000);
-      weeklyKgChange = ((weights[0] - weights[weights.length - 1]) / spanDays) * 7;
+  if (progress) {
+    const verdict = await weightDirectionSpeakable(weightPoints, client);
+    trendUsable = verdict.speakable;
+    if (verdict.speakable && progress.weight.changeKg !== null) {
+      weeklyKgChange = (progress.weight.changeKg / Math.max(1, progress.weight.spanDays)) * 7;
     }
   }
 
@@ -967,7 +952,6 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
   const sessionsThisWeek = (workoutRows as any[]).filter((r: any) => r.at && new Date(r.at).getTime() >= weekStart.getTime()).length;
   const loggedDays7d = progress ? progress.window.daysLogged : null;
   const lastMealAt = (lastMeal as any[])[0]?.at ? new Date((lastMeal as any[])[0].at) : null;
-  const lastWeighAt = (lastWeigh as any[])[0]?.at ? new Date((lastWeigh as any[])[0].at) : null;
 
   return {
     userId: client.id,
@@ -1005,8 +989,8 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
     },
     steps: { avg7d: Number((stepAgg as any[])[0]?.avg || 0) || null },
     weight: {
-      weeklyKgChange, trendUsable, stalledWeeks: stalledWeeksFrom(weights),
-      daysSinceWeighIn: lastWeighAt ? sastDaysBetween(lastWeighAt) : null,
+      weeklyKgChange, trendUsable, stalledWeeks: stalledWeeksFrom(weightPoints),
+      daysSinceWeighIn: progress?.weight.daysSinceWeighIn ?? null,
     },
     today: {
       kcal: progress?.today.kcal ?? 0,

--- a/server/scheduler/shared.ts
+++ b/server/scheduler/shared.ts
@@ -870,6 +870,8 @@ export interface ProactiveState {
   /** null everywhere means COULD NOT READ, never zero. A client who logged nothing and a ledger
    *  that failed to answer are different facts and the engine acts differently on each. */
   food: { avgKcal7d: number | null; avgProtein7d: number | null; loggedDays7d: number | null;
+    /** Weekend days represented in the canonical SAST window; null means the read failed. */
+    weekendLoggedDays7d: number | null;
     /** Days since ANY food log. null = never logged, which is not the same as "logged long ago". */
     daysSinceAnyLog: number | null };
   workout: { sessionsLast7d: number; sessionsThisWeek: number; daysSinceLastSession: number | null };
@@ -892,20 +894,6 @@ export interface ProactiveState {
 import { PROACTIVE_LOG_FLOOR } from "../one-action";
 export { PROACTIVE_LOG_FLOOR };
 
-/** Weeks of no meaningful weight movement (<0.3kg swing) from a series, newest first.
- *  Moved here from adaptive.ts so the stall a message TALKS about and the stall the engine ACTS
- *  on are one number. */
-function stalledWeeksFrom(weights: number[]): number {
-  if (weights.length < 3) return 0;
-  const newest = weights[0];
-  let weeks = 0;
-  for (const w of weights.slice(1)) {
-    if (Math.abs(newest - w) < 0.3) weeks++;
-    else break;
-  }
-  return weeks;
-}
-
 /**
  * Assemble one client's proactive state from authoritative ledgers. Read-only, and fail-soft per
  * field: a ledger that cannot be read yields null and lowers the matching evidence flag rather
@@ -914,7 +902,8 @@ function stalledWeeksFrom(weights: number[]): number {
 export async function loadProactiveState(client: any): Promise<ProactiveState> {
   const { weightTrendUsable } = await import("../adaptive-targets");
   const { contactState } = await import("../understanding/reentry");
-  const { gatherReportData } = await import("../report-card");
+  const { getProgressTruth } = await import("../day-ledger");
+  const { stalledWeeksFrom, weekendLoggedDays } = await import("../day-ledger-core");
   const since = (d: number) => new Date(Date.now() - d * 86_400_000);
 
   // ONE READ. This block used to derive sick / recovering / sickYesterday three different ways
@@ -926,12 +915,11 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
   const recovering = health.isRecovering;
   const sickYesterday = health.wasSickYesterday;
 
-  const { getDayLedger } = await import("../day-ledger");
   const { sastDayStart, sastDaysBetween, sastHour, sastWeekStart } = await import("../sast");
   const dayStart0 = sastDayStart();
 
-  const [intake, wRows, stepAgg, workoutRows, lastMeal, lastWeigh, todaySteps, ledger] = await Promise.all([
-    gatherReportData(client, "week").catch(() => null),
+  const [progress, wRows, stepAgg, workoutRows, lastMeal, lastWeigh, todaySteps] = await Promise.all([
+    getProgressTruth(client, { days: 7 }).catch(() => null),
     db.select({ w: weightLogs.weight, at: weightLogs.loggedAt }).from(weightLogs)
       .where(and(eq(weightLogs.userId, client.id), gte(weightLogs.loggedAt, since(28))))
       .orderBy(desc(weightLogs.loggedAt)).limit(12).catch(() => [] as any[]),
@@ -954,7 +942,6 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
     db.select({ steps: stepLogs.steps }).from(stepLogs)
       .where(and(eq(stepLogs.userId, client.id), gte(stepLogs.loggedAt, dayStart0)))
       .orderBy(desc(stepLogs.loggedAt)).limit(1).catch(() => [] as any[]),
-    getDayLedger(client.id, { user: client }).catch(() => null),
   ]);
 
   const weights = (wRows as any[]).map(r => parseFloat(String(r.w))).filter(n => Number.isFinite(n));
@@ -978,7 +965,7 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
   const lastSession = (workoutRows as any[])[0]?.at;
   const weekStart = sastWeekStart();
   const sessionsThisWeek = (workoutRows as any[]).filter((r: any) => r.at && new Date(r.at).getTime() >= weekStart.getTime()).length;
-  const loggedDays7d = intake ? intake.distinctDaysLogged : null;
+  const loggedDays7d = progress ? progress.window.daysLogged : null;
   const lastMealAt = (lastMeal as any[])[0]?.at ? new Date((lastMeal as any[])[0].at) : null;
   const lastWeighAt = (lastWeigh as any[])[0]?.at ? new Date((lastWeigh as any[])[0].at) : null;
 
@@ -1004,9 +991,10 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
       sickUntil, sickSince,
     },
     food: {
-      avgKcal7d: intake ? intake.avgKcal : null,
-      avgProtein7d: intake ? intake.avgProtein : null,
+      avgKcal7d: progress ? progress.window.avgKcal : null,
+      avgProtein7d: progress ? progress.window.avgProtein : null,
       loggedDays7d,
+      weekendLoggedDays7d: progress ? weekendLoggedDays(progress.window.perDay) : null,
       daysSinceAnyLog: lastMealAt ? sastDaysBetween(lastMealAt) : null,
     },
     workout: {
@@ -1021,8 +1009,8 @@ export async function loadProactiveState(client: any): Promise<ProactiveState> {
       daysSinceWeighIn: lastWeighAt ? sastDaysBetween(lastWeighAt) : null,
     },
     today: {
-      kcal: ledger?.kcal ?? 0,
-      protein: ledger?.protein ?? 0,
+      kcal: progress?.today.kcal ?? 0,
+      protein: progress?.today.protein ?? 0,
       steps: Number((todaySteps as any[])[0]?.steps || 0),
       logged: !!lastMealAt && sastDaysBetween(lastMealAt) === 0,
       hour: sastHour(),

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -79,6 +79,8 @@ export async function canonicalDecision(
     const { chooseAction, underPolicy, trainingDayIsDeclined, PROACTIVE_LOG_FLOOR } = await import("../one-action");
     const { readHeldConstraints, foodDayClosedWith } = await import("../held-constraints");
     const { getProgressTruth, sessionsThisCalendarWeek } = await import("../day-ledger");
+    const { stalledWeeksFrom, weekendLoggedDays } = await import("../day-ledger-core");
+    const { weightDirectionSpeakable } = await import("../adaptive-targets");
     const { sastDayKey, sastHour } = await import("../sast");
     const { getTodayWorkoutState } = await import("../workout-state");
     const { readHealthState } = await import("../health-state");
@@ -86,6 +88,7 @@ export async function canonicalDecision(
     const { ensureOpenTrainingLoop, loadOpenTrainingLoop } = await import("../memory");
 
     const truth = await getProgressTruth(user, { days: 7 });
+    const weightVerdict = await weightDirectionSpeakable(truth.weight.points, user);
     const openTraining = await loadOpenTrainingLoop(user);
     const held = await readHeldConstraints(user.phoneNumber, user).catch(() => ({ foodDayClosed: false, trainingDeclined: false, sick: false }));
     const weekSessions = await sessionsThisCalendarWeek(user.id).catch(() => 0);
@@ -130,17 +133,20 @@ export async function canonicalDecision(
       constraints: foodConstraints(user || {}),
       justAteProteinMeal: !!opts?.justAteProteinMeal,
     } as any), { foodSufficient: truth.window.daysLogged >= PROACTIVE_LOG_FLOOR,
-         // WEIGHT EVIDENCE IS NOT COUNTED HERE, and that is a known gap rather than a
-         // decision: the proactive side reads a stall verdict this path never computes, so
-         // passing anything but false would be inventing evidence. It means a client with a
-         // usable weight trend and a thin food log is still held on this path.
-         weightSufficient: false, dreamGoal: user.dreamGoal,
+         weightSufficient: weightVerdict.speakable, dreamGoal: user.dreamGoal,
          // …AND WHAT THE GATE NEEDS TO ASK INSTEAD OF HOLDING (#203). Three facts this call site
          // already computed for the DayState above; without them a sparse client's prescription
          // collapsed to a receipt with no next move at all.
          loggedToday: truth.today.kcal > 0,
          daysSinceWeighIn: truth.weight.daysSinceWeighIn,
-         doNotMention: user.doNotMention });
+         doNotMention: user.doNotMention,
+         hour: sastHour(),
+         loggedDays7d: truth.window.daysLogged,
+         weekendLoggedDays7d: weekendLoggedDays(truth.window.perDay),
+         stalledWeeks: stalledWeeksFrom([...truth.weight.points].reverse().map(p => p.kg)),
+         trainingAwaitingOutcome: !!openTraining,
+         foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
+         trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || "") });
 
     // RECORD THE PROVENANCE. The verifier needs to know what this turn's canonical decision was,
     // so it can tell a model reply that CARRIES the decision from one that invented its own.

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -65,7 +65,7 @@ import { assembleDeficitEvidence, hasRelevantDeficitEvidence, weightTrendUsable,
  */
 export async function canonicalDecision(
   user: any, message?: string, opts?: { justAteProteinMeal?: boolean },
-): Promise<{ todo: string; kind: string; reply: string; day: { kcal: number; kcalTarget: number } | null }> {
+): Promise<{ todo: string; kind: string; reply: string; day: { kcal: number; kcalTarget: number } | null; investigation?: { missingFact: string; whyItMatters: string } }> {
   try {
     // ONE CONSTITUTION (2026-08-21). This called theNextMove(), a SECOND ranked ladder —
     // training → protein → calories → steps → scale — that produced "the one thing to do" from
@@ -85,9 +85,10 @@ export async function canonicalDecision(
     const { getTodayWorkoutState } = await import("../workout-state");
     const { readHealthState } = await import("../health-state");
     const { getDisplayName } = await import("../utils");
-    const { ensureOpenTrainingLoop, loadOpenTrainingLoop } = await import("../memory");
+    const { ensureOpenTrainingLoop, loadOpenTrainingLoop, weekendInvestigationAnswered } = await import("../memory");
+    const { getGoalProfile } = await import("../goal-profiles");
 
-    const truth = await getProgressTruth(user, { days: 7 });
+    const truth = await getProgressTruth(user, { days: 7, weightWindowDays: 28 });
     const weightVerdict = await weightDirectionSpeakable(truth.weight.points, user);
     const openTraining = await loadOpenTrainingLoop(user);
     const held = await readHeldConstraints(user.phoneNumber, user).catch(() => ({ foodDayClosed: false, trainingDeclined: false, sick: false }));
@@ -143,10 +144,12 @@ export async function canonicalDecision(
          hour: sastHour(),
          loggedDays7d: truth.window.daysLogged,
          weekendLoggedDays7d: weekendLoggedDays(truth.window.perDay),
-         stalledWeeks: stalledWeeksFrom([...truth.weight.points].reverse().map(p => p.kg)),
+         stalledWeeks: stalledWeeksFrom(truth.weight.points),
          trainingAwaitingOutcome: !!openTraining,
          foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
-         trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || "") });
+         trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
+         weightIsGoal: getGoalProfile(user.goalType).weightIsGoal,
+         weekendInvestigationAnswered: weekendInvestigationAnswered(user) });
 
     // RECORD THE PROVENANCE. The verifier needs to know what this turn's canonical decision was,
     // so it can tell a model reply that CARRIES the decision from one that invented its own.
@@ -181,6 +184,7 @@ export async function canonicalDecision(
     return {
       todo: act.kind === "hold" ? "" : act.todo, kind: act.kind, reply: rendered,
       day: { kcal: truth.today.kcal, kcalTarget: calTarget },
+      investigation: act.investigation,
     };
   } catch { return { todo: "", kind: "hold", reply: "", day: null }; }
 }
@@ -749,10 +753,18 @@ export async function closeCoachingTurn(user: any, message: string, reply: strin
     // turn, so "did this reply carry an instruction" can no longer be answered by looking for a
     // trailing block — in the log, or in a test. What we told them is the fact worth recording.
     console.log(`[COACH_TURN] MOVE=${moveToUse} (one author closed ${wrote.join("+")})`);
+    if (moveToUse && decided?.investigation?.missingFact === "weekend_food") {
+      const { ensureOpenWeekendInvestigation } = await import("../memory");
+      await ensureOpenWeekendInvestigation(user);
+    }
     return one;
   }
 
   const next = withNextMove(out, moveToUse);
+  if (next !== out && decided?.investigation?.missingFact === "weekend_food") {
+    const { ensureOpenWeekendInvestigation } = await import("../memory");
+    await ensureOpenWeekendInvestigation(user);
+  }
   console.log(`[COACH_TURN] MOVE=${next !== out ? moveToUse : ""} (appended after ${wrote.join("+")})`);
   return next;
 }


### PR DESCRIPTION
Closes #213.

## First divergence

Both reactive and proactive decisions already converged on `underPolicy -> investigateInstead`, but that owner reduced every unknown to two booleans and a fixed food-before-weight fallback. It could not carry which fact blocked the decision, could not see the durable #208 loop, and hard-coded an elapsed “this morning” weigh ask.

## Bounded correction

- Adds explicit missing-fact metadata to the existing `OneAction` INVESTIGATE result.
- Uses canonical SAST per-day food evidence and the existing usable stalled-weight verdict.
- In the one existing policy owner, asks one weekend question only when a usable stalled trend plus thin weekday evidence makes that answer decision-relevant.
- Keeps open training loops, illness, daily holds, do-not-mention, stale-weight, and no-useful-question behavior ahead of that question.
- Routes proactive and reactive decisions through that same owner.
- Makes afternoon weigh asks actionable: “tomorrow morning”.
- Adds one real-PostgreSQL front-door acceptance to the existing authoritative PG job.

## Exact before -> after

- stalled usable weight + 2–3 weekday food days + no weekend evidence:
  food prescription / fixed measurement -> `INVESTIGATE weekend_food`: “What did eating look like over the weekend?”
- same state after a real backdated Sat/Sun answer:
  repeated unknown -> canonical weekend evidence closes it; that question is not repeated and the next decision is recomputed.
- open #208 training loop:
  competing investigation possible -> no new investigation displaces the unresolved outcome.
- adequate food + stale weight at 13:39:
  “Stand on a scale this morning” -> “Stand on a scale tomorrow morning”.
- no stall / no decision-changing unknown:
  unchanged safe action or hold; no manufactured question.

## Local proof

- `npm run check`: PASS
- `npm run test:unit:baseline -- --base=f5d0bee19d06a9424e375cc76e3d21aa535dcc65`: PASS, 0 new failures
- focused gap cases: PASS; suite remains 384/385 with only the unchanged Windows child-process exit-code harness failure
- tracking contract: PASS
- production parity preserves its current-main single known false-green failure
- local `npm test`, `check:arch`, and filesize output reproduce the documented Windows parser/baseline noise; authoritative Linux CI is the grade
- local PostgreSQL acceptance skips honestly because this workstation has no PostgreSQL runtime; the PR’s ephemeral PostgreSQL job runs it as a blocking check

## Decisive counterfactual

I restored the old fixed ladder and old weigh wording and confirmed:
- stalled-weekend case regressed from `INVESTIGATE` to `CHANGE`;
- afternoon control regressed to “this morning”.

The perturbation was confirmed in source, the focused suite went red, and the green implementation was restored.

Not merged or deployed.