### PR TITLE
#221 journey 4: name what the recap counts, so it stops contradicting itself

### DIFF
--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -150,6 +150,13 @@ export const ACCEPTANCES: Acceptance[] = [
     // workout row's logged_at against a user's lastActiveAt, read through the real handler.
     command: ["npx", "tsx", "script/pg-comeback-clock-acceptance.ts"] },
 
+  { id: "session-recap", title: "One training recap that does not contradict itself",
+    // ONE RECAP (#221 journey 4). The contradiction only exists across two row families — workout
+    // rows present, meal rows absent — composed into one card by one owner. A fixture that answers
+    // every query the same way cannot put a client in the state where the card disagrees with
+    // itself, which is how "Sessions this week: 4" sat above "Days logged (7d): 0/7".
+    command: ["npx", "tsx", "script/pg-session-recap-acceptance.ts"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-session-progression-trace.ts
+++ b/script/pg-session-progression-trace.ts
@@ -1,0 +1,84 @@
+/**
+ * TRACE — #221 journeys 4–7, session/progression truth on real PostgreSQL.
+ *
+ * Read-only reproduction, run before anything changes. One client, one sitting, the surfaces that
+ * each state a session number, against the durable rows those numbers claim to describe.
+ */
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const R = console.log.bind(console);
+const { pool, db } = await import("../server/db.ts");
+const schema = await import("../shared/schema.ts");
+const { handleMessage } = await import("../server/routes.ts");
+
+const midday = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`);
+};
+
+const phone = `whatsapp:+2791${String(Math.floor(Math.random() * 900000) + 100000)}`;
+const [u] = await db.insert(schema.users).values({
+  phoneNumber: phone, name: "Sipho", onboardingState: "COMPLETE", subscriptionStatus: "active",
+  popiConsent: true, popiConsentAt: new Date(), goalType: "muscle_gain",
+  calorieTarget: 2600, proteinTarget: 170, stepsTarget: 8000, trainingMode: "gym",
+  trainingDaysPerWeek: 3, currentWeight: "78.0", heightCm: 180, gender: "male", age: 30,
+  weeklyFoodBudget: "300_600",
+  // THE DRIFT, STATED AS DATA. The counter claims 12 lifetime sessions; the ledger below holds 7.
+  totalWorkoutsCompleted: 12,
+  programmeStartDate: midday(30), programmeWeek: 4,
+} as any).returning();
+
+for (const d of [1, 2, 4, 6, 12, 20, 30]) {
+  await pool.query(
+    `INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+    [u.id, midday(d)]);
+}
+
+const ask = (t: string) => handleMessage(phone, t, undefined, undefined, undefined,
+  `SM-${Math.random().toString(36).slice(2, 10)}`).then(r => String(r || ""));
+
+const counts = async () => ({
+  rows: (await pool.query(`SELECT count(*)::int AS n FROM workout_logs WHERE user_id=$1`, [u.id])).rows[0].n,
+  col: (await pool.query(`SELECT total_workouts_completed AS n FROM users WHERE id=$1`, [u.id])).rows[0].n,
+});
+
+const show = (label: string, reply: string) => {
+  R(`\n── ${label}`);
+  const lines = reply.split("\n").filter(l => /[Ss]ession/.test(l));
+  for (const l of lines.slice(0, 3)) R(`   ${l.trim()}`);
+  if (!lines.length) R(`   (no session number stated)`);
+};
+
+const before = await counts();
+R(`\nDURABLE: workout_logs=${before.rows}  users.total_workouts_completed=${before.col}`);
+
+show(`"my progress"`, await ask("my progress"));
+show(`"what's my session"`, await ask("what's my session"));
+show(`"did my workout"`, await ask("did my workout"));
+
+const mid = await counts();
+R(`\nDURABLE after one logged session: workout_logs=${mid.rows}  counter=${mid.col}`);
+
+show(`backdated: "I trained on Monday and Tuesday last week too"`,
+  await ask("I trained on Monday and Tuesday last week too"));
+
+const after = await counts();
+R(`\nDURABLE after backdating: workout_logs=${after.rows}  counter=${after.col}`);
+R(`DRIFT: ${after.col - after.rows} sessions claimed with no durable row behind them\n`);
+
+for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_history",
+                 "turn_ledger", "client_understanding", "daily_constraints"]) {
+  await pool.query(`DELETE FROM ${t} WHERE user_id=$1`, [u.id]).catch(() => {});
+}
+await pool.query(`DELETE FROM users WHERE id=$1`, [u.id]).catch(() => {});
+await pool.end();
+process.exit(0);

