### PR TITLE
#220 recovery: close the rotation's own four regressions

### DIFF
--- a/script/pg-restriction-consistency-acceptance.ts
+++ b/script/pg-restriction-consistency-acceptance.ts
@@ -464,6 +464,109 @@ REAL("    (CTO GATE P1-1 and P1-2 on PR #222, and their mandatory controls.)");
     JSON.stringify(fPlan.slice(0, 160)));
 }
 
+REAL("\n=== K · THE ROTATION'S OWN REGRESSIONS (#220 recovery, post-merge) ===");
+REAL("    (four defects Codex found on b04283a, verified against the real builder and closed.)");
+{
+  // P1 · THE WEEK EATS MORE THAN THE LIST BUYS. Rotation concentrates the plan onto the surviving
+  // candidates while the shopping list stayed a fixed string, so `vegan, lentils` prescribed 1400g
+  // of tofu and 600g of dry soya mince against a list buying 800g and 250g. The client shops on
+  // Sunday, follows the plan exactly, and runs out on Thursday — a worse failure than the one the
+  // rotation fixed, because they did nothing wrong.
+  const v = await client("Zanele", { dietaryRestrictions: "vegan, lentils", weeklyFoodBudget: "300_600" });
+  const plan = await ask(v.phone, "7 day meals");
+  const gramsOf = (re: RegExp) => [...plan.matchAll(re)].reduce((n, m) => n + Number(m[1] || 0), 0);
+  const eatenTofu = gramsOf(/(\d+)\s*g firm tofu/gi);
+  const eatenSoya = gramsOf(/soya mince\s*(\d+)\s*g dry/gi);
+  const boughtOf = (name: RegExp) => {
+    const line = (plan.split("\n").find(l => name.test(l) && /—\s*R\d+$/.test(l)) || "");
+    const m = line.match(/(\d+)\s*g(?:\s*×\s*(\d+))?/);
+    return m ? Number(m[1]) * Number(m[2] || 1) : 0;
+  };
+  chk(eatenTofu > 0 && boughtOf(/^Firm tofu/i) >= eatenTofu,
+    "the shopping list buys at least as much tofu as the week prescribes",
+    `eats ${eatenTofu}g, buys ${boughtOf(/^Firm tofu/i)}g`);
+  chk(eatenSoya > 0 && boughtOf(/^Soya mince/i) >= eatenSoya,
+    "…and at least as much soya mince",
+    `eats ${eatenSoya}g dry, buys ${boughtOf(/^Soya mince/i)}g`);
+  // THE CONTROL. Buying more is trivially satisfied by buying everything in the shop; the list
+  // must also stop listing what the plan never names, and stay priced.
+  chk(!/Cottage cheese|Greek yoghurt|Eggs \d+ pack/i.test(plan),
+    "CONTROL: …and does not list food this vegan's plan never names",
+    JSON.stringify(plan.split("\n").filter(l => /—\s*R\d+$/.test(l))));
+  // A DRY WEIGHT IS NOT A COOKED ONE, AND THE LINE MUST KEEP SAYING SO. Rebuilding the line from
+  // its parsed parts dropped "dry" from "Soya mince 250g dry", and a client buying 750g of soya
+  // mince by cooked weight buys nearly three times what they need.
+  chk(/Soya mince[^\n]*\bdry\b/i.test(plan), "the rewritten quantity keeps the line's own dry-weight wording",
+    JSON.stringify((plan.match(/[^\n]*Soya mince[^\n]*/i) || ["(absent)"])[0]));
+  chk(/Estimated total: R\d+/.test(plan) && !/R0\b/.test(plan), "CONTROL: …and the week still carries a real total",
+    JSON.stringify((plan.match(/Estimated total: R\d+/) || ["(absent)"])[0]));
+
+  // P2 · A DAY-INDEXED SCHEDULE IS NOT A CANDIDATE POOL. For recomposition, dinnerCarbs is
+  // "training days get a carb, rest days get none". Compacting it and rotating printed
+  // "extra veg only (rest day)" on Monday, Wednesday and Friday — the words reaching the client on
+  // a training day, with the training-day calories still claimed over veg.
+  const rc = await client("Lindiwe", { goalType: "recomposition", foodDislikes: "sweet potato" });
+  const rPlan = await ask(rc.phone, "7 day meals");
+  const dinners = rPlan.split("\n\n").join("\n").split("\n");
+  let day = "", misbound = 0, trainingDinners = 0;
+  for (const l of dinners) {
+    if (/^\*(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/.test(l)) day = l;
+    if (/^Dinner:/.test(l) && /Training Day/.test(day)) {
+      trainingDinners++;
+      if (/rest day/i.test(l)) misbound++;
+    }
+  }
+  chk(trainingDinners > 0 && misbound === 0,
+    "a training-day dinner is never given the rest-day entry",
+    `${misbound} of ${trainingDinners} training dinners said "(rest day)"`);
+  chk(!/sweet potato/i.test(body(rPlan)), "…while the excluded carb is still gone",
+    JSON.stringify((body(rPlan).match(/[^\n]*sweet potato[^\n]*/i) || [""])[0]));
+  chk(/½ cup brown rice|samp|pap|oats/i.test(rPlan),
+    "…and the training day still gets a real carb, replaced rather than borrowed",
+    JSON.stringify((rPlan.match(/Dinner:[^\n]*/) || [""])[0]));
+  // THE CONTROL: an unrestricted recomposition client keeps the original schedule exactly.
+  const rc2 = await client("Ayanda", { goalType: "recomposition" });
+  const r2 = await ask(rc2.phone, "7 day meals");
+  chk(/½ medium sweet potato/.test(r2) && /extra veg only \(rest day\)/.test(r2),
+    "CONTROL: an unrestricted recomposition client keeps the stock training/rest split",
+    JSON.stringify((r2.match(/Dinner:[^\n]*/) || [""])[0]));
+
+  // P2 · A FOOD THAT CONTAINS THE WORD IS NOT A DECLARATION. `foodDislikes: "kosher salt"` set
+  // declaredLabel, which set noPork, which — once the builder began failing closed — refused the
+  // client's entire meal plan over a salt preference.
+  const salt = await client("Refilwe", { foodDislikes: "kosher salt" });
+  const sPlan = await ask(salt.phone, "7 day meals");
+  chk(!/can't build/i.test(sPlan) && /Sunday/.test(sPlan),
+    "a `kosher salt` dislike is a food, not a declaration — the plan is still built",
+    JSON.stringify(sPlan.slice(0, 200)));
+  const { foodConstraints: fc } = await import("../server/food-swaps");
+  chk(fc({ foodDislikes: "kosher salt" }).declaredLabel === "",
+    "…and it sets no declared diet label at the canonical owner");
+  chk(!fc({ foodDislikes: "kosher salt" }).noPork,
+    "…nor the no-pork consequence that label used to carry");
+  // THE CONTROL: a real declaration still is one, in every column it can arrive in.
+  chk(fc({ dietaryRestrictions: "kosher" }).declaredLabel === "kosher"
+      && fc({ dietaryRestrictions: "halaal" }).declaredLabel === "halaal"
+      && fc({ foodDislikes: "halaal" }).declaredLabel === "halaal"
+      && fc({ dietaryRestrictions: "kosher" }).noPork,
+    "CONTROL: a declared kosher/halaal is still recognised, and still implies no pork");
+
+  // P2 · NEVER ASK FOR SOMETHING THAT CANNOT CHANGE THE ANSWER. Kosher is refused unconditionally,
+  // so "name two or three proteins you DO eat" was a question no answer could satisfy.
+  const k = await client("Yosef", { dietaryRestrictions: "kosher" });
+  const kPlan = await ask(k.phone, "7 day meals");
+  chk(!/two or three proteins/i.test(kPlan),
+    "the unsupported-kosher reply does not ask for proteins it cannot use",
+    JSON.stringify(kPlan));
+  chk(/can't build you a meal plan for kosher/i.test(kPlan) && /everything else still works/i.test(kPlan),
+    "…it says plainly what is unsupported, and what still is",
+    JSON.stringify(kPlan.slice(0, 240)));
+  // THE CONTROL: the ask is still there when it CAN unblock the plan.
+  const eggs = await client("Naledi", { foodDislikes: "eggs" });
+  chk(/two or three proteins/i.test(await ask(eggs.phone, "7 day meals")),
+    "CONTROL: …while a client whose pools merely ran out is still asked, because naming one helps");
+}
+
 REAL(`\n${failed === 0
   ? "pg-restriction-consistency-acceptance: GREEN — all checks passed"
   : `pg-restriction-consistency-acceptance: RED — ${failed} check(s) failed`}`);

--- a/script/pg-restriction-consistency-acceptance.ts
+++ b/script/pg-restriction-consistency-acceptance.ts
@@ -567,6 +567,76 @@ REAL("    (four defects Codex found on b04283a, verified against the real builde
     "CONTROL: …while a client whose pools merely ran out is still asked, because naming one helps");
 }
 
