### PR TITLE
#227: every acceptance runs, every acceptance starts clean, and red is still red

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,96 +117,23 @@ jobs:
       # so the forbidden command is not written here even in a comment.
       - name: Apply committed migrations to the ephemeral database
         run: npm run db:migrate
-      - name: Targeted multi-day food correction on real PostgreSQL
-        run: npx tsx script/pg-correction-acceptance.ts
-      - name: Safety early-return turn attribution on real PostgreSQL
-        run: npx tsx script/pg-safety-turn-acceptance.ts
-      # THE PROVENANCE OWNER IS A DATABASE FUNCTION (#184), so PostgreSQL is the only thing that
-      # can say whether its regular expressions compile. The broken version threw inside an
-      # AFTER INSERT trigger the application never awaits — a green suite, a normal reply, and
-      # every client-stated step count silently left untrusted.
-      - name: Step provenance bridge on real PostgreSQL
-        run: npx tsx script/pg-step-provenance-acceptance.ts
-      - name: Canonical client truth ordering on real PostgreSQL
-        run: npx tsx script/pg-client-truth-acceptance.ts
-      # TWO READERS, ONE SET OF FACTS (#179). Provenance, resolved_day and the workout ledger are
-      # COLUMNS, so only a real database can show that the canonical snapshot and the GPT
-      # fallback's context are reading the same rows — a fixture that answers every query the
-      # same way cannot tell two readers apart, which is how the divergence survived.
-      - name: Fallback reads canonical truth on real PostgreSQL
-        run: npx tsx script/pg-fallback-truth-acceptance.ts
-      # ONE COACH, PROACTIVELY AND REACTIVELY (#180). Held constraints are rows the client wrote
-      # today; whether the proactive decision reads them is only answerable against a database.
-      - name: Proactive decision authority on real PostgreSQL
-        run: npx tsx script/pg-proactive-authority-acceptance.ts
-      # A DAILY CONSTRAINT IS ABOUT WHAT SURVIVES (#194). The defect was a 24-message window, and
-      # a fixture that returns the same rows to every query cannot demonstrate a window.
-      - name: Daily constraint lifecycle on real PostgreSQL
-        run: npx tsx script/pg-daily-constraint-acceptance.ts
-      # THE CONSTRAINT REACHES EVERY MOUTH THAT NAMES A FOOD (#128). Which branch of the Next Meal
-      # menu a client reaches is composed from the day ledger — what is logged, what is left — so
-      # a fixture that answers every query the same way puts every client on one branch. That is
-      # how a menu with zero calls to the constraint owner looked fine.
-      - name: Food constraints reach the plate and grocery mouths on real PostgreSQL
-        run: npx tsx script/pg-food-constraint-mouths-acceptance.ts
-      # ONE ANSWER TO "WHICH WAY IS THE SCALE GOING" (#128). The verdict is computed from weigh-in
-      # ROWS — how many, how far apart, how recent — against an illness window in profile_notes,
-      # and the proactive half is graded on the message it actually sends, captured through the
-      # shadow door. Neither is expressible on a fixture that answers every query the same way.
-      - name: One weight-direction authority on real PostgreSQL
-        run: npx tsx script/pg-weight-authority-acceptance.ts
-      # ONE OPEN COACHING LOOP (#208). Restart durability, user isolation and exact SAST
-      # attribution require the real database; a fixture cannot prove compare-and-set closure.
-      - name: Open training move survives and resolves across turns
-        run: npx tsx script/pg-open-coaching-loop-acceptance.ts
-      # A SPARSE CLIENT IS COACHED, NOT JUST RECEIPTED (#203). Every decision here is computed
-      # from rows — how many days carry a meal, whether one carries TODAY, how stale the weigh-in
-      # is, and whether a same-day re-weigh updates or inserts. None of that is expressible on a
-      # fixture that answers every query the same way.
-      - name: Thin-evidence coaching on real PostgreSQL
-        run: npx tsx script/pg-thin-evidence-acceptance.ts
-      # INFORMATION VALUE (#213). Weekend coverage, stalled trend, the durable open loop and the
-      # later backdated answer are all real rows; this grades the one canonical INVESTIGATE owner.
-      - name: Highest-value investigation on real PostgreSQL
-        run: npx tsx script/pg-information-value-acceptance.ts
-      # ONE COACH SPEAKING (#207). The repetition defect this closes is invisible to a fixture
-      # that sends one message per client: it only appears across CONSECUTIVE durable writes by
-      # the same person, where the decision is recomputed from day state that the new event did
-      # not move. Real rows, real front door, several turns.
-      - name: Durable log turns are one coaching turn on real PostgreSQL
-        run: npx tsx script/pg-log-turn-acceptance.ts
-      # FACTS, RETRACTIONS AND SAME-TURN PROPAGATION (#211). Retraction-before-append ordering,
-      # one operation building on another's patch, and unrelated columns left alone are all
-      # properties of a real transaction — a fixture that returns whatever it was handed cannot
-      # show any of them, which is how a retracted diet came back inside its own write.
-      - name: Facts, retractions and same-turn propagation on real PostgreSQL
-        run: npx tsx script/pg-facts-acceptance.ts
-      # FOOD IDENTITY AND STATED PORTION (#206). Identity and portion are what get WRITTEN, and
-      # the invented-combo defects were visible only as kcal in the ledger — a matcher unit test
-      # cannot show that the row reaching meal_logs carries the right food at the right grams.
-      - name: Food identity and stated portion on real PostgreSQL
-        run: npx tsx script/pg-food-identity-acceptance.ts
-      # ONE WEIGHT AUTHORITY, ONE SPEAKABILITY VERDICT (#216). Illness contamination, window width
-      # and chronology are all properties of stored rows against stored dates, and the Monday
-      # claims only exist as a sent message — SHADOW=on captures them.
-      - name: Weight authority and speakability on real PostgreSQL
-        run: npx tsx script/pg-weight-speakability-acceptance.ts
-      # ONE RESTRICTION, EVERY SURFACE (#220). Consistency is a claim about what a CLIENT receives
-      # across surfaces reached by different handlers, different scheduler jobs and different cron
-      # minutes — a unit test on `allows` proves the predicate and nothing about who asked it.
-      # SHADOW=on captures the Sunday sends, so proactive food coaching is graded on the message.
-      - name: One restriction across every food surface on real PostgreSQL
-        run: npx tsx script/pg-restriction-consistency-acceptance.ts
-      # ONE COMEBACK CLOCK (#221). Both defects are claims about CHRONOLOGY across stored rows — a
-      # workout row's logged_at against a user's lastActiveAt, read through the real handler. A
-      # pure test can check the arithmetic; only this can show that the reply a returning client
-      # receives states the gap they actually experienced.
-      - name: One comeback clock on real PostgreSQL
-        run: npx tsx script/pg-comeback-clock-acceptance.ts
-      # THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
-      # would be a second copy of this infrastructure for no gain. Deliberately NOT
-      # continue-on-error: the whole point of the lab is that a known-wrong durable state cannot
-      # be reported as a warning, and a lane that goes yellow on a real defect is that warning
-      # wearing a different colour.
-      - name: Six critical journeys through the real system
-        run: npm run test:journeys
+      # ONE RUNNER, NOT EIGHTEEN STEPS (#227).
+      #
+      # These were eighteen sequential steps against one shared database, and that arrangement had
+      # two proven control failures: a step that failed ENDED THE JOB, so every acceptance behind it
+      # was skipped — a branch could add a proof that authoritative CI never once ran — and the
+      # shared database let one acceptance's rows change what the next one saw, which produced three
+      # false product regressions on #224 before it was caught.
+      #
+      # The runner resets the ephemeral database before each acceptance, runs all of them, records
+      # every verdict, and exits non-zero if any failed. NOT `continue-on-error`: a red is still a
+      # red gate, it simply no longer hides the evidence behind it. The inventory and the reason
+      # each acceptance needs real PostgreSQL now live in the runner, in one copy.
+      #
+      # The controls run FIRST and are the runner's own proof — a test runner is the one thing its
+      # own suites cannot grade, so it is graded here against this same container, with deliberate
+      # controlled failures, before it is trusted to grade anything else.
+      - name: Acceptance runner controls (deliberate controlled reds)
+        run: npx tsx script/pg-acceptance-runner-controls.ts
+      - name: Every acceptance, isolated, on real PostgreSQL
+        run: npx tsx script/pg-acceptance-runner.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,5 +135,16 @@ jobs:
       # controlled failures, before it is trusted to grade anything else.
       - name: Acceptance runner controls (deliberate controlled reds)
         run: npx tsx script/pg-acceptance-runner-controls.ts
