### PR TITLE
#221 journeys 1–3: one comeback clock, counted in SAST days

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,12 @@ jobs:
       # SHADOW=on captures the Sunday sends, so proactive food coaching is graded on the message.
       - name: One restriction across every food surface on real PostgreSQL
         run: npx tsx script/pg-restriction-consistency-acceptance.ts
+      # ONE COMEBACK CLOCK (#221). Both defects are claims about CHRONOLOGY across stored rows — a
+      # workout row's logged_at against a user's lastActiveAt, read through the real handler. A
+      # pure test can check the arithmetic; only this can show that the reply a returning client
+      # receives states the gap they actually experienced.
+      - name: One comeback clock on real PostgreSQL
+        run: npx tsx script/pg-comeback-clock-acceptance.ts
       # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
       # would be a second copy of this infrastructure for no gain. Deliberately NOT
       # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot

--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -75,7 +75,7 @@ const BUDGET = {
    * a plateau nudge is a product decision, and this number is where that decision gets made
    * rather than forgotten. LOWER THIS as capabilities are wired or deleted. Never raise it.
    */
-  unreachableCapabilities: 42,
+  unreachableCapabilities: 41,
   /**
    * GUARD #14 — see unclassifiedSenders above. Six proactive senders still choose their own
    * behavioural instruction: monday's weigh-in reminder and diet-break restore, programme's weekly

--- a/script/pg-comeback-clock-acceptance.ts
+++ b/script/pg-comeback-clock-acceptance.ts
@@ -48,7 +48,7 @@ const { pool, db } = await import("../server/db");
 const schema = await import("../shared/schema");
 const { handleMessage } = await import("../server/routes");
 const { resolveReentry } = await import("../server/understanding/reentry");
-const { lastExecutionAtForUser } = await import("../server/understanding/reentry-bridge");
+const { executionEvidenceForUser } = await import("../server/understanding/reentry-bridge");
 
 let failed = 0;
 const chk = (ok: boolean, msg: string, evidence = "") => {
@@ -56,12 +56,13 @@ const chk = (ok: boolean, msg: string, evidence = "") => {
   REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
 };
 
-/** Midday of the SAST day `n` days back — unambiguous whatever hour this suite runs. */
-const middaySastDaysAgo = (n: number) => {
+/** A named hour of the SAST day `n` days back — unambiguous whatever hour this suite runs. */
+const sastDayAt = (n: number, hhmm: string) => {
   const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
     .format(new Date(Date.now() - n * 86_400_000));
-  return new Date(`${key}T12:00:00+02:00`);
+  return new Date(`${key}T${hhmm}:00+02:00`);
 };
+const middaySastDaysAgo = (n: number) => sastDayAt(n, "12:00");
 
 /** The shapes a comeback greeting can take. Deliberately broader than the one string we emit. */
 const WELCOME = /welcome back|good to (have you|see you)|you'?re back|glad you'?re back|where you left off|picking up where|clean restart|start again|fresh start/i;
@@ -132,9 +133,10 @@ REAL("\n=== 3 · WHAT THEY DID WHILE THEY WERE QUIET ===");
   await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
     [c.id, middaySastDaysAgo(3)]);
 
-  const seen = await lastExecutionAtForUser(c.id);
-  chk(!!seen, "the boundary reads execution evidence from the rows that already store it",
-    String(seen));
+  const seen = await executionEvidenceForUser(c.id);
+  chk(!!seen.lastExecutionAt && !!seen.lastWorkoutAt,
+    "the boundary reads execution evidence from the rows that already store it",
+    JSON.stringify(seen));
 
   const reply = await ask(c.phone, BACK);
   chk(/\b3 days away\b/.test(reply), "the gap stated is the one since they last DID something, not since they last wrote",
@@ -166,6 +168,50 @@ REAL("\n=== 3 · WHAT THEY DID WHILE THEY WERE QUIET ===");
     `execution=${r.daysSinceLastExecution}d contact=${r.daysSinceLastContact}d`);
   chk(!/while you were quiet/i.test(await ask(stale.phone, BACK)),
     "CONTROL: …and the reply does not claim they kept going");
+}
+
+REAL("\n=== 3B · THE SAME DAY HAS AN ORDER, AND TRAINING IS NOT ANY ACTIVITY ===");
+{
+  // ORDERING IS BETWEEN INSTANTS, NOT BETWEEN DAY AGES. A client who wrote on Sunday MORNING and
+  // then trained on Sunday EVENING did that workout during the silence — but both timestamps are
+  // the same number of SAST days old, so comparing ages says "not newer" and the evening
+  // disappears. The displayed age is a day count; the ordering question never was.
+  const evening = await client("EveningTrainer", { lastActiveAt: sastDayAt(2, "08:00") });
+  await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [evening.id, sastDayAt(2, "19:00")]);
+  const eveningReply = await ask(evening.phone, BACK);
+  chk(/while you were quiet/i.test(eveningReply),
+    "a workout logged the evening AFTER the last morning message counts as during the silence",
+    JSON.stringify((eveningReply.match(/[^\n]*Training:[^\n]*/) || ["(no training line)"])[0]));
+
+  // THE CONTROL for that ordering, and the reason day-ages were used in the first place: a durable
+  // row written BY the last turn is part of that conversation, not evidence of a silent streak.
+  // The turn stamps lastActiveAt and the log within the same second, in no guaranteed order.
+  const sameTurn = await client("LoggedThenLeft", { lastActiveAt: sastDayAt(3, "18:00") });
+  await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [sameTurn.id, new Date(sastDayAt(3, "18:00").getTime() + 400)]);
+  const sameTurnReply = await ask(sameTurn.phone, BACK);
+  chk(!/while you were quiet/i.test(sameTurnReply),
+    "CONTROL: a log written by the last turn itself is not execution during a silence that had not started",
+    JSON.stringify((sameTurnReply.match(/[^\n]*Training:[^\n]*/) || [""])[0]));
+
+  // ONE FLAG WAS ANSWERING TWO QUESTIONS. "Did they do anything while quiet?" is correctly
+  // type-agnostic — a meal is engagement. "Did they TRAIN while quiet?" is not: this client's only
+  // sessions predate the silence, and saying otherwise tells them about training they did not do.
+  const ate = await client("AteButDidNotTrain", { lastActiveAt: middaySastDaysAgo(9) });
+  await pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     VALUES ($1, $2, 'lunch', 500, 20, $3, 'seed', 'sa_scanner')`,
+    [ate.id, middaySastDaysAgo(3), JSON.stringify([{ name: "pap", grams: 200 }])]);
+  await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [ate.id, middaySastDaysAgo(12)]);
+  const ateReply = await ask(ate.phone, BACK);
+  chk(/\b3 days away\b/.test(ateReply),
+    "a meal during the silence still moves the gap — engagement is engagement",
+    JSON.stringify((ateReply.match(/[^\n]*away[^\n]*/) || ["(no gap stated)"])[0]));
+  chk(/before you went quiet/i.test(ateReply) && !/while you were quiet/i.test(ateReply),
+    "…but the TRAINING line is not credited by it, because every session predates the silence",
+    JSON.stringify((ateReply.match(/[^\n]*Training:[^\n]*/) || ["(no training line)"])[0]));
 }
 
 REAL("\n=== 7 · NEGATIVE CONTROL — A SINGLE QUIET DAY IS NOT A COMEBACK ===");

--- a/script/pg-comeback-clock-acceptance.ts
+++ b/script/pg-comeback-clock-acceptance.ts
@@ -1,0 +1,199 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — one comeback clock (#221, journeys 1-3).
+ *
+ * THE RULE THIS ENFORCES. A client who disappears and comes back meets ONE welcome, measured by
+ * ONE clock that counts the days they actually experienced, and that clock knows about anything
+ * they DID while they were quiet.
+ *
+ * Two defects traced through the real front door on main@e81138e before anything changed:
+ *
+ *   THE CLOCK DIVIDED MILLISECONDS. `daysSinceContact` was
+ *   `Math.floor((now - lastActiveAt) / 86_400_000)` — elapsed 24-hour periods, not days. A client
+ *   last seen 23:30 on Sunday who wrote at 06:00 on Tuesday had been gone two SAST days, counted
+ *   as one, and because RETURNING_DAYS is 2 was DENIED the comeback outright. Evening-then-morning
+ *   is how most gaps in this product actually look.
+ *
+ *   EXECUTION DURING THE ABSENCE WAS INVISIBLE. A client trained on day 3 of a nine-day silence
+ *   and said so on return. They were told "about a week away", and the session was filed under
+ *   "the 14 days BEFORE you went quiet". Both wrong from one cause: the gap was measured from
+ *   CONTACT alone, so the one thing they did while quiet neither moved the number nor was placed
+ *   correctly in the sentence.
+ *
+ * WHY POSTGRESQL. Both are claims about CHRONOLOGY across stored rows — a workout row's logged_at
+ * against a user's lastActiveAt, read through the real handler. A pure test can check the
+ * arithmetic; it cannot show that the reply a returning client receives now states the right gap.
+ *
+ * EVERY CLAIM IS PAIRED WITH ITS CONTROL. "The comeback fires" is trivially satisfied by greeting
+ * everybody, and "execution counts" by treating any old row as recent activity — both are the
+ * opposite defect, and both are asserted against here.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-comeback-clock-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { resolveReentry } = await import("../server/understanding/reentry");
+const { lastExecutionAtForUser } = await import("../server/understanding/reentry-bridge");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+/** Midday of the SAST day `n` days back — unambiguous whatever hour this suite runs. */
+const middaySastDaysAgo = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`);
+};
+
+/** The shapes a comeback greeting can take. Deliberately broader than the one string we emit. */
+const WELCOME = /welcome back|good to (have you|see you)|you'?re back|glad you'?re back|where you left off|picking up where|clean restart|start again|fresh start/i;
+
+const ids: string[] = [];
+async function client(name: string, over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2791${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name, onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "84.0", heightCm: 178, gender: "male", age: 35,
+    weeklyFoodBudget: "300_600", totalWorkoutsCompleted: 12,
+    createdAt: middaySastDaysAgo(60), programmeStartDate: middaySastDaysAgo(60), programmeWeek: 4, ...over,
+  } as any).returning();
+  ids.push(u.id);
+  return { id: u.id, phone };
+}
+const ask = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
+    .then(r => String(r || ""));
+
+const BACK = "Sorry I've been away, I'm back now";
+
+REAL("\n=== 1 · ONE RETURNING CLIENT, ONE WELCOME ===");
+{
+  const c = await client("Returner", { lastActiveAt: middaySastDaysAgo(9) });
+  const first = await ask(c.phone, BACK);
+  chk(WELCOME.test(first), "a client returning after nine days is welcomed back",
+    JSON.stringify(first.slice(0, 200)));
+  const second = await ask(c.phone, "what should I eat");
+  chk(!WELCOME.test(second), "…and the very next turn does not greet them again",
+    JSON.stringify(second.slice(0, 200)));
+  chk(second.length > 40, "…it answers what they actually asked", JSON.stringify(second.slice(0, 160)));
+}
+
+REAL("\n=== 2 · THE CLOCK COUNTS SAST DAYS, NOT ELAPSED MILLISECONDS ===");
+{
+  // The exact shape the old arithmetic denied: away over one night and the whole next day.
+  const sundayNight = Date.parse("2026-09-06T23:30:00+02:00");
+  const tuesdayMorning = Date.parse("2026-09-08T06:00:00+02:00");
+  const r = resolveReentry({ lastActiveAt: new Date(sundayNight), message: BACK, nowMs: tuesdayMorning });
+  chk(r.daysSinceLastContact === 2 && r.shouldHandleComeback,
+    "23:30 Sunday to 06:00 Tuesday is two days away, and reaches the comeback",
+    `days=${r.daysSinceLastContact} comeback=${r.shouldHandleComeback} (elapsed hours: 30.5)`);
+
+  // THE CONTROL. Counting calendar days must not turn every overnight gap into a comeback.
+  const mondayNoon = Date.parse("2026-09-07T12:00:00+02:00");
+  const tuesdayNoon = Date.parse("2026-09-08T12:00:00+02:00");
+  const one = resolveReentry({ lastActiveAt: new Date(mondayNoon), message: BACK, nowMs: tuesdayNoon });
+  chk(one.daysSinceLastContact === 1 && !one.shouldHandleComeback,
+    "CONTROL: yesterday is one day, and is still not a comeback",
+    `days=${one.daysSinceLastContact} comeback=${one.shouldHandleComeback}`);
+
+  // …and the same instant is still zero, not a rounding artefact.
+  const same = resolveReentry({ lastActiveAt: new Date(tuesdayNoon), message: BACK, nowMs: tuesdayNoon });
+  chk(same.daysSinceLastContact === 0 && !same.shouldHandleComeback,
+    "CONTROL: the same SAST day is zero days away", `days=${same.daysSinceLastContact}`);
+
+  // Through the real front door, end to end.
+  const c = await client("Overnight", { lastActiveAt: middaySastDaysAgo(2) });
+  chk(WELCOME.test(await ask(c.phone, BACK)), "…and a two-SAST-day client is welcomed at the front door");
+}
+
+REAL("\n=== 3 · WHAT THEY DID WHILE THEY WERE QUIET ===");
+{
+  const c = await client("LateReporter", { lastActiveAt: middaySastDaysAgo(9) });
+  await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [c.id, middaySastDaysAgo(3)]);
+
+  const seen = await lastExecutionAtForUser(c.id);
+  chk(!!seen, "the boundary reads execution evidence from the rows that already store it",
+    String(seen));
+
+  const reply = await ask(c.phone, BACK);
+  chk(/\b3 days away\b/.test(reply), "the gap stated is the one since they last DID something, not since they last wrote",
+    JSON.stringify((reply.match(/[^\n]*away[^\n]*/) || ["(no gap stated)"])[0]));
+  chk(!/about a week away|\b9 days away\b/.test(reply), "…so they are not told they were gone a week when they trained on Friday",
+    JSON.stringify((reply.match(/[^\n]*away[^\n]*/) || [""])[0]));
+  chk(/while you were quiet/i.test(reply) && !/before you went quiet/i.test(reply),
+    "…and the session is placed DURING the absence, not before it",
+    JSON.stringify((reply.match(/[^\n]*Training:[^\n]*/) || ["(no training line)"])[0]));
+
+  // THE CONTROL. A client who really did go quiet must still be told so — otherwise this fix has
+  // simply stopped the coach noticing absences at all.
+  const gone = await client("TrulyGone", { lastActiveAt: middaySastDaysAgo(9) });
+  const goneReply = await ask(gone.phone, BACK);
+  chk(/about a week away/.test(goneReply), "CONTROL: a client with no execution evidence is still told the real gap",
+    JSON.stringify((goneReply.match(/[^\n]*away[^\n]*/) || ["(none)"])[0]));
+  chk(!/while you were quiet/i.test(goneReply), "CONTROL: …and is not credited with training they never did",
+    JSON.stringify((goneReply.match(/[^\n]*Training:[^\n]*/) || [""])[0]));
+
+  // THE CONTROL that stops "any old row" reading as recent activity.
+  const stale = await client("StaleRow", { lastActiveAt: middaySastDaysAgo(3) });
+  await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [stale.id, middaySastDaysAgo(20)]);
+  const r = resolveReentry({
+    lastActiveAt: middaySastDaysAgo(3), lastExecutionAt: middaySastDaysAgo(20),
+    message: BACK, nowMs: Date.now() });
+  chk(!r.executedDuringAbsence,
+    "CONTROL: a log OLDER than the last message is not execution during the silence",
+    `execution=${r.daysSinceLastExecution}d contact=${r.daysSinceLastContact}d`);
+  chk(!/while you were quiet/i.test(await ask(stale.phone, BACK)),
+    "CONTROL: …and the reply does not claim they kept going");
+}
+
+REAL("\n=== 7 · NEGATIVE CONTROL — A SINGLE QUIET DAY IS NOT A COMEBACK ===");
+{
+  const c = await client("Quiet", { lastActiveAt: middaySastDaysAgo(1) });
+  const reply = await ask(c.phone, BACK);
+  chk(!WELCOME.test(reply), "one quiet day with the same words is not a comeback event",
+    JSON.stringify(reply.slice(0, 200)));
+  const r = resolveReentry({ lastActiveAt: middaySastDaysAgo(1), message: BACK, nowMs: Date.now() });
+  chk(!r.shouldHandleComeback, "…and the canonical owner agrees", `comeback=${r.shouldHandleComeback}`);
+
+  // An ordinary command after a long gap must reach its own handler, not the welcome.
+  const long = await client("Commander", { lastActiveAt: middaySastDaysAgo(9) });
+  chk(!WELCOME.test(await ask(long.phone, "my progress")),
+    "CONTROL: an ordinary command after a long gap is not intercepted by the comeback");
+}
+
+REAL(`\n${failed === 0
+  ? "pg-comeback-clock-acceptance: GREEN — all checks passed"
+  : `pg-comeback-clock-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_logs",
+                   "chat_history", "turn_ledger", "shadow_replies", "daily_sends",
+                   "client_understanding", "client_truth_commits", "daily_constraints"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-221.sh
+++ b/script/red-on-revert-221.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #221, one mechanism at a time.
+#
+# A green suite proves nothing on its own: it may be green because the code is right, or because
+# the checks cannot fail. Each fix is put back the way it was, ALONE, and the acceptance must go
+# red on the checks that fix exists to hold. Anything that stays green under revert is a check
+# that was never testing its mechanism, and is reported as such rather than dressed up.
+#
+# Usage:  DATABASE_URL=... bash script/red-on-revert-221.sh
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-comeback-clock-acceptance.ts
+TRUNC="DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;"
+
+run_case () {
+  local name="$1" patch="$2"
+  cp -r server /tmp/221-server-backup
+  python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221-server-backup; return 1; }
+  # Truncate before EVERY run — these suites are not isolated from each other, and treating them
+  # as if they were is exactly what produced a false four-acceptance regression report on #220.
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c "$TRUNC" >/dev/null 2>&1
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^pg-comeback-clock-acceptance:' || echo '(no verdict — crashed)')"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -8
+  rm -rf server && mv /tmp/221-server-backup server
+}
+
+mkdir -p /tmp/221p
+
+# ── 1 · the clock divides milliseconds again ──────────────────────────────────────────────────
+cat > /tmp/221p/1.py <<'PY'
+p = "server/understanding/reentry.ts"; s = open(p).read()
+before = s
+s = s.replace("  return Math.max(0, sastDaysBetween(at, nowMs));",
+              "  return Math.max(0, Math.floor((nowMs - at) / 86_400_000));")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 2 · execution evidence never reaches the clock ────────────────────────────────────────────
+cat > /tmp/221p/2.py <<'PY'
+p = "server/handlers/early-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("    lastExecutionAt: mayBeComeback ? await lastExecutionAtForUser(user.id) : undefined,\n", "")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 3 · the gap is measured from contact alone again ──────────────────────────────────────────
+cat > /tmp/221p/3.py <<'PY'
+p = "server/handlers/early-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("""    const gap = reentry.executedDuringAbsence && reentry.daysSinceLastExecution !== null
+      ? reentry.daysSinceLastExecution
+      : daysSilent;""", "    const gap = daysSilent;")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 4 · mid-absence training is filed "before you went quiet" again ───────────────────────────
+cat > /tmp/221p/4.py <<'PY'
+p = "server/handlers/early-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("""        ? (reentry.executedDuringAbsence
+            ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the last 14 days — including while you were quiet 👊`
+            : `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`)""",
+              """        ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`""")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 5 · "executed during the absence" stops requiring evidence NEWER than contact ─────────────
+#
+# The opposite defect, and the one a careless fix produces: if any stored log counts, every client
+# with history reads as "still going" and nobody is ever told they were away.
+cat > /tmp/221p/5.py <<'PY'
+p = "server/understanding/reentry.ts"; s = open(p).read()
+before = s
+s = s.replace("    days !== null && daysSinceLastExecution !== null && daysSinceLastExecution < days;",
+              "    daysSinceLastExecution !== null;")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+echo "=============================================================================="
+echo "#221 — RED ON REVERT, one mechanism at a time"
+echo "=============================================================================="
+run_case "the clock divides milliseconds again (SAST days -> elapsed days)"        /tmp/221p/1.py
+run_case "execution evidence never reaches the clock"                             /tmp/221p/2.py
+run_case "the gap is measured from last CONTACT alone again"                      /tmp/221p/3.py
+run_case "mid-absence training is filed 'before you went quiet' again"            /tmp/221p/4.py
+run_case "any stored log counts as execution during the absence (opposite defect)" /tmp/221p/5.py
+echo "=============================================================================="

--- a/script/red-on-revert-221.sh
+++ b/script/red-on-revert-221.sh
@@ -42,7 +42,9 @@ PY
 cat > /tmp/221p/2.py <<'PY'
 p = "server/handlers/early-commands.ts"; s = open(p).read()
 before = s
-s = s.replace("    lastExecutionAt: mayBeComeback ? await lastExecutionAtForUser(user.id) : undefined,\n", "")
+s = s.replace("""    lastExecutionAt: evidence?.lastExecutionAt,
+    lastWorkoutAt: evidence?.lastWorkoutAt,
+""", "")
 assert s != before, "revert patch matched nothing"
 open(p, "w").write(s)
 PY
@@ -62,7 +64,7 @@ PY
 cat > /tmp/221p/4.py <<'PY'
 p = "server/handlers/early-commands.ts"; s = open(p).read()
 before = s
-s = s.replace("""        ? (reentry.executedDuringAbsence
+s = s.replace("""        ? (reentry.trainedDuringAbsence
             ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the last 14 days — including while you were quiet 👊`
             : `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`)""",
               """        ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`""")
@@ -77,8 +79,34 @@ PY
 cat > /tmp/221p/5.py <<'PY'
 p = "server/understanding/reentry.ts"; s = open(p).read()
 before = s
-s = s.replace("    days !== null && daysSinceLastExecution !== null && daysSinceLastExecution < days;",
-              "    daysSinceLastExecution !== null;")
+s = s.replace("    return ms !== null && contactAt !== null && ms > contactAt + SAME_TURN_MS && ms <= nowMs;",
+              "    return ms !== null;")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 6 · event ordering goes back to comparing SAST day AGES ───────────────────────────────────
+#
+# The first Codex P2. Day ages are equal for two events on the same date, so a morning message and
+# an evening workout compare as "not newer" and the evening vanishes into the time before the gap.
+cat > /tmp/221p/6.py <<'PY'
+p = "server/understanding/reentry.ts"; s = open(p).read()
+before = s
+s = s.replace("    return ms !== null && contactAt !== null && ms > contactAt + SAME_TURN_MS && ms <= nowMs;",
+              """    return ms !== null && contactAt !== null && ms <= nowMs
+      && sastDaysBetween(ms, nowMs) < sastDaysBetween(contactAt, nowMs);""")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 7 · the training sentence reads the type-agnostic flag again ──────────────────────────────
+#
+# The second Codex P2. A meal or a step count then satisfies a claim about SESSIONS, and a client
+# who ate while quiet is congratulated for training they did not do.
+cat > /tmp/221p/7.py <<'PY'
+p = "server/handlers/early-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("        ? (reentry.trainedDuringAbsence", "        ? (reentry.executedDuringAbsence")
 assert s != before, "revert patch matched nothing"
 open(p, "w").write(s)
 PY
@@ -91,4 +119,6 @@ run_case "execution evidence never reaches the clock"                           
 run_case "the gap is measured from last CONTACT alone again"                      /tmp/221p/3.py
 run_case "mid-absence training is filed 'before you went quiet' again"            /tmp/221p/4.py
 run_case "any stored log counts as execution during the absence (opposite defect)" /tmp/221p/5.py
+run_case "event ordering compares SAST day AGES again (same-day evening is lost)"  /tmp/221p/6.py
+run_case "the training sentence reads the type-agnostic execution flag again"      /tmp/221p/7.py
 echo "=============================================================================="

--- a/script/reentry-bridge-tests.ts
+++ b/script/reentry-bridge-tests.ts
@@ -38,6 +38,8 @@ assert.deepEqual(
   }),
   {
     daysSinceLastContact: 10,
+    daysSinceLastExecution: null,
+    executedDuringAbsence: false,
     isReturning: true,
     hasExplicitReturnSignal: true,
     shouldHandleComeback: true,
@@ -61,13 +63,33 @@ for (const lastActiveAt of [null, undefined, "", "not-a-date", "2026-09-01T10:00
   assert.equal(r.daysSinceLastContact ?? 0, 0, "?? 0 is what keeps 'null days' out of the reply");
 }
 
-// The 48-hour boundary, through the bridge rather than only the resolver — this is the path the
-// live consumer actually takes.
+// THE BOUNDARY IS A CALENDAR BOUNDARY (#221), through the bridge rather than only the resolver —
+// this is the path the live consumer actually takes. It was written as "47.99 hours is not yet a
+// returning client, 48 hours is", which is the elapsed-millisecond definition this cut replaced:
+// a client last seen at 23:30 on Sunday who writes at 06:00 on Tuesday is two SAST days gone and
+// was refused the comeback by that arithmetic. Same two sides of the same threshold, counted the
+// way the client counts.
+// Far from any boundary — a ten-day gap is ten days under either arithmetic, so these keep the
+// simple hour form.
 const at = (h: number) => new Date(now - h * 3_600_000).toISOString();
-assert.equal(shouldHandleComebackForUser({ user: { lastActiveAt: at(47.99) }, message: "I'm back", nowMs: now }), false,
-  "47.99 hours is not yet a returning client");
-assert.equal(shouldHandleComebackForUser({ user: { lastActiveAt: at(48) }, message: "I'm back", nowMs: now }), true,
-  "48 hours is");
+const middaySastDaysBefore = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(now - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`).toISOString();
+};
+assert.equal(shouldHandleComebackForUser({ user: { lastActiveAt: middaySastDaysBefore(1) }, message: "I'm back", nowMs: now }), false,
+  "yesterday is not yet a returning client");
+assert.equal(shouldHandleComebackForUser({ user: { lastActiveAt: middaySastDaysBefore(2) }, message: "I'm back", nowMs: now }), true,
+  "the day before yesterday is");
+// The case the old arithmetic got wrong, now asserted directly: an evening-then-morning gap.
+{
+  const sundayNight = Date.parse("2026-09-06T23:30:00+02:00");
+  const tuesdayMorning = Date.parse("2026-09-08T06:00:00+02:00");
+  assert.equal(
+    shouldHandleComebackForUser({ user: { lastActiveAt: new Date(sundayNight).toISOString() }, message: "I'm back", nowMs: tuesdayMorning }),
+    true,
+    "23:30 Sunday to 06:00 Tuesday is two SAST days away, and must reach the comeback");
+}
 
 // Ordinary commands must never be read as a comeback, whatever the gap. These are the messages
 // the guard exists for: they have to reach their own handlers.

--- a/script/reentry-bridge-tests.ts
+++ b/script/reentry-bridge-tests.ts
@@ -40,6 +40,7 @@ assert.deepEqual(
     daysSinceLastContact: 10,
     daysSinceLastExecution: null,
     executedDuringAbsence: false,
+    trainedDuringAbsence: false,
     isReturning: true,
     hasExplicitReturnSignal: true,
     shouldHandleComeback: true,

--- a/script/reentry-state-tests.ts
+++ b/script/reentry-state-tests.ts
@@ -83,19 +83,19 @@ assert.equal(isProfileUpdateMessage("I'm back"), false);
 
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "I'm back", nowMs: now }),
-  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, trainedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "workout", nowMs: now }),
-  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, trainedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "I train at home now", nowMs: now }),
-  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, trainedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-17T09:00:00.000Z", message: "I'm back", nowMs: now }),
-  { daysSinceLastContact: 0, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: false, hasExplicitReturnSignal: true, shouldHandleComeback: false },
+  { daysSinceLastContact: 0, daysSinceLastExecution: null, executedDuringAbsence: false, trainedDuringAbsence: false, isReturning: false, hasExplicitReturnSignal: true, shouldHandleComeback: false },
 );
 
 // Consumer boundary: callers receive the canonical result rather than duplicating the rules.
@@ -113,7 +113,7 @@ assert.equal(
 );
 assert.deepEqual(
   resolveReentryForUser({ user: { lastActiveAt: "2026-08-07T10:00:00.000Z" }, message: "sorry I've been busy", nowMs: now }),
-  { daysSinceLastContact: 10, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
+  { daysSinceLastContact: 10, daysSinceLastExecution: null, executedDuringAbsence: false, trainedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
 );
 
 
@@ -179,10 +179,11 @@ console.log("reentry-state-tests: all assertions passed");
     .format(new Date(nowMs - n * 86_400_000))}T12:00:00+02:00`);
 
   const trained = resolveReentry({
-    lastActiveAt: day(9), lastExecutionAt: day(3), message: "I'm back", nowMs });
+    lastActiveAt: day(9), lastExecutionAt: day(3), lastWorkoutAt: day(3), message: "I'm back", nowMs });
   assert.equal(trained.daysSinceLastContact, 9, "contact is still contact");
   assert.equal(trained.daysSinceLastExecution, 3, "and execution is read on the same SAST clock");
   assert.equal(trained.executedDuringAbsence, true, "they kept going while they were quiet");
+  assert.equal(trained.trainedDuringAbsence, true, "and what they did was training");
   assert.equal(trained.shouldHandleComeback, true,
     "the DECISION still keys off contact — they are returning to the conversation either way");
 
@@ -193,15 +194,46 @@ console.log("reentry-state-tests: all assertions passed");
   assert.equal(stale.executedDuringAbsence, false,
     "a log older than the last message is not execution during the silence");
 
-  // CONTROL: same-day execution is not "during an absence" either — the silence had not started.
+  // ORDERING IS BETWEEN INSTANTS (#221 review). This compared SAST day AGES, which are equal for
+  // two events on the same date — so a client who wrote in the morning and trained that evening had
+  // the evening session filed under the time before the silence it actually happened in.
+  const at = (n: number, hhmm: string) => new Date(`${new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Africa/Johannesburg" }).format(new Date(nowMs - n * 86_400_000))}T${hhmm}:00+02:00`);
+  const evening = resolveReentry({
+    lastActiveAt: at(4, "08:00"), lastExecutionAt: at(4, "19:00"), lastWorkoutAt: at(4, "19:00"),
+    message: "I'm back", nowMs });
+  assert.equal(evening.executedDuringAbsence, true,
+    "an evening workout is after a morning message, even though both are four days old");
+  assert.equal(evening.daysSinceLastExecution, 4, "…while the DISPLAYED age stays a day count");
+
+  // CONTROL, and the reason day-ages were reached for in the first place: a durable row written BY
+  // the last turn shares that turn's second, in no guaranteed order — the handlers set lastActiveAt
+  // in the same update that files the log. It is conversation, not a silent streak.
+  const sameTurn = resolveReentry({
+    lastActiveAt: at(4, "12:00"), lastExecutionAt: new Date(at(4, "12:00").getTime() + 400),
+    message: "I'm back", nowMs });
+  assert.equal(sameTurn.executedDuringAbsence, false, "meaningfully newer, not merely newer");
+
+  // CONTROL: the same instant is likewise not "during an absence" — the silence had not started.
   const sameDay = resolveReentry({
     lastActiveAt: day(4), lastExecutionAt: day(4), message: "I'm back", nowMs });
   assert.equal(sameDay.executedDuringAbsence, false, "strictly newer, not merely equal");
+
+  // ONE FLAG WAS ANSWERING TWO QUESTIONS (#221 review). A meal during the silence is engagement and
+  // moves the gap; it is not training, and a coach that says otherwise credits a workout that never
+  // happened. The two must be able to disagree, so this asserts them disagreeing.
+  const ateOnly = resolveReentry({
+    lastActiveAt: day(9), lastExecutionAt: day(3), lastWorkoutAt: day(12), message: "I'm back", nowMs });
+  assert.equal(ateOnly.executedDuringAbsence, true, "eating while quiet is still engagement");
+  assert.equal(ateOnly.trainedDuringAbsence, false,
+    "…but the last session predates the silence, so they did not train during it");
+  assert.equal(ateOnly.daysSinceLastExecution, 3, "and the gap is measured from what they DID do");
 
   // CONTROL: no evidence at all must stay null rather than defaulting to a number.
   const none = resolveReentry({ lastActiveAt: day(9), message: "I'm back", nowMs });
   assert.equal(none.daysSinceLastExecution, null, "unknown execution is unknown, not 0");
   assert.equal(none.executedDuringAbsence, false);
+  assert.equal(none.trainedDuringAbsence, false);
 }
 
 console.log("reentry-state-tests: GREEN");

--- a/script/reentry-state-tests.ts
+++ b/script/reentry-state-tests.ts
@@ -10,18 +10,28 @@ import {
 } from "../server/understanding/reentry";
 import { resolveReentryForUser, shouldHandleComebackForUser } from "../server/understanding/reentry-bridge";
 
-// Existing UnderstandingState boundary: 48 hours is the returning threshold.
-// MIGRATED FROM reentryFromAgeHours (2026-08-17). Same six cases, same expectations, now against
-// the canonical owner and driven by a TIMESTAMP rather than a pre-computed age in hours — because
-// the age was the defect: it was derived from clientUnderstanding.updatedAt, a persistence clock.
-// Verified equivalent before the old function was deleted: both agreed on all six, including the
-// future-clock case, which reentryFromAgeHours caught via its `ageHours < 0` guard.
+// REGRADED FOR SAST DAYS (#221). These cases were written against the ELAPSED-HOURS definition —
+// "48 hours is the returning threshold" — and that definition is the defect #221 names: the clock
+// divided by 86_400_000 instead of counting SAST calendar days, so a client last seen at 23:30 on
+// Sunday who wrote at 06:00 on Tuesday was two days gone, counted as one, and was DENIED the
+// comeback. The expectations move to the calendar because the semantics moved, and the semantics
+// moved because the product is a South African coach whose clients experience days, not periods
+// of 86 400 000 milliseconds.
+//
+// The cases themselves are unchanged and NOT weakened: same instants, same threshold constant,
+// same future/unknown handling. Only the day arithmetic differs, and each expectation below is
+// what the SAST calendar actually says about those two instants.
+//
+// MIGRATED FROM reentryFromAgeHours (2026-08-17), which read clientUnderstanding.updatedAt — a
+// persistence clock. That correction stands; this one replaces the remaining arithmetic.
 const NOW = Date.parse("2026-08-17T10:00:00.000Z");
 const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
 
 assert.equal(RETURNING_DAYS, 2, "the threshold must live in exactly one place");
-assert.deepEqual(contactState(hoursAgo(0), NOW), { daysSinceLastContact: 0, isReturning: false });
-assert.deepEqual(contactState(hoursAgo(47.99), NOW), { daysSinceLastContact: 1, isReturning: false });
+assert.deepEqual(contactState(hoursAgo(0), NOW), { daysSinceLastContact: 0, isReturning: false },
+  "same instant is the same SAST day");
+assert.deepEqual(contactState(hoursAgo(47.99), NOW), { daysSinceLastContact: 2, isReturning: true },
+  "47.99h before noon on the 17th is noon on the 15th — two SAST days, and a client would say two");
 assert.deepEqual(contactState(hoursAgo(48), NOW), { daysSinceLastContact: 2, isReturning: true });
 assert.deepEqual(contactState(hoursAgo(240), NOW), { daysSinceLastContact: 10, isReturning: true });
 assert.deepEqual(contactState(null, NOW), { daysSinceLastContact: null, isReturning: false });
@@ -48,6 +58,12 @@ assert.equal(daysSinceContact("2026-08-07T10:00:00.000Z", now), 10);
 assert.equal(daysSinceContact(undefined, now), null);
 assert.equal(daysSinceContact("not-a-date", now), null);
 assert.equal(daysSinceContact("2026-08-18T10:00:00.000Z", now), null);
+// A TIMESTAMP IS A TIMESTAMP (#221). `new Date(String(1755424800000))` is an Invalid Date, so a
+// caller holding epoch milliseconds used to get a silent null — read downstream as "we have never
+// heard from this client" rather than as the number they passed. All three input shapes agree.
+assert.equal(daysSinceContact(Date.parse("2026-08-15T10:00:00.000Z"), now), 2, "epoch ms is accepted");
+assert.equal(daysSinceContact(new Date("2026-08-15T10:00:00.000Z"), now), 2, "a Date is accepted");
+assert.equal(daysSinceContact("2026-08-15T10:00:00.000Z", now), 2, "an ISO string is accepted");
 
 // Explicit comeback language is a signal; ordinary action messages are not.
 assert.equal(isExplicitReturnSignal("I'm back"), true);
@@ -67,19 +83,19 @@ assert.equal(isProfileUpdateMessage("I'm back"), false);
 
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "I'm back", nowMs: now }),
-  { daysSinceLastContact: 2, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "workout", nowMs: now }),
-  { daysSinceLastContact: 2, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-15T10:00:00.000Z", message: "I train at home now", nowMs: now }),
-  { daysSinceLastContact: 2, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
+  { daysSinceLastContact: 2, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: false, shouldHandleComeback: false },
 );
 assert.deepEqual(
   resolveReentry({ lastActiveAt: "2026-08-17T09:00:00.000Z", message: "I'm back", nowMs: now }),
-  { daysSinceLastContact: 0, isReturning: false, hasExplicitReturnSignal: true, shouldHandleComeback: false },
+  { daysSinceLastContact: 0, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: false, hasExplicitReturnSignal: true, shouldHandleComeback: false },
 );
 
 // Consumer boundary: callers receive the canonical result rather than duplicating the rules.
@@ -97,7 +113,7 @@ assert.equal(
 );
 assert.deepEqual(
   resolveReentryForUser({ user: { lastActiveAt: "2026-08-07T10:00:00.000Z" }, message: "sorry I've been busy", nowMs: now }),
-  { daysSinceLastContact: 10, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
+  { daysSinceLastContact: 10, daysSinceLastExecution: null, executedDuringAbsence: false, isReturning: true, hasExplicitReturnSignal: true, shouldHandleComeback: true },
 );
 
 
@@ -111,19 +127,30 @@ const { compileStateBlurb: promptBlurb } = await import("../server/understanding
 const seedFor = (lastActiveAt: unknown) =>
   seedUnderstanding({ id: "u1", name: "Thandi", lastActiveAt, goalType: "fat_loss" } as any);
 
+// N SAST DAYS AGO, AT MIDDAY (#221). These cases used to subtract hours from Date.now(), which is
+// stable under elapsed-hour arithmetic and NOT stable under calendar days: "47 hours ago" is two
+// SAST days at 09:00 and one at 23:00, so the suite's answer would depend on the hour it happened
+// to run. Anchoring each instant to midday of a named SAST day makes the expectation a fact about
+// the calendar rather than about the clock on the runner.
+const middayNSastDaysAgo = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`).toISOString();
+};
+
 // Normal re-entry: 10 days away must reach the prompt as a returning client.
-const away = seedFor(new Date(Date.now() - 10 * 86_400_000).toISOString());
+const away = seedFor(middayNSastDaysAgo(10));
 assert.equal(away.current.reentry.isReturning, true);
 assert.match(promptBlurb(away), /returning after 10 days away/i);
 assert.match(promptBlurb(away), /do not pretend continuity/i);
 
-// Under the threshold: 47 hours is NOT a comeback and must say nothing about returning.
-const recent = seedFor(new Date(Date.now() - 47 * 3_600_000).toISOString());
+// Under the threshold: YESTERDAY is not a comeback and must say nothing about returning.
+const recent = seedFor(middayNSastDaysAgo(1));
 assert.equal(recent.current.reentry.isReturning, false);
 assert.doesNotMatch(promptBlurb(recent), /returning after/i);
 
 // Exactly at the threshold, and the phrasing the compiler reserves for it.
-const twoDays = seedFor(new Date(Date.now() - 49 * 3_600_000).toISOString());
+const twoDays = seedFor(middayNSastDaysAgo(2));
 assert.equal(twoDays.current.reentry.daysSinceLastContact, 2);
 assert.match(promptBlurb(twoDays), /returning after a couple of days/i);
 
@@ -139,3 +166,42 @@ assert.equal(future.current.reentry.daysSinceLastContact, null);
 assert.doesNotMatch(promptBlurb(future), /returning after/i);
 
 console.log("reentry-state-tests: all assertions passed");
+
+// ── LAST MEANINGFUL ENGAGEMENT, NOT LAST CONTACT (#221) ──────────────────────────────────────
+//
+// A client trained on day 3 of a nine-day silence and said so on return. The coach answered
+// "about a week away" and filed that session under "the 14 days BEFORE you went quiet" — both
+// wrong from one cause: the gap was measured from CONTACT alone, so the thing they actually did
+// during the absence was invisible to the clock.
+{
+  const nowMs = Date.parse("2026-09-08T10:00:00+02:00");
+  const day = (n: number) => new Date(`${new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(nowMs - n * 86_400_000))}T12:00:00+02:00`);
+
+  const trained = resolveReentry({
+    lastActiveAt: day(9), lastExecutionAt: day(3), message: "I'm back", nowMs });
+  assert.equal(trained.daysSinceLastContact, 9, "contact is still contact");
+  assert.equal(trained.daysSinceLastExecution, 3, "and execution is read on the same SAST clock");
+  assert.equal(trained.executedDuringAbsence, true, "they kept going while they were quiet");
+  assert.equal(trained.shouldHandleComeback, true,
+    "the DECISION still keys off contact — they are returning to the conversation either way");
+
+  // CONTROL, and it is the one that matters: execution OLDER than last contact is not evidence of
+  // anything during an absence. Without this, every client with any history reads as "still going".
+  const stale = resolveReentry({
+    lastActiveAt: day(2), lastExecutionAt: day(9), message: "I'm back", nowMs });
+  assert.equal(stale.executedDuringAbsence, false,
+    "a log older than the last message is not execution during the silence");
+
+  // CONTROL: same-day execution is not "during an absence" either — the silence had not started.
+  const sameDay = resolveReentry({
+    lastActiveAt: day(4), lastExecutionAt: day(4), message: "I'm back", nowMs });
+  assert.equal(sameDay.executedDuringAbsence, false, "strictly newer, not merely equal");
+
+  // CONTROL: no evidence at all must stay null rather than defaulting to a number.
+  const none = resolveReentry({ lastActiveAt: day(9), message: "I'm back", nowMs });
+  assert.equal(none.daysSinceLastExecution, null, "unknown execution is unknown, not 0");
+  assert.equal(none.executedDuringAbsence, false);
+}
+
+console.log("reentry-state-tests: GREEN");

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -38,7 +38,7 @@ import { matchStreetDish, isStreetContext, formatStreetDish, streetGuide } from 
 import { handleAdviceCommands } from "./advice-commands";
 import { handleFoodCommands } from "./food-commands";
 import { PRICE_ESTIMATE_NOTE } from "../reply-contract";
-import { resolveReentryForUser, shouldHandleComebackForUser, lastExecutionAtForUser } from "../understanding/reentry-bridge";
+import { resolveReentryForUser, shouldHandleComebackForUser, executionEvidenceForUser } from "../understanding/reentry-bridge";
 
 // In-memory maps for holiday/travel equipment mode — module-level so they
 // persist across requests (same process lifetime as the original routes.ts).
@@ -1289,9 +1289,11 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
   // which now folds in the newest durable meal/workout/step row. Only fetched once the cheap
   // message test has already passed, so an ordinary turn pays nothing for it.
   const mayBeComeback = shouldHandleComebackForUser({ user, message: m });
+  const evidence = mayBeComeback ? await executionEvidenceForUser(user.id) : null;
   const reentry = resolveReentryForUser({
     user, message: m,
-    lastExecutionAt: mayBeComeback ? await lastExecutionAtForUser(user.id) : undefined,
+    lastExecutionAt: evidence?.lastExecutionAt,
+    lastWorkoutAt: evidence?.lastWorkoutAt,
   });
   const isComeback = reentry.shouldHandleComeback;
 
@@ -1362,7 +1364,12 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
         // days, which includes the absence itself, so a session done DURING the silence was filed
         // under the time before it. Naming when it happened is the difference between a coach who
         // noticed they kept going and one that plainly did not.
-        ? (reentry.executedDuringAbsence
+        //
+        // A SENTENCE ABOUT TRAINING READS TRAINING EVIDENCE (#221 review). This asked
+        // `executedDuringAbsence`, which is satisfied by a meal or a step count — so a client who
+        // ate while quiet and last trained before the gap was congratulated for sessions they did
+        // not do. The gap number stays type-agnostic; only this claim narrows.
+        ? (reentry.trainedDuringAbsence
             ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the last 14 days — including while you were quiet 👊`
             : `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`)
         : `🏋️ Training: no sessions logged in the 14 days before your absence`);