+REAL("\n=== L · THE RECOVERY'S OWN SECOND ROUND (#220, CTO blocker + three Codex findings) ===");
+{
+  const { foodConstraints: fc2 } = await import("../server/food-swaps");
+
+  // CTO BLOCKER · AN EMPTY FOOD NAME IS NOT AN ALLOWED FOOD. The schedule was built with
+  // `trainingCarb ?? ""` and graded by the day-bound guard, which asks `c.allows` — and
+  // `allows("")` is deliberately TRUE, because an empty name is not a forbidden food. So an
+  // unbuildable training day could grade as fine and render a blank dinner. It never did, only
+  // because losing every lunch carb also empties safeLunchCarbs and the pool guard fires first —
+  // a coincidence, not a guarantee. The decision now lives where the carb is chosen.
+  const noCarb = await client("Sibongile", { goalType: "recomposition",
+    foodDislikes: "sweet potato, rice, bread, samp, pap, oats, potatoes, pasta" });
+  const nc = await ask(noCarb.phone, "7 day meals");
+  chk(/can't build/i.test(nc), "no compliant training-day carb refuses outright",
+    JSON.stringify(nc.slice(0, 200)));
+  chk(!/Dinner:[^\n]*\+\s*\+|Dinner:[^\n]*\+\s*—/.test(nc), "…and never renders a blank dinner slot",
+    JSON.stringify((nc.match(/Dinner:[^\n]*/) || [""])[0]));
+
+  // CODEX P1 · A FIELD BOUNDARY IS A TERM BOUNDARY. Joining the three profile fields with a space
+  // before splitting turned `dietaryRestrictions: "kosher"` beside `foodDislikes: "broccoli"` into
+  // the single term "kosher broccoli" — no label, no noPork, and the kosher client was handed the
+  // ordinary meat-and-dairy plan. A kosher client with ANY other preference recorded lost the
+  // fail-closed path entirely.
+  for (const [label, over] of [
+    ["dietaryRestrictions + a dislike", { dietaryRestrictions: "kosher", foodDislikes: "broccoli" }],
+    ["dietaryRestrictions + medical notes", { dietaryRestrictions: "kosher", otherMedicalNotes: "lactose" }],
+  ] as Array<[string, Record<string, any>]>) {
+    chk(fc2(over).declaredLabel === "kosher" && fc2(over).noPork,
+      `the declared label survives ${label}`,
+      `declaredLabel=${JSON.stringify(fc2(over).declaredLabel)} noPork=${fc2(over).noPork}`);
+  }
+  const kb = await client("Yosef", { dietaryRestrictions: "kosher", foodDislikes: "broccoli" });
+  const kbPlan = await ask(kb.phone, "7 day meals");
+  chk(/can't build/i.test(kbPlan) && !/chicken|yoghurt/i.test(body(kbPlan)),
+    "…so a kosher client with a dislike still fails closed, and is offered no meat or dairy",
+    JSON.stringify(kbPlan.slice(0, 200)));
+  chk(fc2({ dietaryRestrictions: "halaal", foodDislikes: "broccoli" }).declaredLabel === "halaal",
+    "CONTROL: …and the halaal path survives the same shape");
+
+  // CODEX P2 · THE PRICE IS NOT ALWAYS THE END OF THE LINE. "Oats 500g — R15 (replaces pap)" has a
+  // trailing note; requiring the digits at end-of-line dropped that R15, so the list added up to
+  // R152 and the client was told R137.
+  const lowgi = await client("Palesa", { medicalConditions: "diabetes", weeklyFoodBudget: "under_100" });
+  const lg = await ask(lowgi.phone, "7 day meals");
+  const listed = lg.split("\n").filter(l => /—\s*R\d+/.test(l) && !/^(Estimated|🛒)/.test(l))
+    .reduce((n, l) => n + Number((l.match(/—\s*R(\d+)/) || [0, 0])[1]), 0);
+  const reported = Number((lg.match(/Estimated total: R(\d+)/) || [0, 0])[1]);
+  chk(listed > 0 && reported === listed, "the estimated total counts a price followed by a note",
+    `listed R${listed}, reported R${reported}`);
+  chk(/\(replaces pap\)/.test(lg), "CONTROL: …and the note itself still reaches the client",
+    JSON.stringify((lg.match(/[^\n]*replaces pap[^\n]*/) || ["(absent)"])[0]));
+
+  // CODEX P2 · ONE FOOD, SOMETIMES TWO LINES. A fish exclusion on the R100–300 tier puts two
+  // chicken lines on the list; scaling each to cover the whole week independently ordered 3.5kg
+  // for a 1 050g week — a fix for under-buying that started over-buying.
+  const fishy = await client("Kagiso", { dietaryRestrictions: "fish", weeklyFoodBudget: "100_300" });
+  const fp = await ask(fishy.phone, "7 day meals");
+  let eaten = 0;
+  for (const m of fp.matchAll(/(\d+)\s*g chicken (?:breast|thigh)/gi)) eaten += Number(m[1]);
+  let bought = 0;
+  for (const l of fp.split("\n").filter(l => /chicken/i.test(l) && /—\s*R\d+/.test(l))) {
+    const q = l.match(/(\d+(?:\.\d+)?)\s*(kg|g)\b(?:\s*×\s*(\d+))?/i);
+    if (q) bought += Number(q[1]) * (/kg/i.test(q[2]) ? 1000 : 1) * Number(q[3] || 1);
+  }
+  chk(eaten > 0 && bought >= eaten, "two lines for one food still cover the week between them",
+    `eats ${eaten}g, buys ${bought}g`);
+  chk(bought <= eaten * 2, "…without each line ordering the whole week on its own",
+    `eats ${eaten}g, buys ${bought}g`);
+}
+
 REAL(`\n${failed === 0
   ? "pg-restriction-consistency-acceptance: GREEN — all checks passed"
   : `pg-restriction-consistency-acceptance: RED — ${failed} check(s) failed`}`);

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -179,6 +179,49 @@ assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY2
 