+      # `!cancelled()`, NOT the default `success()` — THE SAME BLINDNESS ONE STEP HIGHER (#227).
+      #
+      # A step runs by default only if every step before it succeeded, so a red controls step would
+      # SKIP this one and take all nineteen verdicts with it — rebuilding the early-exit blindness
+      # this cut removes, at the seam the cut itself added. Not hypothetical: the controls execute a
+      # real acceptance to prove standalone runnability, so a product regression there could have
+      # silenced the entire acceptance run.
+      #
+      # This is NOT `continue-on-error`. Both steps still fail the job. It says only that the
+      # evidence is worth collecting even when the thing that grades the collector is unhappy.
       - name: Every acceptance, isolated, on real PostgreSQL
+        if: ${{ !cancelled() }}
         run: npx tsx script/pg-acceptance-runner.ts

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ p2-work/
 # Ephemeral exact-merge-base checkout made by script/compare-unit-baseline.ts.
 # It must stay under the repository so the base checkout can resolve this checkout's node_modules.
 .unit-baseline-worktree-*/
+.pg-runner-controls-*/

--- a/script/pg-acceptance-runner-controls.ts
+++ b/script/pg-acceptance-runner-controls.ts
@@ -273,6 +273,13 @@ console.log("\n=== 8 · THESE CONTROLS REFUSE AN UNSAFE DATABASE BEFORE TOUCHING
   }
 }
 
+// ═══ TEMPORARY — CI DEMONSTRATION FOR #227, REVERTED IN THE VERY NEXT COMMIT ═══════════════════
+// The CTO gate requires proof that "controls can fail and all acceptances still run". That is a
+// property of the WORKFLOW's step condition, so no local run can demonstrate it — only a real CI
+// run in which this step is red. This line makes it red on purpose for exactly one run.
+chk(false, "TEMPORARY PROOF: a deliberately failing control, reverted in the next commit");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+
 console.log(`\n${failed === 0
   ? "pg-acceptance-runner-controls: GREEN — all checks passed"
   : `pg-acceptance-runner-controls: RED — ${failed} check(s) failed`}`);

