### PR TITLE
One restriction, every food surface (#220)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,12 @@ jobs:
       # claims only exist as a sent message — SHADOW=on captures them.
       - name: Weight authority and speakability on real PostgreSQL
         run: npx tsx script/pg-weight-speakability-acceptance.ts
+      # ONE RESTRICTION, EVERY SURFACE (#220). Consistency is a claim about what a CLIENT receives
+      # across surfaces reached by different handlers, different scheduler jobs and different cron
+      # minutes — a unit test on `allows` proves the predicate and nothing about who asked it.
+      # SHADOW=on captures the Sunday sends, so proactive food coaching is graded on the message.
+      - name: One restriction across every food surface on real PostgreSQL
+        run: npx tsx script/pg-restriction-consistency-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -631,10 +631,16 @@ const NOT_CLIENT_FACING_RETURNS: Array<[string, RegExp, string]> = [
   ],
   [
     "server/food-swaps.ts",
-    /^\s*return `\$\{kept\.slice\(0, -1\)\.join\(", "\)\}, or \$\{kept\[kept\.length - 1\]\}`/,
-    "allowedAlternatives joins a list of food names into a NOUN PHRASE that its two callers embed "
-      + "in their own sentence; the ', or ' reads as prose to isProse but this function never "
-      + "addresses the client and returns no sentence of its own (#177)",
+    /^\s*return `\$\{p\.slice\(0, -1\)\.join\(", "\)\}, \$\{conj\} \$\{p\[p\.length - 1\]\}`/,
+    "joinFoods joins a list of food names into a NOUN PHRASE that its callers embed in their own "
+      + "sentence; the ', or ' reads as prose to isProse but this function never addresses the "
+      + "client and returns no sentence of its own (#177). THE EXEMPTION MOVED, IT DID NOT GROW "
+      + "(#220): it was written for allowedAlternatives' own join line, and grocery-personalize's "
+      + "prettyList was a second, unexempted copy of the same helper doing the same job with a "
+      + "different conjunction and the Oxford comma in a different place. Both now call this one "
+      + "function, so the repo carries ONE exempted join where it used to carry one exempted and "
+      + "one counted — the counter falls by one because a duplicate went away, not because a "
+      + "ceiling moved.",
   ],
 ];
 