+# ── 13 · groceries go back to the unrotated schedule's fixed list ─────────────────────────────
+cat > /tmp/220p/13.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+before = s
+s = s.replace("groceriesForPlan(shopList, planBlock, shopTotal)", "{ list: shopList, total: shopTotal }")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 14 · the day-indexed recomposition schedule is rotated like a pool ────────────────────────
+cat > /tmp/220p/14.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+before = s
+# BOTH HALVES. The day binding is now protected twice: the schedule is BUILT from a compliant
+# training-day carb, and the loop then indexes it by day instead of rotating it. Reverting only
+# the loop leaves the construction holding, so this restores the hardcoded carb as well — the
+# same coupled-mechanism situation already recorded for 4a and 11.
+s = s.replace('const trainingCarb = ["\u00bd medium sweet potato", ...lunchCarbs].find(x => c.allows(x));',
+              'const trainingCarb = "\u00bd medium sweet potato";')
+s = s.replace("    const dc = dinnerCarbsAreDayBound ? dinnerCarbs[i] : safeDinnerCarbs[i % safeDinnerCarbs.length];",
+              "    const dc = safeDinnerCarbs[i % safeDinnerCarbs.length];")
+s = s.replace("  if (dinnerCarbsAreDayBound && !dayBoundOk(dinnerCarbs)) return noPlanWithin(c);", "")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 15 · a declared label is any occurrence of the word again ─────────────────────────────────
+cat > /tmp/220p/15.py <<'PY2'
+p = "server/food-swaps.ts"; s = open(p).read()
+s = s.replace('const declaredLabel = declaredTerms.find(t => /^(halaal|halal|kosher)$/.test(t)) || "";',
+              'const declaredLabel = declared.match(/\\b(halaal|halal|kosher)\\b/)?.[0] || "";')
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 16 · the unsupported-kosher reply goes back to the dead-end ask ───────────────────────────
+cat > /tmp/220p/16.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+s = s.replace("  if (isKosher) return noPlanWithin(c, true);", "  if (isKosher) return noPlanWithin(c);")
+assert s != open(p).read(), "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
 echo "=============================================================================="
 echo "#220 — RED ON REVERT, one mechanism at a time"
 echo "=============================================================================="
@@ -202,4 +245,8 @@ run_case "kosher takes the halal path again (the PR #222 regression)"           
 run_case "the fixed 7-day template stops asking the predicate about its own meals"             /tmp/220p/11.py
 run_case "11b · the slot stops rotating over what the client may eat"                          /tmp/220p/11b.py
 run_case "salmon leaves the fish cluster"                                                      /tmp/220p/12.py
+run_case "groceries go back to the unrotated schedule's fixed list"                            /tmp/220p/13.py
+run_case "the day-indexed recomposition schedule is rotated like a pool"                       /tmp/220p/14.py
+run_case "a declared label is any occurrence of the word again"                                /tmp/220p/15.py
+run_case "the unsupported-kosher reply goes back to the dead-end ask"                          /tmp/220p/16.py
 echo "=============================================================================="

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -222,6 +222,53 @@ assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY2
 
+# ── 17 · the missing training carb becomes an empty string again (CTO blocker) ────────────────
+cat > /tmp/220p/17.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+before = s
+s = s.replace("    if (!trainingCarb) return noPlanWithin(c);\n", "")
+s = s.replace("dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? trainingCarb : restDayCarb)",
+              'dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? (trainingCarb ?? "") : restDayCarb)')
+# and remove the pool guard that masks it, so the mechanism itself is what is under test
+s = s.replace("safeVeg, safePre, safePost]", "safeVeg, safePre, safePost].slice(0, 4).concat([")
+s = s.replace(".some(pool => pool.length === 0)) return noPlanWithin(c);",
+              "]).some(pool => pool.length === 0)) return noPlanWithin(c);")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 18 · profile fields are joined before splitting, losing the declared label ─────────────────
+cat > /tmp/220p/18.py <<'PY2'
+p = "server/food-swaps.ts"; s = open(p).read()
+before = s
+s = s.replace("""  const declaredTerms = [u.dietaryRestrictions, u.foodDislikes, u.otherMedicalNotes]
+    .flatMap(field => String(field || "").toLowerCase().split(/[,;]+|\\band\\b|\\n/))""",
+              """  const declaredTerms = [`${u.dietaryRestrictions || ""} ${u.foodDislikes || ""} ${u.otherMedicalNotes || ""}`]
+    .flatMap(field => String(field || "").toLowerCase().split(/[,;]+|\\band\\b|\\n/))""")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 19 · the price must sit at end of line again ──────────────────────────────────────────────
+cat > /tmp/220p/19.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+before = s
+s = s.replace('const priceOf = (l: string) => Number((l.match(/—\\s*R(\\d+)/) || [0, 0])[1]);',
+              'const priceOf = (l: string) => Number((l.match(/R(\\d+)$/) || [0, 0])[1]);')
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
+# ── 20 · every matching line covers the whole week on its own ─────────────────────────────────
+cat > /tmp/220p/20.py <<'PY2'
+p = "server/onboarding-meal-plan.ts"; s = open(p).read()
+before = s
+s = s.replace("    const extra = short > 0 && parsed.packQty === biggest ? Math.ceil(short / parsed.packQty) : 0;\n    const packs = parsed.packs + extra;",
+              "    const extra = 1;\n    const packs = Math.max(1, Math.ceil(required / parsed.packQty));")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY2
+
 echo "=============================================================================="
 echo "#220 — RED ON REVERT, one mechanism at a time"
 echo "=============================================================================="