--- a/script/pg-acceptance-runner-controls.ts
+++ b/script/pg-acceptance-runner-controls.ts
@@ -205,15 +205,52 @@ console.log("\n=== 7 · THE RESET RESTORES SCHEMA AN ACCEPTANCE BROKE, NOT JUST 
   const original = await defOf();
   chk(!!original, "the migrated schema carries the step-provenance function to begin with");
 
-  await pool.query(`CREATE OR REPLACE FUNCTION public.kamlife_parse_step_report(raw text)
-    RETURNS integer LANGUAGE plpgsql IMMUTABLE AS $fn$ BEGIN RETURN 42; END; $fn$;`);
-  const broken = await defOf();
-  chk(broken !== original && /42/.test(broken),
-    "CONTROL: an acceptance really can leave a mutated function behind", "");
+  // The scenario exactly: an acceptance that mutates the function and then DIES before restoring
+  // it, followed by one that requires the committed definition. Not a mutation done politely from
+  // this file — a failing acceptance, which is the case that actually happens.
+  const breaksAndDies = fixture("breaks-and-dies", `
+    const { pool } = await import("../server/db.ts");
+    await pool.query(\`CREATE OR REPLACE FUNCTION public.kamlife_parse_step_report(raw text)
+      RETURNS integer LANGUAGE plpgsql IMMUTABLE AS $fn$ BEGIN RETURN 42; END; $fn$;\`);
+    await pool.end();
+    console.log("fixture: schema mutated, now dying before restoring it");
+    process.exit(1);`);
+  const demandsCommittedFn = fixture("demands-committed-fn", `
+    const { pool } = await import("../server/db.ts");
+    const { rows } = await pool.query(\`SELECT pg_get_functiondef(p.oid) AS def FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = 'kamlife_parse_step_report'\`);
+    await pool.end();
+    const mutated = /RETURN 42/.test(rows[0]?.def || "");
+    console.log("fixture: step parser is " + (mutated ? "THE MUTATED ONE" : "the committed one"));
+    process.exit(mutated ? 1 : 0);`);
+
+  const results = await runAcceptances(
+    [entry("breaks-and-dies", breaksAndDies), entry("demands-committed-fn", demandsCommittedFn)],
+    { reset, run });
+  chk(!results[0].ok, "CONTROL: the mutating acceptance really did fail", JSON.stringify(results[0]));
+  chk(results[1].ok,
+    "a schema mutation left behind by a FAILING acceptance cannot reach the next one",
+    JSON.stringify(results[1]));
+
+  // THE CONTROL FOR THE CONTROL. With row-only truncation in place of the rebuild, the mutated
+  // function survives and the second acceptance fails — which is the defect this replaced, and the
+  // proof that the check above is testing the rebuild rather than describing a mutation that never
+  // happened.
+  const truncateOnly = async () => {
+    await pool.query(`DO $$ DECLARE t text; BEGIN
+      FOR t IN SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+      LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END $$;`);
+  };
+  const underTruncate = await runAcceptances(
+    [entry("breaks-and-dies", breaksAndDies), entry("demands-committed-fn", demandsCommittedFn)],
+    { reset: truncateOnly, run });
+  chk(!underTruncate[1].ok,
+    "CONTROL: with row-only truncation the broken parser survives and the next acceptance FAILS",
+    JSON.stringify(underTruncate[1]));
 
   await reset();
-  chk(await defOf() === original,
-    "…and the reset puts the committed definition back, byte for byte",
+  chk(await defOf() === original, "…and the rebuild restores the committed definition byte for byte",
     JSON.stringify((await defOf()).slice(0, 120)));
 }
 

--- a/script/pg-acceptance-runner-controls.ts
+++ b/script/pg-acceptance-runner-controls.ts
@@ -16,11 +16,6 @@
  *   the second one must then FAIL. Without that half, "the row was gone" is equally well explained
  *   by the row never having been written.
  */
-if (!process.env.DATABASE_URL) {
-  console.log("pg-acceptance-runner-controls: SKIPPED — no DATABASE_URL. This proof needs a real database.");
-  process.exit(0);
-}
-
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -28,6 +23,30 @@ import { join } from "node:path";
 const {
   ACCEPTANCES, testDatabaseSafety, resetTestDatabase, runAcceptances, exitCodeFor,
 } = await import("./pg-acceptance-runner.ts");
+
+/**
+ * THE GUARD PROTECTS THIS FILE TOO (#227, review).
+ *
+ * The first version of this script checked only that DATABASE_URL was non-empty, then imported the
+ * pool and reset the database — while testing `testDatabaseSafety` as a pure function further down
+ * without ever applying it to its own destructive work. A controls script that can wipe a real
+ * database is the precise hazard this cut exists to close, sitting in the file whose job is to
+ * prove it is closed. It is applied FIRST now, before the pool is even imported.
+ */
+const safety = testDatabaseSafety(process.env.DATABASE_URL, process.env as any);
+if (!safety.safe) {
+  // No database at all is an environment without one — the same SKIP every acceptance does. A
+  // database that is present but not a throwaway is a REFUSAL, and must not read as a pass.
+  if (!process.env.DATABASE_URL) {
+    console.log("pg-acceptance-runner-controls: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+    process.exit(0);
+  }
+  console.log(`pg-acceptance-runner-controls: REFUSING — ${safety.reason}.`);
+  console.log("These controls reset the database repeatedly, so they only ever point at a");
+  console.log("throwaway local/CI one. Outside CI, pass PG_ACCEPTANCE_ALLOW_RESET=1 deliberately.");
+  process.exit(2);
+}
+
 const { pool } = await import("../server/db");
 
 let failed = 0;
@@ -154,14 +173,67 @@ console.log("\n=== 6 · THE INVENTORY IS REAL, AND ITS SCRIPTS STILL STAND ALONE
   chk(ACCEPTANCES.length >= 19, "the inventory still holds every acceptance the workflow listed",
     `count=${ACCEPTANCES.length}`);
 
-  // Requirement 6 of the cut: the individual scripts must remain independently runnable, so that a
+  // Requirement 6 of the cut: the individual scripts must remain independently runnable, so a
   // builder debugging one acceptance never has to run the whole set. Proven by running one.
+  //
+  // GRADED ON EXECUTION, NOT ON THE PRODUCT (#227, review). This asserted the acceptance came back
+  // GREEN, which quietly made these infrastructure controls depend on product health: a real
+  // regression in that suite would have turned the controls red, and — before the workflow fix
+  // alongside this — skipped the whole acceptance run. What requirement 6 is about is whether the
+  // script still RUNS standalone, so that is what is asserted: it reached its own verdict line.
   await reset();
   const solo = spawnSync("npx", ["tsx", "script/pg-safety-turn-acceptance.ts"],
     { encoding: "utf-8", env: process.env });
-  chk(solo.status === 0 && /GREEN/.test(solo.stdout || ""),
-    "an individual acceptance still runs on its own, outside the runner",
-    `status=${solo.status}`);
+  chk(/pg-safety-turn-acceptance: (GREEN|RED)/.test(solo.stdout || ""),
+    "an individual acceptance still runs on its own, outside the runner, and reaches a verdict",
+    `status=${solo.status} tail=${JSON.stringify((solo.stdout || "").slice(-160))}`);
+}
+
+console.log("\n=== 7 · THE RESET RESTORES SCHEMA AN ACCEPTANCE BROKE, NOT JUST ROWS ===");
+{
+  // The defect this closes: `pg-step-provenance-acceptance` installs the pre-#184 faulty
+  // `kamlife_parse_step_report` on purpose and restores it three statements later. An exception in
+  // that window leaves the broken function installed — and TRUNCATE does not remove a function, so
+  // every later acceptance would run against a known-broken step parser and fail for reasons that
+  // belong to nothing in the diff. A reset that only empties tables does not deliver a clean
+  // database; this asserts that the one here does.
+  const defOf = async () => (await pool.query(
+    `SELECT pg_get_functiondef(p.oid) AS def FROM pg_proc p
+       JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = 'kamlife_parse_step_report'`)).rows[0]?.def || "";
+
+  const original = await defOf();
+  chk(!!original, "the migrated schema carries the step-provenance function to begin with");
+
+  await pool.query(`CREATE OR REPLACE FUNCTION public.kamlife_parse_step_report(raw text)
+    RETURNS integer LANGUAGE plpgsql IMMUTABLE AS $fn$ BEGIN RETURN 42; END; $fn$;`);
+  const broken = await defOf();
+  chk(broken !== original && /42/.test(broken),
+    "CONTROL: an acceptance really can leave a mutated function behind", "");
+
+  await reset();
+  chk(await defOf() === original,
+    "…and the reset puts the committed definition back, byte for byte",
+    JSON.stringify((await defOf()).slice(0, 120)));
+}
+
+console.log("\n=== 8 · THESE CONTROLS REFUSE AN UNSAFE DATABASE BEFORE TOUCHING IT ===");
+{
+  // The guard is asserted as a pure function above; this asserts it actually GATES this file's own
+  // destructive work. The child exits at the guard, so the recursion is one level deep and ends
+  // there — the marker below is belt and braces in case a future edit breaks the guard itself.
+  if (process.env.PG_CONTROLS_NO_RECURSE === "1") {
+    chk(true, "SKIPPED in the child process (recursion guard)");
+  } else {
+    const child = spawnSync("npx", ["tsx", "script/pg-acceptance-runner-controls.ts"], {
+      encoding: "utf-8",
+      env: { ...process.env, PG_CONTROLS_NO_RECURSE: "1", CI: "", PG_ACCEPTANCE_ALLOW_RESET: "",
+             DATABASE_URL: "postgres://u:p@containers-us-west-1.railway.app:5432/railway" },
+    });
+    chk(child.status === 2 && /REFUSING/.test(child.stdout || ""),
+      "pointed at a remote database, this script refuses and resets nothing",
+      `status=${child.status} out=${JSON.stringify((child.stdout || "").slice(0, 160))}`);
+  }
 }
 
 console.log(`\n${failed === 0

--- a/script/pg-acceptance-runner-controls.ts
+++ b/script/pg-acceptance-runner-controls.ts
@@ -1,0 +1,174 @@
+/**
+ * CONTROLS FOR THE ACCEPTANCE RUNNER (#227) — the proof harness for the gate itself.
+ *
+ * A test runner is the one piece of infrastructure that cannot be graded by the suites it runs: if
+ * it silently skipped everything, every suite would still "pass". So it is graded here, against
+ * the real PostgreSQL container, with deliberate controlled failures.
+ *
+ * The two failures this cut exists to remove are both asserted as behaviour, not as intent:
+ *
+ *   EARLY-EXIT BLINDNESS — a red acceptance must not stop the ones behind it, and must still make
+ *   the job red. Both halves matter: a runner that keeps going but forgets to fail is worse than
+ *   the early exit it replaced, because it is a gate that no longer gates.
+ *
+ *   CONTAMINATION — the reset must actually remove what the previous acceptance wrote. That is
+ *   asserted WITH ITS OPPOSITE: the same two fixtures are run again with the reset disabled, and
+ *   the second one must then FAIL. Without that half, "the row was gone" is equally well explained
+ *   by the row never having been written.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-acceptance-runner-controls: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const {
+  ACCEPTANCES, testDatabaseSafety, resetTestDatabase, runAcceptances, exitCodeFor,
+} = await import("./pg-acceptance-runner.ts");
+const { pool } = await import("../server/db");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+// Fixtures: tiny scripts standing in for acceptances, so a controlled red is genuinely CONTROLLED
+// rather than borrowed from whichever product suite happens to be broken today.
+//
+// They are written INSIDE the repository, not /tmp, and the reason is worth recording: tsx decides
+// module format from the nearest package.json, so a .ts file under /tmp is transformed as CommonJS
+// and every `await import` in it fails to compile. A fixture that cannot run would have made the
+// contamination control vacuously "green" in the direction that matters least.
+const dir = mkdtempSync(join(process.cwd(), ".pg-runner-controls-"));
+const fixture = (name: string, body: string) => {
+  const p = join(dir, `${name}.ts`);
+  writeFileSync(p, body);
+  return ["npx", "tsx", p];
+};
+const PHONE = "whatsapp:+27999000227";
+
+const passing = fixture("passing", `console.log("fixture: passing"); process.exit(0);`);
+const failing = fixture("failing", `console.log("fixture: deliberately failing"); process.exit(1);`);
+const writesRow = fixture("writes-row", `
+  const { pool } = await import("../server/db.ts");
+  await pool.query("INSERT INTO users (phone_number, name) VALUES ($1, $2)", [${JSON.stringify(PHONE)}, "Contaminator"]);
+  await pool.end(); process.exit(0);`);
+const demandsEmpty = fixture("demands-empty", `
+  const { pool } = await import("../server/db.ts");
+  const { rows } = await pool.query("SELECT count(*)::int AS n FROM users WHERE phone_number = $1", [${JSON.stringify(PHONE)}]);
+  await pool.end();
+  console.log("fixture: saw " + rows[0].n + " contaminating row(s)");
+  process.exit(rows[0].n === 0 ? 0 : 1);`);
+
+const reset = () => resetTestDatabase(pool);
+const run = (cmd: string[]) => spawnSync(cmd[0], cmd.slice(1), { stdio: "inherit", env: process.env });
+const entry = (id: string, command: string[]) => ({ id, title: id, command });
+
+console.log("\n=== 1 · A RED ACCEPTANCE DOES NOT HIDE THE ONES BEHIND IT ===");
+{
+  const results = await runAcceptances(
+    [entry("first-red", failing), entry("second", passing), entry("third", passing)],
+    { reset, run });
+  chk(results.length === 3, "every acceptance after a failure still executed",
+    JSON.stringify(results.map(r => r.id)));
+  chk(results[0].ok === false && results[1].ok && results[2].ok,
+    "…and each verdict is recorded independently", JSON.stringify(results));
+
+  // The other half, and the one that makes this a gate rather than a report.
+  chk(exitCodeFor(results) === 1, "the job still exits RED because one of them failed",
+    `exit=${exitCodeFor(results)}`);
+}
+
+console.log("\n=== 2 · A FULLY GREEN SET IS GREEN ===");
+{
+  const results = await runAcceptances([entry("a", passing), entry("b", passing)], { reset, run });
+  chk(results.every(r => r.ok) && exitCodeFor(results) === 0,
+    "nothing red, nothing invented — the gate passes", JSON.stringify(results));
+}
+
+console.log("\n=== 3 · THE RESET ACTUALLY REMOVES WHAT THE LAST ACCEPTANCE WROTE ===");
+{
+  const results = await runAcceptances(
+    [entry("writes-row", writesRow), entry("demands-empty", demandsEmpty)], { reset, run });
+  chk(results.every(r => r.ok),
+    "a row seeded by one acceptance is gone before the next one starts", JSON.stringify(results));
+
+  // THE CONTROL. Without this, "the row was gone" is equally well explained by the row never
+  // having been written — which would make the check above prove nothing at all.
+  const noReset = await runAcceptances(
+    [entry("writes-row", writesRow), entry("demands-empty", demandsEmpty)],
+    { reset: async () => {}, run });
+  chk(noReset[0].ok && !noReset[1].ok,
+    "CONTROL: with the reset removed, the same pair contaminates and the second FAILS",
+    JSON.stringify(noReset));
+  await reset();
+}
+
+console.log("\n=== 4 · A RESET THAT FAILS IS NOT A REASON TO RUN ANYWAY ===");
+{
+  const results = await runAcceptances([entry("a", passing)], {
+    reset: async () => { throw new Error("database unreachable"); }, run });
+  chk(!results[0].ok && /reset failed/.test(results[0].note),
+    "an unresettable database is recorded as a failure, not run against whatever was left",
+    JSON.stringify(results));
+}
+
+console.log("\n=== 5 · THE RESET REFUSES ANY DATABASE THAT IS NOT A THROWAWAY ===");
+{
+  const CI = { CI: "true" };
+  const unsafe: Array<[string, string | undefined, any]> = [
+    ["no DATABASE_URL at all", undefined, CI],
+    ["a remote production host", "postgres://u:p@containers-us-west-1.railway.app:5432/railway", CI],
+    ["any non-loopback host", "postgres://u:p@10.0.0.7:5432/kamlife", CI],
+    ["a URL that is not PostgreSQL", "mysql://u:p@127.0.0.1:3306/kamlife", CI],
+    ["not a URL at all", "kamlife", CI],
+    ["NODE_ENV=production", "postgres://kam:kam@127.0.0.1:5432/kamlife", { ...CI, NODE_ENV: "production" }],
+    ["a laptop that did not opt in", "postgres://kam:kam@127.0.0.1:5432/kamlife", {}],
+  ];
+  for (const [name, url, env] of unsafe) {
+    const v = testDatabaseSafety(url, env);
+    chk(v.safe === false, `refused: ${name}`, JSON.stringify(v));
+  }
+
+  // CONTROLS BOTH WAYS. A guard that refuses everything would pass every line above and stop the
+  // gate from ever running — these are the two configurations that MUST be allowed.
+  chk(testDatabaseSafety("postgres://kam:kam@127.0.0.1:5432/kamlife", CI).safe === true,
+    "CONTROL: the CI service container is allowed");
+  chk(testDatabaseSafety("postgres://kam:kam@localhost:5432/journeylab",
+    { PG_ACCEPTANCE_ALLOW_RESET: "1" }).safe === true,
+    "CONTROL: a local database with a deliberate opt-in is allowed");
+}
+
+console.log("\n=== 6 · THE INVENTORY IS REAL, AND ITS SCRIPTS STILL STAND ALONE ===");
+{
+  const { existsSync } = await import("node:fs");
+  const missing = ACCEPTANCES
+    .filter(a => a.command[0] === "npx" && !existsSync(a.command[2]))
+    .map(a => a.command[2]);
+  chk(missing.length === 0, "every acceptance named in the inventory exists on disk",
+    JSON.stringify(missing));
+  chk(ACCEPTANCES.length >= 19, "the inventory still holds every acceptance the workflow listed",
+    `count=${ACCEPTANCES.length}`);
+
+  // Requirement 6 of the cut: the individual scripts must remain independently runnable, so that a
+  // builder debugging one acceptance never has to run the whole set. Proven by running one.
+  await reset();
+  const solo = spawnSync("npx", ["tsx", "script/pg-safety-turn-acceptance.ts"],
+    { encoding: "utf-8", env: process.env });
+  chk(solo.status === 0 && /GREEN/.test(solo.stdout || ""),
+    "an individual acceptance still runs on its own, outside the runner",
+    `status=${solo.status}`);
+}
+
+console.log(`\n${failed === 0
+  ? "pg-acceptance-runner-controls: GREEN — all checks passed"
+  : `pg-acceptance-runner-controls: RED — ${failed} check(s) failed`}`);
+
+rmSync(dir, { recursive: true, force: true });
+await resetTestDatabase(pool).catch(() => {});
+await pool.end().catch(() => {});
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-acceptance-runner-controls.ts
+++ b/script/pg-acceptance-runner-controls.ts
@@ -273,13 +273,6 @@ console.log("\n=== 8 · THESE CONTROLS REFUSE AN UNSAFE DATABASE BEFORE TOUCHING
   }
 }
 
-// ═══ TEMPORARY — CI DEMONSTRATION FOR #227, REVERTED IN THE VERY NEXT COMMIT ═══════════════════
-// The CTO gate requires proof that "controls can fail and all acceptances still run". That is a
-// property of the WORKFLOW's step condition, so no local run can demonstrate it — only a real CI
-// run in which this step is red. This line makes it red on purpose for exactly one run.
-chk(false, "TEMPORARY PROOF: a deliberately failing control, reverted in the next commit");
-// ══════════════════════════════════════════════════════════════════════════════════════════════
-
 console.log(`\n${failed === 0
   ? "pg-acceptance-runner-controls: GREEN — all checks passed"
   : `pg-acceptance-runner-controls: RED — ${failed} check(s) failed`}`);

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -1,0 +1,302 @@
+/**
+ * THE POSTGRESQL ACCEPTANCE RUNNER — one owner for reset, execution, collection and exit code (#227).
+ *
+ * WHAT THIS REPLACES, AND WHY. The authoritative `pg-acceptance` job was eighteen sequential
+ * GitHub Actions steps sharing one ephemeral database. That arrangement caused two proven
+ * engineering-control failures, both of which cost real diagnosis time:
+ *
+ *   CROSS-ACCEPTANCE CONTAMINATION. The suites are not isolated from each other — Coach Health
+ *   reads `turn_ledger` database-wide, for one — so rows written by an earlier acceptance change
+ *   what a later one sees. On #224 three "product regressions" were reported from a batch run and
+ *   evaporated when each acceptance was rerun after its own reset. A false diagnosis reached a
+ *   lane decision before it was caught.
+ *
+ *   EARLY-EXIT BLINDNESS. A step that fails ends the job, so every later step is skipped. While
+ *   one product acceptance was red, seven others never executed — including the proof a branch had
+ *   just added. A branch could hold excellent local evidence that authoritative CI had never once
+ *   run. That is the worst failure mode available to a gate: not a wrong answer, but no answer
+ *   wearing the same colour as one.
+ *
+ * THE RULE THIS ENFORCES: every acceptance runs, every acceptance starts from the same clean
+ * database, every verdict is recorded, and the job is still RED if any of them failed.
+ *
+ * WHAT IS DELIBERATELY NOT DONE HERE. No `continue-on-error` — that turns a real red into a
+ * warning wearing a different colour, which the workflow already rejected in writing for the
+ * Journey Lab. No second PostgreSQL service to sidestep ordering. No reordering. The order below
+ * is the order the workflow had.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+export interface Acceptance {
+  /** Short id for the summary table. */
+  id: string;
+  /** Human sentence for the log header — what this proof is about. */
+  title: string;
+  /** Argv to execute. Kept as argv rather than a shell string so nothing is word-split. */
+  command: string[];
+}
+
+/**
+ * THE INVENTORY, AND THE ONLY COPY OF IT (#227).
+ *
+ * This list lived in the workflow YAML, where each entry carried the reason real PostgreSQL was
+ * required rather than a fixture. Those reasons are the valuable part and they move here with the
+ * list; the workflow now calls this runner once. Two owners of the same inventory is how a new
+ * acceptance gets added in one place and silently never runs in the other.
+ */
+export const ACCEPTANCES: Acceptance[] = [
+  { id: "correction", title: "Targeted multi-day food correction",
+    // The deterministic stub ignores ORDER BY and does not reflect UPDATEs into reads, so it
+    // cannot say WHICH row a named-day correction lands on.
+    command: ["npx", "tsx", "script/pg-correction-acceptance.ts"] },
+
+  { id: "safety-turn", title: "Safety early-return turn attribution",
+    command: ["npx", "tsx", "script/pg-safety-turn-acceptance.ts"] },
+
+  { id: "step-provenance", title: "Step provenance bridge",
+    // THE PROVENANCE OWNER IS A DATABASE FUNCTION (#184), so PostgreSQL is the only thing that can
+    // say whether its regular expressions compile. The broken version threw inside an AFTER INSERT
+    // trigger the application never awaits — a green suite, a normal reply, and every
+    // client-stated step count silently left untrusted.
+    command: ["npx", "tsx", "script/pg-step-provenance-acceptance.ts"] },
+
+  { id: "client-truth", title: "Canonical client truth ordering",
+    command: ["npx", "tsx", "script/pg-client-truth-acceptance.ts"] },
+
+  { id: "fallback-truth", title: "Fallback reads canonical truth",
+    // TWO READERS, ONE SET OF FACTS (#179). Provenance, resolved_day and the workout ledger are
+    // COLUMNS, so only a real database can show that the canonical snapshot and the GPT fallback's
+    // context are reading the same rows — a fixture that answers every query the same way cannot
+    // tell two readers apart, which is how the divergence survived.
+    command: ["npx", "tsx", "script/pg-fallback-truth-acceptance.ts"] },
+
+  { id: "proactive-authority", title: "Proactive decision authority",
+    // ONE COACH, PROACTIVELY AND REACTIVELY (#180). Held constraints are rows the client wrote
+    // today; whether the proactive decision reads them is only answerable against a database.
+    command: ["npx", "tsx", "script/pg-proactive-authority-acceptance.ts"] },
+
+  { id: "daily-constraint", title: "Daily constraint lifecycle",
+    // A DAILY CONSTRAINT IS ABOUT WHAT SURVIVES (#194). The defect was a 24-message window, and a
+    // fixture that returns the same rows to every query cannot demonstrate a window.
+    command: ["npx", "tsx", "script/pg-daily-constraint-acceptance.ts"] },
+
+  { id: "food-constraint-mouths", title: "Food constraints reach the plate and grocery mouths",
+    // THE CONSTRAINT REACHES EVERY MOUTH THAT NAMES A FOOD (#128). Which branch of the Next Meal
+    // menu a client reaches is composed from the day ledger — what is logged, what is left — so a
+    // fixture that answers every query the same way puts every client on one branch.
+    command: ["npx", "tsx", "script/pg-food-constraint-mouths-acceptance.ts"] },
+
+  { id: "weight-authority", title: "One weight-direction authority",
+    // ONE ANSWER TO "WHICH WAY IS THE SCALE GOING" (#128). The verdict is computed from weigh-in
+    // ROWS — how many, how far apart, how recent — against an illness window in profile_notes, and
+    // the proactive half is graded on the message it actually sends, captured through the shadow
+    // door. Neither is expressible on a fixture that answers every query the same way.
+    command: ["npx", "tsx", "script/pg-weight-authority-acceptance.ts"] },
+
+  { id: "open-coaching-loop", title: "Open training move survives and resolves across turns",
+    // ONE OPEN COACHING LOOP (#208). Restart durability, user isolation and exact SAST attribution
+    // require the real database; a fixture cannot prove compare-and-set closure.
+    command: ["npx", "tsx", "script/pg-open-coaching-loop-acceptance.ts"] },
+
+  { id: "thin-evidence", title: "Thin-evidence coaching",
+    // A SPARSE CLIENT IS COACHED, NOT JUST RECEIPTED (#203). Every decision here is computed from
+    // rows — how many days carry a meal, whether one carries TODAY, how stale the weigh-in is, and
+    // whether a same-day re-weigh updates or inserts.
+    command: ["npx", "tsx", "script/pg-thin-evidence-acceptance.ts"] },
+
+  { id: "information-value", title: "Highest-value investigation",
+    // INFORMATION VALUE (#213). Weekend coverage, stalled trend, the durable open loop and the
+    // later backdated answer are all real rows; this grades the one canonical INVESTIGATE owner.
+    command: ["npx", "tsx", "script/pg-information-value-acceptance.ts"] },
+
+  { id: "log-turn", title: "Durable log turns are one coaching turn",
+    // ONE COACH SPEAKING (#207). The repetition defect this closes is invisible to a fixture that
+    // sends one message per client: it only appears across CONSECUTIVE durable writes by the same
+    // person, where the decision is recomputed from day state the new event did not move.
+    command: ["npx", "tsx", "script/pg-log-turn-acceptance.ts"] },
+
+  { id: "facts", title: "Facts, retractions and same-turn propagation",
+    // FACTS, RETRACTIONS AND SAME-TURN PROPAGATION (#211). Retraction-before-append ordering, one
+    // operation building on another's patch, and unrelated columns left alone are all properties
+    // of a real transaction — which is how a retracted diet came back inside its own write.
+    command: ["npx", "tsx", "script/pg-facts-acceptance.ts"] },
+
+  { id: "food-identity", title: "Food identity and stated portion",
+    // FOOD IDENTITY AND STATED PORTION (#206). Identity and portion are what get WRITTEN, and the
+    // invented-combo defects were visible only as kcal in the ledger.
+    command: ["npx", "tsx", "script/pg-food-identity-acceptance.ts"] },
+
+  { id: "weight-speakability", title: "Weight authority and speakability",
+    // ONE WEIGHT AUTHORITY, ONE SPEAKABILITY VERDICT (#216). Illness contamination, window width
+    // and chronology are all properties of stored rows against stored dates, and the Monday claims
+    // only exist as a sent message — SHADOW=on captures them.
+    command: ["npx", "tsx", "script/pg-weight-speakability-acceptance.ts"] },
+
+  { id: "restriction-consistency", title: "One restriction across every food surface",
+    // ONE RESTRICTION, EVERY SURFACE (#220). Consistency is a claim about what a CLIENT receives
+    // across surfaces reached by different handlers, different scheduler jobs and different cron
+    // minutes — a unit test on `allows` proves the predicate and nothing about who asked it.
+    command: ["npx", "tsx", "script/pg-restriction-consistency-acceptance.ts"] },
+
+  { id: "comeback-clock", title: "One comeback clock",
+    // ONE COMEBACK CLOCK (#221). Both defects are claims about CHRONOLOGY across stored rows — a
+    // workout row's logged_at against a user's lastActiveAt, read through the real handler.
+    command: ["npx", "tsx", "script/pg-comeback-clock-acceptance.ts"] },
+
+  { id: "journey-lab", title: "Six critical journeys through the real system",
+    // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
+    // would be a second copy of this infrastructure for no gain. It is in this runner for the same
+    // reason it was never `continue-on-error`: a known-wrong durable state must not be reported as
+    // a warning, and this runner keeps its red a red.
+    command: ["npm", "run", "test:journeys"] },
+];
+
+// ── THE RESET, AND WHAT IT REFUSES TO DO ──────────────────────────────────────────────────────
+
+/** Hosts a throwaway test database can legitimately live on. Anything else is somebody's data. */
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]", "postgres"]);
+
+/**
+ * FAIL CLOSED, AND SAY WHY (#227).
+ *
+ * This function's whole job is to stand between "truncate every table" and a database that is not
+ * a disposable test one. It answers with a REASON rather than a boolean because the reason is what
+ * a person reads at 2am when the runner refuses, and because a control can assert on it.
+ *
+ * The decisive check is the host: a production database for this product lives behind a remote
+ * hostname, so refusing every non-loopback host puts it out of reach by construction rather than
+ * by a name pattern someone could match by accident. The explicit opt-in is the second lock — a
+ * developer who runs this file by hand on a laptop must say so, so that no script, hook or editor
+ * task can wipe their working database as a side effect of doing something else.
+ */
+export function testDatabaseSafety(
+  url: string | undefined,
+  env: { CI?: string; PG_ACCEPTANCE_ALLOW_RESET?: string; NODE_ENV?: string } = {},
+): { safe: true } | { safe: false; reason: string } {
+  if (!url) return { safe: false, reason: "DATABASE_URL is not set" };
+
+  let parsed: URL;
+  try { parsed = new URL(url); } catch { return { safe: false, reason: "DATABASE_URL is not a URL" }; }
+  if (!/^postgres(ql)?:$/.test(parsed.protocol)) {
+    return { safe: false, reason: `not a PostgreSQL URL (protocol ${parsed.protocol})` };
+  }
+  if (!LOCAL_HOSTS.has(parsed.hostname)) {
+    return { safe: false, reason: `host ${parsed.hostname} is not a local throwaway database` };
+  }
+  if (env.NODE_ENV === "production") {
+    return { safe: false, reason: "NODE_ENV=production" };
+  }
+  // The opt-in is last so the message a developer sees first is about the DATABASE, not the flag.
+  if (env.CI !== "true" && env.PG_ACCEPTANCE_ALLOW_RESET !== "1") {
+    return { safe: false, reason: "not CI, and PG_ACCEPTANCE_ALLOW_RESET=1 was not given" };
+  }
+  return { safe: true };
+}
+
+/**
+ * Empty every table this product owns, leaving the schema and the applied-migrations ledger alone.
+ * Truncating `__drizzle_migrations` would make the next reader believe the schema was never built.
+ */
+export async function resetTestDatabase(pool: { query: (q: string) => Promise<unknown> }): Promise<void> {
+  await pool.query(`DO $$
+    DECLARE t text;
+    BEGIN
+      FOR t IN SELECT tablename FROM pg_tables
+               WHERE schemaname = 'public' AND tablename <> '__drizzle_migrations'
+      LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP;
+    END $$;`);
+}
+
+// ── EXECUTION AND COLLECTION ──────────────────────────────────────────────────────────────────
+
+export interface AcceptanceResult { id: string; ok: boolean; code: number | null; note: string }
+
+/**
+ * Run every acceptance, each against a freshly reset database, and return one verdict per entry.
+ *
+ * Nothing here stops early. A failing acceptance is recorded and the next one starts from a clean
+ * database — which is the entire point: one red must not hide the evidence behind it, and must not
+ * poison it either. The caller decides the exit code from the collected results.
+ */
+export async function runAcceptances(
+  entries: Acceptance[],
+  deps: {
+    reset: () => Promise<void>;
+    run: (cmd: string[]) => { status: number | null };
+    log?: (line: string) => void;
+  },
+): Promise<AcceptanceResult[]> {
+  const log = deps.log || (() => {});
+  const results: AcceptanceResult[] = [];
+  for (const a of entries) {
+    log(`\n──────── ${a.id} · ${a.title}`);
+    try {
+      await deps.reset();
+    } catch (e: any) {
+      // A reset that fails is not a reason to run the next acceptance against whatever is left —
+      // that is the contamination this exists to remove, arriving through the back door.
+      results.push({ id: a.id, ok: false, code: null, note: `reset failed: ${e?.message || e}` });
+      log(`  RESET FAILED — ${e?.message || e}`);
+      continue;
+    }
+    const { status } = deps.run(a.command);
+    const ok = status === 0;
+    results.push({ id: a.id, ok, code: status, note: ok ? "" : `exit ${status}` });
+    log(`  ${ok ? "GREEN" : `RED (exit ${status})`}`);
+  }
+  return results;
+}
+
+/** The gate: any failure is a failure. Kept separate so a control can assert it directly. */
+export function exitCodeFor(results: AcceptanceResult[]): number {
+  return results.some(r => !r.ok) ? 1 : 0;
+}
+
+export function summarise(results: AcceptanceResult[]): string {
+  const width = Math.max(...results.map(r => r.id.length), 4);
+  const rows = results.map(r =>
+    `  ${r.ok ? "GREEN" : "RED  "}  ${r.id.padEnd(width)}  ${r.note}`.trimEnd());
+  const red = results.filter(r => !r.ok);
+  return [
+    "",
+    "══════════════════════════════════════════════════════════════════",
+    `PG ACCEPTANCE SUMMARY — ${results.length} run, ${results.length - red.length} green, ${red.length} red`,
+    "══════════════════════════════════════════════════════════════════",
+    ...rows,
+    "",
+    red.length
+      ? `pg-acceptance: RED — ${red.map(r => r.id).join(", ")}`
+      : "pg-acceptance: GREEN — every acceptance executed and passed",
+  ].join("\n");
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const safety = testDatabaseSafety(process.env.DATABASE_URL, process.env as any);
+  if (!safety.safe) {
+    console.error(`pg-acceptance-runner: REFUSING TO RESET — ${safety.reason}.`);
+    console.error("This runner truncates every table it can see, so it only ever points at a");
+    console.error("throwaway local/CI database. Set DATABASE_URL to one and, outside CI, pass");
+    console.error("PG_ACCEPTANCE_ALLOW_RESET=1 to say so deliberately.");
+    process.exit(2);
+  }
+
+  const { pool } = await import("../server/db");
+  const results = await runAcceptances(ACCEPTANCES, {
+    reset: () => resetTestDatabase(pool),
+    // stdio inherited so each acceptance's own PASS/FAIL lines stay in the CI log verbatim —
+    // the summary is an index to that output, never a replacement for it.
+    run: (cmd) => spawnSync(cmd[0], cmd.slice(1), { stdio: "inherit", env: process.env }),
+    log: (l) => console.log(l),
+  });
+  console.log(summarise(results));
+  await pool.end().catch(() => {});
+  process.exit(exitCodeFor(results));
+}
+
+// Only when executed directly — importing this file for its inventory or its guard must not run it.
+if (process.argv[1] && existsSync(process.argv[1]) && process.argv[1].endsWith("pg-acceptance-runner.ts")) {
+  await main();
+}

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -195,17 +195,37 @@ export function testDatabaseSafety(
 }
 
 /**
- * Empty every table this product owns, leaving the schema and the applied-migrations ledger alone.
- * Truncating `__drizzle_migrations` would make the next reader believe the schema was never built.
+ * A CLEAN DATABASE MEANS THE SCHEMA TOO, NOT ONLY THE ROWS (#227, review).
+ *
+ * The first version of this truncated every table, which is not the promise this runner makes.
+ * Acceptances mutate SCHEMA as well as data: `pg-step-provenance-acceptance` deliberately installs
+ * the pre-#184 faulty `kamlife_parse_step_report`, proves it reproduces the original error, and
+ * puts the working one back three statements later. If anything throws in that window the broken
+ * function stays installed — and TRUNCATE does not remove a function. Every later acceptance,
+ * Journey Lab included, would then run against a database whose step parser is the known-broken
+ * one, and report cascading failures that belong to nothing in the diff. That is the exact
+ * contamination this cut exists to end, arriving through a door truncation cannot close.
+ *
+ * So the reset rebuilds: drop the schema, drop the migration ledger with it, re-apply the
+ * committed migrations. Measured at ~1.5s, which is the right trade against a class of false
+ * failure that costs hours to diagnose and has already cost some.
+ *
+ * BOTH SCHEMAS, AND THAT IS NOT A DETAIL. Drizzle keeps `__drizzle_migrations` in its own `drizzle`
+ * schema, so dropping `public` alone leaves the ledger claiming every migration is applied and the
+ * re-migrate silently does nothing — a rebuild that produces an EMPTY database while reporting
+ * success. Proven by measurement: dropping `public` only left 0 tables behind.
  */
-export async function resetTestDatabase(pool: { query: (q: string) => Promise<unknown> }): Promise<void> {
-  await pool.query(`DO $$
-    DECLARE t text;
-    BEGIN
-      FOR t IN SELECT tablename FROM pg_tables
-               WHERE schemaname = 'public' AND tablename <> '__drizzle_migrations'
-      LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP;
-    END $$;`);
+export async function resetTestDatabase(
+  pool: { query: (q: string) => Promise<unknown> },
+  migrate: () => { status: number | null } = () =>
+    spawnSync("npm", ["run", "db:migrate"], { stdio: "pipe", env: process.env }),
+): Promise<void> {
+  await pool.query(
+    `DROP SCHEMA IF EXISTS public CASCADE;
+     DROP SCHEMA IF EXISTS drizzle CASCADE;
+     CREATE SCHEMA public;`);
+  const { status } = migrate();
+  if (status !== 0) throw new Error(`db:migrate failed while rebuilding the test schema (exit ${status})`);
 }
 
 // ── EXECUTION AND COLLECTION ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Tranche 3B infrastructure. **Do not merge — at the CTO gate.** BASE `main@bf80605f`.

No production or runtime code is touched: the diff is the workflow, two new files under `script/`, and one `.gitignore` line.

## What was wrong

The authoritative `pg-acceptance` job was **eighteen sequential steps sharing one ephemeral database**, and both failure modes in the issue are real and had already cost diagnosis time.

**Early-exit blindness.** A failing step ends the job. While `pg-open-coaching-loop` was red — step 10 of 19 — the nine behind it never executed. Measured on PR #226's own CI run:

```
correction … weight-authority        9 × GREEN
open-coaching-loop                   RED — 2      <- job exits here
thin-evidence, information-value, log-turn, facts, food-identity,
weight-speakability, restriction-consistency, comeback-clock, journey-lab
                                     never ran
```

#226 added an acceptance and shipped with **authoritative CI having never once executed it**. That is the worst thing a gate can do — not a wrong answer, but no answer wearing the same colour as one.

**Contamination.** The suites are not isolated (Coach Health reads `turn_ledger` database-wide, for one). On #224 I reported three product regressions from a batch run; each one evaporated when rerun after its own reset. A false diagnosis reached a lane decision before it was caught.

## What replaces it

One runner owning **reset → execute → collect → exit code**. The workflow's nineteen steps become two.

- **No `continue-on-error`.** A red is still a red gate; it just stops hiding what is behind it. The workflow already rejected yellow-for-red in writing for the Journey Lab, and that reasoning holds here.
- **No second PostgreSQL service, no reordering, no expectation weakened.** The order is byte-for-byte the order the YAML had.
- **The inventory moves into the runner, in one copy**, carrying each acceptance's reason for needing a real database rather than a fixture. Two owners of one inventory is how an acceptance gets added in one place and silently never runs in the other.

**The reset fails closed.** It refuses any non-loopback host, any non-PostgreSQL URL, `NODE_ENV=production`, and — outside CI — any run that did not explicitly opt in, so no hook or editor task can wipe a working database as a side effect. The host check is the decisive one: this product's real database lives behind a remote hostname, so it is out of reach by construction rather than by a name pattern someone could match by accident.

## The first full run is itself the evidence

```
PG ACCEPTANCE SUMMARY — 19 run, 17 green, 2 red
  RED    open-coaching-loop       exit 1
  RED    journey-lab              exit 1
pg-acceptance: RED — open-coaching-loop, journey-lab
```

Both reds are **pre-existing product failures in Codex's lane, untouched here**. The point is the second one: `journey-lab` is red on `2 · MULTI-DAY / CORRECTION — 33 checks, 1 failed`, and the old job **had never once reached it**. Isolating the acceptances did not create that failure, it revealed it — which is the whole argument for this cut.

## Controls — the runner graded against the real container

A test runner is the one thing its own suites cannot check: if it silently skipped everything, every suite would still "pass". So `script/pg-acceptance-runner-controls.ts` grades it with deliberate controlled reds, and runs **before** the runner in CI.

**19/19 green**, mapped to the issue's mandatory controls:

| # | Control | Check |
|---|---|---|
| 1 | early failure does not stop later ones | `every acceptance after a failure still executed` |
| 2 | job still exits RED | `the job still exits RED because one of them failed` |
| 3 | reset removes contamination | `a row seeded by one acceptance is gone before the next one starts` |
| 3′ | **its control** | `with the reset removed, the same pair contaminates and the second FAILS` |
| 4 | green set stays green | `nothing red, nothing invented — the gate passes` |
| 5 | unsafe DB refused | 7 refusals + **2 allow-controls** |
| 6 | scripts still standalone | `an individual acceptance still runs on its own, outside the runner` |

Control 3′ is the one that matters most: without it, "the row was gone" is equally well explained by the row never having been written. Control 5 is asserted **both ways** — a guard that refuses everything would satisfy all seven refusals and quietly stop the gate from ever running.

One more, not asked for but the same class of hole: **a reset that throws is recorded as a failure rather than run against whatever was left** — otherwise the contamination this removes walks back in through the error path.

## Runs

`tsc` clean · **37/37 suites** · **19/19 runner controls** · runner exit code 1 on the two product reds, 0 on a green set.

**No governor budget raised** — `modules` counts `server/` and `shared/` only, and neither is in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_