### PR TITLE
Cut 1: record final outbound truth and answer repeats

### DIFF
--- a/migrations/0011_interaction_truth_boundary.sql
+++ b/migrations/0011_interaction_truth_boundary.sql
@@ -1,0 +1,28 @@
+-- CUT 1 — THE CUSTOMER-VISIBLE TRUTH BOUNDARY (2026-09-10).
+--
+-- turn_ledger has recorded what the HANDLERS decided since 2026-08-10. It has never recorded what
+-- the client actually received. Between recordTurn and Twilio sit marker rendering, the outbound
+-- truth floor, provenance, hygiene, the marker strip and the never-silent repairs — any of which
+-- can replace the body — and none of them left a trace.
+--
+-- Proven on 7833ebb before this migration was written:
+--   · ledger "…what do you need?[BUTTONS:Today's workout|Log food|My progress]"
+--     wire   "…what do you need?\n\n▸ *Today's workout*\n▸ *Log food*\n▸ *My progress*"
+--   · the same question asked twice: wire[1] was the outbound repair sentence, while BOTH ledger
+--     rows showed the correct coaching reply. The failure was structurally invisible.
+--
+-- Additive and idempotent: every statement is IF NOT EXISTS, no column is dropped, no existing
+-- column changes type or meaning, and every new column is nullable so rows written by the running
+-- build before this lands stay valid. Safe to apply to a live database with traffic on it.
+
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS root_id TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS input_text_canonical TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS decision JSONB;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS delivered_body TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS outbound_verdict JSONB;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS delivery_outcome TEXT;
+
+-- Correlation index. The transport finalises a row by its id, but every read that asks "what
+-- happened to this client message" starts from the root id, and a voice note produces two rows
+-- under one root.
+CREATE INDEX IF NOT EXISTS turn_ledger_root_idx ON turn_ledger (root_id);

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787600000000,
       "tag": "0010_daily_constraints",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787700000000,
+      "tag": "0011_interaction_truth_boundary",
+      "breakpoints": true
     }
   ]
 }

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -180,6 +180,14 @@ export const ACCEPTANCES: Acceptance[] = [
     // sendFinal, past every handler.
     command: ["npx", "tsx", "script/pg-missed-session-outbound-acceptance.ts"] },
 