@@ -249,4 +296,15 @@ run_case "groceries go back to the unrotated schedule's fixed list"             
 run_case "the day-indexed recomposition schedule is rotated like a pool"                       /tmp/220p/14.py
 run_case "a declared label is any occurrence of the word again"                                /tmp/220p/15.py
 run_case "the unsupported-kosher reply goes back to the dead-end ask"                          /tmp/220p/16.py
+# 17 IS EXPECTED TO STAY GREEN, and that is the finding. The CTO blocker is a real unsoundness —
+# `trainingCarb ?? ""` graded by `c.allows`, which returns TRUE for an empty name — but it is not
+# a REACHABLE defect: trainingCarb is drawn from ["\u00bd medium sweet potato", ...lunchCarbs], so it is
+# absent only when every lunch carb is excluded, and that also empties safeLunchCarbs AND
+# safeBfCarbs, so a pool guard refuses first. No client input reaches the empty string. The fix is
+# kept because a guard that holds by coincidence is one edit away from not holding; the proof is
+# the reasoning above, not a red line, and it is reported as such rather than dressed up.
+run_case "17 · the missing training carb becomes an empty string again (CTO blocker)"          /tmp/220p/17.py
+run_case "18 · profile fields are joined before splitting, losing the declared label"          /tmp/220p/18.py
+run_case "19 · the price must sit at end of line again"                                       /tmp/220p/19.py
+run_case "20 · every matching line covers the whole week on its own"                          /tmp/220p/20.py
 echo "=============================================================================="

--- a/script/red-on-revert-220.sh
+++ b/script/red-on-revert-220.sh
@@ -222,17 +222,34 @@ assert s != open(p).read(), "revert patch matched nothing"
 open(p, "w").write(s)
 PY2
 
-# ── 17 · the missing training carb becomes an empty string again (CTO blocker) ────────────────
+# ── 17 · the missing training carb becomes an empty string again (CTO blocker, control 4) ─────
+#
+# THIS CASE IS EXPECTED TO STAY GREEN, and the reason is now measured rather than argued.
+#
+# The CTO blocker is a genuine unsoundness: `trainingCarb ?? ""` graded by `c.allows`, which
+# returns TRUE for an empty name by design. The fix — deciding at the point the carb is chosen —
+# is kept. But the refusal it produces cannot be isolated, because THREE independent guards each
+# prevent the empty string from reaching a client, and they were measured one at a time:
+#
+#   1. this guard            `if (!trainingCarb) return noPlanWithin(c)`
+#   2. the pool guard        losing every lunch carb also empties safeLunchCarbs and safeBfCarbs
+#   3. the whole-plan check  `prescribed(planBlock).some(food => !c.allows(food))`
+#
+# Removing 1 alone: still refuses (2 catches it). Removing 1 and 2 together, with the carb pools
+# dropped from the guard entirely: STILL refuses — 3 catches it, verified by calling the builder
+# directly and reading the returned string. Dismantling 3 as well would prove nothing about
+# production, because at that point no mechanism under test remains.
+#
+# So control 4 is answered honestly: the fix is correct and kept, and it has no red line because
+# the behaviour it protects is unreachable three ways over. A guard that holds by coincidence is
+# still one edit from not holding, which is why it stays. This is the fourth coupled-mechanism
+# finding in this cut, after 4a, 11 and 14.
 cat > /tmp/220p/17.py <<'PY2'
 p = "server/onboarding-meal-plan.ts"; s = open(p).read()
 before = s
 s = s.replace("    if (!trainingCarb) return noPlanWithin(c);\n", "")
 s = s.replace("dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? trainingCarb : restDayCarb)",
               'dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? (trainingCarb ?? "") : restDayCarb)')
-# and remove the pool guard that masks it, so the mechanism itself is what is under test
-s = s.replace("safeVeg, safePre, safePost]", "safeVeg, safePre, safePost].slice(0, 4).concat([")
-s = s.replace(".some(pool => pool.length === 0)) return noPlanWithin(c);",
-              "]).some(pool => pool.length === 0)) return noPlanWithin(c);")
 assert s != before, "revert patch matched nothing"
 open(p, "w").write(s)
 PY2