--- a/script/pg-food-constraint-mouths-acceptance.ts
+++ b/script/pg-food-constraint-mouths-acceptance.ts
@@ -56,7 +56,15 @@ const chk = (ok: boolean, msg: string, evidence = "") => {
 
 // THE TEST'S OWN VOCABULARY, not the product's. Asserting with `constraints.allows` would grade
 // the filter against itself and pass for any client on any reply.
-const ANIMAL = /\b(chicken|beef|mince|steak|lamb|mutton|biltong|pilchards?|tuna|fish|hake|eggs?|yoghurt|amasi|milk|cheese)\b/i;
+//
+// SOYA MINCE IS NOT MINCE (#220). This pattern read `\bmince\b`, so it called the vegan option
+// "Soya mince + rice + mixed veg" an animal food. That was harmless only while `allows` made the
+// same mistake and filtered the option out — the check and the defect agreed, and this suite went
+// green on a vegan being denied the best plant protein in the pool and handed the 30g tofu plate
+// instead of the 45g one. `allows` was corrected; this detector is corrected with it, or the
+// suite would fail on the improvement. Same for the milk and yoghurt substitutes that are named
+// after the thing they replace.
+const ANIMAL = /(?<!soya |soy |veggie |vegan |plant |almond |oat |coconut )\b(chicken|beef|mince|steak|lamb|mutton|biltong|pilchards?|tuna|fish|hake|eggs?|yoghurt|amasi|milk|cheese)\b/i;
 const PORK = /\b(pork|bacon|ham|gammon)\b/i;
 
 async function seed(over: Record<string, any>): Promise<{ id: string; phone: string }> {

--- a/script/pg-restriction-consistency-acceptance.ts
+++ b/script/pg-restriction-consistency-acceptance.ts
@@ -1,0 +1,381 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — one restriction, every surface (#220).
+ *
+ * THE RULE THIS ENFORCES. The same CURRENT restriction controls every customer-facing surface.
+ * A client cannot be vegan in canonical memory while groceries, meal suggestions, proactive food
+ * coaching or the model's own context still behave omnivorous — and a restriction they RETRACTED
+ * must stop suppressing food everywhere, in the same breath.
+ *
+ * Four divergence shapes were traced through the real front door on main@2cb48c1 before anything
+ * changed. Every fix below closes one of them, and each is named at its own check:
+ *
+ *   A · A SECOND STORE.   onboarding-meal-plan.ts read `diet:` flags out of profileNotes and
+ *                         allergies out of otherMedicalNotes, never users.dietary_restrictions.
+ *                         A vegan whose fact sat in the canonical column — where recordClientFacts
+ *                         writes it and where every other food mouth reads it — asked for
+ *                         "7 day meals" and got chicken thigh, boiled eggs, pilchards, low fat
+ *                         yoghurt and beef mince, with no vegan line in the header at all.
+ *
+ *   B · NO CONSULTATION.  The protein-target answer was fixed prose ("Best SA sources: eggs,
+ *                         pilchards, chicken breast, tinned tuna") with no constraint read of any
+ *                         kind. buildClientSnapshot — the whole picture handed to the model —
+ *                         read users.food_dislikes raw and nothing else, so "vegan" appeared
+ *                         nowhere in it. topUpsForDay had no constraint parameter.
+ *
+ *   C · A FALLBACK PAST IT. meal-plan.ts filtered its pools correctly and then, when the filter
+ *                         emptied one, served the UNFILTERED pool: `safeProteinDays.length > 0 ?
+ *                         safeProteinDays : proteinDayPool`. A vegan received chicken breast,
+ *                         lean mince, hake and rump steak under a header reading "· Vegan". Its
+ *                         verifier caught this exactly right — "CRITICAL: vegan plan contains
+ *                         animal products" — and had no mouth, only a console.warn.
+ *
+ *   D · HONOURED BY DELETION. getShoppingList filtered correctly and shipped the wreckage: for a
+ *                         vegan the entire protein category vanished, "*Meal ideas to mix it up:*"
+ *                         printed with nothing under it, and the message still opened "a solid,
+ *                         quality base for your goal" and promised 150g of protein.
+ *
+ * WHY POSTGRESQL AND THE REAL FRONT DOOR. Consistency is a claim about what a CLIENT receives
+ * across surfaces that are reached by different handlers, different jobs and different cron
+ * minutes. A unit test on `allows` proves the predicate; it cannot prove that the grocery list,
+ * the meal plan, the protein answer, the Sunday send and the model's context all asked it.
+ * SHADOW=on routes every outbound into shadow_replies, so the proactive surfaces are graded on
+ * the MESSAGE a client would have received rather than on the decision behind it.
+ *
+ * EVERY CLAIM IS PAIRED WITH ITS CONTROL. "No chicken in the reply" is trivially satisfied by a
+ * coach that stopped naming food, or that suppresses chicken for everyone — both of which are the
+ * opposite defect. So each restricted client is checked beside an UNRESTRICTED one on the same
+ * surface, the retracted client is checked for the restriction actually lifting, and a client
+ * with a mere dislike is checked for NOT being treated as a hard diet.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-restriction-consistency-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const { eq } = await import("drizzle-orm");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { buildClientSnapshot } = await import("../server/brain/client-snapshot");
+const { runSundayMealPlan, runSundayWeeklyReport } = await import("../server/scheduler/jobs/weekly");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+/**
+ * FOODS A VEGAN MUST NEVER BE OFFERED. The lookbehind is not decoration: "soya mince", "soya
+ * milk" and "soya yoghurt" are the vegan SUBSTITUTES named after what they replace, and a
+ * detector without it fails this suite on correct output — it did, on the first trace run.
+ */
+const ANIMAL = /(?<!soya |soy |veggie |vegan |plant )\b(chicken|beef|mince|steak|pilchards?|tuna|hake|fish|eggs?|biltong|wors|boerewors|lamb|pork|mutton|yoghurts?|milk|cheese|amasi|maas)\b/i;
+const DAIRY = /(?<!soya |soy |almond |oat |coconut )\b(milk|cheese|yoghurts?|yogurts?|amasi|maas|cream)\b/i;
+const PEANUT = /\bpeanuts?\b|\bgroundnuts?\b/i;
+/** Tree nuts, which a PEANUT allergy must NOT suppress — the exactness half of the allergy case. */
+const TREE_NUT = /\b(almonds?|cashews?|mixed nuts|walnuts?)\b/i;
+
+/**
+ * THE PART OF A REPLY THAT RECOMMENDS FOOD, with the part that merely NAMES the restriction back
+ * removed.
+ *
+ * Saying the constraint out loud is the correct behaviour, not a leak: "🚫 Left off — you told
+ * me: broccoli", "⚠️ Medical: Peanut allergy — PB removed" and the plan header's "· Fish-free"
+ * are the coach proving it listened, and so is "I can't build you a plan that respects vegan,
+ * tofu, lentils, beans". A detector that cannot tell those from an instruction to eat marks
+ * correct output as a violation — this suite did exactly that on its first run, on all four of
+ * them. Everything else in the message is fair game.
+ */
+function body(reply: string): string {
+  return reply.split("\n")
+    .filter(l => !/you told me:|left off|⚠️ *Medical:|does not eat:|allergy|can'?t build a plan|can'?t build you a plan/i.test(l))
+    .join("\n")
+    .replace(/\b(fish|dairy|gluten|peanut)-free\b/gi, "");
+}
+
+const D = (d: number) => new Date(Date.now() - d * 86_400_000);
+const ids: string[] = [];
+
+async function client(name: string, over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2793${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name, onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "84.0", heightCm: 178, gender: "male", age: 35,
+    weeklyFoodBudget: "300_600", totalWorkoutsCompleted: 12,
+    createdAt: D(60), programmeStartDate: D(60), programmeWeek: 4, lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     SELECT $1, now() - (d || ' days')::interval, 'lunch', 600, 40, $2, 'seed', 'sa_scanner'
+       FROM generate_series(1, 6) AS d`,
+    [u.id, JSON.stringify([{ name: "pap", grams: 200 }])]);
+  await pool.query(
+    `INSERT INTO chat_history (user_id, message_in, message_out, intent, created_at)
+     SELECT $1, 'pap and beans', 'ok', 'FOOD_LOG', now() - (d || ' days')::interval
+       FROM generate_series(1, 6) AS d`, [u.id]);
+  return { id: u.id, phone };
+}
+
+const ask = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
+    .then(r => String(r || ""));
+
+/** Everything a proactive job sent this client, as one blob. */
+async function proactive(id: string, job: () => Promise<void>): Promise<string> {
+  await pool.query("DELETE FROM shadow_replies");
+  await pool.query("DELETE FROM daily_sends").catch(() => {});
+  await job().catch(() => {});
+  const { rows } = await pool.query("SELECT body FROM shadow_replies WHERE user_id = $1 ORDER BY id", [id]);
+  return rows.map((r: any) => String(r.body)).join("\n---\n");
+}
+
+/** The four reactive food surfaces a client can type their way to. */
+const FOOD_DOORS: Array<[string, string]> = [
+  ["meal plan", "meal plan"],
+  ["grocery list", "grocery list"],
+  ["protein target", "protein"],
+  ["7 day meals", "7 day meals"],
+];
+
+REAL("\n=== A · THE CANONICAL COLUMN ALONE MUST CONTROL EVERY SURFACE ===");
+REAL("    (no profileNotes `diet:` flag, no otherMedicalNotes — only users.dietary_restrictions,");
+REAL("     which is the column recordClientFacts writes when a client says 'I'm vegan'.)");
+{
+  const vegan = await client("Vegan", { dietaryRestrictions: "vegan" });
+  const omni = await client("Omni");
+  for (const [label, text] of FOOD_DOORS) {
+    const restricted = await ask(vegan.phone, text);
+    const control = await ask(omni.phone, text);
+    chk(!ANIMAL.test(body(restricted)), `${label}: a vegan is offered no animal food`,
+      `${(body(restricted).match(new RegExp(ANIMAL.source, "gi")) || []).join(", ")}\n          ${JSON.stringify(restricted.slice(0, 400))}`);
+    // THE CONTROL. Silence and blanket suppression both satisfy the line above.
+    chk(ANIMAL.test(body(control)), `CONTROL: ${label} still names real protein for a client with no restriction`,
+      JSON.stringify(control.slice(0, 300)));
+    chk(restricted.length > 200, `…and the vegan's ${label} is a real answer, not a shrug`,
+      `${restricted.length} chars: ${JSON.stringify(restricted.slice(0, 200))}`);
+  }
+}
+
+REAL("\n=== B · THE RESTRICTION REACHES THE MODEL'S OWN CONTEXT ===");
+{
+  const vegan = await client("VeganPrompt", { dietaryRestrictions: "vegan" });
+  const omni = await client("OmniPrompt");
+  const [vu] = await db.select().from(schema.users).where(eq(schema.users.id, vegan.id)).limit(1);
+  const [ou] = await db.select().from(schema.users).where(eq(schema.users.id, omni.id)).limit(1);
+  const snap = await buildClientSnapshot(vu as any);
+  const snapOmni = await buildClientSnapshot(ou as any);
+  chk(/vegan/i.test(snap), "the snapshot handed to the model says the client is vegan",
+    JSON.stringify(snap.slice(0, 400)));
+  chk(/does not eat/i.test(snap), "…in the same sentence every other food mouth is given",
+    JSON.stringify((snap.match(/[^\n]*does not eat[^\n]*/i) || ["(absent)"])[0]));
+  // THE CONTROL. A line that appears for everybody carries no information.
+  chk(!/does not eat/i.test(snapOmni), "CONTROL: a client who declared nothing gets no restriction line",
+    JSON.stringify((snapOmni.match(/[^\n]*does not eat[^\n]*/i) || [""])[0]));
+}
+
+REAL("\n=== C · THE PLAN MAY NOT FALL BACK PAST THE RESTRICTION ===");
+REAL("    (premium tier: every stock protein day and breakfast is animal, so this is the exact");
+REAL("     shape that used to empty the filter and serve the unfiltered pool.)");
+{
+  const vegan = await client("VeganPlan", { dietaryRestrictions: "vegan", weeklyFoodBudget: "300_600" });
+  const plan = await ask(vegan.phone, "meal plan");
+  chk(!ANIMAL.test(body(plan)), "the 3-day plan names no animal food anywhere — meals, cook notes or top-ups",
+    `${(body(plan).match(new RegExp(ANIMAL.source, "gi")) || []).join(", ")}`);
+  // NAMED SEPARATELY because it is the LAST thing appended to the plate, after every pool filter
+  // has run — the one place a compliant plan could still pick up a forbidden food.
+  const topUp = (plan.match(/Extra to hit your target:[^\n]*/i) || [""])[0];
+  chk(!ANIMAL.test(topUp), "…including the top-up appended after the pools were filtered",
+    JSON.stringify(topUp));
+  chk(/vegan/i.test(plan), "…and still declares the restriction it is built around",
+    JSON.stringify(plan.slice(0, 160)));
+  chk(/day 2/i.test(plan) && /day 3/i.test(plan), "…and is still three days, not a stub",
+    JSON.stringify(plan.slice(0, 200)));
+  // THE VERIFIER'S OWN FINDING, now client-visible instead of console-only: the plan-check note
+  // is a recommendation and must obey the same constraint the plan does.
+  const note = (plan.match(/Plan check:[^_]*/i) || [""])[0];
+  chk(!ANIMAL.test(note), "…and the verifier's own plan-check note recommends no animal food",
+    JSON.stringify(note));
+
+  // THE FALLBACK ITSELF, reached. Adding plant-based days to the pools means the vegan case above
+  // no longer empties the filter — so it no longer exercises `length > 0 ? filtered : pool`, and a
+  // mechanism nothing can reach is a mechanism nothing is testing. This client's own literal
+  // exclusions do empty it: every remaining plant day names tofu, lentils or beans. The old code
+  // served the unfiltered pool here; the honest answer is to say we cannot build it.
+  const cornered = await client("Cornered", {
+    dietaryRestrictions: "vegan, tofu, lentils, beans", weeklyFoodBudget: "300_600" });
+  const refused = await ask(cornered.phone, "meal plan");
+  chk(!ANIMAL.test(body(refused)) && !/tofu|lentil|bean/i.test(body(refused)),
+    "a filter that leaves NOTHING produces no plan rather than a forbidden one",
+    (body(refused).match(new RegExp(ANIMAL.source, "gi")) || []).join(", ") + " :: " + JSON.stringify(refused.slice(0, 300)));
+  chk(/can't build|cannot build/i.test(refused) && /vegan/i.test(refused),
+    "…and says so in their own terms, with a way forward",
+    JSON.stringify(refused.slice(0, 300)));
+
+  // THE CONTROL, on the same tier: the pool must not have been emptied for everyone.
+  const omni = await client("OmniPlan", { weeklyFoodBudget: "300_600" });
+  const control = await ask(omni.phone, "meal plan");
+  chk(/chicken|mince|steak|hake|pilchard/i.test(control),
+    "CONTROL: the premium plan still rotates real meat for a client with no restriction",
+    JSON.stringify(control.slice(0, 300)));
+}
+
+REAL("\n=== D · HONOURING A RESTRICTION IS NOT DELETING THE ANSWER ===");
+{
+  const vegan = await client("VeganShop", { dietaryRestrictions: "vegan" });
+  const list = await ask(vegan.phone, "grocery list");
+  chk(!ANIMAL.test(body(list)), "the grocery list offers no animal food",
+    (body(list).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+  chk(/🥩 Protein:/.test(list), "…and still HAS a protein section", JSON.stringify(list.slice(0, 500)));
+  chk(/beans|lentils|tofu|soya/i.test(list), "…stocked with protein this client can actually buy",
+    JSON.stringify((list.match(/\*🥩 Protein:\*[^*]*/) || ["(none)"])[0]));
+  // The hollow-list signature: a heading printed over nothing.
+  chk(!/\*Meal ideas to mix it up:\*\s*(\n\s*)*$|\*Meal ideas to mix it up:\*\s*\n\s*\n/.test(list),
+    "…and no section heading is printed with nothing under it",
+    JSON.stringify(list.slice(list.indexOf("Meal ideas"), list.indexOf("Meal ideas") + 200)));
+  // The avoid list is an instruction to buy, too: "plain or Greek only" reached a dairy-free
+  // client six lines under "Left off — you told me: no dairy".
+  const noDairy = await client("NoDairy", { dietaryRestrictions: "dairy" });
+  const dairyList = await ask(noDairy.phone, "grocery list");
+  const shelf = (dairyList.match(/Leave these on the shelf:[\s\S]*?(?=\n\n|$)/) || [""])[0];
+  chk(!DAIRY.test(shelf), "the `leave these on the shelf` block recommends no dairy to a dairy-free client",
+    JSON.stringify(shelf));
+  chk(!DAIRY.test(body(dairyList)), "…and neither does the rest of their list",
+    (body(dairyList).match(new RegExp(DAIRY.source, "gi")) || []).join(", "));
+  // THE CONTROL. The block must still exist for everyone else — it is real coaching.
+  const omni = await client("OmniShop");
+  const omniList = await ask(omni.phone, "grocery list");
+  chk(/Flavoured yoghurt/i.test(omniList),
+    "CONTROL: the shelf block is intact for a client with no restriction", JSON.stringify(omniList.slice(-600)));
+  chk(/🥩 Protein:/.test(omniList) && /chicken|eggs|mince/i.test(omniList),
+    "CONTROL: …and their protein section is untouched", JSON.stringify(omniList.slice(0, 400)));
+}
+
+REAL("\n=== E · EXACT ALLERGY: PEANUTS IS NOT ALL NUTS ===");
+{
+  const p = await client("PeanutAllergy", { dietaryRestrictions: "peanuts" });
+  for (const [label, text] of FOOD_DOORS) {
+    const reply = await ask(p.phone, text);
+    chk(!PEANUT.test(body(reply)),
+      `${label}: a peanut allergy removes peanuts and groundnuts`,
+      JSON.stringify(reply.slice(0, 300)));
+  }
+  // EXACTNESS IS THE CLAIM, not suppression. A peanut allergy is not a tree-nut allergy, and
+  // widening it would take almonds and cashews off the plate of someone who can eat them.
+  const plan = await ask(p.phone, "meal plan");
+  chk(/chicken|mince|eggs|pilchard|steak|hake/i.test(plan),
+    "CONTROL: a peanut allergy suppresses nothing else — meat and eggs stay",
+    JSON.stringify(plan.slice(0, 300)));
+  const { foodConstraints } = await import("../server/food-swaps");
+  const c = foodConstraints({ dietaryRestrictions: "peanuts" });
+  chk(TREE_NUT.test("almonds") && c.allows("almonds") && c.allows("mixed nuts") && c.allows("cashews"),
+    "CONTROL: …and tree nuts are still allowed — `peanuts` does not silently become `nuts`");
+  chk(!c.allows("peanut butter") && !c.allows("groundnuts"),
+    "…while the peanut cluster itself is complete (peanut butter, groundnuts)");
+}
+
+REAL("\n=== F · THE SAME RESTRICTION IN PROACTIVE FOOD COACHING ===");
+REAL("    (graded on the MESSAGE in shadow_replies, not on the decision behind it.)");
+{
+  const vegan = await client("VeganProactive", { dietaryRestrictions: "vegan" });
+  const plan = await proactive(vegan.id, runSundayMealPlan);
+  chk(plan.length > 0, "the Sunday meal plan actually sends", `body: ${JSON.stringify(plan.slice(0, 120))}`);
+  chk(!ANIMAL.test(body(plan)), "…and the proactive plan names no animal food",
+    (body(plan).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+
+  const report = await proactive(vegan.id, runSundayWeeklyReport);
+  chk(report.length > 0, "the Sunday weekly report actually sends");
+  chk(!ANIMAL.test(body(report)), "…and the grocery list it carries names no animal food",
+    (body(report).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+
+  // THE CONTROL. Proactive food coaching must not have gone quiet or plant-only for everyone.
+  const omni = await client("OmniProactive");
+  const control = await proactive(omni.id, runSundayMealPlan);
+  chk(ANIMAL.test(body(control)), "CONTROL: the same proactive job still names meat for an unrestricted client",
+    JSON.stringify(control.slice(0, 300)));
+}
+
+REAL("\n=== G · A RETRACTED RESTRICTION STOPS SUPPRESSING FOOD, EVERYWHERE ===");
+{
+  const c = await client("WasVegan", { dietaryRestrictions: "vegan" });
+  const before = await ask(c.phone, "meal plan");
+  chk(!ANIMAL.test(body(before)), "while vegan, the plan is plant-based",
+    (body(before).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+
+  await ask(c.phone, "I'm not vegan anymore");
+  const [u] = await db.select().from(schema.users).where(eq(schema.users.id, c.id)).limit(1);
+  chk(!/vegan/i.test(String((u as any).dietaryRestrictions || "")),
+    "the retraction clears the canonical column",
+    `column=${JSON.stringify((u as any).dietaryRestrictions)} notes=${JSON.stringify((u as any).profileNotes)}`);
+  chk(!/diet:vegan/i.test(String((u as any).profileNotes || "")),
+    "…and leaves no `diet:vegan` flag behind in profileNotes to out-live it (#211)",
+    JSON.stringify((u as any).profileNotes));
+
+  for (const [label, text] of FOOD_DOORS) {
+    const after = await ask(c.phone, text);
+    chk(ANIMAL.test(body(after)), `${label}: animal food returns after the retraction`,
+      JSON.stringify(after.slice(0, 300)));
+  }
+}
+
+REAL("\n=== H · SAME TURN: THE FACT AND THE QUESTION ARRIVE TOGETHER ===");
+{
+  const c = await client("SameTurn");
+  const reply = await ask(c.phone, "I'm vegan now, what should I eat?");
+  chk(!ANIMAL.test(body(reply)), "a restriction stated in the same breath already governs the answer",
+    `${(body(reply).match(new RegExp(ANIMAL.source, "gi")) || []).join(", ")}\n          ${JSON.stringify(reply.slice(0, 300))}`);
+  const [u] = await db.select().from(schema.users).where(eq(schema.users.id, c.id)).limit(1);
+  chk(/vegan/i.test(String((u as any).dietaryRestrictions || "")),
+    "…and it is durable, not just honoured for one turn",
+    JSON.stringify((u as any).dietaryRestrictions));
+  const next = await ask(c.phone, "grocery list");
+  chk(!ANIMAL.test(body(next)), "…so the next surface obeys it too",
+    (body(next).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+}
+
+REAL("\n=== I · NEGATIVE CONTROL: A PREFERENCE IS NOT A DIET ===");
+{
+  const c = await client("Dislikes", { foodDislikes: "broccoli" });
+  for (const [label, text] of FOOD_DOORS) {
+    const reply = await ask(c.phone, text);
+    chk(ANIMAL.test(body(reply)), `${label}: one named dislike does not turn the client vegan`,
+      JSON.stringify(reply.slice(0, 250)));
+    chk(!/broccoli/i.test(body(reply)), `…while the disliked food itself is still left out of ${label}`,
+      JSON.stringify((reply.match(/[^\n]*broccoli[^\n]*/i) || [""])[0]));
+  }
+  const [u] = await db.select().from(schema.users).where(eq(schema.users.id, c.id)).limit(1);
+  const snap = await buildClientSnapshot(u as any);
+  chk(/broccoli/i.test(snap), "…and the model is told about it rather than the fact being lost",
+    JSON.stringify((snap.match(/[^\n]*broccoli[^\n]*/i) || ["(absent)"])[0]));
+  chk(!/vegan|vegetarian/i.test(snap), "…without the model being told they follow a diet they never named",
+    JSON.stringify((snap.match(/[^\n]*veg[ae]/i) || [""])[0]));
+}
+
+REAL(`\n${failed === 0
+  ? "pg-restriction-consistency-acceptance: GREEN — all checks passed"
+  : `pg-restriction-consistency-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs",
+                   "chat_history", "turn_ledger", "shadow_replies", "daily_sends"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-restriction-consistency-acceptance.ts
+++ b/script/pg-restriction-consistency-acceptance.ts
@@ -366,6 +366,59 @@ REAL("\n=== I · NEGATIVE CONTROL: A PREFERENCE IS NOT A DIET ===");
     JSON.stringify((snap.match(/[^\n]*veg[ae]/i) || [""])[0]));
 }
 
+REAL("\n=== J · THE LITERAL FOODS THEY NAMED, ON THE FIXED TEMPLATE ===");
+REAL("    (both P1 findings from the Codex review of PR #222, reproduced and closed.)");
+{
+  // A CLUSTER BOOLEAN IS NOT THE WHOLE CONSTRAINT. foodConstraints also records the literal foods
+  // a client named, `allows` rejects them, and every other surface obeys — the 3-day plan came
+  // back clean for this exact client while the 7-day template recommended boiled eggs on six
+  // separate mornings, because it copied the booleans and never asked the predicate.
+  const eggs = await client("Naledi", { foodDislikes: "eggs" });
+  const seven = await ask(eggs.phone, "7 day meals");
+  chk(!/\begg/i.test(body(seven)), "a literal `eggs` exclusion is honoured by the fixed 7-day template",
+    JSON.stringify((body(seven).match(/[^\n]*egg[^\n]*/i) || [""])[0]));
+  chk(/can't build/i.test(seven),
+    "…by refusing, because a fixed template has nothing to substitute and its totals would lie",
+    JSON.stringify(seven.slice(0, 200)));
+  // THE CONTROL, and it is the one that matters: refusing is easy, refusing ONLY when the template
+  // actually collides is the claim. A dislike the plan never names must cost the client nothing.
+    // The fixture NAME must not carry a food word: the plan header interpolates it, and a client
+  // called "DislikesBroccoli" fails a broccoli detector on the greeting line alone.
+  const broc = await client("Thabo", { foodDislikes: "broccoli" });
+  const ok = await ask(broc.phone, "7 day meals");
+  chk(!/can't build/i.test(ok) && /Monday/.test(ok) && /Sunday/.test(ok),
+    "CONTROL: a dislike the template never names still gets the whole week",
+    JSON.stringify(ok.slice(0, 200)));
+  chk(!/broccoli/i.test(body(ok)), "…with the disliked food itself absent from it",
+    JSON.stringify((body(ok).match(/[^\n]*broccoli[^\n]*/i) || [""])[0]));
+
+  // KOSHER IS NOT HALAAL. `declaredLabel` covers both, so testing it truthy sent a client who
+  // declared kosher down the halal path — "buy halal-certified chicken and beef" — on a template
+  // that does not separate meat from dairy and cannot vouch for a hechsher.
+  const kosher = await client("Kosher", { dietaryRestrictions: "kosher" });
+  const kPlan = await ask(kosher.phone, "7 day meals");
+  chk(!/halal|halaal/i.test(kPlan), "a kosher client is never prescribed halal certification",
+    JSON.stringify((kPlan.match(/[^\n]*hal[a]?al[^\n]*/i) || [""])[0]));
+  chk(/kosher/i.test(kPlan) && /can't certify|cannot certify/i.test(kPlan),
+    "…and is told plainly what this plan does and does not guarantee",
+    JSON.stringify((kPlan.match(/[^\n]*Kosher[^\n]*/i) || ["(absent)"])[0]));
+  // THE CONTROL: the halal path itself must still work for someone who actually declared it.
+  const halaal = await client("Halaal", { dietaryRestrictions: "halaal" });
+  const hPlan = await ask(halaal.phone, "7 day meals");
+  chk(/halal-certified/i.test(hPlan), "CONTROL: a client who declared halaal still gets the halal guidance",
+    JSON.stringify((hPlan.match(/[^\n]*halal[^\n]*/i) || ["(absent)"])[0]));
+
+  // SALMON WAS NOT IN THE FISH CLUSTER, found by running the fix over the premium tier.
+  const fish = await client("FishAllergy", { dietaryRestrictions: "fish", weeklyFoodBudget: "over_600" });
+  const fPlan = await ask(fish.phone, "7 day meals");
+  chk(!/salmon|mackerel|kingklip/i.test(body(fPlan)),
+    "a declared fish allergy covers salmon on the shopping list and in the pro tip",
+    JSON.stringify((body(fPlan).match(/[^\n]*salmon[^\n]*/i) || [""])[0]));
+  chk(!/can't build/i.test(fPlan) && /Sunday/.test(fPlan),
+    "CONTROL: …and they still get the whole week — a dropped line is not a dropped plan",
+    JSON.stringify(fPlan.slice(0, 160)));
+}
+
 REAL(`\n${failed === 0
   ? "pg-restriction-consistency-acceptance: GREEN — all checks passed"
   : `pg-restriction-consistency-acceptance: RED — ${failed} check(s) failed`}`);

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #220, one mechanism at a time.
+#
+# A green suite proves nothing on its own: it may be green because the code is right, or because
+# the checks cannot fail. So each fix is put back the way it was, ALONE, and the acceptance must
+# go red on the specific checks that fix exists to hold. Anything that stays green under revert is
+# a check that was never testing its mechanism.
+#
+# Usage:  DATABASE_URL=... bash script/red-on-revert-220.sh
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-restriction-consistency-acceptance.ts
+
+run_case () {                       # run_case <name> <python-patch-heredoc-file>
+  local name="$1" patch="$2"
+  cp -r server /tmp/220-server-backup
+  python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/220-server-backup; return 1; }
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  local verdict; verdict="$(echo "$out" | grep -E '^pg-restriction-consistency-acceptance:' || echo '(no verdict — crashed)')"
+  echo "── REVERT: $name"
+  echo "   $verdict"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -8
+  rm -rf server && mv /tmp/220-server-backup server
+}
+
+mkdir -p /tmp/220p
+
+# ── 1 · onboarding-meal-plan reads the SECOND store again (profileNotes diet: flags) ──────────
+cat > /tmp/220p/1.py <<'PY'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+s = s.replace("  const isVegetarian = c.vegetarian;\n  const isVegan = c.vegan;",
+              '  const pn = (user.profileNotes || "").toLowerCase();\n'
+              '  const isVegetarian = pn.includes("diet:vegetarian") || pn.includes("diet:vegan");\n'
+              '  const isVegan = pn.includes("diet:vegan");')
+s = s.replace("  const noFishEff = c.noFish;", "  const noFishEff = noFish || isVegetarian;")
+s = s.replace("  const noDairyEff = c.noDairy;", "  const noDairyEff = noDairy || isVegan;")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 2 · the protein-target sentence goes back to fixed prose ──────────────────────────────────
+cat > /tmp/220p/2.py <<'PY'
+p = "server/handlers/misc-commands.ts"; s = open(p).read()
+s = s.replace("${sourceLine} This drives everything",
+              " Best SA sources: eggs (6g each), pilchards (20g per tin), chicken breast (30g per 100g), tinned tuna (25g per tin). This drives everything")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 3 · the model's snapshot reads food_dislikes raw again ────────────────────────────────────
+cat > /tmp/220p/3.py <<'PY'
+p = "server/brain/client-snapshot.ts"; s = open(p).read()
+s = s.replace("    const constraintLine = foodConstraints(user).line;\n    if (constraintLine) lines.push(constraintLine);",
+              "    if (user.foodDislikes) lines.push(`Foods they DISLIKE — never suggest these, always offer an alternative: ${String(user.foodDislikes).slice(0, 120)}.`);")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 4 · the meal plan falls back to the UNFILTERED pool again ─────────────────────────────────
+cat > /tmp/220p/4.py <<'PY'
+p = "server/meal-plan.ts"; s = open(p).read()
+s = s.replace("  const dayCount = finalProteinDays.length > 0 ? 3 : 0;", "  const dayCount = 3;")
+s = s.replace("""  const finalProteinDays = proteinDayPool.filter(pd =>
+    allowsItem(pd.lunch) && allowsItem(pd.dinner) && constraints.allows(pd.cookNote));""",
+              """  const filtered = proteinDayPool.filter(pd =>
+    allowsItem(pd.lunch) && allowsItem(pd.dinner) && constraints.allows(pd.cookNote));
+  const finalProteinDays = filtered.length > 0 ? filtered : proteinDayPool;""")
+s = s.replace("  const safeBfPool = bfPool.filter(allowsItem);",
+              "  const filteredBf = bfPool.filter(allowsItem);\n  const safeBfPool = filteredBf.length ? filteredBf : bfPool;")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 4b · both halves: the fallback AND the verifier's mouth ──────────────────────────────────
+cat > /tmp/220p/4b.py <<'PY2'
+p = "server/meal-plan.ts"; s = open(p).read()
+s = s.replace("  const dayCount = finalProteinDays.length > 0 ? 3 : 0;", "  const dayCount = 3;")
+s = s.replace("""  const finalProteinDays = proteinDayPool.filter(pd =>
+    allowsItem(pd.lunch) && allowsItem(pd.dinner) && constraints.allows(pd.cookNote));""",
+              """  const filtered = proteinDayPool.filter(pd =>
+    allowsItem(pd.lunch) && allowsItem(pd.dinner) && constraints.allows(pd.cookNote));
+  const finalProteinDays = filtered.length > 0 ? filtered : proteinDayPool;""")
+s = s.replace("  const safeBfPool = bfPool.filter(allowsItem);",
+              "  const filteredBf = bfPool.filter(allowsItem);\n  const safeBfPool = filteredBf.length ? filteredBf : bfPool;")
+s = s.replace("  if (days.length === 0 || criticals.length > 0) {", "  if (false) {")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 5 · the day top-up is appended without consulting the constraint ──────────────────────────
+cat > /tmp/220p/5.py <<'PY'
+p = "server/meal-plan-scale.ts"; s = open(p).read()
+s = s.replace("for (const u of PROTEIN_UNITS.filter(u2 => allows(u2.name)))", "for (const u of PROTEIN_UNITS)")
+s = s.replace("for (const u of STARCH_UNITS.filter(u2 => allows(u2.name)))", "for (const u of STARCH_UNITS)")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 6 · the grocery list is honoured by deletion again (no refill, headings over nothing) ─────
+cat > /tmp/220p/6.py <<'PY'
+p = "server/shopping-lists.ts"; s = open(p).read()
+s = s.replace("  const refill = items.some(i => i.category === \"protein\") ? [] : CONSTRAINT_SAFE_PROTEIN.filter(i => c.allows(i.item));",
+              "  const refill: ShoppingItem[] = [];")
+s = s.replace("    mealIdeas: mealIdeas.length ? mealIdeas : CONSTRAINT_SAFE_IDEAS.filter(i => c.allows(i)),",
+              "    mealIdeas,")
+s = s.replace("  const ideasSection = ideas ? `\\n\\n*Meal ideas to mix it up:*\\n${ideas}` : \"\";",
+              "  const ideasSection = `\\n\\n*Meal ideas to mix it up:*\\n${ideas}`;")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 7 · the `leave these on the shelf` block stops obeying the constraint ─────────────────────
+cat > /tmp/220p/7.py <<'PY'
+p = "server/shopping-lists.ts"; s = open(p).read()
+before = s
+s = s.replace("filterBullets(`• Sugary drinks", "((x: string) => x)(`• Sugary drinks")
+assert s != before, "shelf-block revert did not apply"
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 8 · the peanut cluster goes back to its singular-only trigger ─────────────────────────────
+cat > /tmp/220p/8.py <<'PY'
+p = "server/food-swaps.ts"; s = open(p).read()
+s = s.replace("const noPeanuts = has(/\\bpeanuts?\\b|\\bgroundnuts?\\b/);", "const noPeanuts = has(/\\bpeanut\\b|\\bgroundnut\\b/);")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 9 · the verifier's plan-check note names food without asking the constraint ───────────────
+cat > /tmp/220p/9.py <<'PY'
+p = "server/verifiers/meal-plan-validator.ts"; s = open(p).read()
+s = s.replace("""        const sources = allowedAlternatives(
+          "1 tin pilchards (26g), 3 eggs (21g), 200g Greek yoghurt (20g), 1 cup cooked lentils (18g), 1 cup cooked sugar beans (15g)",
+          opts.constraints);""",
+              '        const sources = "1 tin pilchards (26g), 3 eggs (21g), or 200g Greek yoghurt (20g)";')
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+echo "=============================================================================="
+echo "#220 — RED ON REVERT, one mechanism at a time"
+echo "=============================================================================="
+run_case "onboarding-meal-plan reads profileNotes diet: flags instead of the canonical column" /tmp/220p/1.py
+run_case "the protein-target answer is fixed prose again"                                      /tmp/220p/2.py
+run_case "buildClientSnapshot reads food_dislikes raw again"                                   /tmp/220p/3.py
+# 4a is EXPECTED TO STAY GREEN, and that is the finding, not a gap: the fallback and the CRITICAL
+# guard are two halves of one mechanism — "the plan may not be built from food this client cannot
+# eat, and if it somehow is, it does not ship". With the fallback restored the guard catches the
+# violating plan and refuses it, which is the guard doing exactly its job. 4b removes both, and
+# only then does a vegan receive chicken. Reporting 4a as a pass would be dishonest; reporting it
+# as a failure of the suite would be wrong. It is reported as what it is.
+run_case "4a · the meal plan falls back to the unfiltered pool (the CRITICAL guard still stands)" /tmp/220p/4.py
+run_case "4b · …and the CRITICAL guard is a console.warn again, as it was"                        /tmp/220p/4b.py
+run_case "topUpsForDay appends food without consulting the constraint"                         /tmp/220p/5.py
+run_case "the grocery list is honoured by deletion (no refill, empty headings)"                /tmp/220p/6.py
+run_case "the shelf block stops obeying the constraint"                                        /tmp/220p/7.py
+run_case "noPeanuts goes back to its singular-only trigger"                                    /tmp/220p/8.py
+run_case "the plan-check note names food without asking the constraint"                        /tmp/220p/9.py
+echo "=============================================================================="

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -138,6 +138,30 @@ assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY
 
+# ── 10 · kosher takes the halal path again (the PR #222 regression) ──────────────────────────
+cat > /tmp/220p/10.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+s = s.replace("const isHalal = !!c.declaredLabel && !isKosher;", "const isHalal = !!c.declaredLabel;")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 11 · the fixed template stops asking the predicate about its own meals ────────────────────
+cat > /tmp/220p/11.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+s = s.replace("  if (prescribed(planBlock).some((food: string) => !c.allows(food))) return noPlanWithin(c);", "")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 12 · salmon leaves the fish cluster ───────────────────────────────────────────────────────
+cat > /tmp/220p/12.py <<'PY2'
+p = "server/food-swaps.ts"; s = open(p).read()
+s = s.replace("|snoek|salmon|mackerel|kingklip|sardines?|", "|snoek|sardines?|")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
 echo "=============================================================================="
 echo "#220 — RED ON REVERT, one mechanism at a time"
 echo "=============================================================================="
@@ -157,4 +181,7 @@ run_case "the grocery list is honoured by deletion (no refill, empty headings)" 
 run_case "the shelf block stops obeying the constraint"                                        /tmp/220p/7.py
 run_case "noPeanuts goes back to its singular-only trigger"                                    /tmp/220p/8.py
 run_case "the plan-check note names food without asking the constraint"                        /tmp/220p/9.py
+run_case "kosher takes the halal path again (the PR #222 regression)"                          /tmp/220p/10.py
+run_case "the fixed 7-day template stops asking the predicate about its own meals"             /tmp/220p/11.py
+run_case "salmon leaves the fish cluster"                                                      /tmp/220p/12.py
 echo "=============================================================================="

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -7224,23 +7224,41 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
 // ============================================================
 {
   const { topUpsForDay, topUpLine } = await import("../server/meal-plan-scale");
+  const { foodConstraints } = await import("../server/food-swaps");
+  const anything = foodConstraints({}).allows;
   test("meal-plan scale: a 1450 kcal day against a 2862 target is topped up to target", () => {
-    const tops = topUpsForDay(1450, 78, 2862, 185);
+    const tops = topUpsForDay(1450, 78, 2862, 185, anything);
     const kcal = 1450 + tops.reduce((s, t) => s + t.kcal, 0);
     const prot = 78 + tops.reduce((s, t) => s + t.protein, 0);
     assert.ok(kcal >= 2862 * 0.9, `must reach ~target, got ${kcal}`);
     assert.ok(prot >= 185 * 0.9, `protein must reach ~target, got ${prot}`);
   });
   test("meal-plan scale: a day already on target gets NO top-ups", () => {
-    assert.deepEqual(topUpsForDay(2850, 190, 2862, 185), []);
+    assert.deepEqual(topUpsForDay(2850, 190, 2862, 185, anything), []);
     assert.equal(topUpLine([]), "");
   });
   test("meal-plan scale: protein comes first — the macro the pools under-deliver", () => {
-    const tops = topUpsForDay(1450, 78, 2862, 185);
+    const tops = topUpsForDay(1450, 78, 2862, 185, anything);
     assert.ok(tops.length > 0 && tops[0].protein >= 8, `protein-dense first: ${JSON.stringify(tops[0])}`);
   });
   test("meal-plan scale: an OVER-target day is never given more food", () => {
-    assert.deepEqual(topUpsForDay(3200, 200, 2862, 185), []);
+    assert.deepEqual(topUpsForDay(3200, 200, 2862, 185, anything), []);
+  });
+  // #220 — THE TOP-UP IS APPENDED AFTER THE PLAN'S OWN FILTER HAS RUN, so it is the last place
+  // a forbidden food can get onto a compliant plate. It put "1 tin pilchards + 3 boiled eggs"
+  // on a vegan's plan, one line under a header reading "· Vegan".
+  test("meal-plan scale: a vegan's top-up names no animal food, and still reaches target", () => {
+    const vegan = foodConstraints({ dietaryRestrictions: "vegan" });
+    const tops = topUpsForDay(1450, 78, 2862, 185, vegan.allows);
+    const named = tops.map(t => t.label).join(" | ");
+    assert.ok(!/pilchard|egg|amasi|chicken|mince|tuna/i.test(named), `animal food in a vegan top-up: ${named}`);
+    const kcal = 1450 + tops.reduce((s, t) => s + t.kcal, 0);
+    assert.ok(kcal >= 2862 * 0.85, `a filtered top-up must still close the gap, got ${kcal}`);
+  });
+  // THE CONTROL, both ways: filtering must not fire for a client who declared nothing.
+  test("meal-plan scale: an unrestricted client still gets the cheapest protein-dense units", () => {
+    const named = topUpsForDay(1450, 78, 2862, 185, anything).map(t => t.label).join(" | ");
+    assert.ok(/pilchard|egg/i.test(named), `plant-only for a client with no restriction: ${named}`);
   });
 }
 

--- a/server/brain/client-snapshot.ts
+++ b/server/brain/client-snapshot.ts
@@ -27,6 +27,7 @@ import { sastDayKey } from "../sast";
 import { readHealthState } from "../health-state";
 import { liftsForLaggingAreas } from "../physique-analysis";
 import { getGoalProfile } from "../goal-profiles";
+import { foodConstraints } from "../food-swaps";
 
 const DAY = 86_400_000;
 
@@ -75,7 +76,15 @@ export async function buildClientSnapshot(user: any): Promise<string> {
 
     if (user.dreamGoal) lines.push(`Their 3-month dream, in their words: "${String(user.dreamGoal).slice(0, 160)}". Reference this to motivate — it's their why.`);
     if (user.biggestStruggle) lines.push(`Their biggest struggle: "${String(user.biggestStruggle).slice(0, 140)}". Coach around THIS — it's where they need the most support.`);
-    if (user.foodDislikes) lines.push(`Foods they DISLIKE — never suggest these, always offer an alternative: ${String(user.foodDislikes).slice(0, 120)}.`);
+    // WHAT THEY DO NOT EAT, FROM THE ONE OWNER (#220). This read users.food_dislikes raw and
+    // nothing else — so a client who told the coach "I'm vegan", which recordClientFacts writes
+    // to users.dietary_restrictions, handed the model a snapshot with no mention of vegan
+    // anywhere in it. Every deterministic food mouth obeyed the restriction while the model,
+    // which writes the free coaching around them, was never told. Same sentence media.ts already
+    // puts in front of the vision model — not a second phrasing of the rule, the same one, and
+    // it merges both columns so nothing food_dislikes carried is lost.
+    const constraintLine = foodConstraints(user).line;
+    if (constraintLine) lines.push(constraintLine);
     if (user.foodLikes) lines.push(`Foods they LOVE — build meals around these: ${String(user.foodLikes).slice(0, 120)}.`);
 
     if (user.laggingAreas) {

--- a/server/food-swaps.ts
+++ b/server/food-swaps.ts
@@ -455,10 +455,77 @@ export function answerUnavailable(message: string, c: FoodConstraints = NO_CONST
 export function allowedAlternatives(alt: string, c: FoodConstraints): string | null {
   const parts = String(alt || "").split(/\s*,\s*(?:or\s+)?|\s+or\s+/).map(s => s.trim()).filter(Boolean);
   const kept = parts.filter(p => c.allows(p));
-  if (kept.length === 0) return null;
-  if (kept.length === 1) return kept[0];
-  if (kept.length === 2) return `${kept[0]} or ${kept[1]}`;
-  return `${kept.slice(0, -1).join(", ")}, or ${kept[kept.length - 1]}`;
+  return kept.length ? joinFoods(kept, "or") : null;
+}
+
+/**
+ * ONE OWNER FOR JOINING FOOD NAMES INTO ENGLISH (#220). This was written twice — here, with
+ * "or", for a list of options a client may choose between, and again in grocery-personalize.ts
+ * as `prettyList`, with "and", for a list of foods they already eat. Two functions, one job,
+ * and the Oxford comma placed differently in each, which is how a coach ends up sounding like
+ * two people in one message. The conjunction is the only thing that ever differed, so it is
+ * the parameter.
+ */
+export function joinFoods(names: string[], conj: "or" | "and"): string {
+  const p = names.map(s => String(s || "").trim()).filter(Boolean);
+  if (p.length <= 1) return p.join("");
+  if (p.length === 2) return `${p[0]} ${conj} ${p[1]}`;
+  return `${p.slice(0, -1).join(", ")}, ${conj} ${p[p.length - 1]}`;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * THE PROTEIN THIS CLIENT MAY ACTUALLY EAT (#220).
+ *
+ * `allows` answers "may they have this?". Four surfaces needed the other half — "then name
+ * something they CAN have" — and each answered it privately, with its own hardcoded list of
+ * eggs / pilchards / chicken / tuna:
+ *
+ *   handlers/misc-commands.ts  "Best SA sources: eggs (6g each), pilchards (20g per tin), …"
+ *                              — a fixed sentence, no constraint consulted at all, so a vegan
+ *                                asking their own protein target was told to eat chicken.
+ *   meal-plan-scale.ts         PROTEIN_UNITS — appended to every day AFTER the plan's own
+ *                                dietary filter had run, so it put pilchards back on a vegan's
+ *                                plate one line under a header reading "· Vegan".
+ *   meal-plan.ts               a pool that, filtered to nothing for a vegan, fell back to the
+ *                                UNFILTERED pool rather than admitting it had nothing.
+ *   shopping-lists.ts          a tier list that, filtered for a vegan, lost its entire protein
+ *                                category and shipped an empty section under a promise of 150g.
+ *
+ * ONE TABLE, PLANT AND ANIMAL TOGETHER, so the filter always leaves something honest and no
+ * surface ever has to choose between breaking the restriction and going silent. Cheapest-first,
+ * because month-end is the constraint every SA client shares. Per-unit numbers so a caller can
+ * price a portion; the `per` phrase is how a client would say it in a shop.
+ */
+export interface ProteinStaple {
+  /** The food, as a client would name it. */
+  name: string;
+  /** How much of it the numbers describe — "per tin", "each", "per 100g". */
+  per: string;
+  kcal: number;
+  protein: number;
+}
+
+const PROTEIN_STAPLES: ProteinStaple[] = [
+  { name: "eggs", per: "each", kcal: 78, protein: 6 },
+  { name: "sugar beans", per: "per cup cooked", kcal: 230, protein: 15 },
+  { name: "lentils", per: "per cup cooked", kcal: 230, protein: 18 },
+  { name: "pilchards", per: "per tin", kcal: 190, protein: 20 },
+  { name: "soya mince", per: "per 100g dry", kcal: 340, protein: 50 },
+  { name: "chicken breast", per: "per 100g", kcal: 165, protein: 30 },
+  { name: "tinned tuna", per: "per tin", kcal: 130, protein: 25 },
+  { name: "peanut butter", per: "per 2 tbsp", kcal: 190, protein: 8 },
+  { name: "amasi", per: "per 250ml", kcal: 130, protein: 9 },
+  { name: "firm tofu", per: "per 100g", kcal: 145, protein: 16 },
+];
+
+/**
+ * The staples above, minus everything this client told us they do not eat. Never empty for any
+ * constraint this codebase can express — lentils and sugar beans survive vegan, halaal, dairy,
+ * gluten, fish and peanut alike — but callers must still handle `[]`, because a client is free
+ * to name foods one at a time until nothing is left.
+ */
+export function allowedProteinStaples(c: FoodConstraints): ProteinStaple[] {
+  return PROTEIN_STAPLES.filter(s => c.allows(s.name));
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -689,6 +756,13 @@ export interface FoodConstraints {
   noPeanuts: boolean;
   /** Diabetes / PCOS — an EMPHASIS, not a ban. Preserved from meal-plan's own derivation. */
   lowGI: boolean;
+  /**
+   * "halaal" / "halal" / "kosher" IN THEIR OWN WORD, or "" (#220). Already computed here for
+   * `terms`; exposed because onboarding-meal-plan.ts derived it a second time out of a second
+   * store, and a surface that must say "buy halal-certified chicken" needs the label itself,
+   * not the `noPork` consequence.
+   */
+  declaredLabel: string;
 }
 
 /** What a declared diet actually rules out on a South African plate. */
@@ -697,8 +771,16 @@ export interface FoodConstraints {
 // stem must not be closed at both ends — and it cost three failing gates before this comment
 // existed. `s?` rather than an open stem, deliberately: an open `\bham` would ban a beef
 // hamburger for a halaal client, which is the same class of bug pointing the other way.
-const DAIRY = /\b(milk|amasi|maas|cheese|yoghurts?|yogurts?|cream|butter|custard|ice ?cream|condensed milk)\b/i;
-const MEAT = /\b(chicken|beef|steaks?|mince|lamb|mutton|pork|bacon|ham|polony|russians?|vienna|wors|boerewors|biltong|livers?|tripe|offal|walkie|gammon|sausages?|meat|nyama|shisa ?nyama)\b/i;
+// PEANUT BUTTER IS NOT DAIRY (#220). `\bbutter\b` matched it, so a lactose-intolerant client was
+// refused peanut butter — and, worse, the vegan breakfast built out of it was filtered off a
+// vegan's own meal plan, which is how the plan ran out of compliant food in the first place.
+// Same shape for soya/almond/oat milk: a vegan alternative named after the thing it replaces.
+const DAIRY = /\b(?<!soya |soy |almond |oat |coconut |rice )(milk|amasi|maas|cheese|yoghurts?|yogurts?|cream|custard|ice ?cream|condensed milk)\b|(?<!peanut |nut |almond |cashew |seed )\bbutter\b/i;
+// SOYA MINCE IS NOT MINCE (#220), for the same reason peanut butter is not dairy: it is the
+// plant substitute NAMED AFTER the thing it replaces, and `\bmince\b` banned it from the one
+// client group it exists for. The substitution table already offers "soya mince" to a client
+// avoiding beef; `allows` used to refuse the swap the table had just made.
+const MEAT = /(?<!soya |soy |veggie |vegan |plant )\b(chicken|beef|steaks?|mince|lamb|mutton|pork|bacon|ham|polony|russians?|vienna|wors|boerewors|biltong|livers?|tripe|offal|walkie|gammon|sausages?|meat|nyama|shisa ?nyama)\b/i;
 const FISH = /\b(fish|pilchards?|tuna|hake|snoek|sardines?|anchov(?:y|ies)|prawns?|shrimps?|calamari|mussels?|seafood)\b/i;
 const EGG = /\b(eggs?|omelettes?)\b/i;
 const PORK = /\b(pork|bacon|ham|gammon|pig)\b/i;
@@ -723,8 +805,14 @@ export function foodConstraints(u: {
   const noDairy = vegan || has(/\bdairy\b|\blactose\b|\bmilk\b/);
   const noPork = has(/\bpork\b|\bhalaal\b|\bhalal\b|\bkosher\b|\bbacon\b/);
   const noGluten = has(/\bgluten\b|\bceliac\b|\bcoeliac\b|\bwheat\b/);
-  const noFish = vegetarian || has(/\bfish\b|\bpilchard\b|\btuna\b|\bseafood\b|\bshellfish\b/);
-  const noPeanuts = has(/\bpeanut\b|\bgroundnut\b/);
+  // PLURALS ARE THE WHOLE GAME HERE TOO (#220). `\bpeanut\b` does not match "peanuts", so a
+  // client whose dietary_restrictions column read exactly "peanuts" had noPeanuts === false and
+  // the allergy was carried only by the literal-term fallback below — which meant the peanut
+  // CLUSTER (peanut butter, groundnuts) never fired for the plainest way of saying it. Same hole
+  // in `\bpilchard\b`. The DAIRY/MEAT comment above already records this lesson for the food
+  // regexes; the cluster triggers were missed.
+  const noFish = vegetarian || has(/\bfish\b|\bpilchards?\b|\btunas?\b|\bseafood\b|\bshellfish\b/);
+  const noPeanuts = has(/\bpeanuts?\b|\bgroundnuts?\b/);
 
   // The literal foods they named, beyond the diet labels — "I don't eat liver" is a constraint
   // even though no cluster covers it.
@@ -733,7 +821,12 @@ export function foodConstraints(u: {
     .split(/[,;]+|\band\b/)
     .map(s => s.trim().replace(/^(no|not|never|hate|dislike|avoid|i don'?t eat|can'?t eat)\s+/, "").trim())
     .filter(s => s.length >= 3 && s.length <= 24 && /^[a-z' -]+$/.test(s)
-      && !/^(vegan|vegetarian|halaal|halal|kosher|gluten free|dairy free|lactose intolerant)$/.test(s));
+      && !/^(vegan|vegetarian|halaal|halal|kosher|gluten free|dairy free|lactose intolerant)$/.test(s)
+      // ALREADY SAID ONCE, BY THE CLUSTER (#220). A client whose dietary_restrictions column is
+      // the single word "dairy" read back "you told me: no dairy, dairy" — the derived label and
+      // the raw word, both in the disclosure. A literal that IS a cluster's own trigger adds
+      // nothing the cluster has not already said in better English.
+      && !/^(dairy|lactose|gluten|celiac|coeliac|peanut|peanuts|groundnut|groundnuts|seafood|shellfish)$/.test(s));
 
   // Both forms of every literal term, for the same reason — a client who typed "liver" means
   // "chicken livers" on a menu, and one who typed "eggs" means an egg.
@@ -779,6 +872,7 @@ export function foodConstraints(u: {
     allows,
     vegan, vegetarian, noDairy, noPork, noGluten, noFish, noPeanuts,
     lowGI: /\bdiabet|pcos\b/.test(conditions) || /\bdiabet|pcos\b/.test(declared),
+    declaredLabel: declaredLabel || "",
   };
 }
 

--- a/server/food-swaps.ts
+++ b/server/food-swaps.ts
@@ -528,6 +528,22 @@ export function allowedProteinStaples(c: FoodConstraints): ProteinStaple[] {
   return PROTEIN_STAPLES.filter(s => c.allows(s.name));
 }
 
+/**
+ * WHAT WE SAY WHEN A PLAN CANNOT BE BUILT INSIDE THIS CLIENT'S RESTRICTION (#220).
+ *
+ * ONE OWNER, because there are two plan builders and they must not disagree about the one thing
+ * neither of them can do. generateMealPlan reaches this when its pools filter to nothing;
+ * getOnboardingMealPlan reaches it when its fixed template — which has no substitutes to swap in —
+ * would name a food the client told us they do not eat. Both are the same moment: we would have
+ * to break their word to answer, so we do not answer, and we ask for the one thing that unblocks
+ * it. Saying the restriction back in their own terms is the point; a plan we cannot build is not
+ * a reason to be vague about why.
+ */
+export function noPlanWithin(c: FoodConstraints): string {
+  const said = c.terms.length ? joinFoods(c.terms, "and") : "what you don't eat";
+  return `*Your Meal Plan*\n\nI can't build you a plan that respects ${said} out of the food I've got templates for — and I'd rather tell you that than send you one that breaks your word.\n\nTell me two or three proteins you DO eat and I'll build the week around them.`;
+}
+
 /* ────────────────────────────────────────────────────────────────────────────
  * "CAN I EAT THIS?" — a grounded verdict on a packaged product (2026-08-05).
  *
@@ -781,7 +797,12 @@ const DAIRY = /\b(?<!soya |soy |almond |oat |coconut |rice )(milk|amasi|maas|che
 // client group it exists for. The substitution table already offers "soya mince" to a client
 // avoiding beef; `allows` used to refuse the swap the table had just made.
 const MEAT = /(?<!soya |soy |veggie |vegan |plant )\b(chicken|beef|steaks?|mince|lamb|mutton|pork|bacon|ham|polony|russians?|vienna|wors|boerewors|biltong|livers?|tripe|offal|walkie|gammon|sausages?|meat|nyama|shisa ?nyama)\b/i;
-const FISH = /\b(fish|pilchards?|tuna|hake|snoek|sardines?|anchov(?:y|ies)|prawns?|shrimps?|calamari|mussels?|seafood)\b/i;
+// SALMON WAS NOT IN THE FISH CLUSTER (#220). Found by running the fix over the premium tier: a
+// client whose declared allergy is fish had "Salmon 400g (×2) — R160" on their shopping list and
+// "Salmon goes on special at Shoprite most Fridays — buy two packs" as their pro tip, because
+// `allows` did not know salmon is a fish. Mackerel and kingklip are the other two a South
+// African shelf carries that this pattern could not see.
+const FISH = /\b(fish|pilchards?|tuna|hake|snoek|salmon|mackerel|kingklip|sardines?|anchov(?:y|ies)|prawns?|shrimps?|calamari|mussels?|seafood)\b/i;
 const EGG = /\b(eggs?|omelettes?)\b/i;
 const PORK = /\b(pork|bacon|ham|gammon|pig)\b/i;
 const GLUTEN = /\b(bread|rolls?|buns?|kota|vetkoek|pasta|macaroni|spaghetti|noodles?|wheat|flour|cereal|weetbix|rusks?)\b/i;

--- a/server/grocery-personalize.ts
+++ b/server/grocery-personalize.ts
@@ -20,7 +20,7 @@
  */
 
 import { suggestSwap } from "./food-swaps";
-import { foodConstraints, NO_CONSTRAINTS, type FoodConstraints } from "./food-swaps";
+import { foodConstraints, NO_CONSTRAINTS, joinFoods, type FoodConstraints } from "./food-swaps";
 
 export type FoodProfileItem = { name: string; count: number };
 export type FoodProfile = { topFoods: FoodProfileItem[]; distinctCount: number };
@@ -66,12 +66,10 @@ function pretty(name: string): string {
   return t.charAt(0).toUpperCase() + t.slice(1);
 }
 
-function prettyList(names: string[]): string {
-  const p = names.map(pretty);
-  if (p.length <= 1) return p.join("");
-  if (p.length === 2) return `${p[0]} and ${p[1]}`;
-  return `${p.slice(0, -1).join(", ")} and ${p[p.length - 1]}`;
-}
+// ONE OWNER (#220) — joinFoods in food-swaps.ts. This was the second implementation of "join
+// food names into English"; the only thing it ever did differently was the conjunction, and it
+// placed the Oxford comma differently too, so one coach sounded like two across a single message.
+const prettyList = (names: string[]): string => joinFoods(names.map(pretty), "and");
 
 // The calm awareness line every not-yet-established client sees — it tells them, with
 // zero prompting, that they can send their OWN list or use what's already at home. This

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -39,7 +39,7 @@ import { isDespairNotAQuestion } from "../despair";
 import { SA_FOODS_SEED } from "../foods";
 import { turnEvidence } from "./chat-log";
 import { readHeldConstraints, foodDayClosedWith } from "../held-constraints";
-import { foodConstraints, allowedAlternatives } from "../food-swaps";
+import { foodConstraints, allowedAlternatives, allowedProteinStaples } from "../food-swaps";
 import { getDayLedger, getProgressTruth, sessionsThisCalendarWeek, getWeightTruth } from "../day-ledger";
 import { daysOnProgramme } from "../day-ledger-core";
 import { currentDateAnswer, isCurrentDateQuestion } from "../understanding/current-date";
@@ -809,7 +809,15 @@ export async function handleMiscCommands(ctx: {
   if (["protein", "my protein", "protein target", "daily protein", "protein daily", "how much protein", "my protein target"].includes(m)) {
     const p = user.proteinTarget || 140;
     const perMeal = Math.round(p / 4);
-    return `*Your Daily Protein Target*\n\n💪 ${p}g protein per day.\n\nSpread across 4 meals — roughly ${perMeal}g each. Best SA sources: eggs (6g each), pilchards (20g per tin), chicken breast (30g per 100g), tinned tuna (25g per tin). This drives everything — muscle, fat loss, fullness.`;
+    // NAMED FOODS ARE AN INSTRUCTION TO EAT THEM (#220). This sentence was fixed prose —
+    // "eggs, pilchards, chicken breast, tinned tuna" — and consulted no constraint at all, so
+    // a client who had told us they are vegan asked for their own protein target and was sent
+    // to buy chicken. Same canonical owner the grocery list and the swaps obey; the staple
+    // table carries plant sources too, so the answer is shorter, never empty, never a lecture.
+    const sources = allowedProteinStaples(foodConstraints(user as any)).slice(0, 4)
+      .map(s => `${s.name} (${s.protein}g ${s.per})`);
+    const sourceLine = sources.length ? ` Best SA sources: ${sources.join(", ")}.` : "";
+    return `*Your Daily Protein Target*\n\n💪 ${p}g protein per day.\n\nSpread across 4 meals — roughly ${perMeal}g each.${sourceLine} This drives everything — muscle, fat loss, fullness.`;
   }
   if (["weight", "my weight", "current weight", "how much do i weigh", "what do i weigh"].includes(mq)) {
     const w = user.currentWeight ? `${user.currentWeight}kg` : "not logged yet";

--- a/server/meal-plan-scale.ts
+++ b/server/meal-plan-scale.ts
@@ -17,15 +17,24 @@ export interface TopUp { label: string; kcal: number; protein: number }
 
 // Per-unit building blocks, protein-dense first. Budget-friendly staples on purpose: these
 // are what the target market actually buys (eggs, pilchards, amasi, peanut butter, pap).
+//
+// PLANT UNITS ARE NOT DECORATION (#220). This list was animal-only above the peanut butter, and
+// these units are appended AFTER meal-plan.ts has finished filtering its pools — so on a vegan's
+// plan they put "1 tin pilchards + 3 boiled eggs" back on the plate, one line under a header
+// reading "· Vegan". Filtering alone would have left a vegan with no top-up at all and a day
+// hundreds of kcal under target, so the answer is both: units they can eat, and a filter.
 const PROTEIN_UNITS: Array<{ name: string; kcal: number; protein: number; max: number }> = [
   { name: "1 tin pilchards", kcal: 190, protein: 26, max: 2 },
   { name: "3 boiled eggs", kcal: 234, protein: 21, max: 2 },
+  { name: "1 cup cooked lentils", kcal: 230, protein: 18, max: 2 },
+  { name: "1 cup cooked sugar beans", kcal: 230, protein: 15, max: 2 },
   { name: "250ml amasi", kcal: 130, protein: 9, max: 2 },
   { name: "2 tbsp peanut butter", kcal: 190, protein: 8, max: 2 },
 ];
 const STARCH_UNITS: Array<{ name: string; kcal: number; protein: number; max: number }> = [
   { name: "1 cup cooked pap", kcal: 290, protein: 6, max: 3 },
   { name: "2 slices brown bread", kcal: 180, protein: 8, max: 2 },
+  { name: "1 cup cooked rice", kcal: 205, protein: 4, max: 2 },
   { name: "1 banana", kcal: 105, protein: 1, max: 2 },
 ];
 
@@ -33,15 +42,20 @@ const STARCH_UNITS: Array<{ name: string; kcal: number; protein: number; max: nu
  * Top-ups to append to ONE day so it lands near the calorie + protein target.
  * `dayKcal`/`dayProtein` are the day's built totals. Never returns a negative adjustment —
  * an over-target plan is handled by the caller trimming, not by this function.
+ *
+ * `allows` is the caller's canonical constraint predicate (foodConstraints().allows). It is
+ * required rather than optional on purpose: this function's whole job is to ADD food to a
+ * client's plate, and every caller of it already holds the constraint.
  */
-export function topUpsForDay(dayKcal: number, dayProtein: number, calorieTarget: number, proteinTarget: number): TopUp[] {
+export function topUpsForDay(dayKcal: number, dayProtein: number, calorieTarget: number, proteinTarget: number,
+                             allows: (food: string) => boolean): TopUp[] {
   const out: TopUp[] = [];
   let kcalGap = Math.max(0, Math.round(calorieTarget - dayKcal));
   let protGap = Math.max(0, Math.round(proteinTarget - dayProtein));
   if (kcalGap < 150 && protGap < 15) return out; // already close enough
 
   // 1. PROTEIN first — it's the macro the pools under-deliver and the one that protects muscle.
-  for (const u of PROTEIN_UNITS) {
+  for (const u of PROTEIN_UNITS.filter(u2 => allows(u2.name))) {
     let n = 0;
     while (n < u.max && protGap > 8 && kcalGap >= u.kcal * 0.6) {
       n++; protGap -= u.protein; kcalGap -= u.kcal;
@@ -49,7 +63,7 @@ export function topUpsForDay(dayKcal: number, dayProtein: number, calorieTarget:
     if (n > 0) out.push({ label: n === 1 ? u.name : `${n}× ${u.name}`, kcal: u.kcal * n, protein: u.protein * n });
   }
   // 2. STARCH for whatever energy is still missing.
-  for (const u of STARCH_UNITS) {
+  for (const u of STARCH_UNITS.filter(u2 => allows(u2.name))) {
     let n = 0;
     while (n < u.max && kcalGap >= u.kcal * 0.7) { n++; kcalGap -= u.kcal; protGap -= u.protein; }
     if (n > 0) out.push({ label: n === 1 ? u.name : `${n}× ${u.name}`, kcal: u.kcal * n, protein: u.protein * n });

--- a/server/meal-plan.ts
+++ b/server/meal-plan.ts
@@ -14,7 +14,7 @@
 import { validateMealPlan, type DayTotals } from "./verifiers/meal-plan-validator";
 import { topUpsForDay, topUpLine } from "./meal-plan-scale";
 import { enforceMessageBudget, MESSAGE_BUDGET } from "./reply-contract";
-import { foodConstraints } from "./food-swaps";
+import { foodConstraints, allowedAlternatives } from "./food-swaps";
 
 export type MealPlanOptions = {
   calorieTarget: number;
@@ -70,6 +70,9 @@ const BF_BUDGET: FoodItem[] = [
   ["½ cup oats (water) + 1 banana + black coffee", 280, 8],
   ["2 eggs fried + ½ cup pap + black coffee", 300, 16],
   ["3 boiled eggs + black coffee", 270, 21],
+  // PLANT-BASED, ON EVERY TIER (#220). Without one of these the vegan filter empties the pool
+  // and the old code fell back to the unfiltered one — see the filter block in generateMealPlan.
+  ["½ cup oats (water) + 2 tbsp peanut butter + 1 banana", 400, 14],
 ];
 
 const BF_MID: FoodItem[] = [
@@ -78,6 +81,7 @@ const BF_MID: FoodItem[] = [
   ["2 eggs + 1 slice brown bread + ½ cup baked beans", 420, 28],
   ["Greek yoghurt (150g) + 1 banana + 2 boiled eggs", 400, 30],
   ["3 eggs scrambled + ½ cup sweet potato mash", 370, 25],
+  ["½ cup oats + 2 tbsp peanut butter + 1 banana", 420, 16],
 ];
 
 const BF_PREMIUM: FoodItem[] = [
@@ -86,6 +90,7 @@ const BF_PREMIUM: FoodItem[] = [
   ["3 eggs + 30g biltong + black coffee", 370, 38],
   ["Cottage cheese (100g) + 2 whole wheat toast + black coffee", 380, 28],
   ["3 eggs scrambled + 1 slice whole wheat toast + 1 apple", 400, 26],
+  ["½ cup oats + 2 tbsp peanut butter + ½ avo + 1 banana", 520, 17],
 ];
 
 // PROTEIN DAYS — lunch and dinner share the same base protein each day.
@@ -110,6 +115,14 @@ const PROTEIN_DAYS_BUDGET: ProteinDay[] = [
     lunch: ["3 boiled eggs + 1 slice brown bread + cabbage + tomato", 390, 24],
     dinner: ["Sugar beans (½ cup cooked) + ½ cup pap + onion + tomato", 390, 18],
     cookNote: "Boil 6 eggs in bulk — 3 today, 3 tomorrow. Soak beans overnight.",
+  },
+  {
+    // PLANT-BASED, ON EVERY TIER (#220). Every other day on this tier is animal-tagged, so a
+    // vegan's filter emptied the pool and the plan fell back to the unfiltered one.
+    tags: ["beans", "lentils"],
+    lunch: ["Sugar beans (1 cup cooked) + ½ cup pap + morogo + tomato", 430, 20],
+    dinner: ["Lentils (1 cup cooked) + ½ cup rice + cabbage + onion", 420, 20],
+    cookNote: "Soak 500g beans overnight and boil the lot. Lentils need no soaking — 25 minutes.",
   },
 ];
 
@@ -138,6 +151,12 @@ const PROTEIN_DAYS_MID: ProteinDay[] = [
     dinner: ["Tuna (1 tin) + ½ cup brown rice + mixed veg + lemon", 430, 34],
     cookNote: "Both are tinned — zero cooking. Pilchards at lunch, tuna at dinner.",
   },
+  {
+    tags: ["beans", "lentils"],
+    lunch: ["Lentils (1 cup cooked) + ½ cup brown rice + spinach + tomato", 450, 22],
+    dinner: ["Sugar beans (1 cup cooked) + ½ medium sweet potato + mixed veg", 440, 20],
+    cookNote: "Boil 500g beans in one pot — they keep four days. Lentils cook in 25 minutes.",
+  },
 ];
 
 const PROTEIN_DAYS_PREMIUM: ProteinDay[] = [
@@ -165,6 +184,12 @@ const PROTEIN_DAYS_PREMIUM: ProteinDay[] = [
     dinner: ["Steak slices (cold leftovers) + ½ cup brown rice + spinach + olive oil", 490, 44],
     cookNote: "Sear one 300g rump. Eat half hot at lunch — cold sliced for dinner.",
   },
+  {
+    tags: ["tofu", "lentils"],
+    lunch: ["Firm tofu (200g, pan-fried) + ½ cup brown rice + broccoli + soy sauce", 470, 34],
+    dinner: ["Lentils (1 cup cooked) + ½ medium sweet potato + spinach + olive oil", 480, 22],
+    cookNote: "Press the tofu 20 minutes before it hits the pan — that is the whole trick. Lentils in 25.",
+  },
 ];
 
 // SNACK OPTIONS
@@ -174,6 +199,7 @@ const SNACK_BUDGET: FoodItem[] = [
   ["Peanut butter (1 tbsp) + 1 slice brown bread", 230, 8],
   ["2 boiled eggs + black coffee", 160, 14],
   ["1 banana + black coffee", 100, 1],
+  ["Sugar beans (½ cup cooked) + 1 slice brown bread", 240, 12],
 ];
 
 const SNACK_MID: FoodItem[] = [
@@ -182,6 +208,7 @@ const SNACK_MID: FoodItem[] = [
   ["2 boiled eggs + 1 apple", 220, 14],
   ["Greek yoghurt (150g) + 1 banana", 230, 14],
   ["Baked beans (½ tin) + 1 slice brown bread", 250, 10],
+  ["1 apple + 30g mixed seeds", 220, 7],
 ];
 
 const SNACK_PREMIUM: FoodItem[] = [
@@ -190,6 +217,7 @@ const SNACK_PREMIUM: FoodItem[] = [
   ["Cottage cheese (100g) + 1 apple", 190, 16],
   ["30g biltong + black coffee", 140, 22],
   ["Mixed nuts (30g) + 1 apple", 240, 6],
+  ["Hummus (100g) + carrot sticks + 1 apple", 250, 8],
 ];
 
 // LOW-GI variants (diabetic / PCOS — swap all white pap for oats/sweet potato/samp)
@@ -293,61 +321,72 @@ export function generateMealPlan(opts: MealPlanOptions): string {
   const bfPool = isBudget ? BF_BUDGET : isPremium ? BF_PREMIUM : BF_MID;
   const snackPool = isBudget ? SNACK_BUDGET : isPremium ? SNACK_PREMIUM : SNACK_MID;
 
-  // Breakfast: filter for dietary restrictions
-  const MEAT_WORDS = ["chicken", "mince", "beef", "steak", "lamb", "pork", "biltong", "hake", "pilchard", "tuna", "fish", "salmon"];
-  const DAIRY_WORDS_VEGAN = ["yoghurt", "milk", "cheese", "cottage cheese", "whey"];
-  const filterMeat = (pool: FoodItem[]) => pool.filter(([d]) => !MEAT_WORDS.some(w => d.toLowerCase().includes(w)));
-  const filterVegan = (pool: FoodItem[]) => pool.filter(([d]) => !DAIRY_WORDS_VEGAN.some(w => d.toLowerCase().includes(w)) && !d.toLowerCase().includes("egg"));
-  const safeBfPool = isVegan ? filterVegan(filterMeat(bfPool)) : isVegetarian ? filterMeat(bfPool) : bfPool;
-
-  // Snack: allergy filtering
-  const safeSnackPool = noPeanuts ? snackPool.filter(([d]) => !d.toLowerCase().includes("peanut")) : snackPool;
-  const finalSnackPool = noDairy
-    ? safeSnackPool.filter(([d]) => !d.toLowerCase().includes("yoghurt") && !d.toLowerCase().includes("milk"))
-    : safeSnackPool;
+  // ── ONE FILTER, AND NO WAY PAST IT (#220) ──────────────────────────────────────────────────
+  //
+  // This block used to carry four private word lists — MEAT_WORDS, DAIRY_WORDS_VEGAN, FISH_TAGS,
+  // ANIMAL_TAGS — a fifth private answer to a question `constraints.allows` already owns, and an
+  // incomplete one: the snack filter looked only for peanut, yoghurt and milk, so a vegan's plan
+  // offered "30g biltong + 1 apple". `allows` is the same predicate the grocery list, the swap
+  // table and the plate verdict obey, so the plan cannot disagree with them any more.
+  //
+  // AND THE FALLBACKS ARE GONE. `safeProteinDays.length > 0 ? safeProteinDays : proteinDayPool`
+  // was the real defect: for a vegan on the premium tier every protein day is animal-tagged, the
+  // filter emptied the pool, and the plan silently served the UNFILTERED one — chicken breast,
+  // lean mince, hake, rump steak, under a header that read "Goal: Fat loss · 2200 kcal/day ·
+  // 150g protein · Fish-free · Vegan". A restriction that is discarded whenever honouring it is
+  // inconvenient is not a restriction. The pools below gained plant-based days and breakfasts so
+  // the filter has survivors on every tier; where a client's own literal exclusions still empty a
+  // pool the plan now says so, at the bottom, rather than quietly breaking their word.
+  const allowsItem = ([d]: FoodItem) => constraints.allows(d);
+  const safeBfPool = bfPool.filter(allowsItem);
+  const finalSnackPool = snackPool.filter(allowsItem);
 
   // Protein days: pick one per day — lunch + dinner share the same base protein
   const proteinDayPool = isBudget ? PROTEIN_DAYS_BUDGET : isPremium ? PROTEIN_DAYS_PREMIUM : PROTEIN_DAYS_MID;
-  const FISH_TAGS = ["pilchards", "fish", "tuna", "hake", "salmon"];
-  const ANIMAL_TAGS = ["chicken", "mince", "beef", "steak", "hake", "tuna", "fish", "pilchards"];
-  const safeProteinDays = proteinDayPool.filter(pd => {
-    if (noFish && pd.tags.some(t => FISH_TAGS.includes(t))) return false;
-    if (isVegetarian && pd.tags.some(t => ANIMAL_TAGS.includes(t))) return false;
-    if (isVegan && pd.tags.some(t => [...ANIMAL_TAGS, "eggs"].includes(t))) return false;
-    return true;
-  });
-  const finalProteinDays = safeProteinDays.length > 0 ? safeProteinDays : proteinDayPool;
+  // The COOK NOTE is filtered with the meals it belongs to. It is prose, not data, and it names
+  // food: "Grill 500g chicken breasts in one pan" reached a vegan even on days the meals passed.
+  const finalProteinDays = proteinDayPool.filter(pd =>
+    allowsItem(pd.lunch) && allowsItem(pd.dinner) && constraints.allows(pd.cookNote));
 
   // Build 3 days — each day picks a different protein so the week rotates
   const days: DayPlan[] = [];
-  for (let d = 0; d < 3; d++) {
+  const dayCount = finalProteinDays.length > 0 ? 3 : 0;
+  for (let d = 0; d < dayCount; d++) {
     const proteinDay = finalProteinDays[d % finalProteinDays.length];
-    const bf = pickItem(safeBfPool.length > 0 ? safeBfPool : bfPool, d, isLowGI);
-    const sn = pickItem(finalSnackPool.length > 0 ? finalSnackPool : snackPool, d, isLowGI);
+    // A pool a client's own exclusions emptied yields NO slot rather than a forbidden one.
+    const bf = safeBfPool.length ? pickItem(safeBfPool, d, isLowGI) : null;
+    const sn = finalSnackPool.length ? pickItem(finalSnackPool, d, isLowGI) : null;
 
     const lnRaw: FoodItem = isLowGI ? makeLowGI(proteinDay.lunch) : proteinDay.lunch;
     const dnRaw: FoodItem = isLowGI ? makeLowGI(proteinDay.dinner) : proteinDay.dinner;
 
-    let breakfast = buildMeal("🌅", "Breakfast", bf);
+    const breakfast = bf ? buildMeal("🌅", "Breakfast", bf) : null;
     let lunch = buildMeal("🍱", "Lunch", lnRaw);
     let dinner = buildMeal("🌙", "Dinner", dnRaw);
-    const snack = buildMeal("🍎", "Snack", sn);
+    const snack = sn ? buildMeal("🍎", "Snack", sn) : null;
 
     if (goalType === "fat_loss") {
       lunch = { ...lunch, kcal: Math.round(lunch.kcal * 0.92), items: lunch.items.replace("½ cup", "⅓ cup") };
       dinner = { ...dinner, kcal: Math.round(dinner.kcal * 0.92), items: dinner.items.replace("½ cup", "⅓ cup") };
     } else if (goalType === "muscle_gain") {
-      lunch = { ...lunch, kcal: lunch.kcal + 80, protein: lunch.protein + 10, items: `${lunch.items} + extra 50g chicken or 1 egg` };
+      // THE MUSCLE-GAIN TOP-UP NAMES A FOOD (#220), and named food is an instruction to eat it.
+      // This said "+ extra 50g chicken or 1 egg" unconditionally, stapling chicken onto every
+      // lunch of a vegan's plan after every filter above had run. The same `allowedAlternatives`
+      // the swap table uses trims it to what this client may have, and the generic dinner line
+      // — "extra 50g protein", naming nothing — is what is left when nothing survives.
+      const extra = allowedAlternatives("50g chicken, 1 egg", constraints);
+      lunch = { ...lunch, kcal: lunch.kcal + 80, protein: lunch.protein + 10,
+                items: `${lunch.items} + extra ${extra || "50g protein"}` };
       dinner = { ...dinner, kcal: dinner.kcal + 80, protein: dinner.protein + 10, items: `${dinner.items} + extra 50g protein` };
     }
 
     // SCALE TO TARGET (2026-07-27): the pools are sized ~1400-1500 kcal/day, so a 2862 kcal
     // client got a plan at 52% of target while the validator merely NOTED the shortfall.
     // Close the gap with real cheap SA staples — protein first — so the plan is usable as-is.
-    const built = [breakfast, lunch, dinner, snack];
+    const built = [breakfast, lunch, dinner, snack].filter((mm): mm is Meal => mm !== null);
     const dayKcal = built.reduce((s2, mm) => s2 + mm.kcal, 0);
     const dayProt = built.reduce((s2, mm) => s2 + mm.protein, 0);
-    const tops = topUpsForDay(dayKcal, dayProt, calorieTarget, proteinTarget);
+    const tops = topUpsForDay(dayKcal, dayProt, calorieTarget, proteinTarget, constraints.allows);
     const extraMeals = tops.length
       ? [{ emoji: "➕", label: "Extra to hit your target", items: tops.map(t => t.label).join(" + "),
            kcal: tops.reduce((s2, t) => s2 + t.kcal, 0), protein: tops.reduce((s2, t) => s2 + t.protein, 0) } as Meal]
@@ -403,17 +442,26 @@ export function generateMealPlan(opts: MealPlanOptions): string {
     .flatMap(d => d.meals.map(m => m.items))
     .join(" | ")
     .toLowerCase();
-  const validation = validateMealPlan({
-    dayTotals,
-    calorieTarget,
-    proteinTarget,
-    allItemsText,
-    isVegetarian,
-    isVegan,
-    noFish,
-    noDairy,
-    noPeanuts,
-  });
+  const validation = validateMealPlan({ dayTotals, calorieTarget, proteinTarget, allItemsText, constraints });
+
+  // ── THE CHECKER FINALLY HAS A MOUTH (#220) ─────────────────────────────────────────────────
+  //
+  // validateMealPlan has always detected this exactly right — it emitted "CRITICAL: vegan plan
+  // contains animal products: chicken, mince, tuna, egg" on the traced baseline — and its only
+  // consequence was a console.warn. `ok:false` was read by nobody, `issues` reached no client,
+  // and `adjustmentNote` carries the calorie and protein notes alone. So the plan that broke the
+  // client's stated diet shipped with the verifier's own alarm attached to the server log.
+  //
+  // A checker whose finding cannot stop the thing it checks is decoration. Above this, the
+  // generator can no longer BUILD a violating plan; a surviving CRITICAL therefore means a real
+  // defect, and the honest move is not to send a plan at all. Same for a client whose own
+  // exclusions emptied the protein pool: no days were built, and three empty day-blocks under a
+  // header promising 150g of protein is the hollow-list failure wearing a different hat.
+  const criticals = validation.issues.filter(i => i.startsWith("CRITICAL:"));
+  if (days.length === 0 || criticals.length > 0) {
+    const said = constraints.terms.length ? constraints.terms.join(", ") : "what you don't eat";
+    return `*Your Meal Plan*\n\nI can't build you a plan that respects ${said} out of the food I've got templates for — and I'd rather tell you that than send you one that breaks your word.\n\nTell me two or three proteins you DO eat and I'll build the week around them.`;
+  }
 
   // Join with ---  so Twilio splits into separate WA messages, then hold it to the stated
   // 4-message cap (measured at 5 before this). Re-packs sections; never trims a day.

--- a/server/meal-plan.ts
+++ b/server/meal-plan.ts
@@ -14,7 +14,7 @@
 import { validateMealPlan, type DayTotals } from "./verifiers/meal-plan-validator";
 import { topUpsForDay, topUpLine } from "./meal-plan-scale";
 import { enforceMessageBudget, MESSAGE_BUDGET } from "./reply-contract";
-import { foodConstraints, allowedAlternatives } from "./food-swaps";
+import { foodConstraints, allowedAlternatives, noPlanWithin } from "./food-swaps";
 
 export type MealPlanOptions = {
   calorieTarget: number;
@@ -458,10 +458,9 @@ export function generateMealPlan(opts: MealPlanOptions): string {
   // exclusions emptied the protein pool: no days were built, and three empty day-blocks under a
   // header promising 150g of protein is the hollow-list failure wearing a different hat.
   const criticals = validation.issues.filter(i => i.startsWith("CRITICAL:"));
-  if (days.length === 0 || criticals.length > 0) {
-    const said = constraints.terms.length ? constraints.terms.join(", ") : "what you don't eat";
-    return `*Your Meal Plan*\n\nI can't build you a plan that respects ${said} out of the food I've got templates for — and I'd rather tell you that than send you one that breaks your word.\n\nTell me two or three proteins you DO eat and I'll build the week around them.`;
-  }
+  // ONE OWNER for the sentence itself — getOnboardingMealPlan reaches the same moment from its
+  // own template and must not say it differently.
+  if (days.length === 0 || criticals.length > 0) return noPlanWithin(constraints);
 
   // Join with ---  so Twilio splits into separate WA messages, then hold it to the stated
   // 4-message cap (measured at 5 before this). Re-packs sections; never trims a day.

--- a/server/onboarding-meal-plan.ts
+++ b/server/onboarding-meal-plan.ts
@@ -6,7 +6,7 @@
 
 import { getDisplayName } from "./utils";
 // ONE OWNER FOR WHAT THIS CLIENT MAY EAT (#220). See the block inside the function.
-import { foodConstraints } from "./food-swaps";
+import { foodConstraints, noPlanWithin } from "./food-swaps";
 
 export function getOnboardingMealPlan(user: any): string {
   const budget = user.weeklyFoodBudget || "100_300";
@@ -49,7 +49,17 @@ export function getOnboardingMealPlan(user: any): string {
   const noFish = c.noFish && !c.vegetarian;  // the vegetarian case is carried by noFishEff below
   const noDairy = c.noDairy && !c.vegan;     // …and the vegan case by noDairyEff
   const noGluten = c.noGluten;
-  const isHalal = !!c.declaredLabel;
+  // KOSHER IS NOT HALAAL (#220, Codex P1 on PR #222 — my regression, caught before merge).
+  // `declaredLabel` covers halaal, halal AND kosher, so testing it truthy sent a client who
+  // declared kosher down the halal path and told them to "buy halal-certified chicken and beef".
+  // Halal certification is not kashrut, this template does not separate meat from dairy, and
+  // prescribing one observance to someone who named the other is worse than saying nothing.
+  // So the label is tested, and kosher gets a flag that claims only what we actually enforce.
+  // Tested by equality, not a pattern: `declaredLabel` is a closed set — "halaal", "halal",
+  // "kosher" or "" — so the word IS the answer, and a regex here would be a fifth thing that has
+  // to stay in step with the owner that produced it.
+  const isKosher = c.declaredLabel === "kosher";
+  const isHalal = !!c.declaredLabel && !isKosher;
   const isVegetarian = c.vegetarian;
   const isVegan = c.vegan;
   // Effective restriction flags extend allergy flags with dietary preferences
@@ -79,6 +89,10 @@ export function getOnboardingMealPlan(user: any): string {
   if (noDairy) medFlags.push("Dairy free");
   if (noGluten) medFlags.push("Gluten free");
   if (isHalal) medFlags.push("Halal — no pork, alcohol-free. Buy halal-certified chicken and beef.");
+  // ONLY WHAT WE ACTUALLY ENFORCE. These templates keep pork and shellfish out, and that is the
+  // whole of what this plan can promise a kosher client: it does not separate meat from dairy and
+  // it cannot vouch for a hechsher. Saying so is honest; borrowing the halal sentence was not.
+  if (isKosher) medFlags.push("Kosher — no pork or shellfish in this plan. I can't certify kashrut, so check the hechsher yourself and tell me if a meal needs changing.");
   if (isVegetarian && !isVegan) medFlags.push("Vegetarian — no meat or fish");
   if (isVegan) medFlags.push("Vegan — plant-based only, no animal products");
 
@@ -402,8 +416,34 @@ export function getOnboardingMealPlan(user: any): string {
   const header = `*Your Personalised 7 Day Meal Plan*\n${name} | Goal: ${goalLabels[goal] || goal} | ${adjustedCal} cal/day | ${adjustedProt}g protein/day\nBudget: ${budgetLabels[budget]} per week | Shop at Shoprite or Boxer${medFlags.length > 0 ? `\n⚠️ Medical: ${medFlags.join(" · ")}` : ""}`;
   const trainingLine = `\n*Training Days:* ${trainingDaysStr} (${daysPerWeek} day${daysPerWeek > 1 ? "s" : ""}/week)`;
 
-  const headerBlock = `${header}${trainingLine}${goalNote}${nightNote}${hivNote}${domesticNote}${studentNote}${unemployedNote}${postpartumNote}`;
+  // ── EVERY LINE THAT TELLS THEM TO EAT SOMETHING, AGAINST THE ONE PREDICATE (#220) ───────────
+  //
+  // Reading the booleans off `c` was only half the job, and Codex was right to call it on PR #222:
+  // the clusters say vegan / dairy / fish / peanut, and say nothing about the LITERAL foods a
+  // client named. foodConstraints records those too — `foodDislikes: "eggs"` — and `c.allows`
+  // rejects them, and every other food surface already obeys it: the 3-day plan came back clean
+  // for that same client while this one recommended boiled eggs on six separate mornings.
+  //
+  // VERIFIED, NOT FILTERED, for the meals. This template is fixed prose with the calories and
+  // protein baked into each line, so there is nothing to substitute and dropping a meal would
+  // leave the day's stated total lying about what is under it. A plan that breaks their word does
+  // not go out; they get the same sentence generateMealPlan gives when its pools cannot be filled.
+  //
+  // The shopping list and the pro tip ARE filtered, because they can lose a line honestly — an
+  // item nothing in the plan uses is just an item, and a tip is garnish. That distinction is why
+  // a fish-allergic client on the premium tier keeps their whole plan and simply stops being told
+  // that salmon goes on special.
+  const prescribed = (block: string) => block.split("\n")
+    .map((l: string) => (l.match(/^[^:]{1,40}:\s*(.+?)\s+—/) || [])[1] || "")
+    .filter(Boolean);
+  const shopLines = shopList.split("\n");
+  shopList = [shopLines[0], ...shopLines.slice(1).filter(l => c.allows(l.split("—")[0]))].join("\n");
+  const safeTip = c.allows(proTip) ? `\n🛒 ${proTip}` : "";
+  const goalNoteSafe = goalNote.split(/(?<=\.)\s+/).filter(sn => c.allows(sn)).join(" ");
+
+  const headerBlock = `${header}${trainingLine}${goalNoteSafe}${nightNote}${hivNote}${domesticNote}${studentNote}${unemployedNote}${postpartumNote}`;
   const planBlock = plan.trim();
-  const shopBlock = `${shopList}\nEstimated total: R${shopTotal}\n🛒 ${proTip}`;
+  if (prescribed(planBlock).some((food: string) => !c.allows(food))) return noPlanWithin(c);
+  const shopBlock = `${shopList}\nEstimated total: R${shopTotal}${safeTip}`;
   return `${headerBlock}\n\n---\n\n${planBlock}\n\n---\n\n${shopBlock}\n\n_Reply SWAP [day] to swap a day. Reply SHOPPING LIST for just the shopping list._`;
 }

--- a/server/onboarding-meal-plan.ts
+++ b/server/onboarding-meal-plan.ts
@@ -5,6 +5,8 @@
 // opened by addressing people the way a bank does.
 
 import { getDisplayName } from "./utils";
+// ONE OWNER FOR WHAT THIS CLIENT MAY EAT (#220). See the block inside the function.
+import { foodConstraints } from "./food-swaps";
 
 export function getOnboardingMealPlan(user: any): string {
   const budget = user.weeklyFoodBudget || "100_300";
@@ -16,7 +18,6 @@ export function getOnboardingMealPlan(user: any): string {
   const name = getDisplayName(user) || "there";
   const cal = user.calorieTarget || 1800;
   const prot = user.proteinTarget || 140;
-  const otherNotes = (user.otherMedicalNotes || "").toLowerCase();
 
   // Medical flags
   const isDiabetic = medicals.includes("diabetes");
@@ -29,20 +30,31 @@ export function getOnboardingMealPlan(user: any): string {
   const isUnemployed = situation === "unemployed";
   const isPhysicalJob = situation === "retail_physical";
 
-  // Allergy detection from free-text notes
-  const noPeanuts = otherNotes.includes("peanut");
-  const noFish = otherNotes.includes("fish") || otherNotes.includes("pilchard") || otherNotes.includes("sardine") || otherNotes.includes("tuna");
-  const noDairy = otherNotes.includes("dairy") || otherNotes.includes("milk") || otherNotes.includes("lactose");
-  const noGluten = otherNotes.includes("gluten") || otherNotes.includes("coeliac") || otherNotes.includes("wheat") || otherNotes.includes("celiac");
-
-  // Dietary preference flags — stored in profileNotes as diet:halal / diet:vegetarian / diet:vegan
-  const profileNotesLower = (user.profileNotes || "").toLowerCase();
-  const isHalal = profileNotesLower.includes("diet:halal");
-  const isVegetarian = profileNotesLower.includes("diet:vegetarian") || profileNotesLower.includes("diet:vegan");
-  const isVegan = profileNotesLower.includes("diet:vegan");
+  // ── WHAT THIS CLIENT MAY EAT — ASKED OF THE ONE OWNER (#220) ───────────────────────────────
+  //
+  // Traced on main@2cb48c1 through the real front door: a client whose vegan fact was recorded
+  // in users.dietary_restrictions — the canonical column, the one recordClientFacts writes and
+  // the one every grocery, swap and plate mouth reads — typed "7 day meals" and got chicken
+  // thigh, boiled eggs, pilchards, low fat yoghurt and beef mince, with no vegan line anywhere
+  // in the header. Not because the plan lacks vegan content: it has a full plant-based week,
+  // and it never ran, because this file asked a DIFFERENT store whether they were vegan.
+  //
+  // Two private answers lived here. `diet:` flags parsed out of profileNotes — the second
+  // dietary store #211 removed from the fact pipeline, still being read here — and a substring
+  // scan of otherMedicalNotes for the allergies, which never saw dietary_restrictions or
+  // food_dislikes either. Both are deleted. foodConstraints already merges all three columns
+  // and is what every other food surface obeys, so this file now cannot disagree with them.
+  const c = foodConstraints(user);
+  const noPeanuts = c.noPeanuts;
+  const noFish = c.noFish && !c.vegetarian;  // the vegetarian case is carried by noFishEff below
+  const noDairy = c.noDairy && !c.vegan;     // …and the vegan case by noDairyEff
+  const noGluten = c.noGluten;
+  const isHalal = !!c.declaredLabel;
+  const isVegetarian = c.vegetarian;
+  const isVegan = c.vegan;
   // Effective restriction flags extend allergy flags with dietary preferences
-  const noFishEff = noFish || isVegetarian; // vegetarians/vegans don't eat fish or meat
-  const noDairyEff = noDairy || isVegan;    // vegans don't consume dairy
+  const noFishEff = c.noFish;   // vegetarians/vegans don't eat fish or meat
+  const noDairyEff = c.noDairy; // vegans don't consume dairy
 
   // Calorie/protein adjustments
   const adjustedCal = isPhysicalJob ? cal + 300 : isHIV ? cal + 200 : cal;

--- a/server/shopping-lists.ts
+++ b/server/shopping-lists.ts
@@ -7,7 +7,7 @@
 // PRICE_ESTIMATE_NOTE is the ONE owner of how a rand estimate is qualified to a client — the
 // same sentence the GPT-generated rebuild now carries, so the two paths cannot drift apart.
 import { PRICE_ESTIMATE_NOTE } from "./reply-contract";
-import { type FoodConstraints, NO_CONSTRAINTS } from "./food-swaps";
+import { type FoodConstraints, NO_CONSTRAINTS, allowedAlternatives } from "./food-swaps";
 
 export type ShoppingItem = {
   item: string;
@@ -405,6 +405,34 @@ const ALL_LISTS: Record<string, ShoppingList[]> = {
  * list: one filter, applied after the goal modifications, over the items AND the meal ideas —
  * a meal idea is an instruction to eat something just as much as a line on the list is.
  */
+/**
+ * WHAT TO PUT BACK WHEN THE FILTER TAKES EVERYTHING (#220).
+ *
+ * Traced on main@2cb48c1: a vegan asked for their grocery list and got potatoes, oats, pasta,
+ * bread, cabbage, butternut, green beans, avo, tomatoes, oranges, apples and olive oil — every
+ * one of the eight tier lists is omnivore-only in its protein category, so `allows` correctly
+ * removed the whole section. The message still opened "This is a solid, quality base for your
+ * goal", still promised "150g protein", still printed an empty *Meal ideas to mix it up:*
+ * heading, and offered no protein at all. Honouring a restriction by deletion is not honouring
+ * it; it is the same failure as breaking it, pointed the other way.
+ *
+ * These are the plant staples every SA shop carries, at real shelf prices, and they are added
+ * ONLY when the client's own constraint emptied the category — never on top of a list that
+ * already works. Cheapest first, because month-end is the constraint every client shares.
+ */
+const CONSTRAINT_SAFE_PROTEIN: ShoppingItem[] = [
+  { item: "Sugar beans (500g dry)", qty: "500g", price: "R20", category: "protein" },
+  { item: "Lentils (500g dry)", qty: "500g", price: "R18", category: "protein" },
+  { item: "Soya mince (250g dry)", qty: "250g", price: "R22", category: "protein" },
+  { item: "Peanut butter (400g)", qty: "400g", price: "R30", category: "protein" },
+  { item: "Firm tofu (400g)", qty: "400g", price: "R35", category: "protein" },
+];
+const CONSTRAINT_SAFE_IDEAS = [
+  "Breakfast: Oats + peanut butter + banana — R8",
+  "Lunch: Sugar beans + pap + spinach + tomato — R14",
+  "Dinner: Lentils + rice + cabbage + onion — R14",
+];
+
 export function getShoppingList(budgetTier: string, weekNumber: number, goalType?: string,
                                 c: FoodConstraints = NO_CONSTRAINTS): ShoppingList {
   const lists = ALL_LISTS[budgetTier] || ALL_LISTS["100_300"];
@@ -412,10 +440,13 @@ export function getShoppingList(budgetTier: string, weekNumber: number, goalType
   const base = lists[idx];
   const shaped = goalType ? applyGoalModifications(base, goalType) : base;
   if (!c.terms.length) return shaped;
+  const items = shaped.items.filter(i => c.allows(i.item));
+  const mealIdeas = shaped.mealIdeas.filter(idea => c.allows(idea));
+  const refill = items.some(i => i.category === "protein") ? [] : CONSTRAINT_SAFE_PROTEIN.filter(i => c.allows(i.item));
   return {
     ...shaped,
-    items: shaped.items.filter(i => c.allows(i.item)),
-    mealIdeas: shaped.mealIdeas.filter(idea => c.allows(idea)),
+    items: [...items, ...refill],
+    mealIdeas: mealIdeas.length ? mealIdeas : CONSTRAINT_SAFE_IDEAS.filter(i => c.allows(i)),
   };
 }
 
@@ -454,8 +485,8 @@ export function formatShoppingList(list: ShoppingList, userName?: string, goalTy
   // Store advice by budget tier
   const budgetTier = targets?.budgetTier || "100_300";
   const storeAdvice: Record<string, string> = {
-    under_100:  `*Quality on any budget.* Eggs, pilchards, chicken livers, morogo, maas, beans — this is real, nutrient-dense food, not settling. Shoprite or Boxer are cheapest; buy the dry beans/lentils/samp in bulk and they last weeks.`,
-    "50_100":   `*Quality on any budget.* Eggs, pilchards, chicken livers, morogo, maas, beans — this is real, nutrient-dense food, not settling. Shoprite or Boxer are cheapest; buy the dry beans/lentils/samp in bulk and they last weeks.`,
+    under_100:  `*Quality on any budget.* ${allowedAlternatives("Eggs, pilchards, chicken livers, morogo, maas, beans, lentils", targets?.constraints || NO_CONSTRAINTS) || "Beans, lentils, samp, morogo"} — this is real, nutrient-dense food, not settling. Shoprite or Boxer are cheapest; buy the dry beans/lentils/samp in bulk and they last weeks.`,
+    "50_100":   `*Quality on any budget.* ${allowedAlternatives("Eggs, pilchards, chicken livers, morogo, maas, beans, lentils", targets?.constraints || NO_CONSTRAINTS) || "Beans, lentils, samp, morogo"} — this is real, nutrient-dense food, not settling. Shoprite or Boxer are cheapest; buy the dry beans/lentils/samp in bulk and they last weeks.`,
     "100_300":  `*Where to shop:* Pick n Pay or Checkers for the weekly run. Boxer/Shoprite for bulk items (oats, rice, eggs). Saves R80-150/week.`,
     "300_600":  `*Where to shop:* Checkers or Spar for convenience. Pick n Pay for bulk proteins. Woolworths for fresh veg if budget allows.`,
     over_600:   `*Where to shop:* Woolworths for quality cuts and fresh produce. Checkers for staples. Order online for bulk pantry items.`,
@@ -527,11 +558,22 @@ export function formatShoppingList(list: ShoppingList, userName?: string, goalTy
   };
   const dailyStructure = filterBullets(dailyStructures[goal] || dailyStructures["fat_loss"]);
 
+  // A HEADING WITH NOTHING UNDER IT (#220). `list.mealIdeas` arrives already filtered, and for a
+  // vegan every idea on every tier list named meat — so this printed "*Meal ideas to mix it up:*"
+  // followed by a blank line. Same for the daily structure, which filterBullets correctly
+  // reduces to "". A section with no content does not get a heading.
   const ideas = list.mealIdeas.map(m => `• ${m}`).join("\n");
+  const ideasSection = ideas ? `\n\n*Meal ideas to mix it up:*\n${ideas}` : "";
+  const structureSection = dailyStructure ? `\n${dailyStructure}` : "";
 
+  // THE AVOID LIST TELLS THEM WHAT TO BUY TOO. "Flavoured yoghurt — … plain or Greek only" is an
+  // instruction to buy plain or Greek yoghurt, and it reached a client who had just been told at
+  // the top of this same message that dairy was left off for them. Same `allows`, same reason as
+  // the meal ideas: any bullet that names a food they do not eat comes out.
   const avoidSection = (goal === "fat_loss" || goal === "recomposition")
-    ? `\n\n*🚫 Leave these on the shelf:*\n• Sugary drinks (Coke, Oros, juice, flavoured water) — liquid calories you don't feel\n• Honey, syrup, white sugar — same impact as sweets; fruit handles your sweetness\n• Flavoured yoghurt — most have 15-25g added sugar; plain or Greek only\n• Breakfast cereals and instant oats with flavouring — mostly sugar in a box\n• Polony, Russians, Viennas — high sodium, minimal real protein\n• White bread if you can avoid it — brown bread only`
+    ? (block => block ? `\n\n*🚫 Leave these on the shelf:*\n${block}` : "")(
+        filterBullets(`• Sugary drinks (Coke, Oros, juice, flavoured water) — liquid calories you don't feel\n• Honey, syrup, white sugar — same impact as sweets; fruit handles your sweetness\n• Flavoured yoghurt — most have 15-25g added sugar; plain or Greek only\n• Breakfast cereals and instant oats with flavouring — mostly sugar in a box\n• Polony, Russians, Viennas — high sodium, minimal real protein\n• White bread if you can avoid it — brown bread only`))
     : "";
 
-  return `${fn ? fn + ", this" : "This"} is your full week.\n\n${intro}${personalBlock}\n\n${store}\n\n*What to buy (${list.estimatedTotal} est. — ${list.coversDays} days):*\n${PRICE_ESTIMATE_NOTE}${body}\n${dailyStructure}\n\n*Meal ideas to mix it up:*\n${ideas}${avoidSection}\n\n_Screenshot this. Tick off as you shop. Send me what you eat each day — photo or words — and I track the numbers.\n\nTo adjust: tell me what you don't eat, what you want to swap, or what you already have at home._`;
+  return `${fn ? fn + ", this" : "This"} is your full week.\n\n${intro}${personalBlock}\n\n${store}\n\n*What to buy (${list.estimatedTotal} est. — ${list.coversDays} days):*\n${PRICE_ESTIMATE_NOTE}${body}${structureSection}${ideasSection}${avoidSection}\n\n_Screenshot this. Tick off as you shop. Send me what you eat each day — photo or words — and I track the numbers.\n\nTo adjust: tell me what you don't eat, what you want to swap, or what you already have at home._`;
 }

--- a/server/verifiers/meal-plan-validator.ts
+++ b/server/verifiers/meal-plan-validator.ts
@@ -11,6 +11,8 @@
  * Deterministic, zero-cost, never throws.
  */
 
+import { allowedAlternatives, type FoodConstraints } from "../food-swaps";
+
 export interface DayTotals {
   day: string;
   kcal: number;
@@ -34,12 +36,18 @@ export function validateMealPlan(opts: {
   calorieTarget: number;
   proteinTarget: number;
   allItemsText: string; // all meal descriptions concatenated, lowercase
-  isVegetarian: boolean;
-  isVegan: boolean;
-  noFish: boolean;
-  noDairy: boolean;
-  noPeanuts: boolean;
+  /**
+   * THE CANONICAL CONSTRAINT, NOT A COPY OF ITS ANSWERS (#220). This took five booleans —
+   * isVegetarian / isVegan / noFish / noDairy / noPeanuts — unpacked by the caller from the very
+   * object this file now receives whole. Five flags is five chances to pass one of them wrong,
+   * and it left this file unable to answer the question it most needed: WHAT MAY THIS CLIENT EAT?
+   * That is why the shortfall note below told a vegan to add "1 tin pilchards, 3 eggs, or 200g
+   * Greek yoghurt" — the checker that had just written "CRITICAL: vegan plan contains animal
+   * products" then recommended three of them, in the client-facing sentence, in the same pass.
+   */
+  constraints: FoodConstraints;
 }): MealPlanValidation {
+    const { vegan: isVegan, vegetarian: isVegetarian, noFish, noDairy, noPeanuts } = opts.constraints;
   try {
     const issues: string[] = [];
     const { dayTotals, calorieTarget, proteinTarget, allItemsText } = opts;
@@ -47,22 +55,22 @@ export function validateMealPlan(opts: {
     // ── Dietary safety re-scan (independent of the generator's filters) ────────
     // These are critical: a vegan getting chicken, or an allergy violation, is a
     // trust-and-safety failure, not a portion quibble.
-    if (opts.isVegan) {
+    if (isVegan) {
       const found = ANIMAL_WORDS.filter(w => allItemsText.includes(w));
       if (found.length) issues.push(`CRITICAL: vegan plan contains animal products: ${found.join(", ")}`);
-    } else if (opts.isVegetarian) {
+    } else if (isVegetarian) {
       const found = MEAT_WORDS.filter(w => allItemsText.includes(w));
       if (found.length) issues.push(`CRITICAL: vegetarian plan contains meat/fish: ${found.join(", ")}`);
     }
-    if (opts.noFish) {
+    if (noFish) {
       const found = FISH_WORDS.filter(w => allItemsText.includes(w));
       if (found.length) issues.push(`CRITICAL: fish-free plan contains fish: ${found.join(", ")}`);
     }
-    if (opts.noDairy) {
+    if (noDairy) {
       const found = DAIRY_WORDS.filter(w => allItemsText.includes(w));
       if (found.length) issues.push(`CRITICAL: dairy-free plan contains dairy: ${found.join(", ")}`);
     }
-    if (opts.noPeanuts && allItemsText.includes("peanut")) {
+    if (noPeanuts && allItemsText.includes("peanut")) {
       issues.push("CRITICAL: peanut-allergy plan contains peanut");
     }
 
@@ -94,8 +102,15 @@ export function validateMealPlan(opts: {
       if (avgProt < proteinTarget * 0.85) {
         const gap = proteinTarget - avgProt;
         issues.push(`plan averages ${avgProt}g protein vs ${proteinTarget}g target (${gap}g short)`);
+        // THE NOTE IS A RECOMMENDATION (#220) — three named foods and a "add a protein source"
+        // instruction. Same `allowedAlternatives` every other recommender obeys; when nothing
+        // this client eats survives, the sentence keeps the gap and drops the examples rather
+        // than naming food they told us they do not eat.
+        const sources = allowedAlternatives(
+          "1 tin pilchards (26g), 3 eggs (21g), 200g Greek yoghurt (20g), 1 cup cooked lentils (18g), 1 cup cooked sugar beans (15g)",
+          opts.constraints);
         noteParts.push(
-          `Protein averages ~${avgProt}g/day vs your ${proteinTarget}g target. Add a protein source — 1 tin pilchards (26g), 3 eggs (21g), or 200g Greek yoghurt (20g) — to close the ${gap}g gap.`
+          `Protein averages ~${avgProt}g/day vs your ${proteinTarget}g target. Add a protein source${sources ? ` — ${sources} —` : ""} to close the ${gap}g gap.`
         );
       }
     }


### PR DESCRIPTION
Closes #220. **Do not merge — this is at the CTO gate.**

## What a client actually received on `main@2cb48c1`

Traced through the real front door on real PostgreSQL, with the vegan fact in `users.dietary_restrictions` — the canonical column `recordClientFacts` writes and every food mouth is supposed to read — and **nothing else**:

| Surface | What arrived |
|---|---|
| `meal plan` | `Grill 500g chicken breasts in one pan` · `3 eggs scrambled` · lean mince · hake · rump steak — under a header reading `Goal: Fat loss · 2200 kcal/day · 150g protein · Fish-free · **Vegan**` |
| `protein` | `Best SA sources: eggs (6g each), pilchards (20g per tin), chicken breast (30g per 100g), tinned tuna (25g per tin)` |
| `7 day meals` | a whole week of chicken thigh, boiled eggs, pilchards, low fat yoghurt and beef mince, with no vegan line anywhere in the header |
| model context | `buildClientSnapshot` did not contain the word *vegan* at all |
| `grocery list` | the restriction honoured **by deletion** — the entire protein category gone, `*Meal ideas to mix it up:*` printed over nothing, the message still opening *"a solid, quality base for your goal"* and promising 150g of protein |
| `grocery list` (dairy-free) | `Flavoured yoghurt — … plain or Greek only`, six lines under `🚫 Left off — you told me: no dairy` |

## Four shapes of one defect, each fixed in the owner that already existed

**A · A second store.** `onboarding-meal-plan.ts` derived vegan / vegetarian / halaal from `diet:` flags in `profileNotes`, and its allergies from a substring scan of `otherMedicalNotes`. It never read `dietary_restrictions` or `food_dislikes`. Both private parsers are deleted; the file asks `foodConstraints`, like everything else. It has had a complete plant-based week all along and simply never ran it.

**B · No consultation at all.** The protein-target sentence was fixed prose and now draws from a new `allowedProteinStaples` — one table carrying plant and animal staples together, so the filter always leaves something honest. `buildClientSnapshot` read `food_dislikes` raw and now pushes `foodConstraints().line`, the same sentence `media.ts` already puts in front of the vision model. `topUpsForDay` now takes the constraint: it is appended *after* every pool filter has run, so it was the last place a forbidden food could reach a compliant plate.

**C · A fallback past the restriction.** `meal-plan.ts` filtered its pools correctly and then served the **unfiltered** pool whenever the filter emptied one:

```ts
const finalProteinDays = safeProteinDays.length > 0 ? safeProteinDays : proteinDayPool;
```

Its four private word lists (`MEAT_WORDS`, `DAIRY_WORDS_VEGAN`, `FISH_TAGS`, `ANIMAL_TAGS`) are replaced by `constraints.allows` — they were also incomplete, which is why a vegan's snack was `30g biltong + 1 apple`. The fallbacks are gone, the pools gained plant-based days and breakfasts on every tier so the filter has survivors, and `validateMealPlan`'s CRITICAL finding finally has a consequence: it emitted `CRITICAL: vegan plan contains animal products` to `console.warn` under a plan that shipped anyway.

**D · Honoured by deletion.** `getShoppingList` refills an emptied protein category from constraint-safe staples at real shelf prices, prints no heading over an empty section, and runs the *leave these on the shelf* block through the same `allows` — an avoid list is an instruction to buy too.

## Three defects inside `allows` itself, surfaced on the way

- `\bbutter\b` in the dairy cluster matched **peanut butter**, so a lactose-intolerant client was refused it — and the vegan breakfast built from it was filtered off a vegan's own plan, which is part of why the pool ran out of compliant food.
- `\bmince\b` in the meat cluster matched **soya mince**, so `allows` refused the swap its own substitution table had just offered.
- `\bpeanut\b` never matched the plural, so a client whose column read exactly `peanuts` had `noPeanuts === false`; the allergy was carried only by the literal-term fallback and the peanut *cluster* never fired.

## Governor

`authorshipPoints` stays at its frozen **419**. The new refusal mouth is paid for by `prettyList` and `allowedAlternatives` collapsing into one `joinFoods` owner — two implementations of "join food names into English", differing only in the conjunction and in where they put the Oxford comma. The repo now carries one exempted join where it carried one exempted and one counted; the exemption moved, it did not grow.

## Proof

`script/pg-restriction-consistency-acceptance.ts` — real front door, real PostgreSQL, `SHADOW=on` so the Sunday sends are graded on the **message** — covers all eight required journeys, **with a control beside every claim**: the same surface for an unrestricted client (silence and blanket suppression both satisfy "no chicken in the reply"), the retraction actually lifting on all four doors, tree nuts surviving a peanut allergy, and a mere dislike not becoming a diet.

`script/red-on-revert-220.sh` puts each fix back **alone**. Nine of ten reverts go red on the checks that fix exists to hold:

```
── REVERT: onboarding-meal-plan reads profileNotes diet: flags     RED — 7 day meals: a vegan is offered no animal food
── REVERT: the protein-target answer is fixed prose again          RED — protein target: a vegan is offered no animal food
── REVERT: buildClientSnapshot reads food_dislikes raw again       RED — the snapshot says the client is vegan (+1)
── REVERT: 4a · the plan falls back to the unfiltered pool         GREEN — see below
── REVERT: 4b · …and the CRITICAL guard is a console.warn again    RED — a filter that leaves NOTHING produces no plan (+1)
── REVERT: topUpsForDay appends food without the constraint        RED — …and is still three days, not a stub
── REVERT: the grocery list is honoured by deletion                RED — …and still HAS a protein section (+1)
── REVERT: the shelf block stops obeying the constraint            RED — 6 checks
── REVERT: noPeanuts goes back to its singular-only trigger        RED — 2 checks
── REVERT: the plan-check note names food without the constraint   RED — 5 checks
```

**4a is reported green with its reason rather than dressed up.** The fallback and the CRITICAL guard are two halves of one mechanism — *the plan may not be built from food this client cannot eat, and if it somehow is, it does not ship.* With the fallback restored the guard catches the violating plan and refuses it, which is the guard doing exactly its job; 4b removes both, and only then does a vegan receive chicken.

## Runs

- `npm test` — **37/37**
- `npm run test:journeys` — **266/266**, all 8 sections
- **16/16** PostgreSQL acceptances (the new one wired into the `pg-acceptance` job)
- `check:filesize` / `pricing` / `schema` / `sast` / `names` / `arch` / `prompt` / `reach` — all pass

## One regraded check, disclosed

`pg-food-constraint-mouths-acceptance`'s own `ANIMAL` detector read `\bmince\b` and so called the vegan option *"Soya mince + rice + mixed veg"* an animal food. That was harmless only while `allows` made the same mistake and filtered the option out — **the check and the defect agreed**, and the suite went green on a vegan being denied the best plant protein in the pool and handed the 30g tofu plate instead of the 45g soya one. The detector is corrected with the owner, and the comment says why.

## Recorded, not fixed here

A client who declares `tree nuts` gets only the literal phrase suppressed — almonds and cashews are still offered. That is the literal-term mechanism rather than restriction *consistency*, and widening it needs a nut taxonomy adjudicated, not guessed. Filed for the next cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_