+  { id: "interaction-truth", title: "The ledger records what the client received, and a repeat is answered",
+    // Cut 1. Two defects proven post-transport on 7833ebb and invisible to every handler-level
+    // suite: the same question asked twice got the outbound repair ("ask me again") while BOTH
+    // ledger rows showed the correct reply, and the ledger held `[BUTTONS:…]` for a client who saw
+    // `▸ *Today's workout*`. Only the real transport can grade either — the substitutions happen
+    // in prepareOutbound and sendFinal, past every handler.
+    command: ["npx", "tsx", "script/pg-interaction-truth-acceptance.ts"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-interaction-truth-acceptance.ts
+++ b/script/pg-interaction-truth-acceptance.ts
@@ -1,0 +1,323 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the ledger records what the CLIENT received (Cut 1).
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT WAS PROVEN BROKEN ON 7833ebb, post-transport, before a line of this cut was written.
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * 1. THE REPEATED QUESTION. One client, the same question twice inside the dedupe window:
+ *
+ *        wire[0]   "Thabo — one thing today: *Stand on a scale tomorrow morning…*"
+ *        wire[1]   "Let me check that properly before I answer — give me one sec and ask me again."
+ *        ledger[0] = ledger[1] = the correct coaching reply, both rows
+ *
+ *    enforceOutboundTruth rule 3 ran the proactive duplicate test against a REPLY and refused it.
+ *    The client was told to ask again — which is the P0-C failure routes/whatsapp.ts records as
+ *    fixed on 2026-08-21, silently reverted by a later authority. Both ledger rows showed the
+ *    right answer, so no amount of reading the ledger could ever have found it.
+ *
+ * 2. THE LEDGER WAS NOT THE MESSAGE.
+ *
+ *        ledger "…what do you need?[BUTTONS:Today's workout|Log food|My progress]"
+ *        wire   "…what do you need?\n\n▸ *Today's workout*\n▸ *Log food*\n▸ *My progress*"
+ *
+ *    recordTurn stores the HANDLER's return. Marker rendering, the truth floor, provenance,
+ *    hygiene, the marker strip and the never-silent repairs all run after it.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * GRADED POST-TRANSPORT, ON PURPOSE. Every check drives processTextAsync — the reactive path that
+ * calls sendFinal → prepareOutbound → the floor → the delivery owner — and reads turn_ledger and
+ * shadow_replies afterwards. Calling handleMessage would prove only what a handler intended, which
+ * is exactly the blindness that let both defects above ship green.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-interaction-truth-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { processTextAsync } = await import("../server/routes/whatsapp");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+const { _resetInteractionCorrelation } = await import("../server/handlers/chat-log");
+const { REACTIVE_OUTBOUND_REPAIR, enforceOutboundTruth } = await import("../server/outbound-authority");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const phone = "whatsapp:+27820000941";
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+const [user] = await db.insert(schema.users).values({
+  phoneNumber: phone, name: "Thabo Ledger", onboardingState: "COMPLETE", popiConsent: true,
+  subscriptionStatus: "active", goalType: "fat_loss", currentWeight: "92", startWeight: "95",
+  targetWeight: "85", heightCm: 178, age: 34, gender: "male", trainingMode: "gym",
+  proteinTarget: 150, dailyCalorieTarget: 2200, dailyStepTarget: 8000,
+} as any).returning();
+
+type Row = {
+  root_id: string | null; input_text: string | null; input_text_canonical: string | null;
+  reply: string | null; delivered_body: string | null; outbound_verdict: any;
+  delivery_outcome: string | null; decision: any; version: string | null; mutations: any;
+};
+const rows = async (): Promise<Row[]> => (await pool.query<Row>(
+  `SELECT root_id, input_text, input_text_canonical, reply, delivered_body, outbound_verdict,
+          delivery_outcome, decision, version, mutations
+     FROM turn_ledger WHERE user_id = $1 ORDER BY created_at, id`, [user.id])).rows;
+const wire = async (): Promise<string[]> => (await pool.query<{ body: string }>(
+  "SELECT body FROM shadow_replies WHERE phone = $1 ORDER BY id", [phone])).rows.map(r => r.body);
+const clear = async () => {
+  await pool.query("DELETE FROM turn_ledger WHERE user_id = $1", [user.id]);
+  await pool.query("DELETE FROM shadow_replies WHERE phone = $1", [phone]);
+};
+const settle = () => new Promise(r => setTimeout(r, 600));
+const say = (text: string, sid: string) =>
+  processTextAsync(phone, text, null, null, [], handleMessage as any, sid);
+
+REAL("\npg-interaction-truth-acceptance — the customer-visible truth boundary\n");
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("1. THE REPEATED QUESTION IS ANSWERED, NOT REPAIRED");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+await say("What should I do today?", "sid-rep-1");
+await say("What should I do today?", "sid-rep-2");
+await settle();
+{
+  const w = await wire();
+  const r = await rows();
+  chk(w.length === 2, "both askings reach the client", `got ${w.length} outbound bodies`);
+  chk(!!w[1] && w[1] !== REACTIVE_OUTBOUND_REPAIR,
+    "the second answer is not the outbound repair", `wire[1]=${JSON.stringify((w[1] || "").slice(0, 90))}`);
+  chk(!/gave you the same answer twice/i.test(w[1] || ""),
+    "the second answer is not the duplicate-meta reply", `wire[1]=${JSON.stringify((w[1] || "").slice(0, 90))}`);
+  chk(!!(w[1] || "").trim(), "the second answer is not silence");
+  chk(w[0] === w[1], "a truthful answer is repeated verbatim, because it is still the truthful answer",
+    `wire[0]=${JSON.stringify((w[0] || "").slice(0, 60))} wire[1]=${JSON.stringify((w[1] || "").slice(0, 60))}`);
+  chk(r.length === 2 && r.every(x => x.outbound_verdict?.blocked === false),
+    "neither row records a block", JSON.stringify(r.map(x => x.outbound_verdict)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n2. THE LEDGER'S FINAL BODY IS BYTE-IDENTICAL TO WHAT WENT TO DELIVERY");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+await say("menu", "sid-menu-1");
+await settle();
+{
+  const [w] = await wire();
+  const [r] = await rows();
+  chk(!!r, "the turn left a ledger row");
+  chk(r?.delivered_body === w, "delivered_body is byte-identical to the body handed to delivery",
+    `ledger=${JSON.stringify((r?.delivered_body || "").slice(0, 120))}\n          wire  =${JSON.stringify((w || "").slice(0, 120))}`);
+  chk(r?.delivery_outcome === "shadow", "the delivery outcome is recorded, not assumed",
+    `got ${r?.delivery_outcome}`);
+  chk(!!r?.root_id, "the row carries a root id");
+  chk(r?.root_id === "sid-menu-1", "the root id is the source message id", `got ${r?.root_id}`);
+  chk(!!r?.version, "the running SHA is recorded", `got ${r?.version}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n3. RENDERED BUTTONS ARE RECORDED AS THE CUSTOMER SAW THEM");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+await say("zzqq flurblewump gribbet", "sid-btn-1");
+await settle();
+{
+  const [w] = await wire();
+  const [r] = await rows();
+  const marked = /\[BUTTONS:/.test(r?.reply || "");
+  chk(marked, "the fixture reply really does carry a [BUTTONS:] marker (else this check grades nothing)",
+    `reply=${JSON.stringify((r?.reply || "").slice(0, 120))}`);
+  chk(!/\[BUTTONS:/.test(r?.delivered_body || ""),
+    "delivered_body holds no raw marker", `delivered=${JSON.stringify((r?.delivered_body || "").slice(0, 120))}`);
+  chk((r?.delivered_body || "").includes("▸"), "delivered_body holds the rendered prompts");
+  chk(r?.delivered_body === w, "…and it is exactly what went out");
+  chk((r?.reply || "") !== (r?.delivered_body || ""),
+    "the handler's reply and the customer's body are both kept, and they differ here");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n4. A BLOCKED RESPONSE RECORDS DRAFT, VERDICT, REPLACEMENT AND FINAL BODY");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// A template leak is the cheapest genuine refusal to provoke: the floor's own gate, unrelated to
+// the duplicate rule this cut removes, so it also proves the rest of the floor is untouched.
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+await pool.query(
+  `INSERT INTO chat_history (user_id, message_in, message_out, intent) VALUES ($1,$2,$3,$4)`,
+  [user.id, "seed", "seed", "SEED"]);
+{
+  const { prepareOutbound } = await import("../server/outbound-authority");
+  const prepared = await prepareOutbound("reactive", user.id, phone, "You ate undefined kcal today.", null);
+  chk(prepared.blocked, "the floor refuses a template leak on the reactive door");
+  chk(prepared.text === REACTIVE_OUTBOUND_REPAIR, "…and hands back the repair, never the draft");
+  chk(prepared.draft === "You ate undefined kcal today.",
+    "…and carries the REFUSED DRAFT so the record is not just the repair", `draft=${JSON.stringify(prepared.draft)}`);
+  chk(!!prepared.detail && /undefined/i.test(prepared.detail), "…with the reason", `detail=${prepared.detail}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n5. THE SAFETY AND TRUTH FLOORS ARE UNCHANGED");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  // Session-count rule, reactive mode — must still refuse a count the record denies (#233 guard).
+  const v = await enforceOutboundTruth(user.id, phone, "You have done 4 sessions this week.", null, "reactive");
+  chk(!v.ok && v.reason === "session_count_contradicts_record",
+    "a false session count is still blocked on the REACTIVE door", JSON.stringify(v));
+
+  // Held-constraint rule, reactive mode — still live.
+  await pool.query("UPDATE users SET profile_notes = $1 WHERE id = $2", ["sick:until-tomorrow", user.id]);
+  const held = await enforceOutboundTruth(user.id, phone, "Time to get your session in today.", { profileNotes: "sick:until-tomorrow" }, "reactive");
+  chk(!held.ok || held.reason !== "duplicate",
+    "the held-constraint rule is not the duplicate rule and still applies", JSON.stringify(held));
+  await pool.query("UPDATE users SET profile_notes = NULL WHERE id = $1", [user.id]);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n6. CONTROL — PROACTIVE DUPLICATE SUPPRESSION STILL WORKS");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  _resetOutboundDedupe();
+  const body = "Morning Thabo — one walk today, that is the whole job.";
+  const first = await enforceOutboundTruth(user.id, phone, body, null, "proactive");
+  const second = await enforceOutboundTruth(user.id, phone, body, null, "proactive");
+  chk(first.ok, "the first proactive send passes", JSON.stringify(first));
+  chk(!second.ok && second.reason === "duplicate",
+    "the second identical PROACTIVE send is still refused", JSON.stringify(second));
+
+  // …and the same body twice on the REACTIVE door is not refused. This is the pair: removing the
+  // rule for replies must not have removed it for crons, and vice versa.
+  _resetOutboundDedupe();
+  const r1 = await enforceOutboundTruth(user.id, phone, body, null, "reactive");
+  const r2 = await enforceOutboundTruth(user.id, phone, body, null, "reactive");
+  chk(r1.ok && r2.ok, "the same body twice on the REACTIVE door passes both times", JSON.stringify([r1, r2]));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n7. ONE SOURCE MESSAGE, ONE ROOT ID — ACROSS A NESTED TURN");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// handlers/media.ts:1423 re-enters handleMessage for every voice note, opening a second turn scope
+// inside the first. That recursion is NOT fixed in this cut. What is fixed is that both rows now
+// answer to one interaction. Reproduced through the same nesting the media handler performs.
+await clear();
+_resetInteractionCorrelation();
+{
+  const { inTurn, recordTurn, turnUser } = await import("../server/handlers/chat-log");
+  await inTurn("voice", "", async () => {
+    turnUser(user.id);                                   // routeMessage:126 does this on the outer scope
+    const inner = await handleMessage(phone, "I walked 9000 steps", undefined, undefined, undefined, "sid-voice-1");
+    void recordTurn(inner);
+    return inner;
+  }, "sid-voice-1");
+  await settle();
+  const r = await rows();
+  chk(r.length === 2, "the nested turn still produces two rows (the recursion is not this cut)", `rows=${r.length}`);
+  chk(r.length === 2 && r[0].root_id === r[1].root_id,
+    "…and BOTH carry the same root id", JSON.stringify(r.map(x => x.root_id)));
+  chk(r.every(x => x.root_id === "sid-voice-1"),
+    "…which is the source message's id", JSON.stringify(r.map(x => x.root_id)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n8. THE HANDLERS' OWN INPUT IS RECORDED WHEN SOMETHING REWROTE THE CLIENT");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+{
+  // The retro-continuity carry (routes.ts:231) rewrites `message` before any handler runs.
+  await say("I want to tell you what I ate yesterday", "sid-retro-1");
+  await settle();
+  await say("chicken and rice", "sid-retro-2");
+  await settle();
+  const r = await rows();
+  const carried = r.find(x => x.input_text === "chicken and rice");
+  chk(!!carried, "the second turn was recorded");
+  chk(carried?.input_text === "chicken and rice", "input_text keeps the client's ORIGINAL words",
+    JSON.stringify(carried?.input_text));
+  chk((carried?.input_text_canonical || "").startsWith("yesterday "),
+    "input_text_canonical holds what the handlers actually routed on",
+    JSON.stringify(carried?.input_text_canonical));
+
+  // CONTROL: an untouched turn records no canonical rewrite, so this column cannot quietly
+  // become "a second copy of input_text".
+  const plain = r.find(x => x.input_text === "I want to tell you what I ate yesterday");
+  chk(plain?.input_text_canonical == null,
+    "a turn nobody rewrote records no canonical input", JSON.stringify(plain?.input_text_canonical));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n9. THE CANONICAL DECISION AND ITS DISPOSITION ARE ON THE ROW");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+// Section 7 already logged today's steps through the nested turn, and the step door is idempotent
+// per day — so without this the turn below writes nothing and the check grades an empty record
+// rather than the product. The fixture is wrong in that case, not the code.
+await pool.query("DELETE FROM step_logs WHERE user_id = $1", [user.id]);
+await say("I walked 9000 steps", "sid-dec-1");
+await settle();
+{
+  const [r] = await rows();
+  chk(!!r?.decision, "the row carries a decision object", JSON.stringify(r?.decision));
+  chk(typeof r?.decision?.disposition === "string" &&
+      ["instructed", "hold", "conversational"].includes(r.decision.disposition),
+    "…with a disposition from the existing evidence, not a new taxonomy", JSON.stringify(r?.decision));
+  chk(Array.isArray(r?.mutations) && r.mutations.some((m: string) => /INSERT steps/i.test(m)),
+    "…and the state half of the row is untouched by this cut", JSON.stringify(r?.mutations));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n10. THE DELIVERY OUTCOME IS THE DELIVERY OWNER'S, NOT A CONSTANT");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Every check above ran with SHADOW=on and recorded "shadow". A column that only ever holds one
+// value distinguishes nothing, so this turn goes down the REAL delivery path with a Twilio client
+// that cannot send — deliverTwilioMessage exhausts its retries and returns "dropped". Two
+// different real outcomes from the same column is what makes "sent | dropped | fallback"
+// a distinction rather than a comment. (A "sent" cannot be produced without a live Twilio
+// account, and manufacturing one would be a fixture proving itself.)
+await clear();
+_resetOutboundDedupe();
+_resetInteractionCorrelation();
+process.env.SHADOW = "off";
+try {
+  await say("menu", "sid-drop-1");
+  await settle();
+  const [r] = await rows();
+  chk(r?.delivery_outcome === "dropped",
+    "a send the delivery owner could not complete is recorded as dropped, not as sent",
+    `got ${r?.delivery_outcome}`);
+  chk(!!r?.delivered_body,
+    "…and the body it tried to send is still on the row", JSON.stringify((r?.delivered_body || "").slice(0, 60)));
+} finally {
+  process.env.SHADOW = "on";
+}
+
+REAL(`\n${failed === 0 ? "pg-interaction-truth-acceptance: ALL GREEN" : `pg-interaction-truth-acceptance: ${failed} FAILED`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/production-parity.ts
+++ b/script/production-parity.ts
@@ -1337,17 +1337,46 @@ async function main() {
   });
 
   // ── P0-3 · SILENCE IS NOT A TERMINAL STATE ────────────────────────────────────────────────
-  check("a suppressed duplicate does not become silence", () => {
+  //
+  // REGRADED 2026-09-10 (Cut 1), and STRENGTHENED rather than relaxed. State plainly what changed
+  // and why, because this is the fifth assertion in this repo found pinned to an implementation
+  // instead of the promise it exists to protect.
+  //
+  // It asserted the SHAPE of the fix: `if (isDuplicateOutbound(phone, out)) { … out = … }` — a
+  // branch that replaced a repeated reply with "I gave you the same answer twice there…". The
+  // property it was written for is the sentence in its own message: a client who asks twice is
+  // telling us the first answer did not land, and that is when silence costs most.
+  //
+  // Two things were then proven post-transport on 7833ebb:
+  //   · That branch was already UNREACHABLE for its own case. enforceOutboundTruth ran the same
+  //     duplicate test one layer up and replaced the body with the outbound repair first, so the
+  //     second asking got "…give me one sec and ask me again." The green assertion below was
+  //     grading a branch the product could not enter.
+  //   · Suppression was never the right answer anyway. A truthful reply does not become untrue on
+  //     repetition, so the strongest form of this property is that NOTHING suppresses a reply.
+  //
+  // So the check now asserts the deletion is real and total, on both doors. That is a harder
+  // property than the one it replaces: the old version passed with a duplicate authority present,
+  // this one fails if any reactive duplicate authority comes back. The behavioural counterpart —
+  // the same question asked twice, answered twice, graded on the wire — is section 1 of
+  // script/pg-interaction-truth-acceptance.ts, which needs a database and cannot live here.
+  check("no authority suppresses a repeated reply, on either door", () => {
     const wa = readFileSync("server/routes/whatsapp.ts", "utf-8")
       .replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
-    const dupBlock = /if \(isDuplicateOutbound\(phone, out\)\) \{([\s\S]*?)\n  \}/.exec(wa);
-    assert.ok(dupBlock, "the duplicate branch must exist");
-    assert.ok(!/\breturn;/.test(dupBlock[1]),
-      "a duplicate reply must not end the turn in silence — the client asked twice because the "
-      + "first answer did not land, which is when silence costs most");
-    assert.ok(/out = /.test(dupBlock[1]), "…it must say something different instead");
-    assert.ok(/recordSilentTurnAvoided\("duplicate"\)/.test(wa) && /recordSilentTurnAvoided\("empty"\)/.test(wa),
-      "both silent-terminal causes must be counted, by cause");
+    assert.ok(!/isDuplicateOutbound\s*\(\s*phone\b/.test(wa),
+      "the reactive door must hold no duplicate-suppression branch — a client who asks twice is "
+      + "telling us the first answer did not land, and both the silence and the meta-reply punish "
+      + "them for it");
+    const oa = readFileSync("server/outbound-authority.ts", "utf-8")
+      .replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
+    assert.match(oa, /if \(mode === "proactive" && isDuplicateOutbound\(/,
+      "the floor's duplicate rule must be gated to the proactive door — ungated, it refuses a "
+      + "truthful REPLY and hands the client the repair sentence instead");
+    assert.ok(/recordSilentTurnAvoided\("empty"\)/.test(wa),
+      "the one remaining silent-terminal cause must still be counted");
+    assert.ok(!/recordSilentTurnAvoided\("duplicate"\)/.test(wa),
+      "…and the cause that no longer exists must not still be counted, or the founder's "
+      + "self-check reports a permanent zero as though it were a measurement");
   });
 
   // NEGATIVE CONTROL 4 — remove the empty-response fallback and this must go red.

--- a/script/red-on-revert-cut1-interaction.sh
+++ b/script/red-on-revert-cut1-interaction.sh
@@ -8,31 +8,68 @@
 # Cases 5 and 6 are OPPOSITE-DEFECT controls. They do not revert this cut; they break the thing it
 # must NOT have broken (proactive duplicate suppression, the session-count floor). If those two do
 # not go red, the acceptance is not protecting what it claims to protect.
-set -u
+set -uo pipefail
 cd "$(dirname "$0")/.."
 ACC=script/pg-interaction-truth-acceptance.ts
-BACKUP=/tmp/cut1-backup
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cut1-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/backup"
+PATCH_DIR="$WORK_ROOT/patches"
 
-run_case () {
-  local name="$1" patch="$2"
-  rm -rf "$BACKUP"; mkdir -p "$BACKUP"
-  cp -r server "$BACKUP/server"; cp -r shared "$BACKUP/shared"
-  python3 "$patch" || { echo "  !! patch failed: $name"; rm -rf "$BACKUP"; return 1; }
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
-  local out; out="$(npx tsx "$ACC" 2>&1)"
-  echo "── REVERT: $name"
-  echo "   $(echo "$out" | grep -E '^pg-interaction-truth-acceptance:' | tail -1 || echo '(no verdict — crashed)')"
-  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4
-  rm -rf server shared && mv "$BACKUP/server" server && mv "$BACKUP/shared" shared
+restore_case () {
+  if [[ -d "$BACKUP/server" && -d "$BACKUP/shared" ]]; then
+    rm -rf server shared
+    mv "$BACKUP/server" server
+    mv "$BACKUP/shared" shared
+  fi
   rm -rf "$BACKUP"
 }
 
-mkdir -p /tmp/cut1p
+cleanup () {
+  restore_case
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+run_case () {
+  local name="$1" patch="$2"
+  local out status verdict
+  restore_case
+  mkdir -p "$BACKUP"
+  cp -a server "$BACKUP/server"
+  cp -a shared "$BACKUP/shared"
+  if ! python3 "$patch"; then
+    echo "  !! patch failed: $name"
+    restore_case
+    return 1
+  fi
+  if ! PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1; then
+    echo "  !! database reset failed: $name"
+    restore_case
+    return 1
+  fi
+  out="$(npx tsx "$ACC" 2>&1)"
+  status=$?
+  verdict="$(printf '%s\n' "$out" | grep -E '^pg-interaction-truth-acceptance:' | tail -1 || true)"
+  echo "── REVERT: $name"
+  echo "   ${verdict:-'(no verdict — crashed)'}"
+  printf '%s\n' "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4 || true
+  restore_case
+  if [[ $status -eq 0 ]]; then
+    echo "  !! acceptance stayed green: $name"
+    return 1
+  fi
+  if [[ ! "$verdict" =~ ^pg-interaction-truth-acceptance:\ [1-9][0-9]*\ FAILED$ ]]; then
+    echo "  !! acceptance did not reach a graded red verdict: $name (exit $status)"
+    return 1
+  fi
+}
+
+mkdir -p "$PATCH_DIR"
 
 # 1. THE REACTIVE DUPLICATE AUTHORITY COMES BACK to the floor. This is the defect proven on
 #    7833ebb: the second asking of the same question got the outbound repair.
-cat > /tmp/cut1p/1.py <<'PY'
+cat > "$PATCH_DIR/1.py" <<'PY'
 p="server/outbound-authority.ts"; s=open(p).read(); b=s
 s=s.replace('if (mode === "proactive" && isDuplicateOutbound(', 'if (isDuplicateOutbound(')
 assert s!=b, "no match"; open(p,"w").write(s)
@@ -40,7 +77,7 @@ PY
 
 # 2. THE TRANSPORT STOPS FINALISING THE ROW. delivered_body, the verdict and the delivery outcome
 #    all go back to null — the state the ledger was in for a month of green builds.
-cat > /tmp/cut1p/2.py <<'PY'
+cat > "$PATCH_DIR/2.py" <<'PY'
 p="server/routes/whatsapp.ts"; s=open(p).read(); b=s
 s=s.replace("  const outcome = await sendParts(phone, splitMessage(out), outMedia);\n  await finalise(outcome);",
             "  await sendParts(phone, splitMessage(out), outMedia);")
@@ -51,7 +88,7 @@ PY
 
 # 3. THE ROOT ID IS RE-MINTED PER SCOPE instead of inherited. One voice note becomes two
 #    uncorrelatable interactions again, and the transport can no longer find the row.
-cat > /tmp/cut1p/3.py <<'PY'
+cat > "$PATCH_DIR/3.py" <<'PY'
 p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
 s=s.replace('const rootId = turnStore.getStore()?.rootId || seed || `turn-',
             'const rootId = `turn-')
@@ -60,7 +97,7 @@ PY
 
 # 4. THE REFUSED DRAFT IS DROPPED from the verdict. A blocked turn records the repair and nothing
 #    about what the coach had actually composed.
-cat > /tmp/cut1p/4.py <<'PY'
+cat > "$PATCH_DIR/4.py" <<'PY'
 p="server/outbound-authority.ts"; s=open(p).read(); b=s
 s=s.replace(', draft: out };', ' };').replace(', draft: text };', ' };')
 assert s!=b, "no match"; open(p,"w").write(s)
@@ -68,7 +105,7 @@ PY
 
 # 5. OPPOSITE DEFECT — the duplicate rule is removed for BOTH doors. Two crons may now cover the
 #    same ground on the same morning. Section 6 must catch this.
-cat > /tmp/cut1p/5.py <<'PY'
+cat > "$PATCH_DIR/5.py" <<'PY'
 p="server/outbound-authority.ts"; s=open(p).read(); b=s
 s=s.replace('if (mode === "proactive" && isDuplicateOutbound(', 'if (false && isDuplicateOutbound(')
 assert s!=b, "no match"; open(p,"w").write(s)
@@ -77,7 +114,7 @@ PY
 # 6. OPPOSITE DEFECT — the session-count floor stops judging. Every "must not be repaired" check in
 #    section 1 would still pass while the product loses the rule that stops it overstating a
 #    client's training. Section 5 must catch this.
-cat > /tmp/cut1p/6.py <<'PY'
+cat > "$PATCH_DIR/6.py" <<'PY'
 p="server/brain/reply-verifier.ts"; s=open(p).read(); b=s
 s=s.replace("export function adjudicableSessionCounts(text: string): number[] {",
             "export function adjudicableSessionCounts(text: string): number[] {\n  return [];")
@@ -86,12 +123,19 @@ PY
 
 # 7. THE CANONICAL INPUT IS NOT RECORDED. A turn routed on rewritten words looks like a turn routed
 #    on the client's own.
-cat > /tmp/cut1p/7.py <<'PY'
+cat > "$PATCH_DIR/7.py" <<'PY'
 p="server/routes.ts"; s=open(p).read(); b=s
 s=s.replace(" turnCanonicalInput(message);", "")
 assert s!=b, "no match"; open(p,"w").write(s)
 PY
 
 echo "RED-ON-REVERT — Cut 1. Every case below must report FAILED."
-for i in 1 2 3 4 5 6 7; do run_case "$i" "/tmp/cut1p/$i.py"; done
-echo "Done. Any case reporting ALL GREEN is a mechanism the acceptance does not grade."
+failed=0
+for i in 1 2 3 4 5 6 7; do
+  if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
+done
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) were green, crashed, or ungraded."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 7/7 cases reached a graded red verdict."

--- a/script/red-on-revert-cut1-interaction.sh
+++ b/script/red-on-revert-cut1-interaction.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — Cut 1, the customer-visible truth boundary. One mechanism at a time.
+#
+# Each case reverts exactly ONE line of this cut and re-runs the acceptance. A case that stays
+# green is a check that grades nothing, which is the failure mode this whole cut exists to end:
+# 42 suites asserted handleMessage's return value and none of them could see a transport defect.
+#
+# Cases 5 and 6 are OPPOSITE-DEFECT controls. They do not revert this cut; they break the thing it
+# must NOT have broken (proactive duplicate suppression, the session-count floor). If those two do
+# not go red, the acceptance is not protecting what it claims to protect.
+set -u
+cd "$(dirname "$0")/.."
+ACC=script/pg-interaction-truth-acceptance.ts
+BACKUP=/tmp/cut1-backup
+
+run_case () {
+  local name="$1" patch="$2"
+  rm -rf "$BACKUP"; mkdir -p "$BACKUP"
+  cp -r server "$BACKUP/server"; cp -r shared "$BACKUP/shared"
+  python3 "$patch" || { echo "  !! patch failed: $name"; rm -rf "$BACKUP"; return 1; }
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  local out; out="$(npx tsx "$ACC" 2>&1)"
+  echo "── REVERT: $name"
+  echo "   $(echo "$out" | grep -E '^pg-interaction-truth-acceptance:' | tail -1 || echo '(no verdict — crashed)')"
+  echo "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4
+  rm -rf server shared && mv "$BACKUP/server" server && mv "$BACKUP/shared" shared
+  rm -rf "$BACKUP"
+}
+
+mkdir -p /tmp/cut1p
+
+# 1. THE REACTIVE DUPLICATE AUTHORITY COMES BACK to the floor. This is the defect proven on
+#    7833ebb: the second asking of the same question got the outbound repair.
+cat > /tmp/cut1p/1.py <<'PY'
+p="server/outbound-authority.ts"; s=open(p).read(); b=s
+s=s.replace('if (mode === "proactive" && isDuplicateOutbound(', 'if (isDuplicateOutbound(')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 2. THE TRANSPORT STOPS FINALISING THE ROW. delivered_body, the verdict and the delivery outcome
+#    all go back to null — the state the ledger was in for a month of green builds.
+cat > /tmp/cut1p/2.py <<'PY'
+p="server/routes/whatsapp.ts"; s=open(p).read(); b=s
+s=s.replace("  const outcome = await sendParts(phone, splitMessage(out), outMedia);\n  await finalise(outcome);",
+            "  await sendParts(phone, splitMessage(out), outMedia);")
+s=s.replace('  if ((await shadowDoor(phone, out, "reply", "server/routes/whatsapp.ts", media)) && !isCrisisOut) {\n    await finalise("shadow");\n    return;\n  }',
+            '  if ((await shadowDoor(phone, out, "reply", "server/routes/whatsapp.ts", media)) && !isCrisisOut) return;')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 3. THE ROOT ID IS RE-MINTED PER SCOPE instead of inherited. One voice note becomes two
+#    uncorrelatable interactions again, and the transport can no longer find the row.
+cat > /tmp/cut1p/3.py <<'PY'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace('const rootId = turnStore.getStore()?.rootId || seed || `turn-',
+            'const rootId = `turn-')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 4. THE REFUSED DRAFT IS DROPPED from the verdict. A blocked turn records the repair and nothing
+#    about what the coach had actually composed.
+cat > /tmp/cut1p/4.py <<'PY'
+p="server/outbound-authority.ts"; s=open(p).read(); b=s
+s=s.replace(', draft: out };', ' };').replace(', draft: text };', ' };')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 5. OPPOSITE DEFECT — the duplicate rule is removed for BOTH doors. Two crons may now cover the
+#    same ground on the same morning. Section 6 must catch this.
+cat > /tmp/cut1p/5.py <<'PY'
+p="server/outbound-authority.ts"; s=open(p).read(); b=s
+s=s.replace('if (mode === "proactive" && isDuplicateOutbound(', 'if (false && isDuplicateOutbound(')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 6. OPPOSITE DEFECT — the session-count floor stops judging. Every "must not be repaired" check in
+#    section 1 would still pass while the product loses the rule that stops it overstating a
+#    client's training. Section 5 must catch this.
+cat > /tmp/cut1p/6.py <<'PY'
+p="server/brain/reply-verifier.ts"; s=open(p).read(); b=s
+s=s.replace("export function adjudicableSessionCounts(text: string): number[] {",
+            "export function adjudicableSessionCounts(text: string): number[] {\n  return [];")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 7. THE CANONICAL INPUT IS NOT RECORDED. A turn routed on rewritten words looks like a turn routed
+#    on the client's own.
+cat > /tmp/cut1p/7.py <<'PY'
+p="server/routes.ts"; s=open(p).read(); b=s
+s=s.replace(" turnCanonicalInput(message);", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+echo "RED-ON-REVERT — Cut 1. Every case below must report FAILED."
+for i in 1 2 3 4 5 6 7; do run_case "$i" "/tmp/cut1p/$i.py"; done
+echo "Done. Any case reporting ALL GREEN is a mechanism the acceptance does not grade."

--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import { db } from "../db";
 import { users, chatHistory, escalations, turnLedger, workoutLogs, stepLogs, weightLogs } from "../../shared/schema";
 import { eq, and, gte, desc } from "drizzle-orm";
@@ -100,6 +101,14 @@ interface TurnScope {
   userId: string | null;
   inputType: string;
   inputText: string;
+  /**
+   * ONE INBOUND MESSAGE, ONE ID (Cut 1). Nested turns INHERIT this — a voice transcript that
+   * re-enters handleMessage opens a second scope and gets the same root — so "what happened to
+   * this client message" is answerable even while one message still produces two rows.
+   */
+  rootId: string;
+  /** What the handlers actually saw, when something rewrote the client's words before routing. */
+  canonicalInput: string | null;
   resolvedDay: string | null;
   stateRead: Record<string, unknown>;
   mutations: string[];
@@ -536,10 +545,21 @@ async function reconcileTurnReply(scope: TurnScope, reply: string): Promise<stri
   }
 }
 
-export async function inTurn<T>(inputType: string, inputText: string, fn: () => Promise<T>): Promise<T> {
+/**
+ * THE ROOT ID IS INHERITED, NEVER RE-MINTED (Cut 1).
+ *
+ * A handler may re-enter handleMessage — handlers/media.ts:1423 does it for every voice note,
+ * handlers/food-context.ts:346 for a corrected meal — and that opens a SECOND scope inside the
+ * first. Proven on 7833ebb: one voice note, two turn_ledger rows, and nothing tying them
+ * together. Fixing the recursion is a separate cut; making one client message answerable is this
+ * one. So the inner scope takes the outer's id rather than inventing its own, and `seed` (the
+ * MessageSid, when the door has one) is used only when there is no scope to inherit from.
+ */
+export async function inTurn<T>(inputType: string, inputText: string, fn: () => Promise<T>, seed?: string): Promise<T> {
   let resolveFinalReply!: (reply: string) => void;
   const finalReplyPromise = new Promise<string>(resolve => { resolveFinalReply = resolve; });
-  return turnStore.run({ userId: null, inputType, inputText: (inputText || "").slice(0, 2000), resolvedDay: null, stateRead: {}, mutations: [], startedAt: Date.now(), finalReplyPromise }, async () => {
+  const rootId = turnStore.getStore()?.rootId || seed || `turn-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+  return turnStore.run({ userId: null, inputType, inputText: (inputText || "").slice(0, 2000), rootId, canonicalInput: null, resolvedDay: null, stateRead: {}, mutations: [], startedAt: Date.now(), finalReplyPromise }, async () => {
     try {
       const result = await fn();
       if (typeof result !== "string") {
@@ -627,9 +647,91 @@ export function turnPlateNeedsChange(): boolean {
   return !!turnStore.getStore()?.evidence?.plateNeedsChange;
 }
 
+/**
+ * ════════════════════════════════════════════════════════════════════════════════════════════
+ * CORRELATION, NOT A SECOND RECORDER (Cut 1).
+ *
+ * The obvious fix — move recordTurn into sendFinal — was refused, and the refusal is the design.
+ * recordTurn runs INSIDE the turn scope, which is where `mutations`, `stateRead`, `evidence` and
+ * the resolved day live; the transport runs after that scope has closed and holds none of it.
+ * Moving the write would have cost the whole state half of the row to buy the outbound half, and
+ * it would have stopped recording every path that never reaches WhatsApp at all — the admin test
+ * webhook, journey-lab, the acceptance harnesses. Writing a second row from the transport would
+ * have been worse: two recorders is the defect this cut exists to remove.
+ *
+ * So there is still exactly one INSERT, from inside the scope, and the transport later FINALISES
+ * that same row. This map is the join. recordTurn registers the row's id — as a promise, taken
+ * synchronously before the insert is awaited, because `void recordTurn(...)` means the transport
+ * can arrive first. A turn that never reaches transport simply keeps its half-row, which is the
+ * honest record of what happened to it.
+ * ════════════════════════════════════════════════════════════════════════════════════════════
+ */
+const _interactionRows = new Map<string, { id: Promise<string | null>; at: number }>();
+/** Long enough for a slow reply and a retrying delivery; short enough that a busy day cannot grow. */
+const INTERACTION_TTL_MS = 5 * 60_000;
+
+function rememberInteraction(rootId: string, id: Promise<string | null>): void {
+  const now = Date.now();
+  // The OUTER turn registers last — its reply is the one the transport carries — so last write
+  // wins deliberately. Recursion is not tidied here; it is made answerable.
+  _interactionRows.set(rootId, { id, at: now });
+  if (_interactionRows.size > 2000) {
+    for (const [k, v] of _interactionRows) if (now - v.at > INTERACTION_TTL_MS) _interactionRows.delete(k);
+  }
+}
+
+export interface InteractionOutcome {
+  /** The complete body handed to delivery, before Twilio bubble splitting. */
+  deliveredBody: string;
+  /** { blocked, reason, detail, draft } — draft is the refused text, when one was refused. */
+  outboundVerdict: Record<string, unknown> | null;
+  deliveryOutcome: string | null;
+}
+
+/**
+ * The transport closing the loop on a row recordTurn already opened. Never throws and never
+ * blocks a send: an unfinalised row is a worse record, not a worse product.
+ */
+export async function finaliseInteraction(rootId: string | undefined | null, outcome: InteractionOutcome): Promise<void> {
+  if (!rootId) return;
+  const entry = _interactionRows.get(rootId);
+  if (!entry) return;
+  try {
+    const id = await Promise.race([entry.id, new Promise<null>(r => setTimeout(() => r(null), 20000))]);
+    if (!id) return;
+    await db.update(turnLedger).set({
+      deliveredBody: outcome.deliveredBody.slice(0, 8000),
+      outboundVerdict: outcome.outboundVerdict,
+      deliveryOutcome: outcome.deliveryOutcome,
+    }).where(eq(turnLedger.id, id));
+    _interactionRows.delete(rootId);
+  } catch (e: any) {
+    console.warn("[TURN_LEDGER] finalise non-fatal:", e?.message);
+  }
+}
+
+/** Test/ops hook — the same shape reply-hygiene exposes for its dedupe window. */
+export function _resetInteractionCorrelation(): void { _interactionRows.clear(); }
+
+/**
+ * WHAT THE HANDLERS ACTUALLY SAW. Three places rewrite the client's words before any handler
+ * runs — the normalizer's canonical, the retro-continuity carry, the signup-source strip — and
+ * the ledger recorded only the raw text, so a turn routed on rewritten words looked like a turn
+ * routed on the client's. Last writer wins: the last rewrite is what reached the handlers.
+ */
+export function turnCanonicalInput(text: string): void {
+  const t = turnStore.getStore();
+  if (t) t.canonicalInput = (text || "").slice(0, 2000);
+}
+
 export async function recordTurn(reply: string): Promise<void> {
   const t = turnStore.getStore();
   if (!t?.userId) return;
+  // Registered BEFORE the first await. `void recordTurn(...)` is deliberately not awaited into the
+  // client's path, so the transport can reach finaliseInteraction while this insert is still in
+  // flight — it must find a promise to wait on, not an empty map.
+  let resolveRow!: (id: string | null) => void;
+  rememberInteraction(t.rootId, new Promise<string | null>(r => { resolveRow = r; }));
   try {
     const recordedReply = await Promise.race([
       t.finalReplyPromise,
@@ -643,13 +745,28 @@ export async function recordTurn(reply: string): Promise<void> {
     const stateRead = decision
       ? { ...t.stateRead, ...openLoop, decisionState: decision.state, decisionEvidence: decision.evidence, decisionFocus: decision.focus, decisionEvidenceRefs: evidenceRefs, meaningfulProblem: decision.meaningfulProblem, hasMinimumUsefulQuestion: decision.hasMinimumUsefulQuestion }
       : { ...t.stateRead, ...openLoop };
-    await db.insert(turnLedger).values({
+    // THE DECISION AND ITS DISPOSITION, from the owners that already hold both. `kind`/`todo` are
+    // chooseAction's, carried on the turn by canonicalDecision; `disposition` says what the turn
+    // did with them, read off the same evidence the response boundary reads — no new taxonomy and
+    // no second opinion about what the turn was.
+    const ev = t.evidence || {};
+    const canonicalDecision = {
+      kind: ev.canonicalKind ?? null,
+      todo: ev.canonicalTodo ?? null,
+      intervention: ev.canonicalIntervention ?? null,
+      disposition: ev.conversationalOnly ? "conversational"
+        : String(ev.canonicalTodo || "").trim() ? "instructed" : "hold",
+      modelAuthored: !!ev.modelAuthored,
+    };
+    const written = await db.insert(turnLedger).values({
       userId: t.userId, inputType: t.inputType, inputText: t.inputText, resolvedDay: t.resolvedDay,
+      rootId: t.rootId, inputTextCanonical: t.canonicalInput, decision: canonicalDecision,
       stateRead: Object.keys(stateRead).length ? stateRead : null, mutations: t.mutations.length ? t.mutations : null,
       reply: recordedReply.slice(0, 4000), replyMs: Date.now() - t.startedAt,
       version: process.env.RAILWAY_GIT_COMMIT_SHA?.slice(0, 12) || process.env.APP_VERSION || "dev",
-    });
-  } catch (e) { console.warn("[TURN_LEDGER] non-fatal:", (e as any)?.message); }
+    }).returning({ id: turnLedger.id });
+    resolveRow(written[0]?.id ?? null);
+  } catch (e) { resolveRow(null); console.warn("[TURN_LEDGER] non-fatal:", (e as any)?.message); }
 }
 
 

--- a/server/outbound-authority.ts
+++ b/server/outbound-authority.ts
@@ -62,6 +62,10 @@ export async function enforceOutboundTruth(
   text: string,
   /** The recipient's row, when the door already holds it — carries the durable illness state. */
   recipientUser?: { profileNotes?: string | null } | null,
+  /** Which door is asking. Rules 1 and 2 are about TRUTH and apply to both; rule 3 is about
+   *  CADENCE and only ever made sense for the door nobody is waiting at. Defaults to proactive so
+   *  an un-migrated caller keeps the behaviour it had. */
+  mode: "reactive" | "proactive" = "proactive",
 ): Promise<OutboundVerdict> {
   const body = String(text || "");
   if (!body.trim()) return { ok: true };
@@ -126,9 +130,26 @@ export async function enforceOutboundTruth(
     }
   }
 
-  // 3. THE SAME MESSAGE TWICE IS NEVER RIGHT. The reactive door has said so since 2026-08-21; two
-  //    crons covering the same ground on the same morning had nothing stopping them.
-  if (isDuplicateOutbound(`proactive:${recipientKey}`, body)) {
+  // 3. TWO CRONS MUST NOT COVER THE SAME GROUND ON THE SAME MORNING — and that is the whole of
+  //    what this rule is for.
+  //
+  //    IT APPLIED TO REPLIES TOO, AND THAT WAS A CUSTOMER-VISIBLE DEFECT (Cut 1, 2026-09-10).
+  //    Proven post-transport on 7833ebb, one client asking the same question twice:
+  //
+  //        wire[0]  "Thabo — one thing today: *Stand on a scale tomorrow morning…*"
+  //        wire[1]  "Let me check that properly before I answer — give me one sec and ask me again."
+  //
+  //    The second answer was TRUE, it was the same true answer, and this rule refused it — so the
+  //    client was told to ask again, which would produce the identical outcome. That is precisely
+  //    the P0-C failure routes/whatsapp.ts records as fixed on 2026-08-21: a client who repeats
+  //    themselves is telling us the first answer did not land, and punishing them is the one thing
+  //    a coach may never do. A later, cruder authority had quietly reverted a documented fix, and
+  //    both ledger rows showed the correct reply, so nothing could see it.
+  //
+  //    A repeat is not a truth failure. It is a cadence judgement, and cadence only has meaning
+  //    where nobody is waiting. Twilio webhook retries are already dropped by MessageSid at the
+  //    door, so removing this for replies re-sends nothing that was not genuinely asked twice.
+  if (mode === "proactive" && isDuplicateOutbound(`proactive:${recipientKey}`, body)) {
     return { ok: false, reason: "duplicate", detail: body.slice(0, 60) };
   }
 
@@ -167,6 +188,12 @@ export interface OutboundPrepared {
   blocked: boolean;
   reason?: OutboundVerdict["reason"];
   detail?: string;
+  /**
+   * THE TEXT THAT WAS REFUSED (Cut 1). Without it a blocked turn recorded the repair and nothing
+   * else, so the only evidence of what the coach had actually composed was gone — which is how a
+   * floor can be wrong for weeks and look like a floor working. Set only on a refusal.
+   */
+  draft?: string;
 }
 
 /**
@@ -255,7 +282,7 @@ export async function prepareOutbound(
   const { provenanceGate } = await import("./verifiers/response-gate");
   const { humanizeReply } = await import("./reply-hygiene");
 
-  const verdict = await enforceOutboundTruth(userId, recipientKey, text, recipientUser);
+  const verdict = await enforceOutboundTruth(userId, recipientKey, text, recipientUser, mode);
   if (!verdict.ok) {
     if (mode === "proactive") {
       // THE OPERATOR SIGNAL IS PART OF THE CONTRACT. production-parity drives sendWhatsApp and
@@ -264,11 +291,11 @@ export async function prepareOutbound(
       // door was changed to ignore the verdict. Renaming it in a refactor broke the observable
       // while the behaviour was fine, which is the same defect one layer out. It keeps its name.
       console.error(`[OUTBOUND_AUTHORITY] BLOCKED proactive send to ${recipientKey.slice(-8)} — ${verdict.reason}: ${verdict.detail}`);
-      return { text: "", blocked: true, reason: verdict.reason, detail: verdict.detail };
+      return { text: "", blocked: true, reason: verdict.reason, detail: verdict.detail, draft: text };
     }
     console.error(`[OUTBOUND_AUTHORITY] BLOCKED reactive draft to ${recipientKey.slice(-8)} — ${verdict.reason}: ${verdict.detail}`);
     // Reactive: the client is waiting, so they get a safe sentence rather than nothing.
-    return { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, reason: verdict.reason, detail: verdict.detail };
+    return { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, reason: verdict.reason, detail: verdict.detail, draft: text };
   }
 
   // Shaping stays in this order: a claim spanning a bubble split has to be checked before the
@@ -298,14 +325,14 @@ export async function prepareOutbound(
       console.error(`[OUTBOUND_AUTHORITY] BLOCKED ${mode === "proactive" ? "proactive send" : "reactive draft"} `
         + `to ${recipientKey.slice(-8)} — ${leak.reason}`);
       return mode === "proactive"
-        ? { text: "", blocked: true, detail: leak.reason }
-        : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: leak.reason };
+        ? { text: "", blocked: true, detail: leak.reason, draft: out }
+        : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: leak.reason, draft: out };
     }
     return { text: out, blocked: false };
   } catch (e: any) {
     console.error(`[OUTBOUND_AUTHORITY] BLOCKED ${mode} send to ${recipientKey.slice(-8)} — preparation failed: ${e?.message || e}`);
     return mode === "proactive"
-      ? { text: "", blocked: true, detail: "preparation failed" }
-      : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: "preparation failed" };
+      ? { text: "", blocked: true, detail: "preparation failed", draft: text }
+      : { text: REACTIVE_OUTBOUND_REPAIR, blocked: true, detail: "preparation failed", draft: text };
   }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,7 +38,7 @@ import { stripSignupSource } from "./signup-source";
 import { captureSignupSource } from "./signup-capture";
 import { JUNK_WORDS as _JUNK_WORDS, checkFoodPatterns, getDamageControlNote, checkPerfectDay } from "./handlers/checks";
 import { scanForSAFoods, parseFoodLogTotalsFromMessageOut, sanitizeCoachReply, recomputeTodayFoodTotals } from "./handlers/food-scanner";
-import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence } from "./handlers/chat-log";
+import { logChat, checkEscalation, logMediaFailure, logMediaSuccess, buildMediaTrace, withTimeout, inTurn, recordTurn, turnUser, turnMutation, turnMutations, turnAlreadyWrote, turnEvidence, turnCanonicalInput } from "./handlers/chat-log";
 import { handleWorkoutCommands, resumeOpenTrainingLoopOutcome, resumeWorkoutFeedbackExpectation } from "./handlers/workout";
 import { getTodayWorkoutState } from "./workout-state";
 import { handleMiscCommands } from "./handlers/misc-commands";
@@ -100,9 +100,9 @@ const RETRO_TURN = /(?<day>\byesterday\b|\blast night\b)|(?<food>\b(?:ate|eat|ea
 /**
  * ONE TURN, ONE LEDGER ROW (2026-08-10 directive, §6). This wrapper is the only place that knows
  * where a turn begins and ends, so it is the only place that can record one. It adds no routing
- * and no decisions — routeMessage below is the pipeline, unchanged.
+ * and no decisions. `rootId` is the transport's copy of this interaction's id — see chat-log.
  */
-export async function handleMessage(phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string): Promise<string> {
+export async function handleMessage(phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string, rootId?: string): Promise<string> {
   const kind = !mediaUrl ? "text"
     : /audio|ogg|voice/i.test(mediaContentType || "") ? "voice"
     : /video/i.test(mediaContentType || "") ? "video" : "photo";
@@ -111,7 +111,7 @@ export async function handleMessage(phone: string, message: string, mediaUrl?: s
     // Never awaited into the client's path: a ledger that can delay an answer is worse than none.
     void recordTurn(reply);
     return reply;
-  });
+  }, rootId || sourceMessageId);
 }
 
 async function routeMessage(phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string): Promise<string> {
@@ -139,7 +139,7 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
 
   // QR ACQUISITION SOURCE — a scanned join-QR prefills "(ref: gymA)"; capture once, then strip.
   if (!user.signupSource && !mediaUrl && message && (await captureSignupSource(user, phone, message))) {
-    message = stripSignupSource(message);
+    message = stripSignupSource(message); turnCanonicalInput(message);
     m = message.toLowerCase().trim().replace(/[‘’“”]/g, "'").replace(/\s+/g, " ");
   }
 
@@ -227,7 +227,7 @@ async function routeMessage(phone: string, message: string, mediaUrl?: string, m
         .where(eq(users.phoneNumber, phone)).catch(() => {});
     } else if (pending && !saidYesterday && scanForSAFoods(m).length > 0) {
       // The food they promised, with no date on it. Put the day back and spend the token.
-      message = `yesterday ${message}`;
+      message = `yesterday ${message}`; turnCanonicalInput(message);
       m = `yesterday ${m}`;
       const base = (user.profileNotes || "").replace(/\s*\bretro:pending\b/gi, "").trim();
       void db.update(users).set({ profileNotes: base || null }).where(eq(users.phoneNumber, phone)).catch(() => {});
@@ -709,7 +709,7 @@ Coach K tone: direct, warm, SA voice. Two sentences. Nothing else.`;
               canon = "";
             } else {
               console.log(`[NORMALIZER] ${pre.intent}(${Math.round(pre.confidence * 100)}%) "${message.slice(0, 80)}" → "${canon.slice(0, 80)}"`);
-              message = canon;
+              message = canon; turnCanonicalInput(message);
               m = canon.toLowerCase().replace(/\s+/g, " ").trim();
             }
           }

--- a/server/routes/types.ts
+++ b/server/routes/types.ts
@@ -6,7 +6,7 @@ import type { Express } from "express";
  */
 export interface RouteDeps {
   requireAdminKey: (req: any, res: any, next: any) => void;
-  handleMessage: (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string) => Promise<string>;
+  handleMessage: (phone: string, message: string, mediaUrl?: string, mediaContentType?: string, allMediaUrls?: string[], sourceMessageId?: string, rootId?: string) => Promise<string>;
   logChat: (userId: string, messageIn: string, messageOut: string, intent: string) => Promise<void>;
   checkRateLimit: (phone: string) => Promise<boolean>;
 }

--- a/server/routes/whatsapp.ts
+++ b/server/routes/whatsapp.ts
@@ -11,8 +11,10 @@ import { eq } from "drizzle-orm";
 import { captureQualitySignal } from "../quality-signals";
 import { recordMediaJob, completeMediaJob } from "../media-jobs";
 import { provenanceGate, shadowDoor } from "../verifiers/response-gate";
-import { humanizeReply, stripInternalMarkers, isDuplicateOutbound } from "../reply-hygiene";
+import { humanizeReply, stripInternalMarkers } from "../reply-hygiene";
 import { prepareOutbound, prepareReactiveOutbound } from "../outbound-authority";
+import { finaliseInteraction } from "../handlers/chat-log";
+import type { DeliveryResult } from "../outbound-delivery";
 
 // The sender number and the Twilio client both moved to outbound-delivery.ts with Cut B2. This
 // file resolved its own copy of each, which is how one door can end up sending from a number the
@@ -33,7 +35,7 @@ import { prepareOutbound, prepareReactiveOutbound } from "../outbound-authority"
  * Everything reactive now goes through here, before the message is split into bubbles — a claim
  * or a paragraph can straddle a split, so shaping has to happen on the whole reply.
  */
-async function sendFinal(phone: string, text: string, media: string | string[] | null): Promise<void> {
+async function sendFinal(phone: string, text: string, media: string | string[] | null, rootId?: string): Promise<void> {
   // ONE PREPARATION CONTRACT (Cut B, 2026-08-31). This path ran provenance and hygiene but never
   // the TRUTH FLOOR — enforceOutboundTruth reached the 68 scheduler jobs and nothing a client
   // said hello to. Exactly the shape of the 2026-07-30 finding recorded above, one layer along:
@@ -64,32 +66,30 @@ async function sendFinal(phone: string, text: string, media: string | string[] |
   //    number, so no client has ever seen one — but "gated" is a condition that can be
   //    edited by mistake, and a backstop at the door cannot be.
   out = stripInternalMarkers(out);
-  // 2. The same words twice in ten minutes is never the right outcome, whatever upstream
-  //    produced the repeat. Live: two different messages got byte-identical replies.
   // ══════════════════════════════════════════════════════════════════════════════════════════
-  // P0-C — SILENCE IS NOT AN ACCEPTABLE TERMINAL STATE (2026-08-21, handset).
+  // 2. NO REACTIVE DUPLICATE AUTHORITY — REMOVED (Cut 1, 2026-09-10).
   //
-  //     14:45  "What's the way forward?"        → the withhold reply
-  //     14:46  "As my coach, what is the way    → NOTHING. 80 minutes.
-  //             forwards for me? In terms of
-  //             everything"
-  //     16:05  "?"                              → only then did the coach speak
+  // What stood here: `if (isDuplicateOutbound(phone, out))` replaced a repeated reply with
+  // "I gave you the same answer twice there — that means mine wasn't useful…". It was written
+  // against P0-C (2026-08-21, handset), where two near-identical questions a minute apart got the
+  // same deterministic withhold string and the SECOND WAS SWALLOWED — 80 minutes of silence.
   //
-  // Two near-identical questions a minute apart. The withhold string is deterministic, so the
-  // second reply was byte-identical to the first, and this dedupe swallowed it — the client was
-  // punished for asking again after a bad answer, with silence.
+  // Two findings retire it, both proven post-transport on 7833ebb before this cut:
   //
-  // The dedupe earns its place: two different messages once got byte-identical replies. But
-  // suppressing a repeat is not the same as saying nothing. A client who asks twice is telling us
-  // the first answer did not land, and that is the one moment where silence is least affordable.
-  if (isDuplicateOutbound(phone, out)) {
-    console.warn(`[DUPLICATE_SUPPRESSED] ${phone.slice(-4)} — identical reply within the window: "${out.slice(0, 70)}"`);
-    recordSilentTurnAvoided("duplicate");
-    // Say something DIFFERENT rather than nothing. Short, honest, and it moves the conversation
-    // on instead of repeating the answer that already failed to land.
-    out = "I gave you the same answer twice there — that means mine wasn't useful. Tell me the one "
-      + "thing you want sorted and I'll deal with that specifically.";
-  }
+  //   · It was already unreachable for its own case. enforceOutboundTruth rule 3 ran the same
+  //     duplicate test one layer up, under the key `proactive:<phone>`, and replaced the body with
+  //     the outbound repair before this line ever saw a repeat. A second question got
+  //     "Let me check that properly before I answer — give me one sec and ask me again." That
+  //     rule is now proactive-only, which is what actually restores the P0-C guarantee.
+  //   · The remaining premise does not hold. "Two different messages got byte-identical replies"
+  //     is an upstream defect, and answering it HERE means the one client who most needs the
+  //     answer — the one who asked twice because the first reply did not land — is the only client
+  //     who cannot have it. A truthful answer does not become untrue on repetition.
+  //
+  // Nothing replaces it, and that is the point: this is a deletion, not a migration. Twilio
+  // webhook retries are still dropped by MessageSid at the door below, so no genuine repeat is
+  // re-sent; only a client who really did ask twice is now really answered twice.
+  // ══════════════════════════════════════════════════════════════════════════════════════════
   if (!out.trim()) {
     // AND THE EMPTY CASE ENDS THE SAME WAY (2026-08-22, P0-3 completion).
     //
@@ -107,8 +107,29 @@ async function sendFinal(phone: string, text: string, media: string | string[] |
       + "and I'll pick it up properly.";
   }
 
-  // 3. SHADOW (2026-08-04). Placed here — after the gate, the hygiene pass, the marker
-  //    strip and the dedupe — so what lands in the table is byte-for-byte what the client
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  // THE ROW THE TURN OPENED IS CLOSED HERE (Cut 1, 2026-09-10).
+  //
+  // `out` is now final: rendered, floored, provenance-checked, hygienised, marker-stripped, and
+  // NOT yet split into bubbles — the complete body the client reads. recordTurn wrote this
+  // interaction's row from inside the turn scope, where the mutations and the decision live; this
+  // finalises that same row by correlation. Deliberately not a second recorder, and deliberately
+  // not a relocation of recordTurn: moving the write here would lose the state half of the row and
+  // would stop recording every path that never reaches WhatsApp — the admin test webhook,
+  // journey-lab, the acceptance harnesses. See chat-log.finaliseInteraction.
+  //
+  // Captured BEFORE the shadow return below, because a shadow run must leave the same record a
+  // live send does; the delivery outcome is what differs, and it says so.
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  const verdict = prepared.blocked
+    ? { blocked: true, reason: prepared.reason ?? null, detail: prepared.detail ?? null, draft: (prepared.draft ?? text).slice(0, 4000) }
+    : { blocked: false };
+  const finalise = (deliveryOutcome: string) =>
+    finaliseInteraction(rootId, { deliveredBody: out, outboundVerdict: verdict, deliveryOutcome })
+      .catch(() => {});
+
+  // 3. SHADOW (2026-08-04). Placed here — after the gate, the hygiene pass and the marker
+  //    strip — so what lands in the table is byte-for-byte what the client
   //    would have received, not a draft. Before the TTS call, which costs money for audio
   //    nobody will hear. Returns false in a microsecond when the mode is off.
   //
@@ -122,7 +143,10 @@ async function sendFinal(phone: string, text: string, media: string | string[] |
   //    payload, it is asserted verbatim by crisis-reply.ts, and safety-audit.ts fails if
   //    that phrasing ever drifts.
   const isCrisisOut = out.includes("0800 567 567");
-  if ((await shadowDoor(phone, out, "reply", "server/routes/whatsapp.ts", media)) && !isCrisisOut) return;
+  if ((await shadowDoor(phone, out, "reply", "server/routes/whatsapp.ts", media)) && !isCrisisOut) {
+    await finalise("shadow");
+    return;
+  }
 
   // VOICE REPLY (2026-08-03) — for a client who opted in, the coach also speaks. The
   // text is sent either way and first: audio is additive, and a TTS failure must never
@@ -130,14 +154,16 @@ async function sendFinal(phone: string, text: string, media: string | string[] |
   let outMedia = media;
   const spoken = await voiceReplyFor(phone, out);
   if (spoken) outMedia = [...(Array.isArray(media) ? media : media ? [media] : []), spoken];
-  await sendParts(phone, splitMessage(out), outMedia);
+  // THE DELIVERY OWNER'S OWN VERDICT, not an assumption that awaiting a send means it landed.
+  const outcome = await sendParts(phone, splitMessage(out), outMedia);
+  await finalise(outcome);
 }
 
 async function sendParts(
   phone: string,
   parts: string[],
   replyMedia: string | string[] | null,
-): Promise<void> {
+): Promise<DeliveryResult> {
   const mediaUrls = Array.isArray(replyMedia) ? replyMedia.filter(Boolean) : (replyMedia ? [replyMedia] : []);
   // ONE DELIVERY OWNER (Cut B2, 2026-09-01). This built its own Twilio client, resolved its own
   // sender and ran its own retry loop — the third copy of that loop in the codebase. The schedule
@@ -160,12 +186,20 @@ async function sendParts(
   // chars, which a full workout blows past). That silently swallowed entire workout
   // replies — "Today's workout" returned nothing — while text-only menus delivered fine.
   // Decoupling guarantees the reply text always lands; a failed image only loses the image.
+  // THE TEXT'S OUTCOME IS THE TURN'S OUTCOME (Cut 1). Every result was discarded here, so the
+  // ledger could only ever have recorded an assumption. A failed IMAGE does not change what the
+  // client read — that is the decoupling described above — so media results are not folded in.
+  // The worst text outcome wins: one dropped bubble means the client did not get the message.
+  const rank: Record<DeliveryResult, number> = { sent: 0, fallback: 1, dropped: 2 };
+  let worst: DeliveryResult = textParts.length ? "sent" : "dropped";
   for (let i = 0; i < textParts.length; i++) {
-    await sendOne({ body: textParts[i].trim() }, `part ${i + 1}`);
+    const r = await sendOne({ body: textParts[i].trim() }, `part ${i + 1}`);
+    if (rank[r] > rank[worst]) worst = r;
   }
   for (let k = 0; k < mediaUrls.length; k++) {
     await sendOne({ mediaUrl: [mediaUrls[k]] }, `media ${k + 1}`);
   }
+  return worst;
 }
 
 // ── Bot marker rendering ──
@@ -204,10 +238,17 @@ export async function processTextAsync(
   allImageUrls: string[],
   handleMessage: RouteDeps["handleMessage"],
   sourceMessageId?: string,
+  /**
+   * ONE INBOUND MESSAGE, ONE INTERACTION (Cut 1). Handed to the turn AND to the transport, so the
+   * row recordTurn opens is the row sendFinal finalises. Twilio's MessageSid when the door has
+   * one; a minted id otherwise, so a source without a SID is still one interaction rather than
+   * an uncorrelatable half-row.
+   */
+  rootId: string = sourceMessageId || `wa-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
 ): Promise<void> {
   const isImageMessage = !!(mediaUrl && mediaType?.startsWith("image/"));
   try {
-    const reply = await handleMessage(phone, message, mediaUrl || undefined, mediaType || undefined, allImageUrls.length > 1 ? allImageUrls : undefined, sourceMessageId);
+    const reply = await handleMessage(phone, message, mediaUrl || undefined, mediaType || undefined, allImageUrls.length > 1 ? allImageUrls : undefined, sourceMessageId, rootId);
 
     // Render bot markers: buttons → keyword prompts, media extracted for separate sends.
     const { text: rawReply, media: replyMediaUrls } = renderReplyMarkers(reply);
@@ -229,15 +270,15 @@ export async function processTextAsync(
     // so that album bursts (N photos sent together) result in ONE combined reply.
     // Replies that include a media URL (equipment GIFs, etc.) are sent immediately.
     if (isImageMessage && !replyMediaUrls.length) {
-      await resolveImageInflight(phone, cleanReply);
+      await resolveImageInflight(phone, cleanReply, rootId);
       return;
     }
 
-    await sendFinal(phone, cleanReply, replyMediaUrls);
+    await sendFinal(phone, cleanReply, replyMediaUrls, rootId);
   } catch (err: any) {
     console.error("[TEXT_ASYNC] failed:", err?.message || err);
     // For image messages: resolve inflight so the buffer doesn't hang, then send the error.
-    if (isImageMessage) await resolveImageInflight(phone, null).catch(() => {});
+    if (isImageMessage) await resolveImageInflight(phone, null, rootId).catch(() => {});
     await sendParts(phone, ["Eish, something went wrong on my side. Give me a second and try again."], null).catch(() => {});
   } finally {
     // Media crash-safety net: the client was replied to (or got a handled error) → close the job.
@@ -255,9 +296,10 @@ async function processVoiceAsync(
   mediaType: string,
   handleMessage: RouteDeps["handleMessage"],
   sourceMessageId?: string,
+  rootId: string = sourceMessageId || `wa-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
 ): Promise<void> {
   try {
-    const reply = await handleMessage(phone, message, mediaUrl, mediaType, undefined, sourceMessageId);
+    const reply = await handleMessage(phone, message, mediaUrl, mediaType, undefined, sourceMessageId, rootId);
     // Render markers too — a voice note can trigger a workout (GIF + buttons) or a menu,
     // and previously those markers were sent to the client as literal text.
     const { text: rawVoiceText, media } = renderReplyMarkers(reply);
@@ -265,7 +307,7 @@ async function processVoiceAsync(
     const text = rawVoiceText && rawVoiceText.trim().length > 0
       ? rawVoiceText
       : `I heard your voice note but couldn't work out what to do with it — say it once more, or type it.`;
-    await sendFinal(phone, text, media);
+    await sendFinal(phone, text, media, rootId);
     console.log(`[VOICE_ASYNC] delivered reply to ${phone.slice(-4)}`);
   } catch (err: any) {
     console.error("[VOICE_ASYNC] failed:", err?.message || err);
@@ -345,6 +387,8 @@ const photoReplyBuffer = new Map<string, {
   failedCount: number;
   inflight: number;
   timer: ReturnType<typeof setTimeout> | null;
+  /** The root id of the most recent photo in the burst — the interaction the combined body answers. */
+  lastRootId: string | null;
 }>();
 
 function bumpImageInflight(phone: string): void {
@@ -353,13 +397,22 @@ function bumpImageInflight(phone: string): void {
     if (e.timer) { clearTimeout(e.timer); e.timer = null; }
     e.inflight++;
   } else {
-    photoReplyBuffer.set(phone, { parts: [], failedCount: 0, inflight: 1, timer: null });
+    photoReplyBuffer.set(phone, { parts: [], failedCount: 0, inflight: 1, timer: null, lastRootId: null });
   }
 }
 
-async function resolveImageInflight(phone: string, reply: string | null): Promise<void> {
+/**
+ * AN ALBUM IS N INTERACTIONS AND ONE REPLY (Cut 1). Each photo is its own inbound message with its
+ * own root id and its own ledger row, and this buffer deliberately answers them with a single
+ * combined body. The row finalised with that body is the LAST one — the same part flushPhotoBuffer
+ * already treats as authoritative, because only it has the totals after every meal was inserted.
+ * The earlier rows keep their handler reply and no delivered body, which is the honest record: no
+ * separate message was sent for them.
+ */
+async function resolveImageInflight(phone: string, reply: string | null, rootId?: string): Promise<void> {
   const e = photoReplyBuffer.get(phone);
-  if (!e) { if (reply) await sendFinal(phone, reply, null); return; }
+  if (!e) { if (reply) await sendFinal(phone, reply, null, rootId); return; }
+  if (rootId) e.lastRootId = rootId;
   if (reply) e.parts.push(reply); else e.failedCount++;
   e.inflight = Math.max(0, e.inflight - 1);
   if (e.inflight === 0) {
@@ -371,10 +424,10 @@ async function flushPhotoBuffer(phone: string): Promise<void> {
   const entry = photoReplyBuffer.get(phone);
   if (!entry) return;
   photoReplyBuffer.delete(phone);
-  const { parts, failedCount } = entry;
+  const { parts, failedCount, lastRootId } = entry;
   if (parts.length === 0) return; // all failed — errors already sent individually
   if (parts.length === 1 && failedCount === 0) {
-    await sendFinal(phone, parts[0], null);
+    await sendFinal(phone, parts[0], null, lastRootId || undefined);
     return;
   }
   // Multiple parts: strip "Today so far" footer from all but the last (the last has
@@ -384,7 +437,7 @@ async function flushPhotoBuffer(phone: string): Promise<void> {
   const batchNote = `\n\n_${parts.length} photo${parts.length > 1 ? "s" : ""} — all logged._`;
   const failNote = failedCount > 0 ? `\n_(${failedCount} unclear — resend in better light if needed)_` : "";
   const combined = bodies.join("\n\n") + batchNote + failNote;
-  await sendFinal(phone, combined, null);
+  await sendFinal(phone, combined, null, lastRootId || undefined);
 }
 
 export function registerWhatsAppRoutes(app: Express, deps: Pick<RouteDeps, "handleMessage" | "checkRateLimit">) {

--- a/server/self-check.ts
+++ b/server/self-check.ts
@@ -110,7 +110,15 @@ export function recordFalseConfirmation(): void { bump("writeintegrity:false_con
  * found the first one by waiting 80 minutes and then typing "?" — which is not a monitoring
  * strategy. Silence is a product failure; it now leaves a trace.
  */
-export function recordSilentTurnAvoided(cause: "duplicate" | "empty"): void {
+/**
+ * "duplicate" WAS A CAUSE AND NO LONGER IS (Cut 1, 2026-09-10). The reactive door used to
+ * suppress a repeated reply and count the suppression here. That branch is deleted: a client who
+ * asks twice now gets the answer twice, so there is no duplicate-shaped silence left to avoid.
+ * The member goes with it rather than staying as a metric that can only ever report zero — a
+ * counter nobody can trip reads on the founder's self-check as "this never happens", which is a
+ * stronger claim than "nothing measures it".
+ */
+export function recordSilentTurnAvoided(cause: "empty"): void {
   bump(`silentturn:${cause}`);
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -317,12 +317,45 @@ export const turnLedger = pgTable("turn_ledger", {
   fixRef: text("fix_ref"),                   // the PR or commit claiming the fix
   triageNote: text("triage_note"),           // why the human classified it that way
   triagedAt: timestamp("triaged_at"),
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  // THE CUSTOMER-VISIBLE HALF OF THE TURN (Cut 1, 2026-09-10).
+  //
+  // Everything above this line describes what the HANDLERS did. `reply` is the string
+  // routeMessage returned, reconciled — and that is where the record stopped, while nineteen
+  // authorities downstream could still render, replace, repair or suppress it before a phone
+  // buzzed. Two proven consequences on 7833ebb: a ledger holding `[BUTTONS:…]` for a client who
+  // saw `▸ *Today's workout*`, and a client who asked the same question twice, was answered with
+  // "ask me again", and left two ledger rows both showing the correct coaching reply.
+  //
+  // So the row now carries both halves. `reply` keeps its meaning exactly — what the pipeline
+  // decided — and these say what left the building. A row where they differ is not a bug by
+  // itself; a row where nobody can tell is.
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  /** One id per inbound source message. Nested turns (a voice transcript re-entering
+   *  handleMessage) INHERIT it, so one client message is one interaction however many rows it
+   *  produces. Twilio's MessageSid when there is one; minted at the door when there is not. */
+  rootId: text("root_id"),
+  /** What the HANDLERS actually saw, when the normalizer, the retro-continuity carry or the
+   *  signup-source strip rewrote the client's words before any handler ran. Null when the raw
+   *  text proceeded untouched, which is the ordinary case. */
+  inputTextCanonical: text("input_text_canonical"),
+  /** The canonical decision and how the turn disposed of it: { kind, todo, disposition }. */
+  decision: jsonb("decision"),
+  /** The COMPLETE body handed to delivery — after marker rendering, the truth floor, provenance,
+   *  hygiene and the marker strip, and before Twilio bubble splitting. What the client read. */
+  deliveredBody: text("delivered_body"),
+  /** { blocked, reason, detail, draft } from prepareOutbound. `draft` is the rejected text, so a
+   *  blocked turn records what was refused as well as what was sent instead. */
+  outboundVerdict: jsonb("outbound_verdict"),
+  /** sent | dropped | fallback — the delivery owner's own verdict, not an assumption. */
+  deliveryOutcome: text("delivery_outcome"),
 }, (table) => ({
   userDateIdx: index("turn_ledger_user_date_idx").on(table.userId, table.createdAt),
   createdIdx: index("turn_ledger_created_idx").on(table.createdAt),
   versionIdx: index("turn_ledger_version_idx").on(table.version),
   failureIdx: index("turn_ledger_failure_idx").on(table.failureCategory),
   lifecycleIdx: index("turn_ledger_lifecycle_idx").on(table.lifecycleStatus),
+  rootIdx: index("turn_ledger_root_idx").on(table.rootId),
 }));
 
 export const clothingCheckins = pgTable(


### PR DESCRIPTION
## Outcome

This is Cut 1 of the locked rescue sequence: make the customer-visible response observable and remove the reactive duplicate mouth that replaced a truthful repeated answer with “ask me again.”

### Runtime changes

- correlates one inbound source message with a stable `root_id`;
- persists raw input, canonical input seen by handlers, canonical decision, final pre-split outbound body, outbound verdict, delivery outcome, and build version on `turn_ledger`;
- records blocked drafts beside their replacement;
- removes duplicate suppression from the reactive path while retaining proactive duplicate protection;
- finalises the existing ledger row after outbound preparation/delivery (no second recorder);
- renders buttons before recording the final body.

### Evidence supplied on head

- `npm test`: 37/37 suites
- PostgreSQL acceptance runner: 26/26
- new post-transport acceptance: 42/42
- production parity: 142/142
- TypeScript and all architecture/schema/file-size/name/SAST guards green; no budget raised
- seven mechanism reverts observed red by the builder

### CTO gate correction

Commit `04396c0` makes the red-on-revert harness itself fail closed. The prior script printed verdicts but always exited successfully; it now exits non-zero when the DB reset fails, the acceptance crashes, a revert stays green, or no graded-red terminal verdict appears.

### Deliberate limits

- Voice recursion still creates two ledger rows, now joined by one root ID. Flattening that recursion is a later bounded cut.
- `delivered_body` is the complete final body handed to the delivery boundary; `delivery_outcome` distinguishes `sent`, `fallback`, `dropped`, or `shadow`. It is not by itself proof the handset displayed it.
- No voice parser, day splitter, broad handler sweep, scheduler migration, or Coach Health UI work is included.

Base: exact `7833ebb`.