### PR TITLE
#234: raw client truth survives normalization

### DIFF
--- a/script/normalizer-replay-tests.ts
+++ b/script/normalizer-replay-tests.ts
@@ -136,7 +136,7 @@ async function main() {
   const { sastDayKey } = await import("../server/sast");
 
   /** Run one real turn and capture what it wrote and whether the front door applied a rewrite. */
-  async function turn(input: string): Promise<{ days: string[]; appliedRewrite: boolean }> {
+  async function turn(input: string): Promise<{ days: string[]; appliedRewrite: boolean; producedCanonical: boolean }> {
     const g = globalThis as any;
     g.__KAMLIFE_STUB_USER = { ...USER };
     g.__KAMLIFE_STUB_WRITES = [];
@@ -150,14 +150,20 @@ async function main() {
     // the only honest shape here regardless of the logging.
     const APPLIED = /^\[NORMALIZER\] [A-Z_]+\(\d+%\)/;
     let applied = false;
-    console.log = (...a: unknown[]) => { if (APPLIED.test(String(a[0] ?? ""))) applied = true; };
+    let produced = false;
+    console.log = (...a: unknown[]) => {
+      const l = String(a[0] ?? "");
+      if (APPLIED.test(l)) { applied = true; produced = true; }
+      // A refusal is ALSO proof the classifier ran and returned a canonical — see the guard below.
+      else if (l.startsWith("[NORMALIZER] fidelity gate REJECTED")) produced = true;
+    };
     try { await handleMessage(USER.phoneNumber, input); }
     finally { console.log = REAL_LOG; }
     const days = (g.__KAMLIFE_STUB_WRITES as Array<{ table: unknown; values: any }>)
       .filter(w => w.table === mealLogs && w.values?.loggedAt)
       .map(w => sastDayKey(new Date(w.values.loggedAt)));
     delete g.__KAMLIFE_STUB_WRITES;
-    return { days: [...new Set(days)], appliedRewrite: applied };
+    return { days: [...new Set(days)], appliedRewrite: applied, producedCanonical: produced };
   }
 
   await check("a multi-day batch still lands on three days through the front door", async () => {
@@ -199,12 +205,23 @@ async function main() {
     assert.ok(inventing.length > 0,
       "no recorded canonical carries an unwritten number, so this check graded nothing — re-record, "
       + "or retire it deliberately rather than letting it pass empty");
-    let anyApplied = false;
+    // LIVENESS IS "THE CLASSIFIER RAN", NOT "A REWRITE SURVIVED" (#234).
+    //
+    // This asserted that some corpus rewrite was APPLIED, to prove the brakes were not being
+    // graded against a dead normalizer. That signal stopped being available for an honest reason:
+    // the one entry still satisfying it was "you missed the black coffee yesterday" ->
+    // "i had black coffee for breakfast yesterday", which INVENTS the meal slot. #234 closed that
+    // class, so of the five recorded canonicals four now fail fidelity and the fifth is refused by
+    // the pre-existing number brake ("10k" -> "10000"). Nothing in this recording should be
+    // applied, and a guard demanding that one be applied would only be satisfied by reopening the
+    // defect. The purpose survives unchanged: prove the normalizer PRODUCED a canonical — applied
+    // or refused — because a dead normalizer produces neither.
+    let anyProduced = false;
     for (const c of CORPUS.filter(c => recorded.entries[c.input.toLowerCase()]?.canonical)) {
-      if ((await turn(c.input)).appliedRewrite) { anyApplied = true; break; }
+      if ((await turn(c.input)).producedCanonical) { anyProduced = true; break; }
     }
-    assert.ok(anyApplied,
-      "the front door applied NO rewrite from the whole corpus — the brakes cannot be graded "
+    assert.ok(anyProduced,
+      "the front door produced NO canonical from the whole corpus — the brakes cannot be graded "
       + "against a normalizer that is off");
   });
 

--- a/script/red-on-revert-234.sh
+++ b/script/red-on-revert-234.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #234, one mechanism at a time.
+#
+# The point of this cut is a CLASS, so the reverts restore the class, not the pear. Each puts one
+# part of the boundary back the way it was, ALONE, and the fidelity coverage must go red on the
+# checks that part exists to hold.
+set -u
+cd "$(dirname "$0")/.."
+
+run_case () {
+  local name="$1" patch="$2"
+  cp server/normalizer-fidelity.ts /tmp/234-fid-backup.ts
+  python3 "$patch" || { echo "  !! patch failed to apply: $name"; cp /tmp/234-fid-backup.ts server/normalizer-fidelity.ts; return 1; }
+  local out; out="$(npx tsx script/unit-tests.ts 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^unit-tests: [0-9]+' || echo '(no verdict — crashed)')"
+  echo "$out" | grep -E '^\s+✗' | sed 's/^/   /' | head -4
+  cp /tmp/234-fid-backup.ts server/normalizer-fidelity.ts
+}
+
+mkdir -p /tmp/234p
+
+# ── 1 · the semantic vocabulary goes back into the exemption set ──────────────────────────────
+#
+# The whole class at once: meal slots, days, times, activity and goal words exempt from the
+# invention check again. This is the state that shipped the founder's pear.
+cat > /tmp/234p/1.py <<'PY'
+p = "server/normalizer-fidelity.ts"; s = open(p).read()
+before = s
+s = s.replace('  "gonna", "going", "will", "be", "get", "got", "just", "then", "also", "too", "about", "s",',
+              '  "gonna", "going", "will", "be", "get", "got", "just", "then", "also", "too", "about", "s",\n'
+              '  "breakfast", "lunch", "dinner", "supper", "snack", "meal", "today", "yesterday", "morning",\n'
+              '  "afternoon", "evening", "night", "tonight", "steps", "step", "workout", "session",\n'
+              '  "training", "gym", "change", "goal", "muscle", "gain", "fat", "loss", "did", "do", "done",')
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 2 · the client's NO stops being read ──────────────────────────────────────────────────────
+cat > /tmp/234p/2.py <<'PY'
+p = "server/normalizer-fidelity.ts"; s = open(p).read()
+before = s
+s = s.replace("  if (negates(orig) && !negates(canon)) {", "  if (false) {")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 3 · a canonical may ask a question the client did not ─────────────────────────────────────
+cat > /tmp/234p/3.py <<'PY'
+p = "server/normalizer-fidelity.ts"; s = open(p).read()
+before = s
+s = s.replace("  if (looksLikeQuestion(canon) && !looksLikeQuestion(orig)) {", "  if (false) {")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+# ── 4 · the gate refuses EVERYTHING (the opposite defect) ─────────────────────────────────────
+#
+# Tightening a brake until nothing survives passes every "must be blocked" assertion and silently
+# turns the normalizer off — which is why the preserved-behaviour test exists beside the class.
+cat > /tmp/234p/4.py <<'PY'
+p = "server/normalizer-fidelity.ts"; s = open(p).read()
+before = s
+s = s.replace("  return { ok: true, reason: \"faithful\" };",
+              "  return { ok: false, reason: \"refuse everything\" };")
+assert s != before, "revert patch matched nothing"
+open(p, "w").write(s)
+PY
+
+echo "=============================================================================="
+echo "#234 — RED ON REVERT, one mechanism at a time"
+echo "=============================================================================="
+run_case "semantic vocabulary is exempt from the invention check again" /tmp/234p/1.py
+run_case "the client's negation is no longer read"                     /tmp/234p/2.py
+run_case "a canonical may invent a question"                           /tmp/234p/3.py
+run_case "the gate refuses every rewrite (opposite defect)"            /tmp/234p/4.py
+echo "=============================================================================="

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -1581,6 +1581,61 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
     assert.equal(normalizerFidelity("Nditye isonka namaqanda kusasa", "i had bread and eggs for breakfast").ok, true);
   });
 
+  // ── THE SEMANTIC-ADDITION CLASS (#234) ──────────────────────────────────────────────────────
+  //
+  // The live founder turn "I had a pear" -> "i had a pear for breakfast" is the evidence, not the
+  // scope. `STRUCTURE` exempted meal slots, day words, times, activity nouns and goal vocabulary
+  // from the invention check, so the gate waved through every rewrite that ADDED meaning of those
+  // kinds. Each row below was ALLOWED before this cut. They are asserted as a class, because a
+  // gate that only knows about pears is the same gate with one more special case.
+  test("normalizer fidelity: unsupported semantic additions fail closed", async () => {
+    const { normalizerFidelity } = await import("../server/normalizer-fidelity");
+    const invented: Array<[string, string, string]> = [
+      ["meal slot (the founder turn)", "I had a pear", "i had a pear for breakfast"],
+      ["meal slot, second phrasing", "ate chicken and rice", "i had chicken and rice for dinner"],
+      ["a day the client never named", "I trained", "i trained yesterday"],
+      ["a time of day", "had eggs", "i had eggs in the morning"],
+      ["a goal change never asked for", "I want to build a bit", "change my goal to muscle gain"],
+      ["a session that never happened", "I was busy", "i did my workout"],
+    ];
+    for (const [why, raw, canon] of invented) {
+      assert.equal(normalizerFidelity(raw, canon).ok, false, `${why}: "${raw}" -> "${canon}"`);
+    }
+
+    // NEGATION IS NOT A WORD, IT IS THE SIGN OF THE CLAIM. Every word of "i did my workout" traces
+    // to "I didn't train" — "did" to "didn't", the rest is structure — so the invention check
+    // could never have caught the client's No being reversed. It has its own rule.
+    assert.equal(normalizerFidelity("I didn't train", "i did my workout").ok, false);
+    assert.equal(normalizerFidelity("I didn't train", "i did train").ok, false);
+    assert.match(normalizerFidelity("I didn't train", "i did train").reason, /negates/i);
+
+    // …and the other direction of rule 2: a canonical may not ASK what the client did not ask.
+    assert.equal(normalizerFidelity("pap and eggs", "pap and eggs?").ok, false);
+  });
+
+  test("normalizer fidelity: legitimate rewrites still survive the tightening", async () => {
+    const { normalizerFidelity } = await import("../server/normalizer-fidelity");
+    // A gate that refuses everything would satisfy every assertion above. These are the rewrites
+    // the normalizer exists to make, and each one must still pass.
+    const kept: Array<[string, string, string]> = [
+      ["client stated the slot", "had a pear for breakfast", "i had a pear for breakfast"],
+      ["client stated the day", "I trained yesterday", "i trained yesterday"],
+      ["retro timing, translated", "I had pap last night", "i had pap yesterday"],
+      ["SA-language translation", "ngidle ipapa", "i had pap"],
+      ["a verb in another form", "workout done", "i did my workout"],
+      ["a typo is still their word", "Luch\nTin fish\nRice", "i had tin fish and rice for lunch"],
+    ];
+    for (const [why, raw, canon] of kept) {
+      assert.equal(normalizerFidelity(raw, canon).ok, true,
+        `${why}: "${raw}" -> "${canon}" was refused: ${normalizerFidelity(raw, canon).reason}`);
+    }
+
+    // A CORRECTION ABOUT OUR RECORD IS NOT THE CLIENT NEGATING THEMSELVES. "you missed X" says we
+    // failed to log it, and the food was really eaten — reading it as their No refused an honest
+    // rewrite, which the recorded corpus caught the moment the negation rule went in.
+    assert.equal(normalizerFidelity("you missed the black coffee", "i had black coffee").ok, true);
+  });
+
   test("normalizer fidelity: a pure question may still become a lookup", async () => {
     const { normalizerFidelity } = await import("../server/normalizer-fidelity");
     // Nothing is discarded when the question IS the whole message, so this rewrite stays legal —

--- a/server/normalizer-fidelity.ts
+++ b/server/normalizer-fidelity.ts
@@ -58,15 +58,87 @@ export function normalizerLive(): boolean {
 
 // Words a canonical is MADE of. Everything else it says is a claim about what the client ate,
 // did, or wants — and every one of those has to be traceable to their own words.
+//
+// THIS SET USED TO CARRY MEANING, AND THAT WAS THE HOLE (#234).
+//
+// It also held `breakfast lunch dinner supper snack meal`, `today yesterday morning afternoon
+// evening night tonight`, `steps step workout session training gym`, `change goal muscle gain fat
+// loss recomposition`, `kg kgs calories calorie protein`, `same repeat copy again` and
+// `did do done`. Exempting a word from the invention check says it carries no claim. Every one of
+// those carries a claim, so the check waved through exactly the rewrites that matter most:
+//
+//     "I had a pear"              -> "i had a pear for breakfast"      a meal slot, invented
+//     "I trained"                 -> "i trained yesterday"             a day, invented
+//     "had eggs"                  -> "i had eggs in the morning"       a time, invented
+//     "I was busy"                -> "i did my workout"                a session that never happened
+//     "I want to build a bit"     -> "change my goal to muscle gain"   a goal change never asked for
+//     "I didn't train"            -> "i did my workout"                the client's NO, reversed
+//
+// All six were ALLOWED before this cut and all six are measured in the acceptance. What remains
+// here is syntax: pronouns, auxiliaries, articles, prepositions, conjunctions. A word that could
+// finish the sentence "the client told us ___" does not belong in this set.
 const STRUCTURE = new Set([
   "i", "im", "i'm", "id", "i'd", "ill", "i'll", "had", "have", "has", "ate", "eat", "eating",
-  "did", "do", "done", "was", "were", "is", "are", "am", "for", "and", "or", "a", "an", "the",
+  "was", "were", "is", "are", "am", "for", "and", "or", "a", "an", "the",
   "some", "of", "with", "my", "me", "to", "it", "that", "this", "at", "on", "in", "plus", "as",
-  "gonna", "going", "will", "be", "get", "got", "just", "then", "also", "too", "about",
-  "breakfast", "lunch", "dinner", "supper", "snack", "meal", "today", "yesterday", "morning",
-  "afternoon", "evening", "night", "tonight", "steps", "step", "kg", "kgs", "workout", "session",
-  "training", "gym", "change", "goal", "muscle", "gain", "fat", "loss", "recomposition",
-  "calories", "calorie", "protein", "same", "repeat", "copy", "again", "s",
+  "gonna", "going", "will", "be", "get", "got", "just", "then", "also", "too", "about", "s",
+]);
+
+/**
+ * WHEN-WORDS, kept as a named class rather than an exemption.
+ *
+ * They must trace like anything else, with ONE authorisation: a raw message the retro-meal owner
+ * already reads as historical may be restated with a day word it does not literally contain —
+ * "I had pap last night" → "…yesterday" is that owner's translation of the client's own timing,
+ * not the normalizer inventing a day. `isRetroactiveMeal` is that owner and is asked here rather
+ * than re-implemented.
+ */
+const WHEN = new Set([
+  "today", "yesterday", "tomorrow", "morning", "afternoon", "evening", "night", "tonight",
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+]);
+
+/**
+ * The signs of a client saying something did NOT happen.
+ *
+ * A closed token set rather than a pattern, for the same reason the food constraint owner uses one:
+ * a set is read against `words()`, which already strips the apostrophe — so "didn't" arrives as
+ * "didn" and is listed as such rather than needing a pattern to anticipate every spelling of it.
+ * It also keeps this file's regex count where it was; the budget is not raised for a brake.
+ *
+ * `workout.ts` holds NEGATED_SESSION for a NARROWER question — did the client negate a training
+ * session — and is deliberately not merged with this. That one decides whether to log; this one
+ * decides whether a rewrite may speak. Folding them would give one owner two jobs.
+ */
+const NEGATORS = new Set([
+  "no", "not", "never", "none", "without", "skipped", "missed", "failed", "forgot", "couldnt",
+  "didn", "dont", "doesnt", "havent", "hasnt", "hadnt", "wasnt", "werent", "isnt", "arent",
+  "wont", "cant", "couldn", "shouldnt", "wouldnt", "nothing", "neither", "nor",
+]);
+/**
+ * A negation the CLIENT is making about their own action.
+ *
+ * "you missed the black coffee yesterday" negates the COACH's logging, not the client's eating —
+ * they are correcting our record and the food really was eaten. Reading that as "the client says
+ * it did not happen" rejected an honest rewrite, which the recorded corpus caught immediately. So
+ * a negator directly after "you" is the client talking about us, and is not their No.
+ */
+const negates = (s: string): boolean => {
+  const ws = words(s);
+  return ws.some((w, i) => NEGATORS.has(w) && !["you", "u", "your", "youre", "ur"].includes(ws[i - 1] || ""));
+};
+
+/**
+ * What a LOOKUP names. A message that is only a question discards nothing by becoming a canonical
+ * command — "how many calories do I have left?" → "today's calories" is routing, not testimony,
+ * and rule 2 already says so. These words may therefore appear in such a canonical without
+ * tracing, because they name what is being ASKED FOR rather than claiming what the client did.
+ * Deliberately narrow, and only ever reachable when the canonical reports nothing itself, so
+ * "what should I eat?" → "i had pap for lunch" stays blocked.
+ */
+const LOOKUP = new Set([
+  "today", "calories", "calorie", "protein", "steps", "step", "weight", "kg", "kgs",
+  "left", "total", "totals", "remaining",
 ]);
 
 // Canonicalisation the classifier is explicitly asked to do (see the prompt in gpt.ts). These are
@@ -77,6 +149,9 @@ const TRANSLATIONS: Record<string, string[]> = {
   bread: ["isonka", "brood"],
   eggs: ["amaqanda", "mazai", "eier"],
   chicken: ["inkukhu", "kgoho", "hoender"],
+  // A MEAL SLOT NAMED IN ANOTHER LANGUAGE IS STILL THE CLIENT NAMING IT (#234).
+  // "Nditye isonka namaqanda kusasa" states the slot; only the language differs.
+  breakfast: ["kusasa", "ekuseni", "ontbyt"],
 };
 
 const words = (s: string): string[] =>
@@ -85,14 +160,55 @@ const words = (s: string): string[] =>
     .replace(/[^\w\s-]/g, " ")
     .split(/\s+/).filter(Boolean);
 
+/**
+ * Irregular forms of one verb. Morphology, not meaning: a client who wrote "done" and a canonical
+ * that says "did" are making the same claim, and the stemmer below cannot see that.
+ */
+const FORMS: Record<string, string[]> = {
+  did: ["do", "done", "doing"],
+  done: ["do", "did", "doing"],
+  doing: ["do", "did", "done"],
+  ate: ["eat", "eaten", "eating"],
+  had: ["have", "has", "having"],
+};
+
 /** Does this canonical word trace back to something the client actually wrote? */
 function traces(word: string, originalLower: string): boolean {
   if (word.length < 3) return true;                          // too short to be a claim on its own
   if (originalLower.includes(word)) return true;
-  const stem = word.replace(/(?:es|s)$/, "");                // veggies/veggie, eggs/egg
-  if (stem.length >= 3 && originalLower.includes(stem)) return true;
+  // veggies/veggie, eggs/egg, trained/train, training/train — the same claim in another form is
+  // not a new claim. Widened from `s|es` only, so that tightening STRUCTURE does not start
+  // blocking honest paraphrase along with the inventions.
+  for (const stem of [word.replace(/(?:es|s)$/, ""), word.replace(/(?:ed|ing)$/, "")]) {
+    if (stem.length >= 3 && originalLower.includes(stem)) return true;
+  }
+  for (const src of FORMS[word] || []) if (originalLower.includes(src)) return true;
   for (const src of TRANSLATIONS[word] || []) if (originalLower.includes(src)) return true;
+  // A TYPO IS STILL THE CLIENT'S WORD (#234). "Luch / Tin fish / Rice" → "…for lunch" is the
+  // flagship case this gate was built to ALLOW: they wrote the meal slot, they misspelled it.
+  // Tightening STRUCTURE made that a strict-trace question for the first time, so one edit of
+  // slack is the difference between reading a typo and inventing a meal. Bounded deliberately:
+  // distance 1, words of four letters or more, so it can forgive a slip and not a different word.
+  if (word.length >= 4) {
+    for (const raw of originalLower.split(/[^a-z]+/)) {
+      if (raw.length >= 4 && withinOneEdit(word, raw)) return true;
+    }
+  }
   return false;
+}
+
+/** True when one insertion, deletion or substitution turns `a` into `b`. */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (Math.abs(a.length - b.length) > 1) return false;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  let i = 0, j = 0, edits = 0;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) { i++; j++; continue; }
+    if (++edits > 1) return false;
+    if (short.length === long.length) { i++; j++; } else { j++; }
+  }
+  return edits + (long.length - j) + (short.length - i) <= 1;
 }
 
 /**
@@ -141,10 +257,39 @@ export function normalizerFidelity(original: string, canonical: string): Fidelit
     return { ok: false, reason: "original reports steps; canonical drops the walk" };
   }
 
-  // 5. NOTHING INVENTED. Every claim in the canonical must trace to the client's own words.
+  // 5. THE CLIENT'S "NO" SURVIVES (#234). A rewrite that drops the negation reverses what
+  //    happened: "I didn't train" → "i did my workout" logged a session they had just told us
+  //    they did not do. Every word in that canonical traced — "did" to "didn't", "train" to
+  //    "train" — so the invention check could never have caught it. Negation is not a word, it is
+  //    the sign of the claim.
+  if (negates(orig) && !negates(canon)) {
+    return { ok: false, reason: "original negates; canonical asserts it happened" };
+  }
+
+  // 6. A STATEMENT IS NOT A QUESTION (#234). Rule 2 stops a question being flattened into a log.
+  //    This is the other direction: a canonical that ASKS something the client did not ask puts
+  //    words in their mouth and sends the coach off answering itself.
+  if (looksLikeQuestion(canon) && !looksLikeQuestion(orig)) {
+    return { ok: false, reason: "canonical asks a question the client did not ask" };
+  }
+
+  // 7. NOTHING INVENTED. Every claim in the canonical must trace to the client's own words.
+  //
+  //    The ONE authorised addition is a day word on a message the retro-meal owner already reads
+  //    as historical: "I had pap last night" → "…yesterday" is that owner restating the client's
+  //    own timing. Everything else — a meal slot, a time of day, a day on a message with no
+  //    timing in it at all — has to come from the client.
+  const retroAuthorised = isRetroactiveMeal(orig);
+  // Only when the client ASKED and the canonical claims nothing of its own.
+  const canonReports = canonIntents.hasFoodReport || canonIntents.hasStepsReport
+    || canonIntents.stepCount != null;
+  const lookupAuthorised = looksLikeQuestion(orig) && !carriesFacts && !canonReports;
   for (const w of words(canonLower)) {
     if (STRUCTURE.has(w) || /^\d+$/.test(w)) continue;        // numbers have their own brake
-    if (!traces(w, origLower)) return { ok: false, reason: `canonical invents "${w}"` };
+    if (traces(w, origLower)) continue;
+    if (WHEN.has(w) && retroAuthorised) continue;
+    if (LOOKUP.has(w) && lookupAuthorised) continue;
+    return { ok: false, reason: `canonical invents "${w}"` };
   }
 
   return { ok: true, reason: "faithful" };


### PR DESCRIPTION
**Do not merge — at the CTO gate.** BASE `main@a15166a`.

## First divergence

`normalizer-fidelity.ts` exempted a set of words from its invention check, on the stated grounds that they are what a canonical is *made of*. That set held meal slots, day words, times, activity nouns, goal vocabulary and `did do done`.

**Exempting a word from the invention check says it carries no claim.** Every one of those carries a claim — so the gate waved through exactly the rewrites that matter.

## Systemic before → after

Every row was **ALLOWED** before this cut. All measured, all now blocked:

| class | raw | canonical | now |
|---|---|---|---|
| meal slot *(the founder turn)* | `I had a pear` | `i had a pear for breakfast` | `invents "breakfast"` |
| meal slot | `ate chicken and rice` | `i had chicken and rice for dinner` | `invents "dinner"` |
| date | `I trained` | `i trained yesterday` | `invents "yesterday"` |
| time of day | `had eggs` | `i had eggs in the morning` | `invents "morning"` |
| goal change | `I want to build a bit` | `change my goal to muscle gain` | `invents "change"` |
| fabricated session | `I was busy` | `i did my workout` | `invents "did"` |
| **negation flip** | `I didn't train` | `i did my workout` | `original negates; canonical asserts` |
| **negation flip** | `I didn't train` | `i did train` | `original negates; canonical asserts` |
| statement → question | `pap and eggs` | `pap and eggs?` | `asks a question the client did not ask` |

## Exact owner changed

`server/normalizer-fidelity.ts` — one existing owner, no second normalizer, parser or router. `STRUCTURE` now holds syntax only; **a word that could finish "the client told us ___" does not belong in it.**

Two rules join it, because two members of the class are not words at all:

- **Negation is the sign of a claim, not a word.** Every word of `i did my workout` traces back to `I didn't train` — `did` to `didn't`, the rest is structure — so no invention check could ever have caught the client's No being reversed.
- **Rule 2 had one direction only.** It stopped a question being flattened into a log; a canonical *asking* what the client never asked was open.

Requirement 5 needed no change — `routes.ts:707` already sets `canon = ""` on refusal and the raw message proceeds. Verified, not assumed.

## Controls for preserved behaviour

Tightening a brake is half a change. The other half is asserted beside it:

```
PASS  a typo is still their word    "Luch\nTin fish\nRice" -> "…for lunch"
PASS  SA-language translation       "ngidle ipapa" -> "i had pap"
PASS  client stated the slot / the day
PASS  retro timing translated       "I had pap last night" -> "…yesterday"
PASS  a verb in another form        "workout done" -> "i did my workout"
PASS  pure question -> lookup       "how many calories do I have left?" -> "today's calories"
```

Two of those came from the tightening breaking honest cases, caught by existing coverage rather than by me:

- The documented `"Luch"` case became a strict-trace question for the first time. One edit of slack — distance 1, words of 4+ letters — reads a typo without inventing a meal.
- **`"you missed the black coffee"` is a correction about *our record*, not the client negating themselves.** The coffee was real; we failed to log it. The recorded corpus caught that false positive immediately, so a negator directly after "you" is not their No.

## Red on revert — the class, four mechanisms, all red

```
── semantic vocabulary is exempt from the invention check again   RED
── the client's negation is no longer read                        RED
── a canonical may invent a question                              RED
── the gate refuses every rewrite (opposite defect)               RED — 3
```

The fourth is the one that matters most: **a gate tightened until nothing survives passes every "must be blocked" assertion and silently turns the normalizer off.** It goes red on the preserved-behaviour tests, which is what they are for.

## One test changed its signal, not its purpose

The replay guard proved liveness by requiring some corpus rewrite to be **applied**. The last entry satisfying it was `"you missed the black coffee yesterday"` → `"i had black coffee for breakfast yesterday"` — which invents the slot. **The guard was being kept alive by an instance of the defect this cut closes.**

Of five recorded production canonicals, **four now fail fidelity and the fifth is refused by the pre-existing number brake** (`10k` → `10000`). Nothing in that recording should be applied, and a guard demanding otherwise could only be satisfied by reopening the defect. It now proves the classifier *ran* — applied or refused — which is what it was always trying to establish.

## Residual semantic additions this owner still cannot prove

Stated rather than hidden:

1. **A named weekday is not read as retro.** `isRetroactiveMeal("Monday I had pap…")` is `false`, so `Monday` → `yesterday` is refused as an invented day. That refusal is correct — the rewrite is only true on Tuesdays — but it means named-day messages never normalise, and the raw carries them downstream.
2. **The gate cannot see meaning that no word carries.** Emphasis, hedging ("maybe", "I think"), and quantity vagueness survive only because the words themselves trace.
3. **`traces()` is substring-based**, so a canonical word contained in an unrelated raw word passes — e.g. `ate` inside `later`. Bounded by the ≥3-char rule, not eliminated.

## Runs

`tsc` clean · **37/37 suites** · **1065/1065 unit checks** · **14/14 normalizer replay** · **22/22 PG acceptances GREEN**.

No governor budget raised — the negation brake is a token set rather than a pattern, so `regexLiterals` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_