### PR TITLE
A miss is not a completion, and a question about today gets an answer about today (#233)

### DIFF
--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4420,7 +4420,14 @@ test("#128/4: the action ladder's protein rung asks too, and does not re-issue t
   assert.equal(after.kind, "protein", "protein is still the lever");
   assert.ok(!/make (?:your next meal|lunch) a (?:proper )?protein/i.test(after.todo),
     `it must not re-issue the instruction just carried out — "${after.todo}"`);
-  assert.match(after.todo, /one proper protein down/i, "it acknowledges the plate that landed");
+  // THE PROMISE IS "MOVE FORWARD FROM THE PLATE", NOT ONE PHRASE (#233 Gate 3 copy adjudication).
+  // This pinned the literal "one proper protein down". The rung's just-ate wording was adjudicated
+  // to "For today, make your next meal another proper protein meal. That's your one move." — which
+  // still acknowledges the plate that landed, in the word ANOTHER, and still does not re-issue the
+  // instruction just carried out (asserted immediately above, unchanged and still passing). What
+  // #128/4 exists to stop is the re-issue; that is what stays pinned.
+  assert.ok(/one proper protein down|another proper protein/i.test(after.todo),
+    `it moves forward from the plate that landed — "${after.todo}"`);
   // CONTROL: the same client who did NOT just eat one still gets the instruction.
   assert.match(chooseAction({ ...base }).todo, /protein/i);
   assert.ok(/make your next meal a proper protein meal/i.test(chooseAction({ ...base }).todo),

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4476,7 +4476,12 @@ test("cut8: the decision stands down before the mouth ever has to", () => {
   // morning free to tell a client to stand on a scale they asked us never to raise.
   assert.ok(/const scaleIsOffLimits = mentionsForbidden\("weight scale weigh", s\.doNotMention\)/.test(code),
     "the weigh ask is never chosen");
-  assert.ok(/!scaleIsOffLimits && \(\(neverWeighed/.test(code), "…in the ordering itself");
+  // THE PROMISE IS THE ORDERING, NOT THE ADJACENCY (#233 Gate 3). This pinned
+  // `!scaleIsOffLimits && ((neverWeighed` as one literal string, so adding any second guard to the
+  // rung broke it even though the boundary still leads the condition — exactly the stale-shape
+  // trap the comment below describes and this file already learned once. What must hold is that
+  // the rung is gated on the boundary FIRST; what follows it is the rung's own business.
+  assert.ok(/if \(!scaleIsOffLimits\b/.test(code), "…in the ordering itself");
   // …AND IN THE VERDICT DOWNGRADE, WHICH REACHES askToWeigh BY A SECOND ROUTE.
   //
   // This used to grep for `mentionsForbidden("weight scale weigh", p.doNotMention)` in this file.

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -173,6 +173,13 @@ export const ACCEPTANCES: Acceptance[] = [
   { id: "messy-reentry-reverts", title: "Messy re-entry controls fail on every mechanism revert",
     command: ["npx", "tsx", "script/pg-messy-reentry-red-on-revert.ts"] },
 
+  { id: "missed-session-outbound", title: "The missed-session answer survives the outbound floor",
+    // #233. The handler's return was correct the whole time; the truth floor threw it away and the
+    // client got the generic repair. Only a real database and the real transport path can show
+    // that — the record the floor checks against IS the ledger, and the substitution happens in
+    // sendFinal, past every handler.
+    command: ["npx", "tsx", "script/pg-missed-session-outbound-acceptance.ts"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-food-constraint-mouths-acceptance.ts
+++ b/script/pg-food-constraint-mouths-acceptance.ts
@@ -207,7 +207,11 @@ chk(!/make (?:your next meal|lunch) a (?:proper )?protein/i.test(afterPlate),
   afterPlate.slice(0, 300));
 // NON-VACUOUS: a move WAS appended, and it moves forward from the plate rather than restating it.
 // Without this, a turn that appended nothing at all would satisfy the check above.
-chk(/one proper protein down/i.test(afterPlate),
+// THE PROMISE, NOT THE PHRASE (#233 Gate 3 copy adjudication). The rung's just-ate wording
+// became "For today, make your next meal another proper protein meal. That's your one move."
+// It still moves forward from the plate that landed — that is what ANOTHER carries — and it is
+// still a move rather than an empty turn, which is what this check exists to establish.
+chk(/one proper protein down|another proper protein/i.test(afterPlate),
   "…the move acknowledges the plate that landed, so this is not an empty turn",
   afterPlate.slice(0, 300));
 

--- a/script/pg-log-turn-acceptance.ts
+++ b/script/pg-log-turn-acceptance.ts
@@ -211,7 +211,11 @@ REAL("\n=== CANONICAL TRUTH REACHES THE ACKNOWLEDGEMENT ===");
   _resetOutboundDedupe();
   const good = await client({}, EV);
   const win = await say(good.phone, "grilled chicken breast with broccoli and sweet potato for lunch");
-  chk(/one proper protein down/i.test(win.reply),
+  // THE PROMISE, NOT THE PHRASE (#233 Gate 3 copy adjudication). The rung's just-ate wording
+  // became "For today, make your next meal another proper protein meal. That's your one move."
+  // It still moves forward from the plate that landed — that is what ANOTHER carries — and it is
+  // still a move rather than an empty turn, which is what this check exists to establish.
+  chk(/one proper protein down|another proper protein/i.test(win.reply),
     "CONTROL: a plate we did NOT ask them to change still earns the protein closer",
     JSON.stringify(win.reply));
 }

--- a/script/pg-missed-session-outbound-acceptance.ts
+++ b/script/pg-missed-session-outbound-acceptance.ts
@@ -193,41 +193,55 @@ REAL("\n=== 5 · THE CATCH-UP ANSWERS THE QUESTION IT WAS ASKED (Gate 3) ===");
   chk(!/lunch was|for lunch you had/i.test(body), "…the unknown lunch stays unknown",
     JSON.stringify((body.match(/[^\n]*lunch[^\n]*/) || ["(not mentioned)"])[0]));
 
-  // GATE 3 ITSELF. The client asked what to do TODAY.
   const closing = body.trim().split("\n").filter(l => l.trim()).slice(-1)[0] || "";
+
+  // THE EXACT TODO, from the existing today-scoped fuelling rung. Pinned rather than pattern-
+  // matched: this client logged 56g against a 150g target on a plate that cleared PROPER_PROTEIN_G,
+  // so the rung's own wording is the one below, and nothing else in the ladder produces it.
+  chk(closing === "That's one proper protein down — same again at your next meal.",
+    "the closing answer is the fuelling rung's own move, verbatim", JSON.stringify(closing));
+
+  chk(!/Nothing new today/i.test(body),
+    "…it is not the hold copy", JSON.stringify(closing));
+  chk(!/do exactly what you did yesterday/i.test(body),
+    "…and it does not invent a yesterday there is no evidence for", JSON.stringify(closing));
   chk(!/scale (tomorrow|tonight)|tomorrow morning/i.test(closing),
-    "the closing answer is not a task for another day", JSON.stringify(closing));
+    "…nor a task for another day", JSON.stringify(closing));
   chk(closing.trim().length > 0 && !/next move stays small\.?$/i.test(closing),
-    "…and it is not an empty hold — the turn ends on a move, not on an acknowledgement",
-    JSON.stringify(closing));
+    "…and the turn does not end on an acknowledgement with no move", JSON.stringify(closing));
   chk(!body.includes(REACTIVE_OUTBOUND_REPAIR), "…and the body is not the generic repair",
     JSON.stringify(body.slice(0, 90)));
 }
 
-REAL("\n=== 6 · CONTROL — A SPARSE NON-DIRECTION TURN KEEPS ITS INVESTIGATION ===");
+REAL("\n=== 6 · CONTROL — ORDINARY SPARSE TURNS ARE UNCHANGED ===");
 {
   // #203 is narrowed for one case, not disabled. A client who did NOT ask what to do today must
   // still meet the investigation ladder exactly as before — otherwise this cut has quietly turned
   // the sparse-client downgrade off for everyone.
-  const { underPolicy } = await import("../server/one-action");
-  const base = { kind: "protein", todo: "Make your next meal a proper protein meal.", why: "x" } as any;
-  const optsNoAsk = { foodSufficient: false, weightSufficient: false, loggedToday: true,
+  const { underPolicy, chooseAction } = await import("../server/one-action");
+  const fuelling = { kind: "protein", todo: "Make your next meal a protein one.", why: "x" } as any;
+  const sparse = { foodSufficient: false, weightSufficient: false, loggedToday: true,
     daysSinceWeighIn: null as number | null, hour: 19 };
-  const investigated = underPolicy(base, optsNoAsk);
-  chk(investigated.kind === "weigh",
-    "CONTROL: without a today-question the ladder still downgrades to the weigh investigation",
-    JSON.stringify({ kind: investigated.kind, todo: investigated.todo }));
 
-  const asked = underPolicy(base, { ...optsNoAsk, asksAboutToday: true });
-  chk(asked.kind !== "weigh" || !/tomorrow/i.test(String(asked.todo || "")),
-    "…and with one, it is not answered with a tomorrow-only weigh",
-    JSON.stringify({ kind: asked.kind, todo: asked.todo }));
+  chk(underPolicy(fuelling, sparse).kind === "weigh",
+    "CONTROL: without a today-question the downgrade still investigates, unchanged",
+    JSON.stringify(underPolicy(fuelling, sparse)));
 
-  // …and before midday the weigh is unchanged, because then it IS today's job.
-  const morning = underPolicy(base, { ...optsNoAsk, hour: 8, asksAboutToday: true });
-  chk(morning.kind === "weigh" && /this morning/i.test(String(morning.todo || "")),
-    "CONTROL: before midday a today-question still gets the weigh, worded for today",
-    JSON.stringify({ kind: morning.kind, todo: morning.todo }));
+  const asked = underPolicy(fuelling, { ...sparse, asksAboutToday: true });
+  chk(asked.kind === "protein" && asked.todo === fuelling.todo,
+    "…and with one, the today-scoped rung the ladder already chose is what stands",
+    JSON.stringify(asked));
+
+  // …and the weigh itself is untouched when it IS today's job.
+  const day = { firstName: "T", goal: "fat_loss", weeksOnProgramme: 3, daysSinceAnyLog: 0,
+    daysSinceWeighIn: 40, loggedToday: true, proteinPct: 1, caloriePct: 1, sessionsThisWeek: 3,
+    sessionsTarget: 3, stepsToday: 9000, stepsTarget: 8000, sick: false, atKeyboard: true } as any;
+  chk(chooseAction({ ...day, hour: 8, asksAboutToday: true }).kind === "weigh",
+    "CONTROL: before midday a today-question still reaches the weigh rung",
+    JSON.stringify(chooseAction({ ...day, hour: 8, asksAboutToday: true })));
+  chk(chooseAction({ ...day, hour: 19, asksAboutToday: false }).kind === "weigh",
+    "CONTROL: …and after midday it is unchanged for any turn that did not ask about today",
+    JSON.stringify(chooseAction({ ...day, hour: 19, asksAboutToday: false })));
 }
 
 REAL(`\n${failed === 0

--- a/script/pg-missed-session-outbound-acceptance.ts
+++ b/script/pg-missed-session-outbound-acceptance.ts
@@ -195,11 +195,25 @@ REAL("\n=== 5 · THE CATCH-UP ANSWERS THE QUESTION IT WAS ASKED (Gate 3) ===");
 
   const closing = body.trim().split("\n").filter(l => l.trim()).slice(-1)[0] || "";
 
-  // THE EXACT TODO, from the existing today-scoped fuelling rung. Pinned rather than pattern-
-  // matched: this client logged 56g against a 150g target on a plate that cleared PROPER_PROTEIN_G,
-  // so the rung's own wording is the one below, and nothing else in the ladder produces it.
-  chk(closing === "That's one proper protein down — same again at your next meal.",
-    "the closing answer is the fuelling rung's own move, verbatim", JSON.stringify(closing));
+  // THE EXACT SENTENCE, pinned deterministically. The rung's wording turns tomorrow-facing after
+  // 20:00 — a rule that predates this cut and stays — so asserting it through the body alone would
+  // pass or fail on the hour CI happened to run, the run-hour dependence removed from two suites in
+  // #221. So it is pinned at a fixed hour on the rung itself, and the body is asserted to carry a
+  // fuelling move and never the old receipt wording, whatever the clock says.
+  const { chooseAction } = await import("../server/one-action");
+  const atMidday = chooseAction({
+    firstName: "Bonolo", goal: "fat_loss", weeksOnProgramme: 3, daysSinceAnyLog: 0,
+    daysSinceWeighIn: 40, loggedToday: true, proteinPct: 0.37, caloriePct: 0.27,
+    sessionsThisWeek: 3, sessionsTarget: 3, stepsToday: 6400, stepsTarget: 8000, sick: false,
+    hour: 13, atKeyboard: true, asksAboutToday: true, justAteProteinMeal: true,
+  } as any);
+  chk(atMidday.todo === "For today, make your next meal another proper protein meal. That's your one move.",
+    "the fuelling rung's move is the exact adjudicated sentence", JSON.stringify(atMidday.todo));
+
+  chk(!/one proper protein down — same again at your next meal/i.test(body),
+    "…and the old receipt wording is gone from the body", JSON.stringify(closing));
+  chk(/proper protein meal|proper protein down — start tomorrow/i.test(closing),
+    "the closing answer is the fuelling rung's move", JSON.stringify(closing));
 
   chk(!/Nothing new today/i.test(body),
     "…it is not the hold copy", JSON.stringify(closing));

--- a/script/pg-missed-session-outbound-acceptance.ts
+++ b/script/pg-missed-session-outbound-acceptance.ts
@@ -176,6 +176,60 @@ REAL("\n=== 4 · THE PEAR AND THE MESSY CATCH-UP ARE UNCHANGED ===");
     JSON.stringify((catchup.match(/[^\n]*lunch[^\n]*/) || ["(not mentioned)"])[0]));
 }
 
+REAL("\n=== 5 · THE CATCH-UP ANSWERS THE QUESTION IT WAS ASKED (Gate 3) ===");
+{
+  _resetOutboundDedupe();
+  const c = await client("Bonolo", { lastActiveAt: midday(4) });
+  const body = await outbound(c.phone,
+    "I'm back after a few days. Saturday breakfast I had eggs and rice. Sunday I walked 6400 steps "
+    + "and I can't remember lunch. Monday I felt flat because work was chaos, but I did the workout "
+    + "you told me to do. Today breakfast I had pap and chicken. What should I do today?");
+
+  // The facts stay exactly as #233 already landed them.
+  chk(/Saturday/i.test(body) && /Sunday/i.test(body) && /Monday/i.test(body),
+    "the days the client reported are all named back", JSON.stringify(body.slice(0, 120)));
+  chk(!/no catch-?up needed|we start from today/i.test(body),
+    "…no refusal and no start-from-today language", JSON.stringify(body.slice(0, 140)));
+  chk(!/lunch was|for lunch you had/i.test(body), "…the unknown lunch stays unknown",
+    JSON.stringify((body.match(/[^\n]*lunch[^\n]*/) || ["(not mentioned)"])[0]));
+
+  // GATE 3 ITSELF. The client asked what to do TODAY.
+  const closing = body.trim().split("\n").filter(l => l.trim()).slice(-1)[0] || "";
+  chk(!/scale (tomorrow|tonight)|tomorrow morning/i.test(closing),
+    "the closing answer is not a task for another day", JSON.stringify(closing));
+  chk(closing.trim().length > 0 && !/next move stays small\.?$/i.test(closing),
+    "…and it is not an empty hold — the turn ends on a move, not on an acknowledgement",
+    JSON.stringify(closing));
+  chk(!body.includes(REACTIVE_OUTBOUND_REPAIR), "…and the body is not the generic repair",
+    JSON.stringify(body.slice(0, 90)));
+}
+
+REAL("\n=== 6 · CONTROL — A SPARSE NON-DIRECTION TURN KEEPS ITS INVESTIGATION ===");
+{
+  // #203 is narrowed for one case, not disabled. A client who did NOT ask what to do today must
+  // still meet the investigation ladder exactly as before — otherwise this cut has quietly turned
+  // the sparse-client downgrade off for everyone.
+  const { underPolicy } = await import("../server/one-action");
+  const base = { kind: "protein", todo: "Make your next meal a proper protein meal.", why: "x" } as any;
+  const optsNoAsk = { foodSufficient: false, weightSufficient: false, loggedToday: true,
+    daysSinceWeighIn: null as number | null, hour: 19 };
+  const investigated = underPolicy(base, optsNoAsk);
+  chk(investigated.kind === "weigh",
+    "CONTROL: without a today-question the ladder still downgrades to the weigh investigation",
+    JSON.stringify({ kind: investigated.kind, todo: investigated.todo }));
+
+  const asked = underPolicy(base, { ...optsNoAsk, asksAboutToday: true });
+  chk(asked.kind !== "weigh" || !/tomorrow/i.test(String(asked.todo || "")),
+    "…and with one, it is not answered with a tomorrow-only weigh",
+    JSON.stringify({ kind: asked.kind, todo: asked.todo }));
+
+  // …and before midday the weigh is unchanged, because then it IS today's job.
+  const morning = underPolicy(base, { ...optsNoAsk, hour: 8, asksAboutToday: true });
+  chk(morning.kind === "weigh" && /this morning/i.test(String(morning.todo || "")),
+    "CONTROL: before midday a today-question still gets the weigh, worded for today",
+    JSON.stringify({ kind: morning.kind, todo: morning.todo }));
+}
+
 REAL(`\n${failed === 0
   ? "pg-missed-session-outbound-acceptance: GREEN — all checks passed"
   : `pg-missed-session-outbound-acceptance: RED — ${failed} check(s) failed`}`);

--- a/script/pg-missed-session-outbound-acceptance.ts
+++ b/script/pg-missed-session-outbound-acceptance.ts
@@ -1,0 +1,192 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the missed-session answer survives the outbound floor (#233).
+ *
+ * THE LIVE FAILURE, on 06330d2. A client typed "I didn't train" and received:
+ *
+ *     "Let me check that properly before I answer — give me one sec and ask me again."
+ *
+ * …and on repeating themselves, the duplicate-meta reply. The truthful owner had composed the
+ * right answer and the outbound truth floor threw it away:
+ *
+ *     enforceOutboundTruth -> session_count_contradicts_record: "said 1, record holds 0 in 7 days"
+ *
+ * THE CAUSE, and it is one word. `SESSION_COUNT` permits up to two filler words between a number
+ * and the noun, so "3 gym sessions this week" reads. That window also admits the word that
+ * REVERSES the claim: "**One missed session**" extracted as a claim of 1 session completed, which
+ * the record denied. The floor was right that no session happened; the sentence was saying so.
+ *
+ * A second, independent block sat behind it: the same reply states "You have 8 sessions
+ * completed", a LIFETIME figure, checked against a SEVEN-DAY record. #221 already settled how a
+ * lifetime number must read — "8 sessions overall" — and the floor already knows four other
+ * lifetime markers. It did not know that one.
+ *
+ * GRADED ON THE BODY AFTER TRANSPORT. `processTextAsync` is the reactive path that calls
+ * sendFinal → prepareOutbound → the floor, so these checks read what the client would actually
+ * receive. Calling handleMessage alone proves only what a handler intended, which is precisely the
+ * gap that let this ship: the handler's return was correct the whole time.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-missed-session-outbound-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { processTextAsync } = await import("../server/routes/whatsapp");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+const { REACTIVE_OUTBOUND_REPAIR } = await import("../server/outbound-authority");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const midday = (n: number) => {
+  const key = new Intl.DateTimeFormat("en-CA", { timeZone: "Africa/Johannesburg" })
+    .format(new Date(Date.now() - n * 86_400_000));
+  return new Date(`${key}T12:00:00+02:00`);
+};
+
+const ids: string[] = [];
+async function client(name: string, over: Record<string, any> = {}) {
+  const phone = `whatsapp:+2791${String(Math.floor(Math.random() * 900000) + 100000)}`;
+  const [u] = await db.insert(schema.users).values({
+    phoneNumber: phone, name, onboardingState: "COMPLETE", subscriptionStatus: "active",
+    popiConsent: true, popiConsentAt: new Date(), goalType: "fat_loss",
+    calorieTarget: 2200, proteinTarget: 150, stepsTarget: 8000, trainingMode: "gym",
+    trainingDaysPerWeek: 3, currentWeight: "84.0", heightCm: 178, gender: "male", age: 35,
+    weeklyFoodBudget: "300_600", totalWorkoutsCompleted: 8,
+    programmeStartDate: midday(30), programmeWeek: 3, programmeDayInWeek: 2, programmePhase: 1,
+    lastActiveAt: new Date(), ...over,
+  } as any).returning();
+  ids.push(u.id);
+  return { id: u.id, phone };
+}
+
+/** THE BODY AFTER TRANSPORT — sendFinal's own output, read off the shadow door. */
+async function outbound(phone: string, text: string): Promise<string> {
+  await pool.query("DELETE FROM shadow_replies").catch(() => {});
+  await processTextAsync(phone, text, null, null, [], handleMessage as any,
+    `SM-${Math.random().toString(36).slice(2, 10)}`);
+  const { rows } = await pool.query<{ body: string }>("SELECT body FROM shadow_replies ORDER BY id ASC")
+    .catch(() => ({ rows: [] as any[] }));
+  return rows.map(r => r.body).join("\n\n");
+}
+
+/** An instruction to train TODAY — the thing a rest/miss answer must never contain. */
+const TRAIN_TODAY = /\b(?:do|get|finish|start|complete|hit)\b[^.!?\n]{0,40}\b(?:today'?s session|today'?s workout)\b|\b(?:train|get to the gym)\b[^.!?\n]{0,30}\b(?:today|tonight)\b/i;
+const DUPLICATE_META = /gave you the same answer twice/i;
+
+REAL("\n=== 1 · \"I didn't train\" REACHES THE CLIENT ===");
+{
+  _resetOutboundDedupe();
+  const c = await client("Sipho");
+  const body = await outbound(c.phone, "I didn't train");
+
+  chk(body.length > 0, "the turn produced an outbound body", JSON.stringify(body.slice(0, 80)));
+  chk(!body.includes(REACTIVE_OUTBOUND_REPAIR),
+    "it is NOT the generic outbound repair", JSON.stringify(body.slice(0, 120)));
+  chk(!DUPLICATE_META.test(body), "…and not the duplicate-meta reply", JSON.stringify(body.slice(0, 120)));
+  chk(/miss(ed)?/i.test(body), "…it acknowledges the missed session",
+    JSON.stringify(body.split("\n")[0]));
+  chk(/pick the time|when you train next/i.test(body),
+    "…and gives one valid next move", JSON.stringify(body.slice(-90)));
+  chk(!TRAIN_TODAY.test(body), "…without instructing them to train TODAY",
+    JSON.stringify(body.slice(0, 200)));
+
+  // The lifetime figure is stated AS lifetime — #221's settled rule, and the second block here.
+  chk(!/\d+ sessions completed/i.test(body),
+    "…and its lifetime count does not read as a seven-day claim",
+    JSON.stringify((body.match(/[^\n]*sessions[^\n]*/) || [""])[0]));
+}
+
+REAL("\n=== 2 · REPEATING IT IS NOT PUNISHED FOR THE FIRST ANSWER BEING BLOCKED ===");
+{
+  // Requirement 4 exactly: the duplicate floor is a real safety rule and stays. What must not
+  // happen is a client meeting it because the FIRST answer never went out. Once the first answer
+  // is delivered, a later identical turn outside the dedupe window gets the same real answer.
+  _resetOutboundDedupe();
+  const c = await client("Naledi");
+  const first = await outbound(c.phone, "I didn't train");
+  chk(!first.includes(REACTIVE_OUTBOUND_REPAIR), "the first answer is delivered, not repaired",
+    JSON.stringify(first.slice(0, 90)));
+
+  _resetOutboundDedupe();                       // a later turn, outside the dedupe window
+  const later = await outbound(c.phone, "I didn't train");
+  chk(!later.includes(REACTIVE_OUTBOUND_REPAIR) && !DUPLICATE_META.test(later),
+    "…and saying it again later gets the real answer, not a meta-reply about repetition",
+    JSON.stringify(later.slice(0, 120)));
+}
+
+REAL("\n=== 3 · CONTROL — THE TRUTH FLOOR STILL BLOCKS A REAL FALSE CLAIM ===");
+{
+  // The opposite defect. Loosening the floor until a genuine overstatement passes would satisfy
+  // every check above. A claim that sessions WERE completed, against a record holding none, must
+  // still be refused — that is the rule this cut narrows, not the rule it removes.
+  const { enforceOutboundTruth } = await import("../server/outbound-authority");
+  const c = await client("Thabo");
+  const lie = await enforceOutboundTruth(c.id, c.phone,
+    "Strong week — you got 4 sessions done. Keep that going.", null);
+  chk(lie.ok === false && lie.reason === "session_count_contradicts_record",
+    "CONTROL: a completed-session count the record denies is still blocked", JSON.stringify(lie));
+
+  const miss = await enforceOutboundTruth(c.id, c.phone,
+    "One missed session — that is all it is.", null);
+  chk(miss.ok === true, "…while a count of MISSES is not read as a claim of sessions done",
+    JSON.stringify(miss));
+}
+
+REAL("\n=== 4 · THE PEAR AND THE MESSY CATCH-UP ARE UNCHANGED ===");
+{
+  _resetOutboundDedupe();
+  const c = await client("Zanele");
+  const pear = await outbound(c.phone, "I had a pear");
+  chk(!pear.includes(REACTIVE_OUTBOUND_REPAIR), "the pear turn still reaches the client",
+    JSON.stringify(pear.slice(0, 90)));
+  chk(!/breakfast|lunch|dinner|supper/i.test(pear),
+    "…and still invents no meal slot (#234 holding at the outbound body)",
+    JSON.stringify(pear.slice(0, 140)));
+
+  _resetOutboundDedupe();
+  const b = await client("Bonolo", { lastActiveAt: midday(4) });
+  const catchup = await outbound(b.phone,
+    "I'm back after a few days. Saturday breakfast I had eggs and rice. Sunday I walked 6400 steps "
+    + "and I can't remember lunch. Monday I felt flat because work was chaos, but I did the workout "
+    + "you told me to do. Today breakfast I had pap and chicken. What should I do today?");
+  chk(!catchup.includes(REACTIVE_OUTBOUND_REPAIR), "the four-day catch-up still reaches the client",
+    JSON.stringify(catchup.slice(0, 90)));
+  chk(!/no catch-?up needed|we start from today/i.test(catchup),
+    "…with no refusal and no start-from-today language", JSON.stringify(catchup.slice(0, 140)));
+  chk(!/lunch was|for lunch you had/i.test(catchup), "…and the unknown lunch stays unknown",
+    JSON.stringify((catchup.match(/[^\n]*lunch[^\n]*/) || ["(not mentioned)"])[0]));
+}
+
+REAL(`\n${failed === 0
+  ? "pg-missed-session-outbound-acceptance: GREEN — all checks passed"
+  : `pg-missed-session-outbound-acceptance: RED — ${failed} check(s) failed`}`);
+
+await pool.query("DELETE FROM shadow_replies").catch(() => {});
+for (const id of ids) {
+  for (const t of ["meal_logs", "step_logs", "weight_logs", "workout_logs", "chat_history",
+                   "turn_ledger", "client_understanding", "daily_constraints"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [id]).catch(() => {});
+  }
+  await pool.query(`DELETE FROM users WHERE id = $1`, [id]).catch(() => {});
+}
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-233-outbound.sh
+++ b/script/red-on-revert-233-outbound.sh
@@ -39,6 +39,27 @@ s=s.replace("export function adjudicableSessionCounts(text: string): number[] {"
             "export function adjudicableSessionCounts(text: string): number[] {\n  return [];")
 assert s!=b, "no match"; open(p,"w").write(s)
 PY
+cat > /tmp/233p/5.py <<'PY2'
+# Gate 3: the ladder rung may answer a today-question with a tomorrow-only weigh again.
+p="server/one-action.ts"; s=open(p).read(); b=s
+s=s.replace("  if (!scaleIsOffLimits && !(s.asksAboutToday && weighWouldBeTomorrow)\n      && ((neverWeighed",
+            "  if (!scaleIsOffLimits\n      && ((neverWeighed")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY2
+cat > /tmp/233p/6.py <<'PY2'
+# Gate 3: the investigation ladder may do the same.
+p="server/one-action.ts"; s=open(p).read(); b=s
+s=s.replace("    && !(ctx.asksAboutToday && ctx.hour >= WEIGH_ACTIONABLE_BEFORE_HOUR)\n","")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY2
+cat > /tmp/233p/7.py <<'PY2'
+# Gate 3: a hold goes back to answering a direct question with silence.
+p="server/understanding/live.ts"; s=open(p).read(); b=s
+s=s.replace('todo: act.kind === "hold" && !asksAboutToday ? "" : act.todo,', 'todo: act.kind === "hold" ? "" : act.todo,')
+s=s.replace('const rendered = act.kind === "hold" && !asksAboutToday\n      ? "" : formatOneAction(act, getDisplayName(user) || undefined);',
+            'const rendered = act.kind === "hold" ? "" : formatOneAction(act, getDisplayName(user) || undefined);')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY2
 echo "=============================================================================="
 echo "#233 outbound — RED ON REVERT"
 echo "=============================================================================="
@@ -46,4 +67,7 @@ run_case "a miss is read as a completed session again"            /tmp/233p/1.py
 run_case "the lifetime figure says 'completed' again"             /tmp/233p/2.py
 run_case "the floor no longer knows 'overall' is lifetime"        /tmp/233p/3.py
 run_case "the floor stops judging session counts (opposite defect)" /tmp/233p/4.py
+run_case "a today-question is answered with a tomorrow-only weigh again"  /tmp/233p/5.py
+run_case "the investigation ladder does the same"                        /tmp/233p/6.py
+run_case "a hold answers a direct question with silence again"           /tmp/233p/7.py
 echo "=============================================================================="

--- a/script/red-on-revert-233-outbound.sh
+++ b/script/red-on-revert-233-outbound.sh
@@ -40,24 +40,18 @@ s=s.replace("export function adjudicableSessionCounts(text: string): number[] {"
 assert s!=b, "no match"; open(p,"w").write(s)
 PY
 cat > /tmp/233p/5.py <<'PY2'
-# Gate 3: the ladder rung may answer a today-question with a tomorrow-only weigh again.
+# Gate 3, mechanism 1: the ladder rung answers a today-question with a tomorrow-only weigh again,
+# masking the fuelling rung below it.
 p="server/one-action.ts"; s=open(p).read(); b=s
 s=s.replace("  if (!scaleIsOffLimits && !(s.asksAboutToday && weighWouldBeTomorrow)\n      && ((neverWeighed",
             "  if (!scaleIsOffLimits\n      && ((neverWeighed")
 assert s!=b, "no match"; open(p,"w").write(s)
 PY2
 cat > /tmp/233p/6.py <<'PY2'
-# Gate 3: the investigation ladder may do the same.
+# Gate 3, mechanism 2: the today-action precedence is removed, so the #203 downgrade replaces the
+# fuelling rung with an investigation even when the client asked what to do today.
 p="server/one-action.ts"; s=open(p).read(); b=s
-s=s.replace("    && !(ctx.asksAboutToday && ctx.hour >= WEIGH_ACTIONABLE_BEFORE_HOUR)\n","")
-assert s!=b, "no match"; open(p,"w").write(s)
-PY2
-cat > /tmp/233p/7.py <<'PY2'
-# Gate 3: a hold goes back to answering a direct question with silence.
-p="server/understanding/live.ts"; s=open(p).read(); b=s
-s=s.replace('todo: act.kind === "hold" && !asksAboutToday ? "" : act.todo,', 'todo: act.kind === "hold" ? "" : act.todo,')
-s=s.replace('const rendered = act.kind === "hold" && !asksAboutToday\n      ? "" : formatOneAction(act, getDisplayName(user) || undefined);',
-            'const rendered = act.kind === "hold" ? "" : formatOneAction(act, getDisplayName(user) || undefined);')
+s=s.replace("    if ((futureOnlyWeigh || saysNothing) && String(action.todo || \"\").trim()) return action;\n","")
 assert s!=b, "no match"; open(p,"w").write(s)
 PY2
 echo "=============================================================================="
@@ -67,7 +61,6 @@ run_case "a miss is read as a completed session again"            /tmp/233p/1.py
 run_case "the lifetime figure says 'completed' again"             /tmp/233p/2.py
 run_case "the floor no longer knows 'overall' is lifetime"        /tmp/233p/3.py
 run_case "the floor stops judging session counts (opposite defect)" /tmp/233p/4.py
-run_case "a today-question is answered with a tomorrow-only weigh again"  /tmp/233p/5.py
-run_case "the investigation ladder does the same"                        /tmp/233p/6.py
-run_case "a hold answers a direct question with silence again"           /tmp/233p/7.py
+run_case "the weigh rung masks the fuelling rung on a today-question"    /tmp/233p/5.py
+run_case "the today-action precedence is removed"                       /tmp/233p/6.py
 echo "=============================================================================="

--- a/script/red-on-revert-233-outbound.sh
+++ b/script/red-on-revert-233-outbound.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — #233 outbound, one mechanism at a time.
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-missed-session-outbound-acceptance.ts
+run_case () {
+  local name="$1" patch="$2"
+  cp -r server /tmp/233-server-backup
+  python3 "$patch" || { echo "  !! patch failed: $name"; rm -rf /tmp/233-server-backup; return 1; }
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^pg-missed-session-outbound-acceptance:' || echo '(no verdict — crashed)')"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4
+  rm -rf server && mv /tmp/233-server-backup server
+}
+mkdir -p /tmp/233p
+cat > /tmp/233p/1.py <<'PY'
+p="server/brain/reply-verifier.ts"; s=open(p).read(); b=s
+s=s.replace(" && !isMissClaim(seg)","")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+cat > /tmp/233p/2.py <<'PY'
+p="server/handlers/lifecycle.ts"; s=open(p).read(); b=s
+s=s.replace("You have ${total} sessions overall.","You have ${total} sessions completed.")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+cat > /tmp/233p/3.py <<'PY'
+p="server/brain/reply-verifier.ts"; s=open(p).read(); b=s
+s=s.replace(r"|\baltogether\b|\boverall\b|\blifetime\b", r"|\baltogether\b|\blifetime\b")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+cat > /tmp/233p/4.py <<'PY'
+# OPPOSITE DEFECT: the floor stops judging session counts at all. Every "must not be repaired"
+# check passes and the product loses the rule that stops it overstating a client's training.
+p="server/brain/reply-verifier.ts"; s=open(p).read(); b=s
+s=s.replace("export function adjudicableSessionCounts(text: string): number[] {",
+            "export function adjudicableSessionCounts(text: string): number[] {\n  return [];")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+echo "=============================================================================="
+echo "#233 outbound — RED ON REVERT"
+echo "=============================================================================="
+run_case "a miss is read as a completed session again"            /tmp/233p/1.py
+run_case "the lifetime figure says 'completed' again"             /tmp/233p/2.py
+run_case "the floor no longer knows 'overall' is lifetime"        /tmp/233p/3.py
+run_case "the floor stops judging session counts (opposite defect)" /tmp/233p/4.py
+echo "=============================================================================="

--- a/server/brain/reply-verifier.ts
+++ b/server/brain/reply-verifier.ts
@@ -356,12 +356,39 @@ function withoutTargetSegments(reply: string): string {
 export function adjudicableSessionCounts(text: string): number[] {
   return String(text || "")
     .split(/(\n+|(?<=[.!?])\s+)/)
-    .filter(seg => !OUT_OF_WINDOW.test(seg) && !TARGET_MARKER.test(seg))
+    .filter(seg => !OUT_OF_WINDOW.test(seg) && !TARGET_MARKER.test(seg) && !isMissClaim(seg))
     // "2/4 sessions" — keep the numerator, drop the denominator. The trailing space matters:
     // without it "2/4" would become "24".
     .map(seg => seg.replace(/(\d{1,2})\s*\/\s*\d{1,2}/g, "$1 "))
     .flatMap(seg => sessionCountsIn(seg));
 }
+
+/**
+ * A COUNT OF MISSES IS NOT A COUNT OF SESSIONS (#233).
+ *
+ * `SESSION_COUNT` allows up to two filler words between the number and the noun, so that
+ * "3 gym sessions this week" and "2 hard sessions" both read. That window also admits the word
+ * that REVERSES the claim: "One missed session" extracted as 1, the floor compared it to a record
+ * holding 0 completed in seven days, and blocked the message.
+ *
+ * The client had just said "I didn't train". The reply was the truthful missed-session response —
+ * the one owner that exists for exactly this turn — and the truth floor rejected it for asserting
+ * a session that had happened, when the sentence says the opposite. The client received
+ * REACTIVE_OUTBOUND_REPAIR instead, and on repeating themselves got the duplicate-meta reply,
+ * because the first answer had been wrongly blocked rather than wrongly written.
+ *
+ * This belongs here and not in the extractor: `sessionCountsIn` answers "what session numbers
+ * appear", which is deliberately not "what does this message CLAIM" — the distinction this
+ * function was created to draw. The floor keeps its full strength over every real completion
+ * claim; it stops reading a miss as one.
+ */
+const NOT_A_COMPLETION = new Set([
+  "missed", "miss", "misses", "missing", "skipped", "skip", "skipping",
+  "lost", "dropped", "cancelled", "canceled",
+]);
+/** A closed token set, not a pattern — the same shape #234 used, and it costs no regex budget. */
+const isMissClaim = (seg: string): boolean =>
+  seg.toLowerCase().split(/[^a-z]+/).some(w => NOT_A_COMPLETION.has(w));
 
 /**
  * DOES THIS CLAIM NAME A WINDOW WE MEASURED? One question, one owner (merged 2026-08-22).
@@ -373,7 +400,7 @@ export function adjudicableSessionCounts(text: string): number[] {
  * matcher gave each rule half a guard — the step rule could not see "this month" and the session
  * rule could not see "this morning" — so it is one list of the windows we do not hold.
  */
-const OUT_OF_WINDOW = /\b(?:before|after|by)\s+(?:lunch|breakfast|dinner|noon|midday|\d{1,2}\s?(?:am|pm))\b|\bthis (?:morning|afternoon|evening)\b|\bin the (?:morning|afternoon|evening)\b|\bper hour\b|\bsince (?:lunch|breakfast|this morning)\b|\b(?:this|last|the past|next)\s+month\b|\bin total\b|\ball[\s-]?time\b|\bsince you (?:started|began|joined)\b|\bthis year\b|\baltogether\b|\blifetime\b|\bin the bank\b|\btotal\s+(?:workouts?|sessions?|trainings?)\b/i;
+const OUT_OF_WINDOW = /\b(?:before|after|by)\s+(?:lunch|breakfast|dinner|noon|midday|\d{1,2}\s?(?:am|pm))\b|\bthis (?:morning|afternoon|evening)\b|\bin the (?:morning|afternoon|evening)\b|\bper hour\b|\bsince (?:lunch|breakfast|this morning)\b|\b(?:this|last|the past|next)\s+month\b|\bin total\b|\ball[\s-]?time\b|\bsince you (?:started|began|joined)\b|\bthis year\b|\baltogether\b|\boverall\b|\blifetime\b|\bin the bank\b|\btotal\s+(?:workouts?|sessions?|trainings?)\b/i;
 
 function verifyStepAttribution(reply: string, clientMessage: string, evidence?: VerifierFacts["evidence"]): VerifierResult {
   const replySteps = extractStepNumbers(withoutTargetSegments(reply));

--- a/server/handlers/lifecycle.ts
+++ b/server/handlers/lifecycle.ts
@@ -1365,7 +1365,7 @@ export async function handleLifecycle(ctx: {
   } else if (isMissedWorkout) {
     const name = spaceName(user);
     const total = user.totalWorkoutsCompleted || 0;
-    const missedReply = `One missed session${name} — that is all it is.\n\n${total > 0 ? `You have ${total} sessions completed. One miss does not erase that.` : "Getting back on track starts now."}\n\n*The rule:* Never miss twice. One miss is life. Two misses in a row is the start of a habit.\n\n*What to do right now:*\nDecide when you train next — not "tomorrow maybe", give me the specific time. 6am? 12pm? After work at 5pm?\n\nThat is your only job. Pick the time.`;
+    const missedReply = `One missed session${name} — that is all it is.\n\n${total > 0 ? `You have ${total} sessions overall. One miss does not erase that.` : "Getting back on track starts now."}\n\n*The rule:* Never miss twice. One miss is life. Two misses in a row is the start of a habit.\n\n*What to do right now:*\nDecide when you train next — not "tomorrow maybe", give me the specific time. 6am? 12pm? After work at 5pm?\n\nThat is your only job. Pick the time.`;
     await logChat(user.id, message, missedReply, "MISSED_WORKOUT");
     return missedReply;
   }

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -1010,7 +1010,7 @@ export function underPolicy(
     loggedToday: opts.loggedToday ?? true,
     daysSinceWeighIn: opts.daysSinceWeighIn === undefined ? 0 : opts.daysSinceWeighIn,
     doNotMention: opts.doNotMention, dreamGoal: opts.dreamGoal, hour: opts.hour ?? 8,
-    trainingAwaitingOutcome: opts.trainingAwaitingOutcome, asksAboutToday: opts.asksAboutToday,
+    trainingAwaitingOutcome: opts.trainingAwaitingOutcome,
   });
 
   // A QUESTION ABOUT TODAY MUST GET AN ANSWER ABOUT TODAY (#233 Gate 3).
@@ -1056,15 +1056,12 @@ export function underPolicy(
 function investigateInstead(ctx: {
   foodSufficient: boolean; weightSufficient: boolean; loggedToday: boolean;
   daysSinceWeighIn: number | null; doNotMention?: string | null; dreamGoal?: string | null;
-  hour: number; trainingAwaitingOutcome?: boolean; asksAboutToday?: boolean;
+  hour: number; trainingAwaitingOutcome?: boolean;
 }): OneAction {
   if (ctx.trainingAwaitingOutcome) return holdAction(ctx.dreamGoal);
   const canAskForFood = !ctx.foodSufficient && !ctx.loggedToday;
   const staleWeight = ctx.daysSinceWeighIn === null || ctx.daysSinceWeighIn >= 3;
-  // …and it must be askable TODAY when today is what was asked (#233 Gate 3), for the same
-  // reason as the ladder rung above.
   const canAskForWeight = !ctx.weightSufficient && staleWeight
-    && !(ctx.asksAboutToday && ctx.hour >= WEIGH_ACTIONABLE_BEFORE_HOUR)
     && !mentionsForbidden("weight scale weigh", ctx.doNotMention);
   return canAskForFood ? askToLog(ctx.dreamGoal)
     : canAskForWeight ? askToWeigh(ctx.dreamGoal, ctx.daysSinceWeighIn === null, ctx.hour)

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -71,6 +71,11 @@ export interface DayState {
    */
   atKeyboard?: boolean;
   /**
+   * The client asked, in this turn, what to do TODAY (#233 Gate 3). Read by the rungs that can
+   * only offer a future date, so a question about today is never answered with another day.
+   */
+  asksAboutToday?: boolean;
+  /**
    * What is going on in their life, in their own words — "night shift", "just had a baby",
    * "retrenched". A durable fact from users.life_context (Cut 7), not an inference.
    *
@@ -248,14 +253,22 @@ function holdAction(dream?: string | null): OneAction {
   };
 }
 
+/**
+ * THE HOUR AFTER WHICH A FIRST-THING WEIGH-IN IS NO LONGER TODAY'S JOB. Named once because two
+ * places depend on it: this action's own wording, and the gate that decides whether it may be the
+ * ANSWER to a question about today.
+ */
+export const WEIGH_ACTIONABLE_BEFORE_HOUR = 12;
+
 function askToWeigh(dream?: string | null, neverWeighed = false, hour = 8): OneAction {
+  const forTomorrow = hour >= WEIGH_ACTIONABLE_BEFORE_HOUR;
   return {
     kind: "weigh",
-    todo: `Stand on a scale ${hour >= 12 ? "tomorrow morning" : "this morning"}, before you eat.`,
+    todo: `Stand on a scale ${forTomorrow ? "tomorrow morning" : "this morning"}, before you eat.`,
     why: why(
       neverWeighed
         ? "It's one number and it's the only way either of us sees this working."
-        : `It's been a while — one number ${hour >= 12 ? "tomorrow morning" : "today"} and I can show you what's actually happening.`,
+        : `It's been a while — one number ${forTomorrow ? "tomorrow morning" : "today"} and I can show you what's actually happening.`,
       dream,
     ),
     investigation: { missingFact: "weight_current", whyItMatters: "The weight evidence is missing or stale." },
@@ -581,7 +594,16 @@ export function chooseAction(s: DayState): OneAction {
   //    outcomes data — a client with no weigh-in is one we can never prove we helped.
   const neverWeighed = s.daysSinceWeighIn === null;
   const scaleIsOffLimits = mentionsForbidden("weight scale weigh", s.doNotMention);
-  if (!scaleIsOffLimits && ((neverWeighed && s.weeksOnProgramme >= 1) || (s.daysSinceWeighIn !== null && s.daysSinceWeighIn >= 10))) {
+  //    …BUT NOT AS THE ANSWER TO "WHAT SHOULD I DO TODAY" (#233 Gate 3). askToWeigh words itself
+  //    honestly for the clock — a first-thing weigh-in cannot happen retroactively, so after
+  //    midday it asks for TOMORROW morning. Correct as a nudge, wrong as an answer: a four-day
+  //    catch-up ending "What should I do today?" closed on "Stand on a scale tomorrow morning",
+  //    and every rung below that might have given them something to do today was skipped to say
+  //    it. Before midday this is unchanged and still outranks fuelling and steps; the morning and
+  //    proactive paths never set this flag at all.
+  const weighWouldBeTomorrow = s.hour >= WEIGH_ACTIONABLE_BEFORE_HOUR;
+  if (!scaleIsOffLimits && !(s.asksAboutToday && weighWouldBeTomorrow)
+      && ((neverWeighed && s.weeksOnProgramme >= 1) || (s.daysSinceWeighIn !== null && s.daysSinceWeighIn >= 10))) {
     return askToWeigh(s.dreamGoal, neverWeighed, s.hour);
   }
 
@@ -951,6 +973,8 @@ export function underPolicy(
     stalledWeeks?: number; trainingAwaitingOutcome?: boolean;
     foodDayClosed?: boolean; trainingDeclined?: boolean; weekendInvestigationAnswered?: boolean;
     weightIsGoal?: boolean;
+    /** The client asked, in this turn, what to do TODAY. See the gate below. */
+    asksAboutToday?: boolean;
   },
 ): OneAction {
   const asksUsefulWeekendFact = action.kind !== "rest" && action.kind !== "weigh"
@@ -981,13 +1005,37 @@ export function underPolicy(
   // and we did not ask". That is the receipt-only dead end, and the ladder below already knows
   // what to ask; it was simply never consulted from here.
   if (!PRESCRIPTIVE.has(action.kind) && action.kind !== "hold") return action;
-  return investigateInstead({
+  const investigation = investigateInstead({
     foodSufficient: opts.foodSufficient, weightSufficient: opts.weightSufficient,
     loggedToday: opts.loggedToday ?? true,
     daysSinceWeighIn: opts.daysSinceWeighIn === undefined ? 0 : opts.daysSinceWeighIn,
     doNotMention: opts.doNotMention, dreamGoal: opts.dreamGoal, hour: opts.hour ?? 8,
-    trainingAwaitingOutcome: opts.trainingAwaitingOutcome,
+    trainingAwaitingOutcome: opts.trainingAwaitingOutcome, asksAboutToday: opts.asksAboutToday,
   });
+
+  // A QUESTION ABOUT TODAY MUST GET AN ANSWER ABOUT TODAY (#233 Gate 3).
+  //
+  // The downgrade above is right for a nudge: when the evidence cannot carry a prescription, ask
+  // for the measurement instead of inventing one. But it has only three answers — log, weigh, or
+  // hold — and when the client is ASKING what to do today, two of them are not answers:
+  //
+  //   a weigh after midday   askToWeigh words itself honestly for the clock, so it says TOMORROW
+  //                          morning. A four-day catch-up ending "What should I do today?" closed
+  //                          on "Stand on a scale tomorrow morning, before you eat."
+  //   a hold with no todo    silence dressed as a decision. The client asked and got nothing.
+  //
+  // In that case the ladder's own answer — already computed, already today-scoped, and reached by
+  // the same evidence rules everything else uses — is the better one, so it stands. This does not
+  // disable #203: the downgrade still governs every nudge and every turn that is not a direct
+  // question about today, and the weigh is unchanged for the mornings when it IS today's job. It
+  // narrows one case, and only when the alternative is a future date or nothing at all.
+  if (opts.asksAboutToday) {
+    const futureOnlyWeigh = investigation.kind === "weigh"
+      && (opts.hour ?? 8) >= WEIGH_ACTIONABLE_BEFORE_HOUR;
+    const saysNothing = !String(investigation.todo || "").trim();
+    if ((futureOnlyWeigh || saysNothing) && String(action.todo || "").trim()) return action;
+  }
+  return investigation;
 }
 
 /**
@@ -1008,12 +1056,15 @@ export function underPolicy(
 function investigateInstead(ctx: {
   foodSufficient: boolean; weightSufficient: boolean; loggedToday: boolean;
   daysSinceWeighIn: number | null; doNotMention?: string | null; dreamGoal?: string | null;
-  hour: number; trainingAwaitingOutcome?: boolean;
+  hour: number; trainingAwaitingOutcome?: boolean; asksAboutToday?: boolean;
 }): OneAction {
   if (ctx.trainingAwaitingOutcome) return holdAction(ctx.dreamGoal);
   const canAskForFood = !ctx.foodSufficient && !ctx.loggedToday;
   const staleWeight = ctx.daysSinceWeighIn === null || ctx.daysSinceWeighIn >= 3;
+  // …and it must be askable TODAY when today is what was asked (#233 Gate 3), for the same
+  // reason as the ladder rung above.
   const canAskForWeight = !ctx.weightSufficient && staleWeight
+    && !(ctx.asksAboutToday && ctx.hour >= WEIGH_ACTIONABLE_BEFORE_HOUR)
     && !mentionsForbidden("weight scale weigh", ctx.doNotMention);
   return canAskForFood ? askToLog(ctx.dreamGoal)
     : canAskForWeight ? askToWeigh(ctx.dreamGoal, ctx.daysSinceWeighIn === null, ctx.hour)

--- a/server/one-action.ts
+++ b/server/one-action.ts
@@ -647,10 +647,14 @@ export function chooseAction(s: DayState): OneAction {
     // is still short, so the move goes forward from what they did.
     return {
       kind: "protein",
+      // THE MOVE IS AN INSTRUCTION, NOT A RECEIPT (#233 Gate 3). "That's one proper protein down —
+      // same again at your next meal" reads as a summary of what already happened; a client who
+      // asked what to do today has to find the instruction inside it. Same rung, same evidence,
+      // same clock rule — it now says the thing to do first and names itself as the one move.
       todo: s.justAteProteinMeal
         ? (closingTheDay
             ? "That's one proper protein down — start tomorrow the same way."
-            : "That's one proper protein down — same again at your next meal.")
+            : "For today, make your next meal another proper protein meal. That's your one move.")
         : closingTheDay
         ? eat("eggs, amasi or tin fish", "sugar beans, lentils or peanuts",
             kept => `Start tomorrow with protein — ${kept} at breakfast.`,

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -175,17 +175,12 @@ export async function canonicalDecision(
     // renderer that already speaks in the coach's voice. No new vocabulary: formatOneAction is
     // what the morning brief has always used.
     const { formatOneAction } = await import("../one-action");
-    // A HOLD IS SILENCE UNLESS THEY ASKED (#233 Gate 3). "hold" means nothing needs changing,
-    // and as a nudge that is correctly said by saying nothing. As the answer to "What should I do
-    // today?" silence is not an answer — holdAction's own words ("Nothing new today. Do exactly
-    // what you did yesterday.") are the honest one, and are rendered by the same renderer.
-    const rendered = act.kind === "hold" && !asksAboutToday
-      ? "" : formatOneAction(act, getDisplayName(user) || undefined);
+    const rendered = act.kind === "hold" ? "" : formatOneAction(act, getDisplayName(user) || undefined);
 
     const { turnEvidence } = await import("../handlers/chat-log");
     turnEvidence({
       canonicalKind: act.kind,
-      canonicalTodo: act.kind === "hold" && !asksAboutToday ? null : act.todo,
+      canonicalTodo: act.kind === "hold" ? null : act.todo,
       canonicalReply: rendered || null,
       canonicalIntervention: act.intervention === "minimum_training" ? "minimum" : "standard",
       openLoopRef: openTraining?.ref || null,
@@ -201,7 +196,7 @@ export async function canonicalDecision(
     // because that fact stopped at this boundary. No extra query: these are the same two numbers
     // the caloriePct above is computed from.
     return {
-      todo: act.kind === "hold" && !asksAboutToday ? "" : act.todo, kind: act.kind, reply: rendered,
+      todo: act.kind === "hold" ? "" : act.todo, kind: act.kind, reply: rendered,
       day: { kcal: truth.today.kcal, kcalTarget: calTarget },
       investigation: act.investigation,
     };

--- a/server/understanding/live.ts
+++ b/server/understanding/live.ts
@@ -17,6 +17,8 @@
  * keeps growing.
  */
 
+import { looksLikeDirectionRequest } from "../daily-direction";
+import { clausesOf } from "./messy-intake";
 import { eq, desc, inArray, and, gte } from "drizzle-orm";
 import { db } from "../db";
 import { readHealthState } from "../health-state";
@@ -101,6 +103,10 @@ export async function canonicalDecision(
     const calTarget = Number(user.calorieTarget) || 0;
     const protTarget = Number(user.proteinTarget) || 0;
 
+    // THE CLIENT ASKED WHAT TO DO TODAY (#233 Gate 3). Read with the owner routes.ts already
+    // uses to decide the canonical close owns the question, on the same last clause, so the turn
+    // and the decision agree about what was asked.
+    const asksAboutToday = looksLikeDirectionRequest(clausesOf(message || "").slice(-1)[0] || message || "");
     const act = underPolicy(chooseAction({
       firstName: getDisplayName(user) || undefined,
       goal: (user.goalType as any) || "general",
@@ -119,6 +125,7 @@ export async function canonicalDecision(
       hour: sastHour(),
       // They are typing to us right now — this rides out on a reply, not as a nudge.
       atKeyboard: true,
+      asksAboutToday,
       // A CONSTRAINT OUTLIVES THE SENTENCE THAT STATED IT (2026-08-25, P0-4b). This read only the
       // CURRENT message, so a client who closed food at 12:00 and asked an unrelated question at
       // 19:00 was decided for as though they had never said it — the constraint expired at the end
@@ -154,6 +161,11 @@ export async function canonicalDecision(
          foodDayClosed: foodDayClosedWith(held.foodDayClosed, message || ""),
          trainingDeclined: held.trainingDeclined || trainingDayIsDeclined(message || ""),
          weightIsGoal: getGoalProfile(user.goalType).weightIsGoal,
+         // THE CLIENT ASKED WHAT TO DO TODAY (#233 Gate 3). Read with the same owner routes.ts
+         // uses to decide the canonical close owns the question, on the same last clause — so the
+         // turn that hands this decision the question and the decision itself agree about what
+         // was asked. The gate it feeds is in underPolicy.
+         asksAboutToday: looksLikeDirectionRequest(clausesOf(message || "").slice(-1)[0] || message || ""),
          weekendInvestigationAnswered: weekendInvestigationAnswered(user) });
 
     // RECORD THE PROVENANCE. The verifier needs to know what this turn's canonical decision was,
@@ -163,12 +175,17 @@ export async function canonicalDecision(
     // renderer that already speaks in the coach's voice. No new vocabulary: formatOneAction is
     // what the morning brief has always used.
     const { formatOneAction } = await import("../one-action");
-    const rendered = act.kind === "hold" ? "" : formatOneAction(act, getDisplayName(user) || undefined);
+    // A HOLD IS SILENCE UNLESS THEY ASKED (#233 Gate 3). "hold" means nothing needs changing,
+    // and as a nudge that is correctly said by saying nothing. As the answer to "What should I do
+    // today?" silence is not an answer — holdAction's own words ("Nothing new today. Do exactly
+    // what you did yesterday.") are the honest one, and are rendered by the same renderer.
+    const rendered = act.kind === "hold" && !asksAboutToday
+      ? "" : formatOneAction(act, getDisplayName(user) || undefined);
 
     const { turnEvidence } = await import("../handlers/chat-log");
     turnEvidence({
       canonicalKind: act.kind,
-      canonicalTodo: act.kind === "hold" ? null : act.todo,
+      canonicalTodo: act.kind === "hold" && !asksAboutToday ? null : act.todo,
       canonicalReply: rendered || null,
       canonicalIntervention: act.intervention === "minimum_training" ? "minimum" : "standard",
       openLoopRef: openTraining?.ref || null,
@@ -184,7 +201,7 @@ export async function canonicalDecision(
     // because that fact stopped at this boundary. No extra query: these are the same two numbers
     // the caloriePct above is computed from.
     return {
-      todo: act.kind === "hold" ? "" : act.todo, kind: act.kind, reply: rendered,
+      todo: act.kind === "hold" && !asksAboutToday ? "" : act.todo, kind: act.kind, reply: rendered,
       day: { kcal: truth.today.kcal, kcalTarget: calTarget },
       investigation: act.investigation,
     };


### PR DESCRIPTION
Closes the two live customer failures traced on `06330d2`.

## Failure 1 — "I didn't train" was blocked by the outbound truth floor

`enforceOutboundTruth` read `You have 8 sessions completed` out of the reply, checked that
figure against the 7-day window, found no support, and replaced the whole coaching turn with
the generic repair. The client asking for help after a missed session got a non-answer.

Two seams, each fixed in its existing owner:

- `server/brain/reply-verifier.ts` — `adjudicableSessionCounts` no longer adjudicates a
  segment that *claims a miss*. A closed token set (`NOT_A_COMPLETION`), the same shape #234
  used, so it costs no regex budget. `OUT_OF_WINDOW` gains `\boverall\b` beside
  `altogether|lifetime`.
- `server/handlers/lifecycle.ts:1368` — the lifetime figure now says `sessions overall`,
  not `sessions completed`. A lifetime total was being described in the words of a
  programme-window count, which is the same second-answer defect #221 closed.

The floor still blocks a genuinely false claim — CONTROL section 3 proves it.

## Failure 2 — Gate 3: a today-question answered with a tomorrow-action

A contentful multi-day catch-up ending in an explicit current-day direction question could be
answered with "stand on a scale tomorrow morning" — or with nothing at all.

- `server/one-action.ts` — the weigh boundary is named once
  (`WEIGH_ACTIONABLE_BEFORE_HOUR`). Rung 3 does not select a weigh action that can only land
  tomorrow when the client asked about today; `underPolicy` gives the today-scoped action
  precedence over a future-only weigh or an empty investigation. The fuelling rung's copy is
  now an instruction rather than a receipt: *"For today, make your next meal another proper
  protein meal. That's your one move."*
- `server/understanding/live.ts` — supplies the `asksAboutToday` signal from the last clause,
  through the existing `looksLikeDirectionRequest` owner. No new classifier.

## File-count discrepancy — please read before merging

The approval text describes **eight** reviewed files. The diff against `06330d2` contains
**ten**. The two extras are `script/pg-log-turn-acceptance.ts` and
`script/pg-food-constraint-mouths-acceptance.ts`, added in the final copy commit `30be0bb1`:
both pinned the literal string `"one proper protein down"`, which the ordered copy change
retires. Both were regraded to accept the *promise* rather than the phrase
(`/one proper protein down|another proper protein/i`). This was disclosed in that commit
message; it is surfaced here rather than merged past.

The same regrade class covers `script/gap-tests.ts` (`#128/4` and `cut8`). The `#128/4`
negative assertion — must not re-issue the instruction — was left untouched and still passes.

## Evidence

- New acceptance `script/pg-missed-session-outbound-acceptance.ts` — **29/29**, asserted
  **post-transport** through `processTextAsync` → `sendFinal` → `prepareOutbound`, because the
  claim is about what the client receives. Six sections, three of them controls.
- `script/red-on-revert-233-outbound.sh` — **6/6 red**, one case per mechanism, including two
  opposite-defect controls (floor stops judging counts; today-precedence removed).
- Full local gate: **37/37** suites, **25/25** PG acceptances, `tsc` clean.
- No governor budget raised. `regexLiterals` paid back with token sets.

## Not proven here

`#233` cannot be closed on this merge alone: both paths still need to pass on a *deployed*
SHA, and production replay access is unavailable from this environment (no `railway` CLI, no
`RAILWAY_*`/`TWILIO_*` credentials, no production `DATABASE_URL`; the agent proxy returns 403
CONNECT for `api.twilio.com` and both Railway hosts). Reported as `DEPLOYMENT_UNVERIFIED`
rather than substituted with local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_