--- a/server/food-swaps.ts
+++ b/server/food-swaps.ts
@@ -841,8 +841,15 @@ export function foodConstraints(u: {
   //
   // THEIR WORD, NOT OUR DERIVATION. A client who told us "halaal" should hear "halaal" back, not
   // "no pork" — saying it in their own language is most of what makes being remembered land.
-  const declaredTerms = `${u.dietaryRestrictions || ""} ${u.foodDislikes || ""} ${u.otherMedicalNotes || ""}`
-    .toLowerCase().split(/[,;]+|\band\b|\n/).map(t => t.trim().replace(/^(no|not|never|only|i(?:'m| am)?)\s+/, "").trim());
+  // EACH FIELD IS SPLIT BEFORE THEY ARE COMBINED (#220 recovery, second round). Joining them with
+  // a space first meant `dietaryRestrictions: "kosher"` beside `foodDislikes: "broccoli"` became
+  // the single term "kosher broccoli", which matched no label — so a kosher client with ANY other
+  // preference recorded lost their declaration, lost noPork with it, and was handed the ordinary
+  // meat-and-dairy plan. A field boundary IS a term boundary; that is the whole reason there are
+  // three fields.
+  const declaredTerms = [u.dietaryRestrictions, u.foodDislikes, u.otherMedicalNotes]
+    .flatMap(field => String(field || "").toLowerCase().split(/[,;]+|\band\b|\n/))
+    .map(t => t.trim().replace(/^(no|not|never|only|i(?:'m| am)?)\s+/, "").trim());
   const declaredLabel = declaredTerms.find(t => /^(halaal|halal|kosher)$/.test(t)) || "";
 
   const has = (re: RegExp) => re.test(declared);

--- a/server/food-swaps.ts
+++ b/server/food-swaps.ts
@@ -539,9 +539,21 @@ export function allowedProteinStaples(c: FoodConstraints): ProteinStaple[] {
  * it. Saying the restriction back in their own terms is the point; a plan we cannot build is not
  * a reason to be vague about why.
  */
-export function noPlanWithin(c: FoodConstraints): string {
+export function noPlanWithin(c: FoodConstraints, unsupported = false): string {
   const said = c.terms.length ? joinFoods(c.terms, "and") : "what you don't eat";
-  return `*Your Meal Plan*\n\nI can't build you a plan that respects ${said} out of the food I've got templates for — and I'd rather tell you that than send you one that breaks your word.\n\nTell me two or three proteins you DO eat and I'll build the week around them.`;
+  // NEVER ASK FOR SOMETHING THAT CANNOT CHANGE THE ANSWER (#220 recovery). The default ask —
+  // "name two or three proteins" — is real when the pools merely ran out for THIS client, because
+  // naming a protein they eat genuinely unblocks it. It is a dead end when we do not support the
+  // observance at all: kosher is refused unconditionally, so no answer they could give would ever
+  // produce a plan, and a question that cannot be answered usefully is worse than an honest no.
+  // One mouth, two closings, chosen by the caller that knows which case it is in.
+  const lead = unsupported
+    ? `I can't build you a meal plan for ${said} yet — these plans put meat and dairy in the same day and I can't vouch for how the food was prepared, so anything I sent you would only look right.`
+    : `I can't build you a plan that respects ${said} out of the food I've got templates for — and I'd rather tell you that than send you one that breaks your word.`;
+  const ask = unsupported
+    ? `Everything else still works. Log what you eat and I'll coach you on your real food, your targets and your training — and send me a specific meal any time you want it checked.`
+    : `Tell me two or three proteins you DO eat and I'll build the week around them.`;
+  return `*Your Meal Plan*\n\n${lead}\n\n${ask}`;
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -820,11 +832,24 @@ export function foodConstraints(u: {
   const declared = `${u.dietaryRestrictions || ""} ${u.foodDislikes || ""} ${u.otherMedicalNotes || ""}`.toLowerCase();
   const conditions = (u.medicalConditions || "").toLowerCase();
 
+  // A DECLARATION, NOT A WORD THAT APPEARS (#220 recovery). `kosher` was matched ANYWHERE in the
+  // merged free text, so `foodDislikes: "kosher salt"` — an ingredient preference, and a common
+  // one — classified the client as observing kashrut AND set noPork. On its own that was a wrong
+  // label; once onboarding-meal-plan.ts began failing closed on it, a salt preference refused the
+  // client's entire meal plan. A label is a whole declared TERM: "kosher" is a declaration,
+  // "kosher salt" is a food. Same split the literal terms below already use.
+  //
+  // THEIR WORD, NOT OUR DERIVATION. A client who told us "halaal" should hear "halaal" back, not
+  // "no pork" — saying it in their own language is most of what makes being remembered land.
+  const declaredTerms = `${u.dietaryRestrictions || ""} ${u.foodDislikes || ""} ${u.otherMedicalNotes || ""}`
+    .toLowerCase().split(/[,;]+|\band\b|\n/).map(t => t.trim().replace(/^(no|not|never|only|i(?:'m| am)?)\s+/, "").trim());
+  const declaredLabel = declaredTerms.find(t => /^(halaal|halal|kosher)$/.test(t)) || "";
+
   const has = (re: RegExp) => re.test(declared);
   const vegan = has(/\bvegan\b/) || /\bvegan\b/.test(conditions);
   const vegetarian = vegan || has(/\bvegetarian\b|\bno meat\b|\bplant.?based\b/) || /\bvegetarian\b/.test(conditions);
   const noDairy = vegan || has(/\bdairy\b|\blactose\b|\bmilk\b/);
-  const noPork = has(/\bpork\b|\bhalaal\b|\bhalal\b|\bkosher\b|\bbacon\b/);
+  const noPork = !!declaredLabel || has(/\bpork\b|\bbacon\b/);
   const noGluten = has(/\bgluten\b|\bceliac\b|\bcoeliac\b|\bwheat\b/);
   // PLURALS ARE THE WHOLE GAME HERE TOO (#220). `\bpeanut\b` does not match "peanuts", so a
   // client whose dietary_restrictions column read exactly "peanuts" had noPeanuts === false and
@@ -861,7 +886,7 @@ export function foodConstraints(u: {
 
   // THEIR WORD, NOT OUR DERIVATION. A client who told us "halaal" should hear "halaal" back, not
   // "no pork" — saying it in their own language is most of what makes being remembered land.
-  const declaredLabel = declared.match(/\b(halaal|halal|kosher)\b/)?.[0];
+
   const terms = [
     ...(vegan ? ["vegan"] : vegetarian ? ["vegetarian"] : []),
     ...(declaredLabel ? [declaredLabel] : []),
@@ -893,7 +918,7 @@ export function foodConstraints(u: {
     allows,
     vegan, vegetarian, noDairy, noPork, noGluten, noFish, noPeanuts,
     lowGI: /\bdiabet|pcos\b/.test(conditions) || /\bdiabet|pcos\b/.test(declared),
-    declaredLabel: declaredLabel || "",
+    declaredLabel,
   };
 }
 

--- a/server/onboarding-meal-plan.ts
+++ b/server/onboarding-meal-plan.ts
@@ -8,6 +8,90 @@ import { getDisplayName } from "./utils";
 // ONE OWNER FOR WHAT THIS CLIENT MAY EAT (#220). See the block inside the function.
 import { foodConstraints, noPlanWithin } from "./food-swaps";
 
+/**
+ * WHAT THE WEEK ACTUALLY EATS, AND THEREFORE WHAT TO BUY (#220 recovery).
+ *
+ * The shopping lists below are fixed strings sized for the plan the template USED to produce.
+ * Once the meal slots began rotating over what a client may eat, the week concentrated onto the
+ * surviving candidates and the list stopped covering it: `vegan, lentils` on the R300–600 tier
+ * prescribed 1 400g of tofu and 600g of dry soya mince while the list bought 800g and 250g. The
+ * client shops on Sunday and runs out on Thursday, which is a worse failure than the one the
+ * rotation fixed — they followed the instructions exactly.
+ *
+ * So the quantities are DERIVED. Each entry names the food as the MEALS write it and as the SHOP
+ * LINE writes it; the week's requirement is summed off the built plan, and the line is re-rendered
+ * at however many packs that needs, with the price scaled to match. Nothing is invented: the pack
+ * size and the pack price both come from the line that was already there.
+ *
+ * DRY VERSUS COOKED IS NOT A ROUNDING ERROR. "150g cooked lentils" against a 500g bag of DRY
+ * lentils is a 2.5× difference, and treating them as the same unit would under-buy by more than
+ * the defect this fixes. Where the meal states a cooked weight and the shop sells it dry, the
+ * ratio is stated on the entry.
+ */
+const SHOP_DERIVED: Array<{
+  /** Matches the shop line's leading name, anchored. */
+  shop: RegExp;
+  /** Captures the amount used in ONE meal component. Global — a line may name it more than once. */
+  meal: RegExp;
+  /** Meal weight -> shop weight. 1 when the shop sells it the way the meal states it. */
+  dryRatio?: number;
+}> = [
+  { shop: /^Firm tofu\b/i,      meal: /(\d+)\s*g firm tofu/gi },
+  { shop: /^Soya mince\b/i,     meal: /soya mince\s*(\d+)\s*g dry/gi },
+  { shop: /^Lentils\b/i,        meal: /(\d+)\s*g cooked lentils/gi, dryRatio: 1 / 2.5 },
+  { shop: /^Sugar beans\b/i,    meal: /(\d+)\s*g (?:cooked )?sugar beans|sugar beans \((\d+)\s*g[^)]*\)/gi, dryRatio: 1 / 2.5 },
+  { shop: /^Beef mince\b/i,     meal: /(\d+)\s*g beef mince/gi },
+  { shop: /^(?:Frozen )?[Cc]hicken\b/i, meal: /(\d+)\s*g chicken (?:breast|thigh)/gi },
+  { shop: /^Peanut butter\b/i,  meal: /(\d+)\s*tbsp (?:PB|peanut butter)/gi },
+];
+
+/** `Firm tofu 400g×2 — R70` -> { name, packQty: 400, unit: "g", packs: 2, packPrice: 35 }. */
+function readShopLine(line: string): { name: string; packQty: number; unit: string; packs: number; packPrice: number } | null {
+  const m = line.match(/^(.+?)\s+(\d+(?:\.\d+)?)\s*(kg|g|tins?|pack)\b(?:\s*×\s*(\d+))?(.*?)\s*—\s*R(\d+)$/i);
+  if (!m) return null;
+  const packs = Number(m[4] || 1);
+  const qty = Number(m[2]) * (/^kg$/i.test(m[3]) ? 1000 : 1);
+  const price = Number(m[6]);
+  if (!qty || !price || !packs) return null;
+  return { name: m[1].trim(), packQty: qty, unit: /^kg$/i.test(m[3]) ? "g" : m[3].toLowerCase(), packs, packPrice: price / packs };
+}
+
+/**
+ * Re-render the shopping list so its quantities cover the plan that was actually built, and drop
+ * any derived item the plan never names. Returns the list and its new estimated total; items this
+ * table does not know are passed through untouched and keep their original price.
+ */
+function groceriesForPlan(shopList: string, plan: string, originalTotal: number): { list: string; total: number } {
+  const need = new Map<RegExp, number>();
+  for (const row of SHOP_DERIVED) {
+    let grams = 0;
+    for (const hit of plan.matchAll(row.meal)) grams += Number(hit[1] || hit[2] || 0);
+    if (grams > 0) need.set(row.shop, grams * (row.dryRatio ?? 1));
+  }
+  let total = 0;
+  const lines = shopList.split("\n").map((line, i) => {
+    if (i === 0 || !line.trim()) return line;                       // the "*Your Weekly Shopping List*" header
+    const parsed = readShopLine(line);
+    const row = SHOP_DERIVED.find(r => r.shop.test(line));
+    if (!parsed || !row) { total += Number((line.match(/R(\d+)$/) || [0, 0])[1]); return line; }
+    const required = need.get(row.shop);
+    if (!required) return null;                                     // the plan never names it — do not buy it
+    const packs = Math.max(1, Math.ceil(required / parsed.packQty));
+    const price = Math.round(parsed.packPrice * packs);
+    total += price;
+    // EDIT THE LINE THAT IS ALREADY THERE, rather than rebuilding one from its parts. Two reasons:
+    // the line carries detail the parse does not model — "Soya mince 250g dry" loses its "dry" the
+    // moment it is reassembled, and a client reading "buy 750g of soya mince" for a dry weight
+    // buys three times too much — and this stays a QUANTITY EDIT rather than becoming a second
+    // place that authors shopping-list text.
+    return line
+      .replace(/(\d+(?:\.\d+)?\s*(?:kg|g|tins?|pack)\b)(\s*×\s*\d+)?/i,
+               (_m, q) => (packs > 1 ? `${q}×${packs}` : `${q}`))
+      .replace(/R\d+$/, `R${price}`);
+  }).filter((l): l is string => l !== null);
+  return { list: lines.join("\n"), total: total || originalTotal };
+}
+
 export function getOnboardingMealPlan(user: any): string {
   const budget = user.weeklyFoodBudget || "100_300";
   const goal = user.goalType || "fat_loss";
@@ -67,7 +151,7 @@ export function getOnboardingMealPlan(user: any): string {
   // mistake as reinterpreting kosher as halal, just quieter. Until a kosher-safe owner exists, the
   // honest answer is the one generateMealPlan already gives when it cannot build inside a
   // constraint, and the client is asked for what would let us build it.
-  if (isKosher) return noPlanWithin(c);
+  if (isKosher) return noPlanWithin(c, true);
   const isVegetarian = c.vegetarian;
   const isVegan = c.vegan;
   // Effective restriction flags extend allergy flags with dietary preferences
@@ -217,13 +301,28 @@ export function getOnboardingMealPlan(user: any): string {
 
   // ---- DINNER carbs — lighter for fat loss, same as lunch for others ----
   let dinnerCarbs: string[];
+  let dinnerCarbsAreDayBound = false;
   if (goal === "fat_loss") {
     dinnerCarbs = noGluten
       ? ["½ medium sweet potato", "½ cup samp and beans", "½ medium sweet potato", "½ cup brown rice", "½ medium sweet potato", "½ cup samp and beans", "½ medium sweet potato"]
       : ["½ cup brown rice", "½ medium sweet potato", "½ cup samp and beans", "½ medium sweet potato", "½ cup brown rice", "½ medium sweet potato", "½ cup samp and beans"];
   } else if (goal === "recomposition") {
     // Recomp: carbs on training days, veg-only on rest days — use isTraining per-day in the loop, not hardcoded positions
-    dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? "½ medium sweet potato" : "extra veg only (rest day)") as string[];
+    // REPLACE THE DAY'S ENTRY, DON'T BORROW ANOTHER DAY'S. A training day needs a carb and a rest
+    // day deliberately has none, so when the stock training-day carb is excluded the substitute
+    // comes from the LUNCH CARB pool — still a carb, still this file's own vocabulary, still on
+    // the day that is supposed to have one. Only when no carb at all survives is there nothing
+    // honest to put on a training day, and the guard below refuses.
+    const restDayCarb = "extra veg only (rest day)";
+    const trainingCarb = ["½ medium sweet potato", ...lunchCarbs].find(x => c.allows(x));
+    dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? (trainingCarb ?? "") : restDayCarb) as string[];
+    // A SCHEDULE, NOT A POOL (#220 recovery). Entry i means "what day i gets", and the other six
+    // entries are not interchangeable with it — index 0 is a TRAINING-day carb and index 1 says
+    // "(rest day)" in the client's own reply. Every other array in this file is a variety pool
+    // where any entry may land on any day; this one alone is day-bound, and rotating it printed
+    // "Dinner: 150g chicken breast + extra veg only (rest day)" on a Friday training day, with the
+    // training-day calories still claimed over veg. Flagged here, beside the line that builds it.
+    dinnerCarbsAreDayBound = true;
   } else {
     dinnerCarbs = lunchCarbs;
   }
@@ -287,6 +386,9 @@ export function getOnboardingMealPlan(user: any): string {
   // refusal below is for the case where a slot genuinely has nothing left, which is where the
   // fixed template really cannot answer.
   const survives = (pool: string[]) => pool.filter(x => c.allows(x));
+  // A DAY-BOUND SCHEDULE CANNOT BE ROTATED. Its entries carry the day's meaning, so the honest
+  // options are "every day's own entry is allowed" or "refuse" — never "borrow another day's".
+  const dayBoundOk = (schedule: string[]) => schedule.every(x => c.allows(x));
   const safeBf = survives(bfProteins);
   const safeLunch = survives(lunchProteins);
   const safeDinner = survives(dinnerProteins);
@@ -302,6 +404,7 @@ export function getOnboardingMealPlan(user: any): string {
   const safePost = survives(postOptions);
   if ([safeBf, safeLunch, safeDinner, safeBfCarbs, safeLunchCarbs, safeDinnerCarbs, safeVeg, safePre, safePost]
         .some(pool => pool.length === 0)) return noPlanWithin(c);
+  if (dinnerCarbsAreDayBound && !dayBoundOk(dinnerCarbs)) return noPlanWithin(c);
 
   // Build 7-day plan
   let plan = "";
@@ -312,7 +415,7 @@ export function getOnboardingMealPlan(user: any): string {
     const lp = safeLunch[i % safeLunch.length];
     const lc = safeLunchCarbs[i % safeLunchCarbs.length];
     const dp = safeDinner[i % safeDinner.length];
-    const dc = safeDinnerCarbs[i % safeDinnerCarbs.length];
+    const dc = dinnerCarbsAreDayBound ? dinnerCarbs[i] : safeDinnerCarbs[i % safeDinnerCarbs.length];
     const v = safeVeg[i % safeVeg.length];
     const v2 = safeVeg[(i + 3) % safeVeg.length];
     const pre = safePre[i % safePre.length];
@@ -477,6 +580,8 @@ export function getOnboardingMealPlan(user: any): string {
   const headerBlock = `${header}${trainingLine}${goalNoteSafe}${nightNote}${hivNote}${domesticNote}${studentNote}${unemployedNote}${postpartumNote}`;
   const planBlock = plan.trim();
   if (prescribed(planBlock).some((food: string) => !c.allows(food))) return noPlanWithin(c);
-  const shopBlock = `${shopList}\nEstimated total: R${shopTotal}${safeTip}`;
+  // THE LIST COVERS THE WEEK THAT WAS BUILT, not the week the template used to build.
+  const groceries = groceriesForPlan(shopList, planBlock, shopTotal);
+  const shopBlock = `${groceries.list}\nEstimated total: R${groceries.total}${safeTip}`;
   return `${headerBlock}\n\n---\n\n${planBlock}\n\n---\n\n${shopBlock}\n\n_Reply SWAP [day] to swap a day. Reply SHOPPING LIST for just the shopping list._`;
 }

--- a/server/onboarding-meal-plan.ts
+++ b/server/onboarding-meal-plan.ts
@@ -68,17 +68,42 @@ function groceriesForPlan(shopList: string, plan: string, originalTotal: number)
     for (const hit of plan.matchAll(row.meal)) grams += Number(hit[1] || hit[2] || 0);
     if (grams > 0) need.set(row.shop, grams * (row.dryRatio ?? 1));
   }
+
+  // ONE FOOD, SOMETIMES TWO LINES (#220 recovery, second round). On the R100–300 tier a fish
+  // exclusion puts BOTH "Chicken portions extra 500g" and "Frozen chicken portions 1kg" on the
+  // list, and scaling each to cover the whole week independently ordered 3.5kg of chicken for a
+  // 1 050g week — a fix for under-buying that started over-buying. Demand is shared across the
+  // lines that carry it, so the group is topped up only if what the list ALREADY provides falls
+  // short, and the extra packs go on the biggest pack size, which is the cheapest per gram.
+  const lines = shopList.split("\n");
+  const shortfall = new Map<RegExp, number>();
+  for (const [shop, required] of need) {
+    const group = lines.map(readShopLine).filter((x): x is NonNullable<typeof x> => !!x && shop.test(`${x.name} `));
+    const provided = group.reduce((g, x) => g + x.packQty * x.packs, 0);
+    if (provided < required) shortfall.set(shop, required - provided);
+  }
+
   let total = 0;
-  const lines = shopList.split("\n").map((line, i) => {
+  const out = lines.map((line, i) => {
     if (i === 0 || !line.trim()) return line;                       // the "*Your Weekly Shopping List*" header
     const parsed = readShopLine(line);
     const row = SHOP_DERIVED.find(r => r.shop.test(line));
-    if (!parsed || !row) { total += Number((line.match(/R(\d+)$/) || [0, 0])[1]); return line; }
+    // THE PRICE IS NOT ALWAYS THE END OF THE LINE. "Oats 500g — R15 (replaces pap)" carries a
+    // trailing note, and requiring the digits at end-of-line dropped that R15 from the recomputed
+    // total — the list added up to R152 and the client was told R137.
+    const priceOf = (l: string) => Number((l.match(/—\s*R(\d+)/) || [0, 0])[1]);
+    if (!parsed || !row) { total += priceOf(line); return line; }
     const required = need.get(row.shop);
     if (!required) return null;                                     // the plan never names it — do not buy it
-    const packs = Math.max(1, Math.ceil(required / parsed.packQty));
+    const short = shortfall.get(row.shop) ?? 0;
+    const biggest = Math.max(...lines.map(readShopLine)
+      .filter((x): x is NonNullable<typeof x> => !!x && row.shop.test(`${x.name} `))
+      .map(x => x.packQty));
+    const extra = short > 0 && parsed.packQty === biggest ? Math.ceil(short / parsed.packQty) : 0;
+    const packs = parsed.packs + extra;
     const price = Math.round(parsed.packPrice * packs);
     total += price;
+    if (extra === 0) return line;                                   // the list already covers it
     // EDIT THE LINE THAT IS ALREADY THERE, rather than rebuilding one from its parts. Two reasons:
     // the line carries detail the parse does not model — "Soya mince 250g dry" loses its "dry" the
     // moment it is reassembled, and a client reading "buy 750g of soya mince" for a dry weight
@@ -87,9 +112,9 @@ function groceriesForPlan(shopList: string, plan: string, originalTotal: number)
     return line
       .replace(/(\d+(?:\.\d+)?\s*(?:kg|g|tins?|pack)\b)(\s*×\s*\d+)?/i,
                (_m, q) => (packs > 1 ? `${q}×${packs}` : `${q}`))
-      .replace(/R\d+$/, `R${price}`);
+      .replace(/—\s*R\d+/, `— R${price}`);
   }).filter((l): l is string => l !== null);
-  return { list: lines.join("\n"), total: total || originalTotal };
+  return { list: out.join("\n"), total: total || originalTotal };
 }
 
 export function getOnboardingMealPlan(user: any): string {
@@ -315,7 +340,16 @@ export function getOnboardingMealPlan(user: any): string {
     // honest to put on a training day, and the guard below refuses.
     const restDayCarb = "extra veg only (rest day)";
     const trainingCarb = ["½ medium sweet potato", ...lunchCarbs].find(x => c.allows(x));
-    dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? (trainingCarb ?? "") : restDayCarb) as string[];
+    // NO CARB MEANS NO SCHEDULE, DECIDED HERE (#220 recovery, second round — CTO blocker). The
+    // first draft wrote `trainingCarb ?? ""` and left the refusal to the day-bound guard below,
+    // which grades with `c.allows` — and `allows("")` is deliberately TRUE, because an empty food
+    // name is not a forbidden food. So an unbuildable training day could have graded as fine and
+    // rendered a blank dinner. It never did, only because losing every lunch carb also empties
+    // safeLunchCarbs and the pool guard fires first — a coincidence, not a guarantee, and exactly
+    // the kind of second-guard-happens-to-catch-it that this cut keeps finding. Decided at the
+    // point that knows: if there is no compliant training-day carb, there is no plan.
+    if (!trainingCarb) return noPlanWithin(c);
+    dinnerCarbs = allDays.map((day) => trainingSet.has(day) ? trainingCarb : restDayCarb) as string[];
     // A SCHEDULE, NOT A POOL (#220 recovery). Entry i means "what day i gets", and the other six
     // entries are not interchangeable with it — index 0 is a TRAINING-day carb and index 1 says
     // "(rest day)" in the client's own reply. Every other array in this file is a variety pool


### PR DESCRIPTION
Fix-forward from `main@d8823c5`. **Do not merge — at the CTO gate.** No rollback: the earlier #220 work is correct and rolling back would reintroduce it.

Codex reviewed `b04283a` thirteen seconds before it merged. All four findings are real, and **three were introduced by the slot rotation and kosher change in that commit**. Every one reproduced against the real builder before anything changed.

## P1 · The week ate more than the list bought

Rotation concentrates the plan onto the surviving candidates; the shopping list stayed a fixed string sized for the plan the template *used to* produce. Measured on `vegan, lentils` at R300–600:

```
eats  1400g firm tofu        list bought  800g   (Firm tofu 400g×2)
eats   600g soya mince dry   list bought  250g   (Soya mince 250g dry)
```

The client shops on Sunday, follows the plan exactly, and runs out on Thursday — a worse failure than the one rotation fixed, because they did nothing wrong.

Quantities are now **derived**: the week's requirement is summed off the plan that was actually built, and each line re-rendered at however many packs that needs, price scaled to match. Nothing is invented — pack size and pack price both come from the line that was already there — and an item the plan never names is dropped rather than bought.

**Dry versus cooked is stated, not rounded away.** "150g cooked lentils" against a 500g bag of *dry* lentils is a 2.5× difference; treating them as one unit would under-buy by more than the defect being fixed.

The line is **edited in place** rather than rebuilt from parsed parts. Rebuilding dropped `dry` from `Soya mince 250g dry` — a client buying 750g by cooked weight buys nearly three times what they need — and it would have made this a second place that authors shopping-list text. It stays a quantity edit.

## P2 · A day-indexed schedule is not a candidate pool

For recomposition, `dinnerCarbs` is *"training days get a carb, rest days get none"* — the file's own comment says so. Every other array is a variety pool where any entry may land on any day; **I treated all of them alike.** Compacting and rotating this one printed, for a client excluding sweet potato:

```
Monday — Training Day 🏋️   Dinner: 100g beef mince + extra veg only (rest day) … 616 cal
```

The words "(rest day)" reaching them on a Monday, training-day calories still claimed over veg.

Now flagged day-bound where it is built, indexed by day rather than rotated, and — per the finding — the day's entry is **replaced rather than borrowed**: a training day whose stock carb is excluded takes a compliant carb from the lunch-carb pool, so it still gets a carb, on the day that is meant to have one. Only when no carb at all survives does it refuse.

## P2 · A food that contains the word is not a declaration

`declaredLabel` matched `kosher` **anywhere** in the merged free text, so `foodDislikes: "kosher salt"` classified the client as observing kashrut and set `noPork`. On its own a wrong label; once the builder began failing closed on it, **a salt preference refused the entire meal plan**.

A label is now a whole declared *term* — `kosher` is a declaration, `kosher salt` is a food — using the same split the literal terms already use. `noPork` takes the religious implication from the declaration rather than any occurrence of the word.

## P2 · Never ask for something that cannot change the answer

Kosher is refused unconditionally, so *"tell me two or three proteins you DO eat"* was a question no answer could satisfy. `noPlanWithin` gained one bounded variant, still **one mouth**: the default ask stays where naming a protein genuinely unblocks the plan; the unsupported case says plainly what cannot be built, why, and what still works.

## Proof

Acceptance **section K** — fifteen checks, each finding with its control both ways:

```
PASS  the shopping list buys at least as much tofu as the week prescribes
PASS  …and at least as much soya mince
PASS  CONTROL: …and does not list food this vegan's plan never names
PASS  the rewritten quantity keeps the line's own dry-weight wording
PASS  CONTROL: …and the week still carries a real total
PASS  a training-day dinner is never given the rest-day entry
PASS  …while the excluded carb is still gone
PASS  …and the training day still gets a real carb, replaced rather than borrowed
PASS  CONTROL: an unrestricted recomposition client keeps the stock training/rest split
PASS  a `kosher salt` dislike is a food, not a declaration — the plan is still built
PASS  …and it sets no declared diet label at the canonical owner
PASS  …nor the no-pork consequence that label used to carry
PASS  CONTROL: a declared kosher/halaal is still recognised, and still implies no pork
PASS  the unsupported-kosher reply does not ask for proteins it cannot use
PASS  …it says plainly what is unsupported, and what still is
PASS  CONTROL: …while a client whose pools merely ran out is still asked, because naming one helps
```

**Red on revert, sixteen mechanisms**, all four new ones red:

```
── REVERT: groceries go back to the unrotated schedule's fixed list   RED — 2
── REVERT: the day-indexed schedule is rotated like a pool            RED — 1
── REVERT: a declared label is any occurrence of the word again       RED — 3
── REVERT: the unsupported-kosher reply goes back to the dead-end ask RED — 2
```

Two of those required reverting **both halves** to reach: groceries and the day-bound schedule are each protected at construction *and* again at use. That is the same coupled-mechanism situation already recorded for 4a and 11, and it is reported rather than dressed up.

## Runs

37/37 suites · 266/266 Journey Lab · 16/16 PostgreSQL acceptances · governors `filesize`/`pricing`/`schema`/`sast`/`names`/`arch` all pass.

`authorshipPoints` held at its frozen **419** — the in-place quantity edit removed the mouth the first draft added, rather than a budget moving.

## On how these got in

The rotation was the right fix for the gate's control 3, and it carried a defect I did not look for: I generalised "these arrays are candidate pools" across all seven without checking whether any of them was a schedule, and I changed what the plan eats without checking what the list buys. Both are the same omission — changing the selection without following it to everything downstream that depended on the old selection.

Builder-state packet on request. #221 / 2E untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_