--- a/server/handlers/early-commands.ts
+++ b/server/handlers/early-commands.ts
@@ -38,7 +38,7 @@ import { matchStreetDish, isStreetContext, formatStreetDish, streetGuide } from 
 import { handleAdviceCommands } from "./advice-commands";
 import { handleFoodCommands } from "./food-commands";
 import { PRICE_ESTIMATE_NOTE } from "../reply-contract";
-import { resolveReentryForUser } from "../understanding/reentry-bridge";
+import { resolveReentryForUser, shouldHandleComebackForUser, lastExecutionAtForUser } from "../understanding/reentry-bridge";
 
 // In-memory maps for holiday/travel equipment mode — module-level so they
 // persist across requests (same process lifetime as the original routes.ts).
@@ -1285,7 +1285,14 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
   // back after a real gap?" — was therefore answered here and, once the canonical resolver landed,
   // in two places at once. The regexes were byte-identical, so this swap is behaviour-preserving
   // by construction; what it removes is the second definition, not the behaviour.
-  const reentry = resolveReentryForUser({ user, message: m });
+  // EXECUTION EVIDENCE REACHES THE CLOCK (#221). The gap is read from the boundary that owns it,
+  // which now folds in the newest durable meal/workout/step row. Only fetched once the cheap
+  // message test has already passed, so an ordinary turn pays nothing for it.
+  const mayBeComeback = shouldHandleComebackForUser({ user, message: m });
+  const reentry = resolveReentryForUser({
+    user, message: m,
+    lastExecutionAt: mayBeComeback ? await lastExecutionAtForUser(user.id) : undefined,
+  });
   const isComeback = reentry.shouldHandleComeback;
 
   if (isComeback) {
@@ -1294,7 +1301,14 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
     // DISPLAY path, which needs a number, and the legacy code read 0 there. Keeping that default
     // is deliberate: null would render as "null days" to a client.
     const daysSilent = reentry.daysSinceLastContact ?? 0;
-    const daysText = daysSilent <= 7 ? `${daysSilent} day${daysSilent === 1 ? "" : "s"}` : daysSilent <= 14 ? "about a week" : "a while";
+    // HOW LONG THEY WERE REALLY GONE (#221). A client who trained on day 3 of a nine-day silence
+    // was told "about a week away" — measured from their last MESSAGE, as though the session had
+    // not happened. The gap the client recognises is the one since they last did something, and
+    // when that is newer than their last contact it is the honest number to say back to them.
+    const gap = reentry.executedDuringAbsence && reentry.daysSinceLastExecution !== null
+      ? reentry.daysSinceLastExecution
+      : daysSilent;
+    const daysText = gap <= 7 ? `${gap} day${gap === 1 ? "" : "s"}` : gap <= 14 ? "about a week" : "a while";
 
     // Pull their last-logged stats so the comeback feels informed, not generic.
     const snapLines: string[] = [];
@@ -1344,7 +1358,13 @@ ${goal === "fat_loss" ? "Fat loss focus: protein and veg first, carbs last. Cut 
 
       const sessions = workoutCount[0]?.n || 0;
       snapLines.push(sessions > 0
-        ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`
+        // "BEFORE YOU WENT QUIET" WAS A CLAIM, AND IT WAS FALSE (#221). This window is the last 14
+        // days, which includes the absence itself, so a session done DURING the silence was filed
+        // under the time before it. Naming when it happened is the difference between a coach who
+        // noticed they kept going and one that plainly did not.
+        ? (reentry.executedDuringAbsence
+            ? `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the last 14 days — including while you were quiet 👊`
+            : `🏋️ Training: *${sessions}* session${sessions !== 1 ? "s" : ""} in the 14 days before you went quiet`)
         : `🏋️ Training: no sessions logged in the 14 days before your absence`);
     } catch { /* briefing is non-critical — warm restart still happens */ }
 

--- a/server/understanding/reentry-bridge.ts
+++ b/server/understanding/reentry-bridge.ts
@@ -7,13 +7,45 @@
  */
 import { resolveReentry, type ReentryResolution } from "./reentry";
 
+/**
+ * THE NEWEST DURABLE THING THIS CLIENT DID (#221).
+ *
+ * The boundary's whole purpose is that a consumer hands over a user and cannot choose which
+ * timestamp counts as engagement. Execution evidence is part of that answer, so it is read HERE,
+ * once, from the rows that already store it — meal_logs, workout_logs, step_logs — rather than
+ * each caller assembling its own idea of "when did they last do something".
+ *
+ * Lazy import so the pure resolver and its unit tests never pull in a database connection, the
+ * same shape grocery-personalize uses for its profile read. Fails soft to null: a client must not
+ * lose their comeback because a query timed out.
+ */
+export async function lastExecutionAtForUser(userId: string): Promise<Date | null> {
+  try {
+    const { pool } = await import("../db");
+    const { rows } = await pool.query<{ at: string | null }>(
+      `SELECT GREATEST(
+          COALESCE((SELECT MAX(logged_at) FROM meal_logs    WHERE user_id = $1), 'epoch'),
+          COALESCE((SELECT MAX(logged_at) FROM workout_logs WHERE user_id = $1), 'epoch'),
+          COALESCE((SELECT MAX(logged_at) FROM step_logs    WHERE user_id = $1), 'epoch')) AS at`,
+      [userId]);
+    const at = rows[0]?.at ? new Date(rows[0].at) : null;
+    // 'epoch' is the no-rows sentinel from the COALESCE above, not a real event.
+    return at && at.getUTCFullYear() > 1971 ? at : null;
+  } catch (e: any) {
+    console.warn("[REENTRY] execution evidence unavailable:", e?.message);
+    return null;
+  }
+}
+
 export function resolveReentryForUser(input: {
   user: { lastActiveAt?: unknown };
   message: string;
+  lastExecutionAt?: unknown;
   nowMs?: number;
 }): ReentryResolution {
   return resolveReentry({
     lastActiveAt: input.user.lastActiveAt,
+    lastExecutionAt: input.lastExecutionAt,
     message: input.message,
     nowMs: input.nowMs,
   });

--- a/server/understanding/reentry-bridge.ts
+++ b/server/understanding/reentry-bridge.ts
@@ -7,33 +7,53 @@
  */
 import { resolveReentry, type ReentryResolution } from "./reentry";
 
+/** What this client durably did, at the resolution the resolver needs to speak about it. */
+export interface ExecutionEvidence {
+  /** The newest durable event of ANY kind — meal, workout or steps. */
+  lastExecutionAt: Date | null;
+  /**
+   * The newest WORKOUT specifically. Carried separately because a claim about training must rest
+   * on training: a client who logged meals while quiet has engaged without having trained, and one
+   * flag cannot answer both questions without saying something false to one of them.
+   */
+  lastWorkoutAt: Date | null;
+}
+
 /**
- * THE NEWEST DURABLE THING THIS CLIENT DID (#221).
+ * THE NEWEST DURABLE THINGS THIS CLIENT DID (#221).
  *
  * The boundary's whole purpose is that a consumer hands over a user and cannot choose which
  * timestamp counts as engagement. Execution evidence is part of that answer, so it is read HERE,
  * once, from the rows that already store it — meal_logs, workout_logs, step_logs — rather than
  * each caller assembling its own idea of "when did they last do something".
  *
+ * The three maxima come back separately and are compared in TypeScript. The earlier version did
+ * `GREATEST(COALESCE(…, 'epoch'), …)`, which then had to tell a real event apart from the sentinel
+ * by its year — a second thing to get right for no gain — and could only ever return ONE
+ * timestamp, which is precisely why the training sentence had to speak from evidence that was not
+ * about training.
+ *
  * Lazy import so the pure resolver and its unit tests never pull in a database connection, the
- * same shape grocery-personalize uses for its profile read. Fails soft to null: a client must not
+ * same shape grocery-personalize uses for its profile read. Fails soft to nulls: a client must not
  * lose their comeback because a query timed out.
  */
-export async function lastExecutionAtForUser(userId: string): Promise<Date | null> {
+export async function executionEvidenceForUser(userId: string): Promise<ExecutionEvidence> {
   try {
     const { pool } = await import("../db");
-    const { rows } = await pool.query<{ at: string | null }>(
-      `SELECT GREATEST(
-          COALESCE((SELECT MAX(logged_at) FROM meal_logs    WHERE user_id = $1), 'epoch'),
-          COALESCE((SELECT MAX(logged_at) FROM workout_logs WHERE user_id = $1), 'epoch'),
-          COALESCE((SELECT MAX(logged_at) FROM step_logs    WHERE user_id = $1), 'epoch')) AS at`,
+    const { rows } = await pool.query<{ meal_at: string | null; workout_at: string | null; step_at: string | null }>(
+      `SELECT (SELECT MAX(logged_at) FROM meal_logs    WHERE user_id = $1) AS meal_at,
+              (SELECT MAX(logged_at) FROM workout_logs WHERE user_id = $1) AS workout_at,
+              (SELECT MAX(logged_at) FROM step_logs    WHERE user_id = $1) AS step_at`,
       [userId]);
-    const at = rows[0]?.at ? new Date(rows[0].at) : null;
-    // 'epoch' is the no-rows sentinel from the COALESCE above, not a real event.
-    return at && at.getUTCFullYear() > 1971 ? at : null;
+    const at = (v: string | null | undefined) => (v ? new Date(v) : null);
+    const workout = at(rows[0]?.workout_at);
+    const newest = [at(rows[0]?.meal_at), workout, at(rows[0]?.step_at)]
+      .filter((d): d is Date => d !== null)
+      .sort((a, b) => b.getTime() - a.getTime())[0] || null;
+    return { lastExecutionAt: newest, lastWorkoutAt: workout };
   } catch (e: any) {
     console.warn("[REENTRY] execution evidence unavailable:", e?.message);
-    return null;
+    return { lastExecutionAt: null, lastWorkoutAt: null };
   }
 }
 
@@ -41,11 +61,13 @@ export function resolveReentryForUser(input: {
   user: { lastActiveAt?: unknown };
   message: string;
   lastExecutionAt?: unknown;
+  lastWorkoutAt?: unknown;
   nowMs?: number;
 }): ReentryResolution {
   return resolveReentry({
     lastActiveAt: input.user.lastActiveAt,
     lastExecutionAt: input.lastExecutionAt,
+    lastWorkoutAt: input.lastWorkoutAt,
     message: input.message,
     nowMs: input.nowMs,
   });

--- a/server/understanding/reentry.ts
+++ b/server/understanding/reentry.ts
@@ -34,8 +34,15 @@ export interface ReentryResolution {
    * us, and can write to us without executing.
    */
   daysSinceLastExecution: number | null;
-  /** Did they execute DURING the silence? True only when evidence is newer than last contact. */
+  /** Did they do ANYTHING durable during the silence — meal, workout or steps? */
   executedDuringAbsence: boolean;
+  /**
+   * Did they TRAIN during the silence? Deliberately separate from `executedDuringAbsence`: a
+   * client who logged meals while quiet but whose last session predates the gap has engaged and
+   * has NOT trained, and a coach that congratulates them on training tells them about a workout
+   * they did not do. Any surface making a claim about sessions reads this one.
+   */
+  trainedDuringAbsence: boolean;
   isReturning: boolean;
   hasExplicitReturnSignal: boolean;
   shouldHandleComeback: boolean;
@@ -59,20 +66,37 @@ const PROFILE_UPDATE = /\b(train(ing)?\s+(at|from|to)?\s*(home|gym)|home\s+worko
  * second definition of what a day is.
  */
 export function daysSinceContact(lastActiveAt: unknown, nowMs = Date.now()): number | null {
-  if (!lastActiveAt) return null;
-  // A TIMESTAMP IS A TIMESTAMP (#221). This did `new Date(String(x))`, which turns an epoch
-  // number into the string "1757289600000" and then into an Invalid Date — so a caller holding
-  // milliseconds got a silent `null`, read downstream as "we have never heard from them" rather
-  // than as the number they actually passed. Date and ISO string both still work; the number no
-  // longer falls through a stringify.
-  const at = typeof lastActiveAt === "number"
-    ? lastActiveAt
-    : lastActiveAt instanceof Date
-      ? lastActiveAt.getTime()
-      : new Date(String(lastActiveAt)).getTime();
-  if (!Number.isFinite(at) || at > nowMs) return null;
+  const at = instantOf(lastActiveAt);
+  if (at === null || at > nowMs) return null;
   return Math.max(0, sastDaysBetween(at, nowMs));
 }
+
+/**
+ * A TIMESTAMP IS A TIMESTAMP (#221). This module did `new Date(String(x))`, which turns an epoch
+ * number into the string "1757289600000" and then into an Invalid Date — so a caller holding
+ * milliseconds got a silent `null`, read downstream as "we have never heard from them" rather than
+ * as the number they actually passed. Date, ISO string and number all mean the same instant here.
+ *
+ * It is one function rather than a line inside `daysSinceContact` because the DAY AGE and the
+ * ORDERING of two events are different questions asked of the same reading, and they must not
+ * disagree about what a caller's value meant.
+ */
+function instantOf(at: unknown): number | null {
+  if (!at) return null;
+  const ms = typeof at === "number" ? at
+    : at instanceof Date ? at.getTime()
+    : new Date(String(at)).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * A durable row written BY the client's last turn lands within the same second as the contact
+ * stamp that turn wrote, in no guaranteed order — the handlers set `lastActiveAt` in the same
+ * update that files the log. Such a row is part of that conversation, not evidence of a silent
+ * streak, so "after the last contact" means after it by more than one turn's width. The smallest
+ * absence that can reach this code is two SAST days, so nothing real sits near this boundary.
+ */
+const SAME_TURN_MS = 5 * 60_000;
 
 /**
  * The gap at which a client counts as RETURNING. Lives here and nowhere else — this number was
@@ -130,21 +154,35 @@ export function isProfileUpdateMessage(message: string): boolean {
 export function resolveReentry(input: {
   lastActiveAt?: unknown;
   lastExecutionAt?: unknown;
+  lastWorkoutAt?: unknown;
   message: string;
   nowMs?: number;
 }): ReentryResolution {
-  const { daysSinceLastContact: days, isReturning } = contactState(input.lastActiveAt, input.nowMs);
+  const nowMs = input.nowMs ?? Date.now();
+  const { daysSinceLastContact: days, isReturning } = contactState(input.lastActiveAt, nowMs);
   const hasExplicitReturnSignal = isExplicitReturnSignal(input.message);
   const shouldHandleComeback = isReturning && hasExplicitReturnSignal && !isProfileUpdateMessage(input.message);
-  const daysSinceLastExecution = daysSinceContact(input.lastExecutionAt, input.nowMs);
-  // Newer than contact — strictly, so a log written in the same turn as the last message is not
-  // read as execution during a silence that had not started yet.
-  const executedDuringAbsence =
-    days !== null && daysSinceLastExecution !== null && daysSinceLastExecution < days;
+  const daysSinceLastExecution = daysSinceContact(input.lastExecutionAt, nowMs);
+
+  // ORDERING IS BETWEEN INSTANTS; ONLY THE DISPLAYED AGE IS A DAY COUNT (#221 review).
+  // This compared the two SAST day ages — `daysSinceLastExecution < days` — which cannot see
+  // inside a day. A client who wrote on Sunday MORNING and trained on Sunday EVENING has both
+  // events at the same age, so the evening session read as "not newer than contact" and was filed
+  // under the time before the silence it actually happened in. Days are the right unit for telling
+  // someone how long they were gone and the wrong one for asking which of two events came first.
+  const contactAt = instantOf(input.lastActiveAt);
+  const afterLastContact = (at: unknown) => {
+    const ms = instantOf(at);
+    return ms !== null && contactAt !== null && ms > contactAt + SAME_TURN_MS && ms <= nowMs;
+  };
+  const executedDuringAbsence = afterLastContact(input.lastExecutionAt);
+  const trainedDuringAbsence = afterLastContact(input.lastWorkoutAt);
+
   return {
     daysSinceLastContact: days,
     daysSinceLastExecution,
     executedDuringAbsence,
+    trainedDuringAbsence,
     isReturning,
     hasExplicitReturnSignal,
     shouldHandleComeback,

--- a/server/understanding/reentry.ts
+++ b/server/understanding/reentry.ts
@@ -24,8 +24,18 @@
  * should be told. Leave them where they are.
  */
 
+import { sastDaysBetween } from "../sast";
+
 export interface ReentryResolution {
   daysSinceLastContact: number | null;
+  /**
+   * The last DURABLE thing this client did — a meal, a workout, a step count — as SAST days ago,
+   * or null when nothing is known. Distinct from contact: a client can execute without writing to
+   * us, and can write to us without executing.
+   */
+  daysSinceLastExecution: number | null;
+  /** Did they execute DURING the silence? True only when evidence is newer than last contact. */
+  executedDuringAbsence: boolean;
   isReturning: boolean;
   hasExplicitReturnSignal: boolean;
   shouldHandleComeback: boolean;
@@ -35,11 +45,33 @@ const RETURN_SIGNAL = /\b(i.?m back|i am back|back now|returning|i.?ve been|been
 
 const PROFILE_UPDATE = /\b(train(ing)?\s+(at|from|to)?\s*(home|gym)|home\s+workout|i\s+train|working\s+out\s+(at\s+)?home|joined.*gym|going.*gym|quit.*gym|no.*gym|left.*gym|change.*goal|my\s+goal\s+is|switch\s+to|new\s+goal|update.*goal|change.*training|training\s+days?)\b/i;
 
+/**
+ * SAST CALENDAR DAYS, NOT ELAPSED MILLISECONDS (#221).
+ *
+ * This divided by 86_400_000, which counts 24-hour periods and not days. A client last seen at
+ * 23:30 on Sunday who writes at 06:00 on Tuesday has been gone two SAST days and counted as one —
+ * and because RETURNING_DAYS is 2, that did not merely misprint a number, it DENIED THEM THE
+ * COMEBACK. Every evening-then-morning gap in the product lands on the wrong side of that
+ * boundary, which is most of them: people go quiet at night and come back in the morning.
+ *
+ * `sastDaysBetween` is the existing owner of this question — day-ledger, one-action-command and
+ * the outcomes audit all already count days through it. This module was the outlier holding a
+ * second definition of what a day is.
+ */
 export function daysSinceContact(lastActiveAt: unknown, nowMs = Date.now()): number | null {
   if (!lastActiveAt) return null;
-  const at = new Date(String(lastActiveAt)).getTime();
+  // A TIMESTAMP IS A TIMESTAMP (#221). This did `new Date(String(x))`, which turns an epoch
+  // number into the string "1757289600000" and then into an Invalid Date — so a caller holding
+  // milliseconds got a silent `null`, read downstream as "we have never heard from them" rather
+  // than as the number they actually passed. Date and ISO string both still work; the number no
+  // longer falls through a stringify.
+  const at = typeof lastActiveAt === "number"
+    ? lastActiveAt
+    : lastActiveAt instanceof Date
+      ? lastActiveAt.getTime()
+      : new Date(String(lastActiveAt)).getTime();
   if (!Number.isFinite(at) || at > nowMs) return null;
-  return Math.max(0, Math.floor((nowMs - at) / 86_400_000));
+  return Math.max(0, sastDaysBetween(at, nowMs));
 }
 
 /**
@@ -77,13 +109,44 @@ export function isProfileUpdateMessage(message: string): boolean {
   return PROFILE_UPDATE.test(String(message || ""));
 }
 
+/**
+ * LAST MEANINGFUL ENGAGEMENT, NOT LAST CONTACT (#221).
+ *
+ * `lastExecutionAt` is the newest durable thing the client actually DID — a meal, a workout, a
+ * step count — read by the caller from the rows that already store it. It is not a new clock and
+ * not a new store: it is the same evidence every other surface reads, finally reaching the one
+ * place that decides how long someone has been gone.
+ *
+ * Traced on main@e81138e: a client trained on day 3 of a nine-day silence and said so on return.
+ * The coach answered "about a week away" and filed that session under "the 14 days BEFORE you went
+ * quiet". Both wrong from the same cause — the gap was measured from CONTACT alone, so the one
+ * thing they did during the absence was invisible to the clock and mislabelled by the copy.
+ *
+ * The DECISION still keys off contact: someone who trained silently and has now written to us
+ * after two days IS returning to the conversation, and should be greeted. What execution changes
+ * is the TRUTH the greeting is built on — how long they were really gone, and whether they kept
+ * going while they were quiet.
+ */
 export function resolveReentry(input: {
   lastActiveAt?: unknown;
+  lastExecutionAt?: unknown;
   message: string;
   nowMs?: number;
 }): ReentryResolution {
   const { daysSinceLastContact: days, isReturning } = contactState(input.lastActiveAt, input.nowMs);
   const hasExplicitReturnSignal = isExplicitReturnSignal(input.message);
   const shouldHandleComeback = isReturning && hasExplicitReturnSignal && !isProfileUpdateMessage(input.message);
-  return { daysSinceLastContact: days, isReturning, hasExplicitReturnSignal, shouldHandleComeback };
+  const daysSinceLastExecution = daysSinceContact(input.lastExecutionAt, input.nowMs);
+  // Newer than contact — strictly, so a log written in the same turn as the last message is not
+  // read as execution during a silence that had not started yet.
+  const executedDuringAbsence =
+    days !== null && daysSinceLastExecution !== null && daysSinceLastExecution < days;
+  return {
+    daysSinceLastContact: days,
+    daysSinceLastExecution,
+    executedDuringAbsence,
+    isReturning,
+    hasExplicitReturnSignal,
+    shouldHandleComeback,
+  };
 }


### PR DESCRIPTION
Journeys 1–3 of #221. **Do not merge — at the CTO gate.** BASE `main@e81138e`.

Journeys 4–7 are traced and [externalised on the issue](https://github.com/ButiMM/KamLife-Coach/issues/221#issuecomment-5580746992) but **not touched** — the open-coaching-loop / final-training-move seam is held while Codex repairs it. Journey 5's evidence is banked for when it clears.

## Journey 1 — GREEN, recorded not rewritten

One welcome, and the next turn answers what was asked instead of greeting again. No change made.

## Journey 2 — the clock divided milliseconds

`daysSinceContact` was `Math.floor((now - lastActiveAt) / 86_400_000)` — elapsed 24-hour periods, not days. Pinned to 06:00 SAST on a Tuesday:

| last contact | elapsed count | SAST calendar | returning? |
|---|---|---|---|
| 23:30 Sunday | 1 | **2** | `false` |
| 23:30 Saturday | 2 | **3** | `true` |
| 12:00 Sunday | 1 | **2** | `false` |

**The decision flipped, not just a printed number.** `RETURNING_DAYS` is 2, so a client last seen 23:30 Sunday who writes 06:00 Tuesday was two days gone, counted as one, and was **denied the comeback entirely**. Evening-then-morning is what most gaps in this product actually look like — people go quiet at night and come back in the morning.

`sastDaysBetween` is the existing owner; day-ledger, one-action-command and the outcomes audit already count days through it. This module held the last second definition of what a day is.

**Found while proving it:** `daysSinceContact` did `new Date(String(x))`, so a caller holding epoch **milliseconds** got an Invalid Date and a silent `null` — read downstream as *"we have never heard from this client"* rather than as the number they passed. Date, ISO string and number all work now.

## Journey 3 — what they did while they were quiet was invisible

```
lastActiveAt      9 days ago
workout_logs row  3 days ago      <- mid-absence, real, durable

"about a week away — everyone has those stretches."
"🏋️ Training: *1* session in the 14 days BEFORE you went quiet"
```

Both wrong from one cause: the gap was measured from **contact** alone, so the one thing they did during the silence neither moved the number nor was placed correctly in the sentence. They read a coach that did not notice they trained. Now:

```
"3 days away — everyone has those stretches."
"🏋️ Training: *1* session in the last 14 days — including while you were quiet 👊"
```

The canonical resolver takes `lastExecutionAt`, and the **boundary** reads it — once, from `meal_logs`/`workout_logs`/`step_logs`. Not a new clock and not a new store: the same evidence every other surface reads, finally reaching the one place that decides how long someone has been gone. The bridge exists precisely so a consumer cannot pick its own timestamp.

The **decision** still keys off contact — someone who trained silently and has now written after two days *is* returning to the conversation and should be greeted. What execution changes is the truth the greeting is built on.

## Proof

`script/pg-comeback-clock-acceptance.ts`, wired into `pg-acceptance`. Every claim paired with its control — greeting everybody satisfies "the comeback fires", and treating any old row as recent activity satisfies "execution counts"; both are the opposite defect and both are asserted against:

```
PASS  CONTROL: yesterday is one day, and is still not a comeback
PASS  CONTROL: the same SAST day is zero days away
PASS  CONTROL: a client with no execution evidence is still told the real gap
PASS  CONTROL: …and is not credited with training they never did
PASS  CONTROL: a log OLDER than the last message is not execution during the silence
PASS  CONTROL: an ordinary command after a long gap is not intercepted by the comeback
```

**Red on revert, five mechanisms, all five red** — including the opposite defect:

```
── the clock divides milliseconds again                      RED — 3
── execution evidence never reaches the clock                RED — 3
── the gap is measured from last CONTACT alone again         RED — 2
── mid-absence training filed 'before you went quiet' again  RED — 1
── any stored log counts as execution (opposite defect)      RED — 1
```

## Two suites regraded, not weakened

`reentry-state-tests` and `reentry-bridge-tests` pinned the elapsed-hours definition — *"48 hours is the returning threshold"* — which is the arithmetic this cut replaces. Same instants, same threshold constant, same future/unknown handling; only the day arithmetic moves, and each new expectation is what the SAST calendar says about those two instants.

Their boundary cases also stop subtracting hours from `Date.now()`. That was stable under elapsed hours and **is not** under calendar days: "47 hours ago" is two SAST days at 09:00 and one at 23:00, so the suite's answer would have depended on the hour CI ran. They are anchored to midday of a named SAST day.

`unreachableCapabilities` **falls 42 → 41** and is locked in: `shouldHandleComebackForUser` was exported and unreached, and is now the cheap pre-test deciding whether the execution query is worth running at all.

## Runs

37/37 suites · 16 of 17 PostgreSQL acceptances green · governors all pass, none raised.

**Not this branch's, established by measurement:** `pg-open-coaching-loop` (2) and journey-lab's *"the day BEFORE the target is byte-identical"* both reproduce identically on `main@e81138e` with this branch **stashed entirely**. Codex's lane, untouched.

Builder-state packet on request. Journeys 4–7 resume on one rebase once the open-loop seam lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_