### PR TITLE
#221 journeys 5–7: lifetime history is not a programme position

### DIFF
--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -157,6 +157,14 @@ export const ACCEPTANCES: Acceptance[] = [
     // itself, which is how "Sessions this week: 4" sat above "Days logged (7d): 0/7".
     command: ["npx", "tsx", "script/pg-session-recap-acceptance.ts"] },
 
+  { id: "session-owner", title: "One progression owner, despite a legacy lifetime mismatch",
+    // ONE PROGRESSION OWNER (#221 journeys 5-7). The whole proof is a legacy client whose lifetime
+    // counter disagrees with the durable ledger — seven rows against twelve — read through five
+    // different handlers that must still agree about where the client is in the programme. A
+    // fixture that answers every query the same way cannot produce that disagreement, and the
+    // cursor discipline on a backfill is a claim about what a write did NOT touch.
+    command: ["npx", "tsx", "script/pg-session-owner-acceptance.ts"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-session-owner-acceptance.ts
+++ b/script/pg-session-owner-acceptance.ts
@@ -1,0 +1,230 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — one progression owner (#221, journeys 5-7).
+ *
+ * THE RULE THIS ENFORCES, as adjudicated:
+ *
+ *   Current session, next session, programme week/day and backdated progression come from the ONE
+ *   existing progression owner — the programme cursor (`programmeWeek` / `programmeDayInWeek`) and
+ *   what the durable ledger says was done. NEVER from the lifetime counter.
+ *
+ *   `users.totalWorkoutsCompleted` survives as LEGACY LIFETIME HISTORY, because clients who
+ *   started before every session had a durable row may genuinely own sessions no row can prove.
+ *   Deliberately NOT replaced with `workout_logs.length` (which would erase that history) and
+ *   deliberately NOT `max(counter, rows)` (which would promote corruption to programme truth).
+ *
+ *   If that lifetime value is shown at all it must read as lifetime — "12 sessions overall". It
+ *   may never read as programme position — "You are on Session 13".
+ *
+ * THE UGLY STATE IS SEEDED ON PURPOSE: seven durable workout rows against a lifetime counter of
+ * twelve. That mismatch is exactly what a legacy client carries, and every surface below has to
+ * agree about where the client is in the programme regardless of it.
+ *
+ * WHY POSTGRESQL. Progression is a claim about stored rows against a stored cursor, read through
+ * five different handlers. A fixture that answers every query the same way cannot show five
+ * surfaces disagreeing, which is the only thing worth proving here.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-session-owner-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const midday = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`);
+};
+
+const ids: string[] = [];
+/** THE UGLY STATE: seven durable rows, a lifetime counter of twelve, cursor at week 4 day 2. */
+async function legacyClient(name: string, over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2791${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name, onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "muscle_gain",
+    calorieTarget: 2600, proteinTarget: 170, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "78.0", heightCm: 180, gender: "male", age: 30,
+    weeklyFoodBudget: "300_600",
+    totalWorkoutsCompleted: 12,
+    programmeStartDate: midday(30), programmeWeek: 4, programmeDayInWeek: 2, programmePhase: 1,
+    lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  for (const d of [2, 4, 6, 9, 12, 16, 20]) {
+    await pool.query(`INSERT INTO workout_logs (user_id, logged_at, workout_completed) VALUES ($1,$2,true)`,
+      [u.id, midday(d)]);
+  }
+  return { id: u.id, phone };
+}
+const ask = (phone: string, text: string) =>
+  handleMessage(phone, text, undefined, undefined, undefined, `SM-${Math.random().toString(36).slice(2, 10)}`)
+    .then(r => String(r || ""));
+
+const cursor = async (id: string) => (await pool.query(
+  `SELECT programme_week AS w, programme_day_in_week AS d, total_workouts_completed AS c FROM users WHERE id=$1`,
+  [id])).rows[0];
+const rowCount = async (id: string) => (await pool.query(
+  `SELECT count(*)::int AS n FROM workout_logs WHERE user_id=$1`, [id])).rows[0].n;
+
+/**
+ * A PROGRAMME-POSITION CLAIM: the coach telling the client which session they are ON or about to
+ * do. "Session 13 overall" / "13 sessions overall" is lifetime and allowed; "· Session 13" beside
+ * a week and a day is a position claim and is not.
+ */
+const claimsPosition = (r: string) => /·\s*Session\s*\d+(?!\s*overall)/i.test(r)
+  || /\bYou(?:'re| are) on Session\s*\d+/i.test(r);
+const line = (r: string, re: RegExp) => (r.match(re) || ["(not stated)"])[0].trim();
+
+REAL("\n=== 5 · FIVE SURFACES, ONE PROGRESSION, DESPITE A LEGACY MISMATCH ===");
+{
+  const c = await legacyClient("Sipho");
+  const start = await cursor(c.id);
+  chk(await rowCount(c.id) === 7 && Number(start.c) === 12,
+    "the ugly state is real: 7 durable rows against a lifetime counter of 12",
+    `rows=${await rowCount(c.id)} counter=${start.c}`);
+
+  // The three READING surfaces. "what session am I on" is the one that delivers today's session
+  // with its header — confirmed by routing it and reading what came back, not assumed.
+  const view = await ask(c.phone, "what session am I on");
+  const next = await ask(c.phone, "next workout");
+  const prog = await ask(c.phone, "my programme");
+
+  chk(!claimsPosition(view), "today's session header does not claim a programme position from the counter",
+    JSON.stringify(line(view, /^\*[^\n]*Week[^\n]*/m)));
+  chk(!claimsPosition(next), "the next session does not either",
+    JSON.stringify(line(next, /[^\n]*Next Session[^\n]*/)));
+  chk(!claimsPosition(prog), "…and neither does the programme view",
+    JSON.stringify(line(prog, /[^\n]*Session[^\n]*/)));
+
+  // The cursor is the owner, so every surface that names a day must name the SAME day.
+  const day = Number(start.d);
+  chk(new RegExp(`Day ${day}\\b`).test(view), `today's workout is day ${day} — the cursor's day`,
+    JSON.stringify(line(view, /[^\n]*Day \d[^\n]*/)));
+  chk(new RegExp(`Day ${day}\\b`).test(next), `…and the next session names the same day ${day}`,
+    JSON.stringify(line(next, /[^\n]*Next Session[^\n]*/)));
+  chk(new RegExp(`Week ${start.w}\\b`).test(view) && new RegExp(`Week ${start.w}\\b`).test(next),
+    `…and both name week ${start.w}`, JSON.stringify([line(view, /[^\n]*Week \d[^\n]*/), line(next, /[^\n]*Week \d[^\n]*/)]));
+
+  // READING THOSE THREE MUST NOT HAVE MOVED ANYTHING.
+  const afterReads = await cursor(c.id);
+  chk(String(afterReads.w) === String(start.w) && String(afterReads.d) === String(start.d)
+      && String(afterReads.c) === String(start.c),
+    "CONTROL: asking three questions moved neither the cursor nor the counter",
+    JSON.stringify({ start, afterReads }));
+
+  // 4 · completing today's session — the one surface allowed to advance the cursor.
+  await ask(c.phone, "did my workout");
+  const afterDone = await cursor(c.id);
+  chk(await rowCount(c.id) === 8, "completing a session writes one durable row", `rows=${await rowCount(c.id)}`);
+  chk(String(afterDone.d) !== String(start.d),
+    "…and advances the programme cursor, which is what owns 'which session is next'",
+    JSON.stringify({ before: start.d, after: afterDone.d }));
+  chk(Number(afterDone.c) === Number(start.c) + 1,
+    "…and moves lifetime history by exactly one, still ahead of the rows and still legacy",
+    `counter=${afterDone.c} rows=${await rowCount(c.id)}`);
+
+  // 5 · the surfaces AGREE after the advance — the whole point of one owner.
+  const nextAfter = await ask(c.phone, "next workout");
+  chk(new RegExp(`Day ${afterDone.d}\\b`).test(nextAfter),
+    "the next session follows the cursor, not the counter",
+    JSON.stringify(line(nextAfter, /[^\n]*Next Session[^\n]*/)));
+  chk(!claimsPosition(nextAfter), "…and still claims no position from the lifetime number",
+    JSON.stringify(line(nextAfter, /[^\n]*Session[^\n]*/)));
+}
+
+REAL("\n=== 5b · CONTROL — THE LIFETIME NUMBER MAY STILL BE SHOWN, AS LIFETIME ===");
+{
+  // The adjudication permits the legacy value; it forbids only the position claim. A fix that
+  // simply deleted the number would pass every check above and lose real client history.
+  const c = await legacyClient("Naledi");
+  const view = await ask(c.phone, "what session am I on");
+  chk(/\b12\b/.test(view), "the legacy lifetime figure is not deleted from the client's view",
+    JSON.stringify(line(view, /^\*[^\n]*Week[^\n]*/m)));
+  chk(/12 sessions overall/i.test(view),
+    "…and it says what it is: sessions overall, not a session you are on",
+    JSON.stringify(line(view, /^\*[^\n]*Week[^\n]*/m)));
+}
+
+REAL("\n=== 6 · BACKDATED TRAINING UPDATES THAT SAME TRUTH, AND ONLY IT ===");
+{
+  const c = await legacyClient("Thabo");
+  const start = await cursor(c.id);
+  const reply = await ask(c.phone, "I trained yesterday");
+
+  chk(await rowCount(c.id) === 8, "a backdated session writes its durable row", `rows=${await rowCount(c.id)}`);
+  chk(Number((await cursor(c.id)).c) === Number(start.c) + 1,
+    "…and moves lifetime history by one", `counter=${(await cursor(c.id)).c}`);
+  chk(String((await cursor(c.id)).w) === String(start.w) && String((await cursor(c.id)).d) === String(start.d),
+    "…and does NOT move the programme cursor — a past day answers nothing about today",
+    JSON.stringify({ before: { w: start.w, d: start.d }, after: await cursor(c.id) }));
+  chk(!claimsPosition(reply), "…and the reply claims no programme position from the counter",
+    JSON.stringify(line(reply, /[^\n]*[Ss]ession[^\n]*/)));
+
+  // CONTROL: a second report of the same day is not a second session.
+  await ask(c.phone, "I trained yesterday");
+  chk(await rowCount(c.id) === 8 && Number((await cursor(c.id)).c) === Number(start.c) + 1,
+    "CONTROL: reporting the same day twice adds neither a row nor a lifetime session",
+    `rows=${await rowCount(c.id)} counter=${(await cursor(c.id)).c}`);
+
+  // …and the surface a client checks next agrees with the cursor, not the backfill.
+  const next = await ask(c.phone, "next workout");
+  chk(new RegExp(`Day ${start.d}\\b`).test(next),
+    "the next session is still the cursor's day after a backfill",
+    JSON.stringify(line(next, /[^\n]*Next Session[^\n]*/)));
+}
+
+REAL("\n=== 7 · A QUIET DAY OR AN UNRELATED MESSAGE FABRICATES NOTHING ===");
+{
+  const c = await legacyClient("Zanele", { lastActiveAt: midday(1) });
+  const start = await cursor(c.id);
+  const rows = await rowCount(c.id);
+
+  const quiet = await ask(c.phone, "Sorry I've been away, I'm back now");
+  chk(!/welcome back|where you left off/i.test(quiet),
+    "one quiet day with comeback words is not a comeback", JSON.stringify(quiet.slice(0, 120)));
+
+  const chat = await ask(c.phone, "is brown rice better than white rice");
+  chk(!claimsPosition(chat), "an unrelated question states no programme position",
+    JSON.stringify(line(chat, /[^\n]*Session[^\n]*/)));
+
+  const after = await cursor(c.id);
+  chk(String(after.w) === String(start.w) && String(after.d) === String(start.d)
+      && String(after.c) === String(start.c) && await rowCount(c.id) === rows,
+    "…and neither message moved the cursor, the counter or the ledger",
+    JSON.stringify({ start, after, rows, now: await rowCount(c.id) }));
+}
+
+REAL(`\n${failed === 0
+  ? "pg-session-owner-acceptance: GREEN — all checks passed"
+  : `pg-session-owner-acceptance: RED — ${failed} check(s) failed`}`);
+
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_history",
+                   "turn_ledger", "client_understanding", "daily_constraints"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-221-owner.sh
+++ b/script/red-on-revert-221-owner.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #221 journeys 5-7, one mechanism at a time.
+#
+# Each mechanism is put back the way it was, ALONE, and the acceptance must go red on the checks
+# that mechanism exists to hold. Anything that stays green under revert is a check that was never
+# testing its mechanism, and is reported as such rather than dressed up.
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-session-owner-acceptance.ts
+
+run_case () {
+  local name="$1" patch="$2"
+  cp -r server /tmp/221o-server-backup
+  python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221o-server-backup; return 1; }
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^pg-session-owner-acceptance:' || echo '(no verdict — crashed)')"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -6
+  rm -rf server && mv /tmp/221o-server-backup server
+}
+
+mkdir -p /tmp/221op
+
+# ── 1 · the header claims a programme position from the lifetime counter again ────────────────
+cat > /tmp/221op/1.py <<'PY'
+p = "server/handlers/misc-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("const sessionNote = totalSessions > 0 ? ` · ${totalSessions} sessions overall` : \"\";",
+              "const sessionNote = totalSessions > 0 ? ` · Session ${totalSessions + 1}` : \"\";")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 2 · the lifetime number is DELETED instead of relabelled (the opposite defect) ────────────
+#
+# Deleting it satisfies every position check — no number, no position claim — and silently loses
+# the legacy history the counter exists to carry. Section 5b is the only thing standing between
+# this cut and that "fix", so it must go red here.
+cat > /tmp/221op/2.py <<'PY'
+p = "server/handlers/misc-commands.ts"; s = open(p).read()
+before = s
+s = s.replace("const sessionNote = totalSessions > 0 ? ` · ${totalSessions} sessions overall` : \"\";",
+              "const sessionNote = \"\";")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 3 · a backfill moves the programme cursor again (journey 6) ───────────────────────────────
+#
+# The defect P0-3 closed: "I trained on Monday" advanced TODAY's programme cursor, so the client
+# was correctly told Monday was logged and silently lost today's session slot with it.
+cat > /tmp/221op/3.py <<'PY'
+p = "server/handlers/workout.ts"; s = open(p).read()
+before = s
+s = s.replace("    await applyRetroSessionState(user, [retroDate]);",
+              "    await applyRetroSessionState(user, [retroDate]);\n"
+              "    await db.update(users).set({ programmeDayInWeek: (user.programmeDayInWeek || 1) + 1 })\n"
+              "      .where(eq(users.id, user.id));")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+echo "=============================================================================="
+echo "#221 journeys 5-7 — RED ON REVERT, one mechanism at a time"
+echo "=============================================================================="
+run_case "the header claims a programme position from the lifetime counter"     /tmp/221op/1.py
+run_case "the lifetime number is deleted rather than relabelled (opposite defect)" /tmp/221op/2.py
+run_case "a backfill advances the programme cursor again"                        /tmp/221op/3.py
+echo "=============================================================================="

--- a/server/handlers/misc-commands.ts
+++ b/server/handlers/misc-commands.ts
@@ -1089,7 +1089,20 @@ export async function handleMiscCommands(ctx: {
     // programmeWeek is phase-relative (resets to 1 each new phase), so "Week 1 | Session 19"
     // read as broken. Anchor the week to its phase so the two numbers make sense together.
     const phaseName = getPhaseNames()[user.programmePhase || 1] || "Foundation";
-    const sessionNote = totalSessions > 0 ? ` · Session ${totalSessions + 1}` : "";
+    // LIFETIME IS NOT A PROGRAMME POSITION (#221 journey 5).
+    //
+    // This read ` · Session ${totalSessions + 1}`, so a legacy client with twelve on the counter
+    // and seven durable rows was told "*Foundation Phase · Week 4 · Session 13*" — the header of
+    // the session they are about to do. That is a claim about WHERE THEY ARE IN THE PROGRAMME,
+    // built from a number that cannot answer it: `totalWorkoutsCompleted` is lifetime history,
+    // kept precisely because clients who started before every session had a durable row may own
+    // sessions no row can prove. Which session is due is owned by the programme cursor, and the
+    // next line of this very message already states it as "Day N — Today's Workout".
+    //
+    // The number is not deleted — deleting it would lose the real history the counter exists to
+    // carry. It is made to say what it is, the same way sessionHeaderLine already does with
+    // "Session N overall" after the same defect reached a client in July.
+    const sessionNote = totalSessions > 0 ? ` · ${totalSessions} sessions overall` : "";
     const gif2 = getPrimaryWorkoutGifUrl(workout);
     return `*${phaseName} Phase · Week ${week}${sessionNote}*\n\n*Day ${dayNum} — Today's Workout*\n\n${workout}\n\nSend *done* when finished.${viewerLine}${gif2 ? `\n[MEDIA:${gif2}]` : ""}`;
   }


### PR DESCRIPTION
Journeys 5–7 of #221, to the adjudicated rule. **Do not merge — at the CTO gate.** BASE `main@f399309`.

## The defect

A legacy client — twelve on the lifetime counter, seven durable workout rows — opened today's session and read:

```
*Foundation Phase · Week 4 · Session 13*
*Day 2 — Today's Workout*
```

Two numbers, two clocks, and one of them answering a question it cannot answer. **"Session 13" is a claim about where this client is in the programme**, built from `totalWorkoutsCompleted` — which is lifetime history, kept precisely because clients who started before every session had a durable row may own sessions no row can prove. The line directly beneath it already states the real position, from the owner that holds it.

## The fix, and the two shortcuts not taken

Per the adjudication — **not** `workout_logs.length` (erases legitimate history), **not** `max(counter, rows)` (promotes drift into programme truth). The counter stays exactly what it is, and says so:

```
*Foundation Phase · Week 4 · 12 sessions overall*
```

That is the convention `sessionHeaderLine` already adopted after the same defect reached a client in July — `Session N overall` — applied to the one header left behind.

## Proof — the exact ugly state you named

`rows = 7`, `counter = 12`, cursor at week 4 day 2, run against five surfaces. **24/24 green.**

```
=== 5 · FIVE SURFACES, ONE PROGRESSION, DESPITE A LEGACY MISMATCH ===
  PASS  the ugly state is real: 7 durable rows against a lifetime counter of 12
  PASS  today's session header does not claim a programme position from the counter
  PASS  the next session does not either
  PASS  …and neither does the programme view
  PASS  today's workout is day 2 — the cursor's day
  PASS  …and the next session names the same day 2
  PASS  CONTROL: asking three questions moved neither the cursor nor the counter
  PASS  completing a session writes one durable row
  PASS  …and advances the programme cursor, which is what owns 'which session is next'
  PASS  …and moves lifetime history by exactly one, still ahead of the rows and still legacy
  PASS  the next session follows the cursor, not the counter
```

### Journeys 6 and 7 needed no change — now pinned rather than assumed

```
=== 6 · BACKDATED TRAINING UPDATES THAT SAME TRUTH, AND ONLY IT ===
  PASS  a backdated session writes its durable row
  PASS  …and moves lifetime history by one
  PASS  …and does NOT move the programme cursor — a past day answers nothing about today
  PASS  CONTROL: reporting the same day twice adds neither a row nor a lifetime session

=== 7 · A QUIET DAY OR AN UNRELATED MESSAGE FABRICATES NOTHING ===
  PASS  one quiet day with comeback words is not a comeback
  PASS  an unrelated question states no programme position
  PASS  …and neither message moved the cursor, the counter or the ledger
```

I found both already correct when I probed them, and said so rather than manufacturing a fix. What they lacked was a test that would notice if that stopped being true — P0-3's cursor discipline in particular was protected only by a comment.

## Red on revert — three mechanisms, all three red

```
── the header claims a programme position from the counter        RED — 3
── the lifetime number is DELETED rather than relabelled          RED — 2   (opposite defect)
── a backfill advances the programme cursor again                 RED — 2
```

The middle one is the one worth reading. **Deleting the number satisfies every position check** — no number, no position claim — and silently loses the legacy history the counter exists to carry. Section 5b is the only thing standing between this cut and that "fix".

The third restores the exact P0-3 defect: "I trained on Monday" advancing today's cursor, so the client is correctly told Monday was logged and silently loses today's session slot.

## Runs

`tsc` clean · **37/37 suites** · **22/22 PG acceptances GREEN**, each isolated by the #227 runner. New acceptance wired into the inventory. No governor budget raised. No new owner, no second counter, no migration, no new response author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_