### PR TITLE
#220 recovery: rotate the slot before refusing, and fail kosher closed

### DIFF
--- a/script/pg-restriction-consistency-acceptance.ts
+++ b/script/pg-restriction-consistency-acceptance.ts
@@ -367,23 +367,60 @@ REAL("\n=== I · NEGATIVE CONTROL: A PREFERENCE IS NOT A DIET ===");
 }
 
 REAL("\n=== J · THE LITERAL FOODS THEY NAMED, ON THE FIXED TEMPLATE ===");
-REAL("    (both P1 findings from the Codex review of PR #222, reproduced and closed.)");
+REAL("    (CTO GATE P1-1 and P1-2 on PR #222, and their mandatory controls.)");
 {
   // A CLUSTER BOOLEAN IS NOT THE WHOLE CONSTRAINT. foodConstraints also records the literal foods
-  // a client named, `allows` rejects them, and every other surface obeys — the 3-day plan came
-  // back clean for this exact client while the 7-day template recommended boiled eggs on six
-  // separate mornings, because it copied the booleans and never asked the predicate.
+  // a client named, `c.allows` rejects them, and every other surface obeys — the 3-day plan came
+  // back clean for these clients while the 7-day template recommended eggs on six mornings and
+  // lentils in eight lines, because it copied the booleans and never asked the predicate.
+  //
+  // THE SLOT ROTATES BEFORE IT REFUSES. Each meal is chosen from a seven-candidate array whose
+  // line carries a FIXED protein figure, so swapping candidates inside one array changes no number
+  // and invents no food. Refusing while a compliant option sits one index away would be honouring
+  // the constraint by giving up, which is the same failure as the hollow grocery list.
+
+  // P1-1 control 1 — the ordinary client is untouched.
+  const plain = await client("Sipho");
+  const plainPlan = await ask(plain.phone, "7 day meals");
+  chk(!/can't build/i.test(plainPlan) && /Monday/.test(plainPlan) && /Sunday/.test(plainPlan),
+    "CONTROL: an unrestricted client still receives the ordinary 7-day plan",
+    JSON.stringify(plainPlan.slice(0, 160)));
+
+  // P1-1 control 2 — a literal `eggs` exclusion. Every breakfast candidate in this template is an
+  // egg, so no rotation can save it and the honest refusal is the answer.
   const eggs = await client("Naledi", { foodDislikes: "eggs" });
   const seven = await ask(eggs.phone, "7 day meals");
-  chk(!/\begg/i.test(body(seven)), "a literal `eggs` exclusion is honoured by the fixed 7-day template",
+  chk(!/\begg/i.test(body(seven)), "a literal `eggs` exclusion reaches the fixed 7-day template",
     JSON.stringify((body(seven).match(/[^\n]*egg[^\n]*/i) || [""])[0]));
   chk(/can't build/i.test(seven),
-    "…by refusing, because a fixed template has nothing to substitute and its totals would lie",
+    "…and with no egg-free breakfast candidate to rotate to, it refuses rather than prescribing one",
     JSON.stringify(seven.slice(0, 200)));
-  // THE CONTROL, and it is the one that matters: refusing is easy, refusing ONLY when the template
-  // actually collides is the claim. A dislike the plan never names must cost the client nothing.
-    // The fixture NAME must not carry a food word: the plan header interpolates it, and a client
-  // called "DislikesBroccoli" fails a broccoli detector on the greeting line alone.
+
+  // P1-1 control 3 — THE ONE THAT DISTINGUISHES ROTATION FROM GIVING UP. Vegan AND no lentils: the
+  // same arrays carry tofu, soya mince and sugar beans, so a plan must still come out.
+  const noLentils = await client("Zanele", { dietaryRestrictions: "vegan, lentils" });
+  const vPlan = await ask(noLentils.phone, "7 day meals");
+  chk(!/lentil/i.test(body(vPlan)), "vegan + `lentils` excluded: no lentil is recommended anywhere",
+    JSON.stringify((body(vPlan).match(/[^\n]*lentil[^\n]*/i) || [""])[0]));
+  chk(!/can't build/i.test(vPlan) && /Sunday/.test(vPlan),
+    "…and the plant-based alternative survives — they still get the whole week",
+    JSON.stringify(vPlan.slice(0, 200)));
+  chk(/tofu|soya|sugar beans/i.test(vPlan), "…built on the compliant plant proteins the arrays already carry",
+    JSON.stringify((vPlan.match(/[^\n]*(tofu|soya|sugar beans)[^\n]*/i) || ["(none)"])[0]));
+  chk(!ANIMAL.test(body(vPlan)), "…and it is still vegan", (body(vPlan).match(new RegExp(ANIMAL.source, "gi")) || []).join(", "));
+
+  // The same rotation is what keeps a coeliac covered: every gluten carb has a non-gluten
+  // candidate in its own array, so the plan changes rather than disappearing.
+  const coeliac = await client("Lerato", { dietaryRestrictions: "gluten" });
+  const gPlan = await ask(coeliac.phone, "7 day meals");
+  chk(!/bread|pasta|wheat/i.test(body(gPlan)), "a gluten-free client is recommended no bread, pasta or wheat",
+    JSON.stringify((body(gPlan).match(/[^\n]*(bread|pasta|wheat)[^\n]*/i) || [""])[0]));
+  chk(!/can't build/i.test(gPlan) && /Sunday/.test(gPlan), "…and still gets the whole week",
+    JSON.stringify(gPlan.slice(0, 160)));
+
+  // The control on the control: a dislike the plan never names must cost the client nothing.
+  // The fixture NAME must not carry a food word — the header interpolates it, and a client called
+  // "DislikesBroccoli" fails a broccoli detector on the greeting line alone.
   const broc = await client("Thabo", { foodDislikes: "broccoli" });
   const ok = await ask(broc.phone, "7 day meals");
   chk(!/can't build/i.test(ok) && /Monday/.test(ok) && /Sunday/.test(ok),
@@ -392,24 +429,32 @@ REAL("    (both P1 findings from the Codex review of PR #222, reproduced and clo
   chk(!/broccoli/i.test(body(ok)), "…with the disliked food itself absent from it",
     JSON.stringify((body(ok).match(/[^\n]*broccoli[^\n]*/i) || [""])[0]));
 
-  // KOSHER IS NOT HALAAL. `declaredLabel` covers both, so testing it truthy sent a client who
-  // declared kosher down the halal path — "buy halal-certified chicken and beef" — on a template
-  // that does not separate meat from dairy and cannot vouch for a hechsher.
-  const kosher = await client("Kosher", { dietaryRestrictions: "kosher" });
+  // ── P1-2 · KOSHER IS NOT HALAAL, AND IT FAILS CLOSED ───────────────────────────────────────
+  //
+  // `declaredLabel` covers both, so testing it truthy sent a kosher client down the halal path —
+  // "buy halal-certified chicken and beef". The first fix gave them the plan with a "check the
+  // hechsher yourself" caveat, which is a kosher rule invented at the mouth: these templates put
+  // chicken and yoghurt in the same day, so they break kashrut on what may be eaten TOGETHER, and
+  // nothing in this product owns that rule. Until a kosher-safe owner exists, it fails closed.
+  const kosher = await client("Yosef", { dietaryRestrictions: "kosher" });
   const kPlan = await ask(kosher.phone, "7 day meals");
-  chk(!/halal|halaal/i.test(kPlan), "a kosher client is never prescribed halal certification",
+  chk(!/halal|halaal/i.test(kPlan), "a kosher client is never labelled halal",
     JSON.stringify((kPlan.match(/[^\n]*hal[a]?al[^\n]*/i) || [""])[0]));
-  chk(/kosher/i.test(kPlan) && /can't certify|cannot certify/i.test(kPlan),
-    "…and is told plainly what this plan does and does not guarantee",
-    JSON.stringify((kPlan.match(/[^\n]*Kosher[^\n]*/i) || ["(absent)"])[0]));
-  // THE CONTROL: the halal path itself must still work for someone who actually declared it.
-  const halaal = await client("Halaal", { dietaryRestrictions: "halaal" });
+  chk(/can't build/i.test(kPlan), "…and an unsupported kosher plan fails honestly rather than being caveated",
+    JSON.stringify(kPlan.slice(0, 220)));
+  chk(!/chicken|beef|yoghurt|milk|cheese/i.test(body(kPlan)),
+    "…prescribing no food at all rather than food we cannot vouch for",
+    (body(kPlan).match(/chicken|beef|yoghurt|milk|cheese/gi) || []).join(", "));
+  // P1-2 control 1 — the halal path itself must be untouched for someone who declared it.
+  const halaal = await client("Aisha", { dietaryRestrictions: "halaal" });
   const hPlan = await ask(halaal.phone, "7 day meals");
-  chk(/halal-certified/i.test(hPlan), "CONTROL: a client who declared halaal still gets the halal guidance",
+  chk(/halal-certified/i.test(hPlan), "CONTROL: a client who declared halaal still gets the halal-safe path",
     JSON.stringify((hPlan.match(/[^\n]*halal[^\n]*/i) || ["(absent)"])[0]));
+  chk(!/can't build/i.test(hPlan) && /Sunday/.test(hPlan), "CONTROL: …and their whole week",
+    JSON.stringify(hPlan.slice(0, 160)));
 
   // SALMON WAS NOT IN THE FISH CLUSTER, found by running the fix over the premium tier.
-  const fish = await client("FishAllergy", { dietaryRestrictions: "fish", weeklyFoodBudget: "over_600" });
+  const fish = await client("Bongani", { dietaryRestrictions: "fish", weeklyFoodBudget: "over_600" });
   const fPlan = await ask(fish.phone, "7 day meals");
   chk(!/salmon|mackerel|kingklip/i.test(body(fPlan)),
     "a declared fish allergy covers salmon on the shopping list and in the pro tip",

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -142,6 +142,7 @@ PY
 cat > /tmp/220p/10.py <<'PY2'
 p = "server/onboarding-meal-plan.ts"; s = open(p).read()
 s = s.replace("const isHalal = !!c.declaredLabel && !isKosher;", "const isHalal = !!c.declaredLabel;")
+s = s.replace("  if (isKosher) return noPlanWithin(c);", "")
 assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY2
@@ -150,6 +151,22 @@ PY2
 cat > /tmp/220p/11.py <<'PY2'
 p = "server/onboarding-meal-plan.ts"; s = open(p).read()
 s = s.replace("  if (prescribed(planBlock).some((food: string) => !c.allows(food))) return noPlanWithin(c);", "")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 11b · the slot stops rotating over what the client may eat (it refuses instead) ───────────
+cat > /tmp/220p/11b.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+for a, b in [("safeBf[i % safeBf.length]", "bfProteins[i]"),
+             ("safeBfCarbs[i % safeBfCarbs.length]", "bfCarbs[i]"),
+             ("safeLunch[i % safeLunch.length]", "lunchProteins[i]"),
+             ("safeLunchCarbs[i % safeLunchCarbs.length]", "lunchCarbs[i]"),
+             ("safeDinner[i % safeDinner.length]", "dinnerProteins[i]"),
+             ("safeDinnerCarbs[i % safeDinnerCarbs.length]", "dinnerCarbs[i]"),
+             ("safePre[i % safePre.length]", "preOptions[i % preOptions.length]"),
+             ("safePost[i % safePost.length]", "postOptions[i % postOptions.length]")]:
+    s = s.replace(a, b)
 assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY2
@@ -183,5 +200,6 @@ run_case "noPeanuts goes back to its singular-only trigger"                     
 run_case "the plan-check note names food without asking the constraint"                        /tmp/220p/9.py
 run_case "kosher takes the halal path again (the PR #222 regression)"                          /tmp/220p/10.py
 run_case "the fixed 7-day template stops asking the predicate about its own meals"             /tmp/220p/11.py
+run_case "11b · the slot stops rotating over what the client may eat"                          /tmp/220p/11b.py
 run_case "salmon leaves the fish cluster"                                                      /tmp/220p/12.py
 echo "=============================================================================="

--- a/server/onboarding-meal-plan.ts
+++ b/server/onboarding-meal-plan.ts
@@ -60,6 +60,14 @@ export function getOnboardingMealPlan(user: any): string {
   // to stay in step with the owner that produced it.
   const isKosher = c.declaredLabel === "kosher";
   const isHalal = !!c.declaredLabel && !isKosher;
+  // AND KOSHER FAILS CLOSED. A caveat does not make a plan kosher: these templates put chicken and
+  // yoghurt in the same day, so they break kashrut at the level of what may be eaten TOGETHER, and
+  // nothing in this product owns that rule. The first draft of this fix shipped the plan with a
+  // "check the hechsher yourself" line, which is a rule invented at the mouth — the same class of
+  // mistake as reinterpreting kosher as halal, just quieter. Until a kosher-safe owner exists, the
+  // honest answer is the one generateMealPlan already gives when it cannot build inside a
+  // constraint, and the client is asked for what would let us build it.
+  if (isKosher) return noPlanWithin(c);
   const isVegetarian = c.vegetarian;
   const isVegan = c.vegan;
   // Effective restriction flags extend allergy flags with dietary preferences
@@ -89,10 +97,6 @@ export function getOnboardingMealPlan(user: any): string {
   if (noDairy) medFlags.push("Dairy free");
   if (noGluten) medFlags.push("Gluten free");
   if (isHalal) medFlags.push("Halal — no pork, alcohol-free. Buy halal-certified chicken and beef.");
-  // ONLY WHAT WE ACTUALLY ENFORCE. These templates keep pork and shellfish out, and that is the
-  // whole of what this plan can promise a kosher client: it does not separate meat from dairy and
-  // it cannot vouch for a hechsher. Saying so is honest; borrowing the halal sentence was not.
-  if (isKosher) medFlags.push("Kosher — no pork or shellfish in this plan. I can't certify kashrut, so check the hechsher yourself and tell me if a meal needs changing.");
   if (isVegetarian && !isVegan) medFlags.push("Vegetarian — no meat or fish");
   if (isVegan) medFlags.push("Vegan — plant-based only, no animal products");
 
@@ -270,20 +274,49 @@ export function getOnboardingMealPlan(user: any): string {
   const lunchCal = Math.round(adjustedCal * 0.35);
   const dinnerCal = Math.round(adjustedCal * 0.28);
 
+  // ── THE SLOT ROTATES OVER WHAT THIS CLIENT MAY EAT (#220, CTO GATE P1-1) ────────────────────
+  //
+  // The arrays above are seven candidate proteins per slot, and the line they land in carries a
+  // FIXED protein figure ("— 25g protein") that does not depend on which candidate is chosen. So
+  // swapping one candidate for another inside the same array changes no number and invents no
+  // food: it picks a different day's option from the same vocabulary the plan already owns.
+  //
+  // That is what makes the honest answer for a vegan who also excludes lentils a PLAN rather than
+  // a refusal — the same array carries tofu, soya mince and sugar beans, and refusing while a
+  // compliant option sits one index away would be honouring the constraint by giving up. The
+  // refusal below is for the case where a slot genuinely has nothing left, which is where the
+  // fixed template really cannot answer.
+  const survives = (pool: string[]) => pool.filter(x => c.allows(x));
+  const safeBf = survives(bfProteins);
+  const safeLunch = survives(lunchProteins);
+  const safeDinner = survives(dinnerProteins);
+  const safeBfCarbs = survives(bfCarbs);
+  const safeLunchCarbs = survives(lunchCarbs);
+  const safeDinnerCarbs = survives(dinnerCarbs);
+  const safeVeg = survives(vegOptions);
+  // The pre/post-workout lines are candidate arrays too, and each carries its OWN calories and
+  // protein inside the string — so rotating within one of them is self-consistent in exactly the
+  // way the protein slots are. This is where a vegan's lentils actually came from: postOptions[0]
+  // and [3] are lentil lines the protein arrays never touch.
+  const safePre = survives(preOptions);
+  const safePost = survives(postOptions);
+  if ([safeBf, safeLunch, safeDinner, safeBfCarbs, safeLunchCarbs, safeDinnerCarbs, safeVeg, safePre, safePost]
+        .some(pool => pool.length === 0)) return noPlanWithin(c);
+
   // Build 7-day plan
   let plan = "";
   allDays.forEach((day, i) => {
     const isTraining = trainingSet.has(day);
-    const bfProt = bfProteins[i];
-    const bfCarb = bfCarbs[i];
-    const lp = lunchProteins[i];
-    const lc = lunchCarbs[i];
-    const dp = dinnerProteins[i];
-    const dc = dinnerCarbs[i];
-    const v = vegOptions[i % vegOptions.length];
-    const v2 = vegOptions[(i + 3) % vegOptions.length];
-    const pre = preOptions[i % preOptions.length];
-    const post = postOptions[i % postOptions.length];
+    const bfProt = safeBf[i % safeBf.length];
+    const bfCarb = safeBfCarbs[i % safeBfCarbs.length];
+    const lp = safeLunch[i % safeLunch.length];
+    const lc = safeLunchCarbs[i % safeLunchCarbs.length];
+    const dp = safeDinner[i % safeDinner.length];
+    const dc = safeDinnerCarbs[i % safeDinnerCarbs.length];
+    const v = safeVeg[i % safeVeg.length];
+    const v2 = safeVeg[(i + 3) % safeVeg.length];
+    const pre = safePre[i % safePre.length];
+    const post = safePost[i % safePost.length];
 
     // ---- BREAKFAST ----
     let bf: string;


### PR DESCRIPTION
Recovery for #220. **Do not merge — this is at the CTO gate.**

## The diff was never at risk

I want to be precise about this, because the concern is reasonable and the answer is checkable. The pending corrections were moved onto a fresh branch from `main@cf2f2ff` with `git checkout -B`, which **preserves working-tree modifications**. No `reset`, no `clean`, no destructive rebase, no stash drop. They were then verified green *before* being committed.

Base: `main@cf2f2ff` · `6e6eeb7` confirmed an ancestor · this branch adds one commit on top.

One deletion I should disclose rather than let you find: `script/pg-220-probe.ts`, my own untracked scratch probe from this session, was removed. It was never part of the deliverable and nothing references it.

## What the merged head does not do

Both of these are CTO gate controls that `6e6eeb7` does not satisfy.

### P1-1 control 3 — *"a valid plant-based alternative survives if available"*

The merged head verifies the assembled plan and refuses on any violation. That is right when nothing compliant exists and wrong the moment something does — and in this template something usually does. Each meal is chosen from a **seven-candidate array**, and the line it lands in carries a **fixed** protein figure that does not depend on which candidate is picked:

```ts
lunch = `${lp} + ${lc} + ${v}${seasonNote} — ${lunchCal} cal, 25g protein, ${maxPrep}`;
```

So swapping candidates *inside one array* changes no number and invents no food. The slot now rotates over the survivors — proteins, carbs, veg, and the pre/post-workout options, which is where a vegan's lentils actually came from (`postOptions[0]` and `[3]` are lentil lines the protein arrays never touch).

| client | merged `6e6eeb7` | this branch |
|---|---|---|
| vegan + `lentils` excluded | **REFUSED** | 7 days, tofu/soya/sugar beans, no lentil |
| gluten free | **REFUSED** | 7 days, no bread/pasta/wheat |

The coeliac case is the one that shows why this matters: the merged head gives them **nothing**, and every gluten carb in this template has a non-gluten candidate sitting in its own array. Honouring a restriction by giving up is the hollow grocery list wearing a different hat, and this cut exists to stop that.

The refusal stays for the case it was written for: a client who excludes eggs has no egg-free breakfast candidate anywhere in the array, so there is nothing to rotate to and the honest answer is still no plan.

### P1-2 control 3 — *"fail closed / give the existing honest unsupported-plan response. Do not invent kosher rules in this PR."*

The merged head ships a kosher client the plan with a caveat — *"no pork or shellfish, I can't certify kashrut, check the hechsher yourself"*. **That is a kosher rule invented at the mouth.** These templates put chicken and yoghurt in the same day, so they break kashrut at the level of what may be eaten *together*, and nothing in this product owns that rule. A caveat does not make a plan kosher; it is the same class of mistake as reinterpreting kosher as halal, only quieter.

Kosher now returns `noPlanWithin` — the response that already exists — and the invented flag is deleted. The halal path is untouched and controlled.

## Proof

Acceptance **section J** rewritten to the gate's own mandatory controls, both P1s, both directions:

```
PASS  CONTROL: an unrestricted client still receives the ordinary 7-day plan
PASS  a literal `eggs` exclusion reaches the fixed 7-day template
PASS  …and with no egg-free breakfast candidate to rotate to, it refuses rather than prescribing one
PASS  vegan + `lentils` excluded: no lentil is recommended anywhere
PASS  …and the plant-based alternative survives — they still get the whole week
PASS  …built on the compliant plant proteins the arrays already carry
PASS  …and it is still vegan
PASS  a gluten-free client is recommended no bread, pasta or wheat
PASS  …and still gets the whole week
PASS  CONTROL: a dislike the template never names still gets the whole week
PASS  a kosher client is never labelled halal
PASS  …and an unsupported kosher plan fails honestly rather than being caveated
PASS  …prescribing no food at all rather than food we cannot vouch for
PASS  CONTROL: a client who declared halaal still gets the halal-safe path
PASS  CONTROL: …and their whole week
PASS  a declared fish allergy covers salmon on the shopping list and in the pro tip
```

**Red on revert, thirteen mechanisms.** Reverting the kosher branch turns 3 checks red; reverting the slot rotation turns 3 red.

Case 11 (the final whole-plan verification) now stays **GREEN** under revert, and I am reporting that rather than dressing it up: rotation resolves the violation before the verification sees it, so the two are halves of one mechanism — the same honest situation already recorded for 4a in the original cut.

## Runs

37/37 suites · 266/266 Journey Lab · 16/16 PostgreSQL acceptances · governors `filesize`/`pricing`/`schema`/`sast`/`names`/`arch` all pass, none raised.

## On the sequencing

The merge was reasonable on the evidence available: `6e6eeb7` was pushed, run 799 was green, and both Codex P1s were closed on it. What it did not include was the second round of corrections the gate comment prompted — the gate arrived at 18:17, my P1 push was 18:33, and these controls came out of reading the gate's control list against what I had actually shipped. That is a real gap in #220 and it is closed here.

#221 not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_