--- a/script/pg-session-recap-acceptance.ts
+++ b/script/pg-session-recap-acceptance.ts
@@ -1,0 +1,158 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — one training recap that does not contradict itself (#221, journey 4).
+ *
+ * THE RULE THIS ENFORCES. Every customer-visible recap that states a session count must state the
+ * rest of the card in terms the same client can reconcile with it. A recap that says a client
+ * trained four times and logged nothing, in two consecutive lines, is not two facts — it is the
+ * coach disagreeing with itself in front of the person paying for it.
+ *
+ * REPRODUCED ON main@5da8e5f BEFORE ANYTHING CHANGED. A client with four workout rows in the last
+ * seven days and no meal rows:
+ *
+ *     💪 Sessions this week: *4*
+ *     📋 Days logged (7d): *0/7*
+ *
+ * `daysLogged` is documented in day-ledger-core as "days that actually carry a MEAL — the only
+ * honest divisor for an average", and it is exactly that. The number is right; the WORD is wrong.
+ * Shown unqualified as "Days logged" it makes a claim about everything the client did, one line
+ * under a count of the training it is silently excluding.
+ *
+ * WHY THE VALUE IS NOT TOUCHED. `window.daysLogged` divides avgKcal and avgProtein, and #203's
+ * thin-evidence coaching keys off it. Changing what it COUNTS would move coaching decisions and
+ * the averages on every card. The defect is the label, so the label is what changes — and this
+ * acceptance asserts the value stays put, so a later "fix" cannot quietly widen it.
+ *
+ * WHY POSTGRESQL. The contradiction only exists across two different row families — workout_logs
+ * present, meal_logs absent — composed into one card by one owner. A fixture that answers every
+ * query the same way cannot put a client in that state.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-session-recap-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const midday = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`);
+};
+
+const ids: string[] = [];
+async function client(name: string, over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2791${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name, onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "muscle_gain",
+    calorieTarget: 2600, proteinTarget: 170, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "78.0", heightCm: 180, gender: "male", age: 30,
+    weeklyFoodBudget: "300_600", totalWorkoutsCompleted: 12,
+    programmeStartDate: midday(30), programmeWeek: 4, ...over,
+  } as any).returning();
+  ids.push(u.id);
+  return { id: u.id, phone };
+}
+const ask = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
+    .then(r => String(r || ""));
+
+const workout = (id: string, d: number) =>
+  pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`, [id, midday(d)]);
+const meal = (id: string, d: number) =>
+  pool.query(
+    `INSERT INTO meal_logs (user_id, logged_at, meal_label, kcal_int, protein_int, items, raw_message, source)
+     VALUES ($1,$2,'lunch',600,40,$3,'seed','sa_scanner')`,
+    [id, midday(d), JSON.stringify([{ name: "pap", grams: 200 }])]);
+
+/** The line that states how many days carry a food log, whatever it ends up called. */
+const foodLine = (r: string) => (r.match(/[^\n]*\b\d+\/7\b[^\n]*/) || ["(no /7 line)"])[0].trim();
+const sessLine = (r: string) => (r.match(/[^\n]*[Ss]essions?[^\n]*/) || ["(no session line)"])[0].trim();
+
+REAL("\n=== 1 · A CLIENT WHO TRAINED IS NOT TOLD THEY LOGGED NOTHING ===");
+{
+  const c = await client("Zanele");
+  for (const d of [1, 2, 4, 6]) await workout(c.id, d);   // four sessions, seven days
+  // …and no meal rows at all.
+
+  const prog = await ask(c.phone, "my progress");
+  chk(/[Ss]essions this week: \*4\*/.test(prog), "the recap states the four sessions it has rows for",
+    JSON.stringify(sessLine(prog)));
+  chk(/\b0\/7\b/.test(prog), "…and still states the food-day count of zero — the NUMBER is right",
+    JSON.stringify(foodLine(prog)));
+  chk(!/Days logged/i.test(prog),
+    "…but does not call it 'Days logged', which reads as a claim about everything they did",
+    JSON.stringify(foodLine(prog)));
+  chk(/food/i.test(foodLine(prog)),
+    "…it names the thing it actually counts: food", JSON.stringify(foodLine(prog)));
+
+  const week = await ask(c.phone, "this week");
+  chk(/[Ss]essions: \*4\*/.test(week), "the 7-day breakdown agrees about the sessions",
+    JSON.stringify(sessLine(week)));
+  chk(!/Days logged/i.test(week) && /food/i.test(foodLine(week)),
+    "…and names its food-day count the same way", JSON.stringify(foodLine(week)));
+}
+
+REAL("\n=== 2 · CONTROL — THE NUMBER ITSELF DID NOT MOVE ===");
+{
+  // The tempting wrong fix is to widen `daysLogged` to count training too. It divides avgKcal and
+  // avgProtein and #203's thin-evidence coaching keys off it, so widening it would move coaching
+  // decisions and every average on the card. A client with food on three days is 3/7, not 5/7.
+  const c = await client("Naledi");
+  for (const d of [1, 3]) await workout(c.id, d);
+  for (const d of [1, 2, 5]) await meal(c.id, d);
+
+  const prog = await ask(c.phone, "my progress");
+  chk(/\b3\/7\b/.test(prog), "CONTROL: three days carry food, so the count is 3/7 and not 5/7",
+    JSON.stringify(foodLine(prog)));
+  chk(/[Ss]essions this week: \*2\*/.test(prog), "CONTROL: …and the session count is still its own number",
+    JSON.stringify(sessLine(prog)));
+}
+
+REAL("\n=== 3 · CONTROL — A CLIENT WHO LOGGED FOOD READS THE SAME WAY ===");
+{
+  // The relabelling must not only make sense in the zero case it was found in.
+  //
+  // The window is TODAY back six days, not the seven days before today. Seeding days 1–7 reads
+  // 6/7 and is a fixture that walks off the end of the window, not a product defect — caught by
+  // running it rather than by reasoning about it.
+  const c = await client("Thabo");
+  for (const d of [0, 1, 2, 3, 4, 5, 6]) await meal(c.id, d);
+  const prog = await ask(c.phone, "my progress");
+  chk(/\b7\/7\b/.test(prog) && /food/i.test(foodLine(prog)),
+    "a fully logged week reads as food on 7 of 7 days", JSON.stringify(foodLine(prog)));
+}
+
+REAL(`\n${failed === 0
+  ? "pg-session-recap-acceptance: GREEN — all checks passed"
+  : `pg-session-recap-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_history",
+                   "turn_ledger", "client_understanding", "daily_constraints"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-221-recap.sh
+++ b/script/red-on-revert-221-recap.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #221 journey 4, one mechanism at a time.
+#
+# A green suite proves nothing on its own: it may be green because the code is right, or because
+# the checks cannot fail. Each mouth is put back the way it was, ALONE, and the acceptance must go
+# red on the checks that mouth exists to hold.
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-session-recap-acceptance.ts
+
+run_case () {
+  local name="$1" patch="$2"
+  cp -r server /tmp/221r-server-backup
+  python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221r-server-backup; return 1; }
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^pg-session-recap-acceptance:' || echo '(no verdict — crashed)')"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -6
+  rm -rf server && mv /tmp/221r-server-backup server
+}
+
+mkdir -p /tmp/221rp
+
+# ── 1 · the Progress card calls its food-day count "Days logged" again ────────────────────────
+cat > /tmp/221rp/1.py <<'PY'
+p = "server/handlers/misc-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("🍽️ Food logged: *${truth.window.daysLogged}/7 days*${weightLine}",
+              "📋 Days logged (7d): *${truth.window.daysLogged}/7*${weightLine}")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 2 · the 7-day breakdown calls it "Days logged" again ──────────────────────────────────────
+cat > /tmp/221rp/2.py <<'PY'
+p = "server/handlers/misc-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("🍽️ Food logged: *${truth.window.daysLogged}/7 days*\\n🔥 Avg:",
+              "📋 Days logged: *${truth.window.daysLogged}/7*\\n🔥 Avg:")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 3 · the count is WIDENED to include training (the tempting wrong fix) ─────────────────────
+#
+# The opposite defect. Making `daysLogged` count training days too would satisfy every relabelling
+# check above and silently move the divisor for avgKcal/avgProtein and #203's thin-evidence
+# threshold. Section 2 exists to catch exactly this, so it must go red here.
+cat > /tmp/221rp/3.py <<'PY'
+p = "server/day-ledger-core.ts"; s = open(p).read()
+before = s
+s = s.replace("  const daysLogged = perDay.length;",
+              "  const daysLogged = perDay.length + 2; // pretend training days were folded in")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+echo "=============================================================================="
+echo "#221 journey 4 — RED ON REVERT, one mechanism at a time"
+echo "=============================================================================="
+run_case "the Progress card says 'Days logged' again"                       /tmp/221rp/1.py
+run_case "the 7-day breakdown says 'Days logged' again"                     /tmp/221rp/2.py
+run_case "the food-day COUNT is widened to include training (opposite defect)" /tmp/221rp/3.py
+echo "=============================================================================="

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -911,13 +911,20 @@ export async function handleMiscCommands(ctx: {
         // report cannot reissue the instruction while the client's answer is still outstanding.
         const { canonicalDecision } = await import("../understanding/live");
         const act = await canonicalDecision(user, message);
-        return `*${name} — last 7 days*\n\n💪 Sessions: *${truth.sessions}*\n📋 Days logged: *${truth.window.daysLogged}/7*\n🔥 Avg: *${truth.window.avgKcal} kcal* · *${truth.window.avgProtein}g* protein\n👟 Avg steps: *${truth.avgSteps.toLocaleString()}*${weightLine}\n\n*${act.todo}*`;
+        // NAME WHAT IT COUNTS (#221 journey 4). `window.daysLogged` is days carrying a MEAL — its
+        // own definition says so, and it is the divisor for the averages on the next line. Shown
+        // as bare "Days logged" it read as a claim about everything the client did, one line under
+        // the training count it silently excludes: "Sessions: 4" above "Days logged: 0/7".
+        return `*${name} — last 7 days*\n\n💪 Sessions: *${truth.sessions}*\n🍽️ Food logged: *${truth.window.daysLogged}/7 days*\n🔥 Avg: *${truth.window.avgKcal} kcal* · *${truth.window.avgProtein}g* protein\n👟 Avg steps: *${truth.avgSteps.toLocaleString()}*${weightLine}\n\n*${act.todo}*`;
       }
       const todayLine = truth.today.kcal > 0
         ? `🔥 Today: *${truth.today.kcal}${calTarget ? `/${calTarget}` : ""} kcal* · *${truth.today.protein}${protTarget ? `/${protTarget}` : ""}g* protein`
         : `🔥 Today: *nothing logged yet*`;
       const stepsLine = truth.today.steps > 0 ? `\n👟 Steps today: *${truth.today.steps.toLocaleString()}*` : "";
-      return `*${name}'s Progress*\n\n${todayLine}${stepsLine}\n💪 Sessions this week: *${truth.sessions}*\n📋 Days logged (7d): *${truth.window.daysLogged}/7*${weightLine}\n\nSend *this week* for the 7-day breakdown.`;
+      // Same relabelling as the 7-day card above, and this is where it was found: a client with
+      // four workout rows and no meal rows was shown "Sessions this week: 4" directly above
+      // "Days logged (7d): 0/7" — the coach contradicting itself in two consecutive lines.
+      return `*${name}'s Progress*\n\n${todayLine}${stepsLine}\n💪 Sessions this week: *${truth.sessions}*\n🍽️ Food logged: *${truth.window.daysLogged}/7 days*${weightLine}\n\nSend *this week* for the 7-day breakdown.`;
     } catch (e) {
       console.warn("[PROGRESS] truth unavailable:", (e as any)?.message || e);
       return `${name}, I can't read your numbers this second — give me a moment and ask again. I'd rather say that than guess.`;

--- a/server/scheduler/jobs/weekly.ts
+++ b/server/scheduler/jobs/weekly.ts
@@ -325,6 +325,10 @@ export async function runSundayEveningCheckin(): Promise<void> {
       if (completedSessions === 0 && distinctFoodDays === 0) {
         question = `${name}, this week was quiet. One question — what got in the way?`;
       } else if (completedSessions >= plannedSessions && distinctFoodDays >= 5) {
+        // NAME WHAT IT COUNTS (#221 journey 4). `distinctFoodDays` is days carrying a MEAL, and
+        // it sat beside a session count reading bare "days logged" — so a client who trained
+        // four times and logged no food was told "4 sessions, 0 days logged" in one sentence.
+        // The variable was always named honestly; only the sentence was not.
         question = isMuscleGainSunday
           ? `${name}, ${completedSessions} sessions done and food tracked all week. Solid. One question — what did you eat that gave you the most energy in the gym this week?`
           : isRecompSunday
@@ -346,10 +350,10 @@ export async function runSundayEveningCheckin(): Promise<void> {
           : `${name}, average steps this week: ${avgSteps.toLocaleString()}. Steps are your daily fat-burning base. What is the real barrier to walking more?`;
       } else {
         question = isMuscleGainSunday
-          ? `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days logged. One sentence — what felt strongest this week in the gym?`
+          ? `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days of food logged. One sentence — what felt strongest this week in the gym?`
           : isRecompSunday
-          ? `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days logged. One sentence — what did you notice changing this week?`
-          : `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days logged. One sentence — what do you want to be different next week?`;
+          ? `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days of food logged. One sentence — what did you notice changing this week?`
+          : `${name}, week done. ${completedSessions} sessions, ${distinctFoodDays} days of food logged. One sentence — what do you want to be different next week?`;
       }
       if (await claimDailySlot(client.id, "sunday_evening")) { await sendWhatsApp(client.phoneNumber, question); }
     } catch (err) { console.error(`[SCHEDULER] Sunday check-in error — ${client.phoneNumber}:`, err); }


### PR DESCRIPTION
Journey 4 of #221. **Do not merge — at the CTO gate.** BASE `main@5da8e5f` (one rebase onto the merged #225, no rediscovery of journeys 1–3).

## The defect, reproduced through the real front door before anything changed

A client with four workout rows in the last seven days and no meal rows:

```
*Zanele's Progress*

🔥 Today: *nothing logged yet*
💪 Sessions this week: *4*
📋 Days logged (7d): *0/7*
```

Two consecutive lines, one owner, and they disagree. A client who trained four times is told they logged nothing.

`window.daysLogged` counts **days carrying a meal** — `day-ledger-core` says exactly that in its own definition, and it is the divisor for the averages on the next line. **The number was right. The word was wrong.** Shown unqualified as "Days logged" it reads as a claim about everything the client did, one line under the training count it silently excludes.

Four customer-visible mouths carried it, three sitting directly beside a session count — both progress cards and all three Sunday check-in variants, where **"4 sessions, 0 days logged"** went out as one sentence.

## The fix

Name the quantity for what it counts, at the mouths that state it:

```
💪 Sessions this week: *4*
🍽️ Food logged: *0/7 days*
```

## The value is untouched, and that is the point

The tempting fix is to widen `daysLogged` to count training days too. It divides `avgKcal` and `avgProtein` and **#203's thin-evidence coaching keys off it**, so widening it would move coaching decisions and every average on every card. Two controls assert the count stays put:

```
PASS  CONTROL: three days carry food, so the count is 3/7 and not 5/7
PASS  CONTROL: …and the session count is still its own number
```

**Red on revert, three mechanisms, all three red** — including that widening as the opposite defect:

```
── the Progress card says 'Days logged' again                     RED — 3
── the 7-day breakdown says 'Days logged' again                   RED — 1
── the food-day COUNT is widened to include training (opposite)   RED — 3
```

The third one goes red on the *value* controls rather than the label ones, which is the proof they are testing different things.

## What did NOT reproduce — recorded, not quietly dropped

**The contradictory session numbers across surfaces (12 / 6 / 13) do not reproduce on current main.** I tried to make the lifetime counter drift from the ledger through ordinary use and could not:

| route | result |
|---|---|
| log the same day twice | guarded — `already logged`, rows and counter both stay |
| repeat a backdated day | guarded — `already got yesterday's workout logged` |
| named-day backdate | correct — today is Tuesday, so "Monday" *is* yesterday |

I nearly filed that last one as a defect before checking the calendar. It is not one.

What remains true: `users.totalWorkoutsCompleted` is a second answer to a question `workout_logs` already answers, and **nothing reconciles them**. Its increment paths are guarded today, but if it ever diverges — as it evidently did on the real client behind the banked 13-vs-7 evidence — three surfaces repeat the wrong number forever with no path back. That is a real gap. It is not the reported defect and is **not fixed here**.

### One design decision, which is yours and not mine

If the counter and the ledger disagree, which is truth? Deriving from `workout_logs` would tell a legacy client they have done **fewer** sessions than they were told yesterday — a visible regression on their own history. Taking `max` never reduces anyone's count and makes future drift impossible, but preserves whatever legacy inflation already exists. I did not pick one silently.

Also recorded: `"I trained Monday and Tuesday"` attributes **one** day. The multi-day attribution owner exists and is deliberately unwired — declared debt in the `unreachableCapabilities` budget, pre-existing, out of this cut's bounds.

## Runs

`tsc` clean · **37/37 suites** · **21/21 PG acceptances GREEN**, each isolated by the #227 runner:

```
PG ACCEPTANCE SUMMARY — 21 run, 21 green, 0 red
pg-acceptance: GREEN — every acceptance executed and passed
```

Worth noting: **`open-coaching-loop` and `journey-lab` are both green now.** They were the two standing product reds; #225 fixed them. This is the first fully green PG gate since the runner landed.

New acceptance wired into the runner inventory. No governor budget raised. No new owner, no second counter, no new response author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_