### PR TITLE
Raw voice provenance: the words the client actually spoke are durable

### DIFF
--- a/migrations/0013_raw_voice_provenance.sql
+++ b/migrations/0013_raw_voice_provenance.sql
@@ -1,0 +1,26 @@
+-- RAW VOICE PROVENANCE (2026-09-10).
+--
+-- A voice note passes three text stages before any handler sees it:
+--
+--     Scribe/Whisper  ->  cleanSATranscript  ->  condenseVoiceRamble (>150 words)  ->  handlers
+--
+-- Only the last was persisted, as `input_text` on the INNER ledger row, and even that is the
+-- CONDENSED text rather than the client's words. The raw transcript existed only in a log line.
+--
+-- The consequence, stated as the question it makes unanswerable: when a voice turn goes wrong,
+-- did we MIS-HEAR the client, or did we hear them correctly and then delete half of it in a
+-- cleaning or condensing step? Those are different defects with different owners and different
+-- fixes, and nothing durable could tell them apart.
+--
+-- Three separate columns, not one, because diffing the stages IS the diagnosis. Plus a small
+-- provenance object saying which STT produced the raw text and which stages actually changed it —
+-- a stage that ran and declined is not the same event as a stage that never ran.
+--
+-- Additive and idempotent: every statement is IF NOT EXISTS, nothing is dropped, no existing
+-- column changes type or meaning, and every new column is nullable so rows written by the running
+-- build before this lands stay valid. Safe to apply to a live database carrying traffic.
+
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS voice_transcript_raw TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS voice_transcript_cleaned TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS voice_text_for_brain TEXT;
+ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS voice_provenance JSONB;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1789056000000,
       "tag": "0012_spoken_step_hundreds",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1789061218646,
+      "tag": "0013_raw_voice_provenance",
+      "breakpoints": true
     }
   ]
 }

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -195,6 +195,19 @@ export const ACCEPTANCES: Acceptance[] = [
     // in prepareOutbound and sendFinal, past every handler.
     command: ["npx", "tsx", "script/pg-interaction-truth-acceptance.ts"] },
 
+  { id: "voice-provenance", title: "The words the client actually spoke are durable",
+    // RAW VOICE PROVENANCE (2026-09-10). A voice note becomes three strings — STT output, cleaned,
+    // condensed — and only the last reached the ledger, so "did we mis-hear them, or hear them and
+    // then delete half of it?" had no durable evidence. Needs a real database: the claim is about
+    // which COLUMNS on which ROW survive the transport, and a fixture that answers every query the
+    // same way cannot tell two ledger rows apart.
+    command: ["npx", "tsx", "script/pg-voice-provenance-acceptance.ts"] },
+
+  { id: "voice-provenance-reverts", title: "Voice provenance fails on every stage revert",
+    // Each media.ts recording seam and the ledger writer are reverted independently; the relevant
+    // suite must turn red. A crash or an absent verdict is itself red.
+    command: ["bash", "script/red-on-revert-voice-provenance.sh"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-voice-provenance-acceptance.ts
+++ b/script/pg-voice-provenance-acceptance.ts
@@ -1,0 +1,334 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the words the client actually spoke are durable (2026-09-10).
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT WAS TRUE BEFORE THIS CUT, verified on 9124647 before a line of it was written.
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * A voice note becomes three different strings before any handler sees it:
+ *
+ *     Scribe/Whisper  →  cleanSATranscript  →  condenseVoiceRamble (>150 words)  →  handlers
+ *
+ * `turn_ledger.input_text` on the inner row held the LAST of those. The client's own words existed
+ * only in a `[VOICE] scribe_ok text="…"` log line. So for any bad voice turn, the first question —
+ * did we mis-hear them, or did we hear them and then delete half of it? — had no durable evidence
+ * behind it at all. One is an STT problem, the other is ours.
+ *
+ * A probe of the nested voice shape on that SHA also showed which row carries what:
+ *     [0] input_type=text  … delivered_body=""      ← the inner turn
+ *     [1] input_type=voice … delivered_body="Voice — one thing today: …"  outcome=shadow
+ * The OUTER voice row is the one the transport finalises, so it is the row the three texts must
+ * land on for a single row to answer the whole question.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT THIS GRADES, AND THE ONE THING IT CANNOT
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * GRADED, for real: the recorder's merge semantics, the derived provenance flags, which row the
+ * texts land on, that they survive an early return, and that the row also carries the decision,
+ * the final post-transport body and the build SHA — read back out of PostgreSQL after the
+ * transport has run.
+ *
+ * NOT GRADED HERE, stated plainly rather than implied: the audio download and the STT call in
+ * media.ts cannot be executed offline. assertSafeMediaUrl requires an https URL on an allow-listed
+ * PUBLIC host — it is an SSRF guard, and weakening it to make a test pass would be a far worse
+ * trade than saying so — and the transcription itself needs the network. The wiring inside
+ * media.ts is therefore covered by the source-ORDER assertions in script/voice-provenance-tests.ts
+ * §4 (raw must be captured before the cleaner reassigns the variable), and by the red-on-revert
+ * script, which reverts each media.ts call site individually.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-voice-provenance-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { inTurn, recordTurn, turnUser, turnVoice, finaliseInteraction, _resetInteractionCorrelation } =
+  await import("../server/handlers/chat-log");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+const phone = "whatsapp:+27820000961";
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+const [user] = await db.insert(schema.users).values({
+  phoneNumber: phone, name: "Nomsa Voice", onboardingState: "COMPLETE", popiConsent: true,
+  subscriptionStatus: "active", goalType: "fat_loss", currentWeight: "92", startWeight: "95",
+  targetWeight: "85", heightCm: 178, age: 34, gender: "female", trainingMode: "gym",
+  proteinTarget: 150, dailyCalorieTarget: 2200, dailyStepTarget: 8000,
+} as any).returning();
+
+type Row = {
+  input_type: string | null; input_text: string | null; root_id: string | null;
+  voice_transcript_raw: string | null; voice_transcript_cleaned: string | null;
+  voice_text_for_brain: string | null; voice_provenance: any;
+  decision: any; delivered_body: string | null; delivery_outcome: string | null;
+  version: string | null;
+};
+const rows = async (): Promise<Row[]> => (await pool.query<Row>(
+  `SELECT input_type, input_text, root_id, voice_transcript_raw, voice_transcript_cleaned,
+          voice_text_for_brain, voice_provenance, decision, delivered_body, delivery_outcome, version
+     FROM turn_ledger WHERE user_id = $1 ORDER BY created_at, id`, [user.id])).rows;
+const clear = async () => {
+  await pool.query("DELETE FROM turn_ledger WHERE user_id = $1", [user.id]);
+  await pool.query("DELETE FROM shadow_replies WHERE phone = $1", [phone]);
+  _resetInteractionCorrelation();
+  _resetOutboundDedupe();
+};
+const settle = () => new Promise(r => setTimeout(r, 700));
+
+/**
+ * The exact shape handlers/media.ts performs for a voice note: the OUTER turn is opened by
+ * handleMessage for the audio, the three stages are recorded onto it as they are produced, and the
+ * for-brain text then RE-ENTERS handleMessage, opening the inner turn. Then the transport
+ * finalises the interaction, as routes/whatsapp.processVoiceAsync does.
+ */
+async function voiceTurn(opts: {
+  rootId: string; raw: string; cleaned?: string; forBrain?: string;
+  engine?: "scribe" | "whisper"; earlyReturn?: string; languageNote?: string;
+}): Promise<string> {
+  const reply = await inTurn("voice", "", async () => {
+    turnUser(user.id);
+    const wordCount = opts.raw.split(/\s+/).filter(Boolean).length;
+    turnVoice({ engine: opts.engine ?? "whisper", raw: opts.raw, wordCount });
+    if (opts.earlyReturn) {
+      // The garble / single-word / refusal branches RETURN from media.ts, and that return
+      // propagates through routeMessage to handleMessage's wrapper — which records the turn on
+      // every path. Recording only on the happy path here would be a fixture that cannot see the
+      // very case this section exists for.
+      void recordTurn(opts.earlyReturn);
+      return opts.earlyReturn;
+    }
+    turnVoice({ cleaned: opts.cleaned ?? opts.raw });
+    // media.ts composes the handler input ONCE and records the same variable it passes. Mirrored
+    // here exactly, including the append, so the reconstruction check below is grading the
+    // contract rather than a string this harness happened to build twice.
+    const base = opts.forBrain ?? opts.cleaned ?? opts.raw;
+    const brainInput = base + (opts.languageNote ? `\n\n[LANGUAGE NOTE: ${opts.languageNote}]` : "");
+    turnVoice({ forBrain: base, handlerInput: brainInput, languageNote: opts.languageNote || null });
+    const inner = await handleMessage(
+      phone, brainInput, undefined, undefined, undefined, opts.rootId);
+    void recordTurn(inner);
+    return inner;
+  }, opts.rootId);
+  await finaliseInteraction(opts.rootId, {
+    deliveredBody: reply, outboundVerdict: { blocked: false }, deliveryOutcome: "shadow",
+  });
+  return reply;
+}
+
+REAL("\npg-voice-provenance-acceptance — the client's own words are durable\n");
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("1. ALL THREE STAGES SURVIVE, SEPARATELY, ON ONE ROW");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+{
+  const RAW = "Yoh I had stamp and beans for lunch and I walked to the shops";
+  const CLEAN = "Yoh I had samp and beans for lunch and I walked to the shops";
+  const BRAIN = "I had samp and beans for lunch. I walked to the shops.";
+  await voiceTurn({ rootId: "sid-voice-a", raw: RAW, cleaned: CLEAN, forBrain: BRAIN, engine: "scribe" });
+  await settle();
+  const r = await rows();
+  const voice = r.find(x => x.input_type === "voice");
+  chk(!!voice, "the voice turn left a row");
+  chk(voice?.voice_transcript_raw === RAW,
+    "the RAW transcript is stored exactly as the STT returned it — 'stamp', the mishear",
+    JSON.stringify(voice?.voice_transcript_raw));
+  chk(voice?.voice_transcript_cleaned === CLEAN,
+    "the CLEANED text is stored separately — 'samp', the repair", JSON.stringify(voice?.voice_transcript_cleaned));
+  chk(voice?.voice_text_for_brain === BRAIN,
+    "the FOR-BRAIN text is stored separately — what the handlers routed on",
+    JSON.stringify(voice?.voice_text_for_brain));
+  chk(voice?.voice_transcript_raw !== voice?.voice_transcript_cleaned
+      && voice?.voice_transcript_cleaned !== voice?.voice_text_for_brain,
+    "…and all three genuinely differ, so the diff that IS the diagnosis is possible");
+  chk(voice?.voice_provenance?.engine === "scribe", "the STT that produced the raw text is named",
+    JSON.stringify(voice?.voice_provenance));
+  chk(voice?.voice_provenance?.cleaned === true && voice?.voice_provenance?.condensed === true,
+    "…and both stages are recorded as having CHANGED the text", JSON.stringify(voice?.voice_provenance));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n2. THE SAME ROW CARRIES THE DECISION, THE FINAL OUTBOUND BODY AND THE BUILD SHA");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  const r = await rows();
+  const voice = r.find(x => x.input_type === "voice");
+  chk(!!voice?.delivered_body, "the row carries the final post-transport body",
+    JSON.stringify((voice?.delivered_body || "").slice(0, 70)));
+  chk(voice?.delivery_outcome === "shadow", "…and the delivery outcome", `got ${voice?.delivery_outcome}`);
+  chk(!!voice?.version, "…and the build SHA", `got ${voice?.version}`);
+  chk(voice?.decision !== null && typeof voice?.decision === "object",
+    "…and the decision object written by the existing owner", JSON.stringify(voice?.decision));
+  chk(!!voice?.voice_transcript_raw,
+    "…on the SAME row as the raw transcript, so one row answers the whole question");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n3. ONE VOICE NOTE IS STILL ONE INTERACTION");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  const r = await rows();
+  chk(r.length === 2, "the nested voice turn produces two rows (the recursion is not this cut)",
+    `rows=${r.length}`);
+  chk(r.every(x => x.root_id === "sid-voice-a"), "…both under one root id",
+    JSON.stringify(r.map(x => x.root_id)));
+  const inner = r.find(x => x.input_type === "text");
+  chk(inner?.voice_transcript_raw == null,
+    "the INNER row carries no transcript — the voice provenance has exactly one home",
+    JSON.stringify(inner?.voice_transcript_raw));
+  chk(inner?.input_text === "I had samp and beans for lunch. I walked to the shops.",
+    "…and the inner row still shows the condensed text it was actually given, unchanged by this cut",
+    JSON.stringify(inner?.input_text));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n4. A STAGE THAT RAN AND DECLINED IS NOT A STAGE THAT NEVER RAN");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Both model stages fail open and return their input unchanged — proven against the real
+// functions in script/voice-provenance-tests.ts §1–2. So `cleaned === raw` is the ORDINARY case on
+// a healthy turn, and the flags record whether the stage CHANGED the text rather than whether it
+// ran. A column that conflated those two would be unreadable in exactly the situation it exists
+// for.
+await clear();
+{
+  const RAW = "I had eggs and toast this morning";
+  await voiceTurn({ rootId: "sid-voice-b", raw: RAW });   // cleaner and condenser both declined
+  await settle();
+  const voice = (await rows()).find(x => x.input_type === "voice");
+  chk(voice?.voice_transcript_raw === RAW && voice?.voice_transcript_cleaned === RAW
+      && voice?.voice_text_for_brain === RAW,
+    "an untouched note stores the same text at all three stages");
+  chk(voice?.voice_provenance?.cleaned === false && voice?.voice_provenance?.condensed === false,
+    "…and both flags say NOT CHANGED, rather than the columns being absent",
+    JSON.stringify(voice?.voice_provenance));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n5. A FAILED VOICE TURN STILL RECORDS WHAT WE HEARD");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// The garble guard, the single-word guard and the refusal floor all RETURN before the cleaner or
+// the condenser run. Those are the turns where "what did we actually hear?" matters most, and
+// recording only at the end of the happy path would have left every one of them blank — which is
+// the state this cut is fixing, reproduced one layer in.
+await clear();
+{
+  const GARBLE = "shombolo weh weh ka ka ka";
+  await voiceTurn({
+    rootId: "sid-voice-c", raw: GARBLE, engine: "whisper",
+    earlyReturn: "I caught some of that, but not clearly enough to be sure I understood you right.",
+  });
+  await settle();
+  const voice = (await rows()).find(x => x.input_type === "voice");
+  chk(voice?.voice_transcript_raw === GARBLE,
+    "a turn that returned early still stores the raw transcript", JSON.stringify(voice?.voice_transcript_raw));
+  chk(voice?.voice_transcript_cleaned == null && voice?.voice_text_for_brain == null,
+    "…and stores nothing for the stages that never ran",
+    JSON.stringify([voice?.voice_transcript_cleaned, voice?.voice_text_for_brain]));
+  chk(voice?.voice_provenance?.cleaned === null && voice?.voice_provenance?.condensed === null,
+    "…with NULL flags, which is distinguishable from the `false` of section 4",
+    JSON.stringify(voice?.voice_provenance));
+  chk(/not clearly enough/.test(voice?.delivered_body || ""),
+    "…beside the refusal the client actually received", JSON.stringify((voice?.delivered_body || "").slice(0, 60)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n6. CONTROL — A TEXT TURN CARRIES NO VOICE PROVENANCE AT ALL");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Without this, every check above would still pass if the recorder wrote the columns on every
+// turn from some other source, and the columns would mean nothing.
+await clear();
+{
+  const { processTextAsync } = await import("../server/routes/whatsapp");
+  await processTextAsync(phone, "I walked 9000 steps", null, null, [], handleMessage as any, "sid-text-a");
+  await settle();
+  const r = await rows();
+  chk(r.length === 1 && r[0].input_type === "text", "the text turn left one row", `rows=${r.length}`);
+  chk(r[0]?.voice_transcript_raw == null && r[0]?.voice_transcript_cleaned == null
+      && r[0]?.voice_text_for_brain == null && r[0]?.voice_provenance == null,
+    "…and every voice column is null on it",
+    JSON.stringify([r[0]?.voice_transcript_raw, r[0]?.voice_provenance]));
+  chk(!!r[0]?.delivered_body,
+    "…while the Cut 1 columns still work on a text turn, untouched by this cut");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n7. THE EXACT HANDLER INPUT CAN BE RECONSTRUCTED FROM THE ROW");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// THE DEFECT THIS EXISTS FOR, found in the first version of THIS cut and corrected the same day.
+//
+// media.ts does not call handleMessage with `forBrain`. It calls it with
+// `forBrain + "\n\n[LANGUAGE NOTE: …]"` whenever the transcript looks like a non-English SA
+// language. The column was nevertheless documented as "what the handlers routed on" — a column
+// holding something other than its label, which is exactly what revert case 2 of this cut's own
+// red-on-revert exists to catch one stage earlier.
+//
+// The contract now: `voice_text_for_brain` is CLIENT-ORIGIN text and nothing else, the note we
+// appended ourselves is recorded beside it, and the exact argument is stored verbatim. All three
+// so the append is reversible in both directions — you can rebuild the call from the client's
+// words, and you can strip our sentence back off the call.
+await clear();
+{
+  const CLEAN = "Ngidle ipapa nenyama namuhla ekuseni";
+  const NOTE = "The client is speaking Zulu";
+  await voiceTurn({ rootId: "sid-voice-d", raw: CLEAN, languageNote: NOTE });
+  await settle();
+  const r = await rows();
+  const voice = r.find(x => x.input_type === "voice");
+  const inner = r.find(x => x.input_type === "text");
+  const expected = `${CLEAN}\n\n[LANGUAGE NOTE: ${NOTE}]`;
+
+  chk(voice?.voice_provenance?.handlerInput === expected,
+    "the row stores the EXACT string handleMessage was called with",
+    JSON.stringify(voice?.voice_provenance?.handlerInput));
+  chk(voice?.voice_text_for_brain === CLEAN,
+    "…while voice_text_for_brain stays client-origin, with no note in it",
+    JSON.stringify(voice?.voice_text_for_brain));
+  chk(voice?.voice_provenance?.languageNote === NOTE,
+    "…and the note we appended is recorded separately", JSON.stringify(voice?.voice_provenance?.languageNote));
+
+  // RECONSTRUCTION, both directions — this is the actual claim.
+  const rebuilt = String(voice?.voice_text_for_brain)
+    + (voice?.voice_provenance?.languageNote ? `\n\n[LANGUAGE NOTE: ${voice.voice_provenance.languageNote}]` : "");
+  chk(rebuilt === voice?.voice_provenance?.handlerInput,
+    "the handler input rebuilds exactly from the client text plus the recorded note", JSON.stringify(rebuilt));
+  chk(String(voice?.voice_provenance?.handlerInput || "").startsWith(String(voice?.voice_text_for_brain))
+      && !String(voice?.voice_text_for_brain).includes("[LANGUAGE NOTE:"),
+    "…and our sentence strips back off it, leaving only what the client said");
+
+  // The independent witness: the inner row's input_text IS what handleMessage received, written by
+  // a different owner (inTurn) on a different row. If these disagree, the provenance is fiction.
+  chk(inner?.input_text === expected,
+    "the inner row — written by inTurn, not by this cut — shows the same exact input",
+    JSON.stringify(inner?.input_text));
+
+  // …and the flag that the correction turns on: `condensed` is computed from the BASE text, so a
+  // language note must not masquerade as the condenser having rewritten the client.
+  chk(voice?.voice_provenance?.condensed === false,
+    "a language note does NOT read as a condense — the flag is computed from the client's text",
+    JSON.stringify(voice?.voice_provenance));
+}
+
+REAL(`\n${failed === 0 ? "pg-voice-provenance-acceptance: ALL GREEN" : `pg-voice-provenance-acceptance: ${failed} FAILED`}`);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-voice-provenance.sh
+++ b/script/red-on-revert-voice-provenance.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — raw voice provenance. One recording seam at a time.
+#
+# Each case removes exactly ONE piece of this cut and re-runs the suite that is supposed to grade
+# it. A case that stays green is a check that grades nothing, which is the failure mode the whole
+# provenance argument rests on: the words the client spoke were absent from the ledger for months
+# and every gate was green throughout.
+#
+# Cases 1-3 revert the media.ts recording seams and are graded by voice-provenance-tests (source
+# ORDER — the voice branch of media.ts cannot be executed offline, see that file's §4 for why, and
+# this script is where that limitation is paid for). Cases 4-6 revert the ledger writer and the
+# recorder itself and are graded by the PostgreSQL acceptance. Case 7 is an OPPOSITE-DEFECT
+# control: it does not revert this cut, it breaks the thing this cut must not have broken.
+# Cases 8-9 cover the handler-input correction: the first version of this cut stored the
+# client-origin text under a comment claiming it was the handler input, while media.ts actually
+# passed that text plus an internal language note.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/voiceprov-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/backup"
+PATCH_DIR="$WORK_ROOT/patches"
+
+restore_case () {
+  if [[ -d "$BACKUP/server" ]]; then
+    rm -rf server && mv "$BACKUP/server" server
+  fi
+  rm -rf "$BACKUP"
+}
+cleanup () { restore_case; rm -rf "$WORK_ROOT"; }
+trap cleanup EXIT INT TERM
+
+reset_db () {
+  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+}
+
+run_case () {
+  local name="$1" patch="$2" suite="$3" label="$4"
+  local out status verdict
+  restore_case
+  mkdir -p "$BACKUP"
+  cp -a server "$BACKUP/server"
+  if ! python3 "$patch"; then
+    echo "  !! patch failed: $name"; restore_case; return 1
+  fi
+  reset_db
+  out="$(npx tsx "$suite" 2>&1)"
+  status=$?
+  verdict="$(printf '%s\n' "$out" | grep -E "^${label}:" | tail -1 || true)"
+  echo "── REVERT $name"
+  echo "   ${verdict:-(no verdict — crashed)}"
+  printf '%s\n' "$out" | grep '^  FAIL' | sed 's/^/   /' | head -3 || true
+  restore_case
+  if [[ $status -eq 0 ]]; then
+    echo "  !! suite stayed green: $name"; return 1
+  fi
+  if [[ ! "$verdict" =~ ^${label}:\ [1-9][0-9]*\ FAILED$ ]]; then
+    echo "  !! suite did not reach a graded red verdict: $name (exit $status)"; return 1
+  fi
+}
+
+mkdir -p "$PATCH_DIR"
+UNIT=script/voice-provenance-tests.ts
+UNIT_LABEL=voice-provenance-tests
+ACC=script/pg-voice-provenance-acceptance.ts
+ACC_LABEL=pg-voice-provenance-acceptance
+
+# 1. THE RAW TRANSCRIPT IS NEVER CAPTURED. The client's own words are gone before anything sees
+#    them — the exact state of the product before this cut.
+cat > "$PATCH_DIR/1.py" <<'PY'
+p="server/handlers/media.ts"; s=open(p).read(); b=s
+s=s.replace(" turnVoice({ engine: sttEngine, raw: transcribedText, wordCount });", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 2. THE RAW CAPTURE MOVES BELOW THE CLEANER. Subtle and much worse than case 1: the column is
+#    populated, so it LOOKS recorded, but `transcribedText` has already been reassigned — the row
+#    would hold cleaned text under the label "raw" and every diff would silently read as "the STT
+#    heard it correctly".
+cat > "$PATCH_DIR/2.py" <<'PY'
+p="server/handlers/media.ts"; s=open(p).read(); b=s
+s=s.replace(" turnVoice({ engine: sttEngine, raw: transcribedText, wordCount });", "")
+s=s.replace("transcribedText = await cleanSATranscript(openai, transcribedText, user.id);",
+            "transcribedText = await cleanSATranscript(openai, transcribedText, user.id); turnVoice({ engine: sttEngine, raw: transcribedText, wordCount });")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 3. THE FOR-BRAIN TEXT IS NOT RECORDED, or is recorded after the recursion has already opened the
+#    inner scope — either way the text the handlers actually routed on is not on the voice row.
+cat > "$PATCH_DIR/3.py" <<'PY'
+p="server/handlers/media.ts"; s=open(p).read(); b=s
+s=s.replace(" turnVoice({ forBrain, handlerInput: brainInput, languageNote: languageNote || null });", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 4. THE LEDGER STOPS WRITING THE THREE COLUMNS. The recorder still runs and the scope still holds
+#    the texts; nothing durable results.
+cat > "$PATCH_DIR/4.py" <<'PY'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("      voiceTranscriptRaw: v?.raw ?? null, voiceTranscriptCleaned: v?.cleaned ?? null,\n      voiceTextForBrain: v?.forBrain ?? null, voiceProvenance,\n", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 5. THE RECORDER OVERWRITES INSTEAD OF MERGING. Called three times as the stages complete, so a
+#    non-merging setter keeps only the last one and the raw transcript is lost again — including on
+#    every early return, where only the raw call ever fires.
+cat > "$PATCH_DIR/5.py" <<'PY'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("  t.voice = { ...(t.voice || {}), ...facts };", "  t.voice = { ...facts };")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 6. THE FLAGS STOP DISTINGUISHING "RAN AND DECLINED" FROM "NEVER RAN". Both stages fail open, so
+#    cleaned === raw is the ordinary case; collapsing null into false makes a failed voice turn
+#    indistinguishable from a healthy one in exactly the column meant to tell them apart.
+cat > "$PATCH_DIR/6.py" <<'PY'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("cleaned: v.cleaned !== undefined ? v.cleaned !== v.raw : null,", "cleaned: v.cleaned !== v.raw,")
+s=s.replace("condensed: v.forBrain !== undefined ? v.forBrain !== v.cleaned : null,", "condensed: v.forBrain !== v.cleaned,")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 7. OPPOSITE DEFECT — the voice columns are written on EVERY turn rather than only a voice turn.
+#    Sections 1-5 of the acceptance would still pass; section 6's control is the only thing that
+#    stops these columns quietly becoming a second copy of input_text.
+cat > "$PATCH_DIR/7.py" <<'PY'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("    const v = t.voice;", "    const v = t.voice || { raw: t.inputText, cleaned: t.inputText, forBrain: t.inputText };")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 8. THE HANDLER INPUT IS NOT RECORDED — the state the first version of this cut shipped in.
+#    voice_text_for_brain was documented as "what the handlers routed on" while media.ts actually
+#    passed that text PLUS an internal language note, so the row held a different string from the
+#    call and nothing could tell.
+cat > "$PATCH_DIR/8.py" <<'PY2'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("        handlerInput: v.handlerInput ?? null,\n        languageNote: v.languageNote ?? null,\n", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY2
+
+# 9. THE CONDENSED FLAG IS COMPUTED FROM THE HANDLER INPUT instead of the base client text. Every
+#    language-note turn then reports as condensed — a claim about how the client spoke, derived
+#    from a sentence we wrote ourselves.
+cat > "$PATCH_DIR/9.py" <<'PY2'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("condensed: v.forBrain !== undefined ? v.forBrain !== v.cleaned : null,",
+            "condensed: v.forBrain !== undefined ? (v.handlerInput ?? v.forBrain) !== v.cleaned : null,")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY2
+
+echo "RED-ON-REVERT — raw voice provenance. Every case below must report FAILED."
+failed=0
+run_case "1 (raw never captured)"        "$PATCH_DIR/1.py" "$UNIT" "$UNIT_LABEL" || failed=$((failed+1))
+run_case "2 (raw captured after clean)"  "$PATCH_DIR/2.py" "$UNIT" "$UNIT_LABEL" || failed=$((failed+1))
+run_case "3 (for-brain not recorded)"    "$PATCH_DIR/3.py" "$UNIT" "$UNIT_LABEL" || failed=$((failed+1))
+run_case "4 (ledger drops the columns)"  "$PATCH_DIR/4.py" "$ACC"  "$ACC_LABEL"  || failed=$((failed+1))
+run_case "5 (recorder overwrites)"       "$PATCH_DIR/5.py" "$ACC"  "$ACC_LABEL"  || failed=$((failed+1))
+run_case "6 (flags lose null vs false)"  "$PATCH_DIR/6.py" "$ACC"  "$ACC_LABEL"  || failed=$((failed+1))
+run_case "7 (OPPOSITE: written on every turn)" "$PATCH_DIR/7.py" "$ACC" "$ACC_LABEL" || failed=$((failed+1))
+run_case "8 (handler input not recorded)"      "$PATCH_DIR/8.py" "$ACC" "$ACC_LABEL" || failed=$((failed+1))
+run_case "9 (condensed flag from our own note)" "$PATCH_DIR/9.py" "$ACC" "$ACC_LABEL" || failed=$((failed+1))
+
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) were green, crashed, or ungraded."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 9/9 cases reached a graded red verdict."

--- a/script/run-suites.ts
+++ b/script/run-suites.ts
@@ -49,7 +49,7 @@ export const SUITES = [
   // The decision-engine-p0 workflow's four. Here so local and CI cover the same surface.
   "decision-state-tests", "decision-runtime-tests", "reply-context-verifier-tests", "decision-doctrine-guard",
   "turn-triage-tests", "normalizer-replay-tests", "tracking-contract-tests",
-  "expectation-continuity-tests",
+  "expectation-continuity-tests", "voice-provenance-tests",
   "production-parity", "cut-a-regression-tests", "check-architecture",
 ];
 

--- a/script/voice-provenance-tests.ts
+++ b/script/voice-provenance-tests.ts
@@ -1,0 +1,164 @@
+/**
+ * VOICE PROVENANCE — focused tests (2026-09-10).
+ *
+ * A voice note becomes three different strings before any handler sees it:
+ *
+ *     Scribe/Whisper  →  cleanSATranscript  →  condenseVoiceRamble (>150 words)  →  handlers
+ *
+ * Until this cut only the last one was persisted, as `input_text` on the inner ledger row. So the
+ * two questions you must be able to answer about a bad voice turn had no evidence behind them:
+ * did we MIS-HEAR the client, or did we hear them correctly and then delete half of what they
+ * said? Different defects, different owners, different fixes.
+ *
+ * These tests drive the two model stages FOR REAL — real cleanSATranscript, real
+ * condenseVoiceRamble, real fail-open guards — against a stub OpenAI client, with OFFLINE_AI=0 so
+ * the offline killswitch does not short-circuit the very code under test. Nothing here is
+ * simulated except the network boundary itself.
+ *
+ * The durable half (which columns, which row, what survives an early return) needs a database and
+ * lives in script/pg-voice-provenance-acceptance.ts.
+ */
+process.env.OFFLINE_AI = "0";          // these stages are the subject; do not skip them
+process.env.KAMLIFE_DB_STUB = "1";     // …but no database
+process.env.OPENAI_API_KEY = "sk-stub";
+process.env.NODE_ENV = "production";
+
+import { readFileSync } from "node:fs";
+
+const { cleanSATranscript, condenseVoiceRamble } = await import("../server/understanding/sa-transcript");
+const { transcriptMustPassWhole } = await import("../server/utils");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+/** A stub OpenAI client that returns whatever the test tells it to. No network. */
+const stubOpenAI = (reply: string) => ({
+  chat: { completions: { create: async () => ({
+    choices: [{ message: { content: reply } }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  }) } },
+} as any);
+
+console.log("\nvoice-provenance-tests\n");
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("1. THE CLEANER FAILS OPEN, SO cleaned === raw IS A REAL EVENT AND NOT A MISSING ONE");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// This is why `voice_provenance.cleaned` records whether the stage CHANGED the text rather than
+// whether it ran. Both stages return their input on refusal, on a runaway rewrite and on a
+// rewrite that dropped the speaker's words — so "cleaned === raw" happens constantly on healthy
+// turns, and a column that conflated it with "the cleaner never ran" would be unreadable.
+{
+  const raw = "Yoh I had samp and beans and chicken for lunch today neh";
+
+  const refused = await cleanSATranscript(stubOpenAI("I'm sorry, I can't help with that."), raw, null);
+  chk(refused === raw, "a model refusal keeps the raw transcript", JSON.stringify(refused));
+
+  const runaway = await cleanSATranscript(stubOpenAI(raw + " " + "and then a very long invented addition ".repeat(12)), raw, null);
+  chk(runaway === raw, "a runaway rewrite keeps the raw transcript", JSON.stringify(runaway.slice(0, 60)));
+
+  const gutted = await cleanSATranscript(stubOpenAI("Lunch."), raw, null);
+  chk(gutted === raw, "a rewrite that drops the speaker's words keeps the raw transcript", JSON.stringify(gutted));
+
+  const empty = await cleanSATranscript(stubOpenAI(""), raw, null);
+  chk(empty === raw, "an empty completion keeps the raw transcript", JSON.stringify(empty));
+
+  // …and the control that makes the four above mean something: a faithful clean IS taken.
+  const good = "Yoh I had samp and beans and chicken for lunch today neh";
+  const fixed = await cleanSATranscript(stubOpenAI(good), "Yoh I had stamp and beans and chicken for lunch today neh", null);
+  chk(fixed === good, "a faithful clean replaces the raw transcript — samp, not stamp", JSON.stringify(fixed));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("\n2. THE CONDENSER IS THE STAGE THAT CAN LOSE THE MOST, AND IT ALSO FAILS OPEN");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  // A LONG NOTE WITH NO FOOD, NO STEPS, NO FEELING AND NO STACKED QUESTION — deliberately, because
+  // that narrow case is the ONLY thing the condenser is still allowed to touch. Everything else is
+  // protected by transcriptMustPassWhole (§3), and a fixture that tripped that guard would be
+  // grading the guard rather than the condenser. Two earlier fixtures did exactly that.
+  const long = ("The taxi from Soweto was late again this morning so I got to the office much "
+    + "later than usual and my manager gave me a warning about it ").repeat(3);
+  chk(!transcriptMustPassWhole(long), "the fixture really does reach the condenser (else §2 grades nothing)");
+
+  const refused = await condenseVoiceRamble(stubOpenAI("I cannot assist with that request."), long, null);
+  chk(refused === long, "a refusal keeps the whole transcript", JSON.stringify(refused.slice(0, 50)));
+
+  const condensed = await condenseVoiceRamble(stubOpenAI("My taxi was late so I got to work late."), long, null);
+  chk(condensed === "My taxi was late so I got to work late.",
+    "a real condense replaces it — and this is the text the handlers route on", JSON.stringify(condensed));
+  chk(condensed !== long, "…so forBrain and cleaned genuinely differ, which is what the flag records");
+
+  const short = "I had eggs.";
+  const untouched = await condenseVoiceRamble(stubOpenAI("SHOULD NOT BE USED"), short, null);
+  chk(untouched === short, "a short note is never condensed", JSON.stringify(untouched));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("\n3. transcriptMustPassWhole STILL PROTECTS A MULTI-PART NOTE FROM THE CONDENSER");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Not changed by this cut. Asserted because the provenance columns are how anyone will now SEE a
+// condense that ate something, and a reader has to be able to trust that a whole-pass note shows
+// forBrain === cleaned for a reason rather than by accident.
+{
+  const multiAsk = "What should I eat today? And also how many steps should I be doing? "
+    + "And can you tell me what my weight is doing? ".repeat(8);
+  chk(transcriptMustPassWhole(multiAsk), "a note asking more than one thing must pass whole");
+  const passed = await condenseVoiceRamble(stubOpenAI("SHOULD NOT BE USED"), multiAsk, null);
+  chk(passed === multiAsk, "…and the condenser declines it, leaving forBrain === cleaned");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("\n4. THE RAW TRANSCRIPT IS CAPTURED BEFORE THE CLEANER CAN OVERWRITE IT");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// A SOURCE-ORDER ASSERTION, and stated as one rather than dressed up as an execution proof.
+//
+// The voice branch of media.ts cannot be executed offline: assertSafeMediaUrl requires an https
+// URL on an allow-listed public host (correctly — it is an SSRF guard, and weakening it for a
+// test would be a worse trade than this assertion), and the STT call needs the network. What CAN
+// be checked without either is the property that actually matters here, because `transcribedText`
+// is REASSIGNED by the cleaner: if the raw capture is not above that line, the client's own words
+// are gone before anything records them, and every column below would silently hold cleaned text
+// wearing the label "raw".
+{
+  const src = readFileSync("server/handlers/media.ts", "utf-8");
+  const rawAt = src.indexOf("turnVoice({ engine: sttEngine, raw: transcribedText");
+  const cleanAt = src.indexOf("transcribedText = await cleanSATranscript(");
+  const cleanedAt = src.indexOf("turnVoice({ cleaned: transcribedText })");
+  const forBrainAt = src.indexOf("turnVoice({ forBrain,");
+  const condenseAt = src.indexOf("await condenseVoiceRamble(");
+
+  chk(rawAt > 0, "media.ts records the raw transcript");
+  chk(cleanAt > 0 && rawAt < cleanAt,
+    "…BEFORE cleanSATranscript reassigns transcribedText", `raw@${rawAt} clean@${cleanAt}`);
+  chk(cleanedAt > cleanAt, "the cleaned text is recorded after the cleaner ran", `cleaned@${cleanedAt}`);
+  chk(forBrainAt > condenseAt && condenseAt > 0,
+    "the for-brain text is recorded after the condenser", `forBrain@${forBrainAt} condense@${condenseAt}`);
+  // The recursion is what hands the text to the handlers. Recording must happen before it, or a
+  // handler's own turn scope is the one in flight and the three texts land on the wrong row.
+  const recurseAt = src.indexOf("handleMessage(phone, brainInput");
+  chk(recurseAt > 0 && forBrainAt < recurseAt,
+    "…and before the transcript re-enters handleMessage", `forBrain@${forBrainAt} recurse@${recurseAt}`);
+
+  // THE RECORDED VALUE AND THE PASSED VALUE ARE THE SAME VARIABLE (corrected 2026-09-10).
+  //
+  // The first version of this cut recorded `forBrain` and then passed
+  // `forBrain + "\n\n[LANGUAGE NOTE: …]"` — two different strings, one of them labelled as the
+  // other. Rebuilding the note at the recording site would have fixed the value and left the
+  // drift: any future edit to one expression and not the other silently makes the record a lie.
+  // So media.ts composes it ONCE, into `brainInput`, records that variable, and passes that
+  // variable. This asserts there is exactly one composition and that both uses read it.
+  chk(src.includes("handlerInput: brainInput"),
+    "media.ts records the composed handler input by reference, not by rebuilding it");
+  chk((src.match(/\[LANGUAGE NOTE: \$\{languageNote\}\]/g) || []).length === 1,
+    "…and the note is appended in exactly ONE place, so the record cannot drift from the call",
+    `found ${(src.match(/\[LANGUAGE NOTE: \$\{languageNote\}\]/g) || []).length}`);
+  chk(!/handleMessage\(phone, forBrain\b/.test(src),
+    "…and nothing passes the bare client text as the handler input any more");
+}
+
+console.log(`\n${failed === 0 ? "voice-provenance-tests: ALL GREEN" : `voice-provenance-tests: ${failed} FAILED`}`);
+process.exit(failed === 0 ? 0 : 1);

--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -109,6 +109,24 @@ interface TurnScope {
   rootId: string;
   /** What the handlers actually saw, when something rewrote the client's words before routing. */
   canonicalInput: string | null;
+  /**
+   * THE THREE TEXTS A VOICE NOTE BECOMES (2026-09-10), recorded as they are produced rather than
+   * reconstructed afterwards. Absent on every non-voice turn.
+   */
+  voice?: {
+    engine?: "scribe" | "whisper";
+    raw?: string;
+    cleaned?: string;
+    /** CLIENT-ORIGIN text only: the condenser's output, or the cleaned text. No internal note. */
+    forBrain?: string;
+    /** The EXACT string handleMessage was called with — forBrain plus the internal language note
+     *  when one was detected. Recorded as the same variable that is passed, so the two cannot
+     *  drift apart. */
+    handlerInput?: string;
+    /** The note that was appended, or null when none was. Kept so the append is reversible. */
+    languageNote?: string | null;
+    wordCount?: number;
+  };
   resolvedDay: string | null;
   stateRead: Record<string, unknown>;
   mutations: string[];
@@ -724,6 +742,34 @@ export function turnCanonicalInput(text: string): void {
   if (t) t.canonicalInput = (text || "").slice(0, 2000);
 }
 
+/**
+ * WHAT THE CLIENT SAID, AT EACH STAGE IT SURVIVED (2026-09-10).
+ *
+ * Three of the four fields are CLIENT-ORIGIN text — raw, cleaned, forBrain. `handlerInput` is
+ * not: it is those words plus an internal language note we append ourselves, and it is stored
+ * separately for exactly that reason. Conflating them would put our own string in a column
+ * labelled as the client's.
+ *
+ * MERGES, and is called three times as the voice path produces each stage — after transcription,
+ * after cleanSATranscript, after condenseVoiceRamble. Incremental on purpose: the voice handler
+ * returns early on a garbled note, a single word and a model refusal, and those are precisely the
+ * turns where "what did we actually hear?" is the question. Recording only at the end would leave
+ * every failed voice turn blank, which is the current state and the reason this exists.
+ *
+ * Writes to the scope in flight, which for a voice note is the OUTER turn — media.ts calls this
+ * before it re-enters handleMessage — so the three texts land on the same row as the decision,
+ * the delivered body and the build SHA.
+ *
+ * Observational only. Nothing reads this back into a routing or coaching decision, and it must
+ * stay that way: the moment a handler consults it, the raw transcript stops being a record and
+ * becomes a second input, which is a different cut and a much bigger claim.
+ */
+export function turnVoice(facts: NonNullable<TurnScope["voice"]>): void {
+  const t = turnStore.getStore();
+  if (!t) return;
+  t.voice = { ...(t.voice || {}), ...facts };
+}
+
 export async function recordTurn(reply: string): Promise<void> {
   const t = turnStore.getStore();
   if (!t?.userId) return;
@@ -758,9 +804,38 @@ export async function recordTurn(reply: string): Promise<void> {
         : String(ev.canonicalTodo || "").trim() ? "instructed" : "hold",
       modelAuthored: !!ev.modelAuthored,
     };
+    // THE THREE VOICE TEXTS (2026-09-10). `cleaned` and `condensed` say whether that STAGE CHANGED
+    // the text, which is not the same question as whether it ran: both fail open and return their
+    // input unchanged, and "ran and declined" is a different diagnosis from "never ran".
+    //
+    // AND THE EXACT HANDLER INPUT, which is NOT `forBrain` (corrected 2026-09-10, same day).
+    // media.ts calls handleMessage with `forBrain + "\n\n[LANGUAGE NOTE: …]"` when the transcript
+    // looks like a non-English SA language. The first version of this cut stored `forBrain` under
+    // a comment claiming it was "what the handlers routed on" — a column holding something other
+    // than its label, which is precisely the defect revert case 2 of this cut's own red-on-revert
+    // exists to catch. Committing it here would have been the same error one layer along.
+    //
+    // So both are kept, and the SPLIT is the point: `voice_text_for_brain` is client-origin text
+    // and nothing else, and the note we appended ourselves lives beside it. `condensed` is
+    // therefore computed from the BASE text — comparing the handler input to the cleaned text
+    // would report every language-note turn as condensed, which is a claim about the client's
+    // words made from a string we wrote.
+    const v = t.voice;
+    const voiceProvenance = v
+      ? {
+        engine: v.engine ?? null,
+        wordCount: v.wordCount ?? null,
+        cleaned: v.cleaned !== undefined ? v.cleaned !== v.raw : null,
+        condensed: v.forBrain !== undefined ? v.forBrain !== v.cleaned : null,
+        handlerInput: v.handlerInput ?? null,
+        languageNote: v.languageNote ?? null,
+      }
+      : null;
     const written = await db.insert(turnLedger).values({
       userId: t.userId, inputType: t.inputType, inputText: t.inputText, resolvedDay: t.resolvedDay,
       rootId: t.rootId, inputTextCanonical: t.canonicalInput, decision: canonicalDecision,
+      voiceTranscriptRaw: v?.raw ?? null, voiceTranscriptCleaned: v?.cleaned ?? null,
+      voiceTextForBrain: v?.forBrain ?? null, voiceProvenance,
       stateRead: Object.keys(stateRead).length ? stateRead : null, mutations: t.mutations.length ? t.mutations : null,
       reply: recordedReply.slice(0, 4000), replyMs: Date.now() - t.startedAt,
       version: process.env.RAILWAY_GIT_COMMIT_SHA?.slice(0, 12) || process.env.APP_VERSION || "dev",

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -1,7 +1,7 @@
 /** Media message handler — images, audio/voice, video. Every branch returns a string. */
 
 import crypto from "crypto";
-import { turnMutation } from "./chat-log";
+import { turnMutation, turnVoice } from "./chat-log";
 import { sttVocabularyPrompt } from "../foods";
 import { verdictFromLabelLine, foodConstraints } from "../food-swaps";
 import { tmpdir } from "os";
@@ -1273,7 +1273,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       // what the scanner matches. Was 26 EXERCISE names until 2026-08-06 — hence the mishears.
       const whisperPrompt = sttVocabularyPrompt();
 
-      let transcribedText: string | undefined;
+      let transcribedText: string | undefined; let sttEngine: "scribe" | "whisper" = "whisper";
       let voiceQuality: { avgLogprob: number; comp: number } | null = null; // Whisper verbose_json only
 
       // ElevenLabs Scribe: better WER than Whisper on SA languages (Afrikaans, Zulu, Xhosa).
@@ -1284,7 +1284,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
             scribeTranscribe(audioBuffer, audioExt, storedLangPref || undefined)
           );
           if (scribeText) {
-            transcribedText = scribeText;
+            transcribedText = scribeText; sttEngine = "scribe";
             console.log(`[VOICE] scribe_ok text="${scribeText.slice(0, 80)}" len=${scribeText.length}`);
           }
         } catch (scribeErr: any) {
@@ -1358,7 +1358,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
           : "I got your voice note but had trouble processing it right now. Please resend it, or type your message and I'll reply straight away.";
       }
 
-      const wordCount = transcribedText.split(/\s+/).filter(Boolean).length;
+      const wordCount = transcribedText.split(/\s+/).filter(Boolean).length; turnVoice({ engine: sttEngine, raw: transcribedText, wordCount });
       if (wordCount < 2) {
         // Known single-word commands pass through directly — asking to resend wastes a round trip.
         const cleanWord = transcribedText.toLowerCase().replace(/[.!?,\s]+$/, "");
@@ -1395,7 +1395,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       clearVoiceFailure(user.id);
 
       // SA cleaner (safeguard D, fail-open) then HARD FLOOR: a transcript is the client's words, never a model refusal.
-      transcribedText = await cleanSATranscript(openai, transcribedText, user.id);
+      transcribedText = await cleanSATranscript(openai, transcribedText, user.id); turnVoice({ cleaned: transcribedText });
       if (looksLikeRefusal(transcribedText)) {
         console.error(`[VOICE][${mediaTrace}] refusal_as_transcript — discarding "${transcribedText.slice(0, 80)}"`);
         await cleanupTmp();
@@ -1415,12 +1415,12 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       // reach food-context / compound handlers WHOLE. Condensing first was deleting the meal.
       const forBrain = (wordCount > 150 && !transcriptMustPassWhole(transcribedText))
         ? await condenseVoiceRamble(openai, transcribedText, user.id)
-        : transcribedText;
+        : transcribedText; const brainInput = forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""); turnVoice({ forBrain, handlerInput: brainInput, languageNote: languageNote || null });
 
       voiceStage = "coach_reply";
       voiceStageStart = Date.now();
       const voiceReply = await withTimeout("voice_coach_reply", 20000, () =>
-        handleMessage(phone, forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""), undefined, undefined, undefined, mediaSourceId)
+        handleMessage(phone, brainInput, undefined, undefined, undefined, mediaSourceId)
       );
       const coachReplyMs = Date.now() - voiceStageStart;
       const voiceTotalMs = Date.now() - voiceFlowStart;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -349,6 +349,47 @@ export const turnLedger = pgTable("turn_ledger", {
   outboundVerdict: jsonb("outbound_verdict"),
   /** sent | dropped | fallback — the delivery owner's own verdict, not an assumption. */
   deliveryOutcome: text("delivery_outcome"),
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  // RAW VOICE PROVENANCE (2026-09-10).
+  //
+  // A voice note is transcribed, then CLEANED by a model, then — over 150 words — CONDENSED by a
+  // second model, and only the last of those three reaches the handlers. Until now none of them
+  // was persisted: `input_text` on the inner row held the CONDENSED text, and the words the
+  // client actually spoke existed only in a log line that rotates.
+  //
+  // So the two questions you must be able to answer about a bad voice turn had no evidence
+  // behind them: did we MIS-HEAR them, or did we hear them and then throw half of it away? One
+  // is an STT problem, the other is ours, and the fix is different in each case. They are stored
+  // as three separate columns rather than one "transcript" because the whole point is being able
+  // to diff them.
+  //
+  // Written on the OUTER voice row — the same row that already carries the decision, the final
+  // post-transport body and the build SHA — so one row answers the whole question. Null on every
+  // non-voice turn, and null on a voice turn that never produced a transcript at all.
+  // ══════════════════════════════════════════════════════════════════════════════════════════
+  /** EXACTLY what Scribe or Whisper returned, before cleanSATranscript touched it. */
+  voiceTranscriptRaw: text("voice_transcript_raw"),
+  /** After cleanSATranscript (which fails open, so this equals the raw text when it declined). */
+  voiceTranscriptCleaned: text("voice_transcript_cleaned"),
+  /** THE CLIENT'S WORDS AFTER THE LAST STAGE THAT TOUCHED THEM — condenseVoiceRamble's output
+   *  over 150 words, otherwise the cleaned text. CLIENT-ORIGIN ONLY.
+   *
+   *  It is deliberately NOT the string handleMessage received. media.ts appends an internal
+   *  "[LANGUAGE NOTE: …]" of our own when the transcript looks like a non-English SA language, and
+   *  putting that in here would mean a column named for the client's words held a sentence we
+   *  wrote. The exact handler input is `voice_provenance.handlerInput`; the two together make the
+   *  append reversible in both directions. */
+  voiceTextForBrain: text("voice_text_for_brain"),
+  /** { engine, wordCount, cleaned, condensed, handlerInput, languageNote }.
+   *
+   *  `cleaned`/`condensed` say whether that STAGE CHANGED the text — not whether it ran, because
+   *  both stages fail open and return their input unchanged. Both are computed from the BASE
+   *  client-origin texts: comparing against handlerInput would report every language-note turn as
+   *  condensed, which is a claim about the client's speech made from a string of ours.
+   *
+   *  `handlerInput` is the EXACT argument handleMessage was called with, recorded as the same
+   *  variable that is passed so the record cannot drift from the call. */
+  voiceProvenance: jsonb("voice_provenance"),
 }, (table) => ({
   userDateIdx: index("turn_ledger_user_date_idx").on(table.userId, table.createdAt),
   createdIdx: index("turn_ledger_created_idx").on(table.createdAt),


### PR DESCRIPTION
## This is observability, not a voice-accuracy cure

**Nothing in this PR makes transcription more accurate.** No model was swapped, no threshold tuned, no prompt changed. It makes the existing pipeline *legible*: after this lands you can tell whether a bad voice turn was a mis-hear, a cleaning loss, a condensation loss, a parsing failure or a response-authorship failure. Before it, you could not tell those apart at all.

Do not read a merge of this PR as voice quality having improved.

## The gap

A voice note becomes three different strings before any handler sees it:

```
Scribe/Whisper  ->  cleanSATranscript  ->  condenseVoiceRamble (>150 words)  ->  handlers
```

Only the last reached the ledger, as `input_text` on the inner row. The client's own words existed solely in a `[VOICE] scribe_ok text="…"` log line that rotates. So the first question about any bad voice turn — *did we mis-hear them, or hear them correctly and then delete half of it?* — had no durable evidence behind it. One is an STT problem, the other is ours, and the fix differs in each case.

## What lands

Four nullable columns on `turn_ledger`, written on the **outer voice row** — the row a probe on `9124647` showed the transport finalises, so it already carries the decision, the final post-transport body and the build SHA. One row now answers the whole question.

| Column | Holds |
|---|---|
| `voice_transcript_raw` | exactly what Scribe/Whisper returned |
| `voice_transcript_cleaned` | after `cleanSATranscript` (equals raw when it declined) |
| `voice_text_for_brain` | client-origin routed text — **no internal note** |
| `voice_provenance` | `{engine, wordCount, cleaned, condensed, handlerInput, languageNote}` |

Recorded **incrementally** as each stage completes, because the garble guard, the single-word guard and the refusal floor all return before the later stages run. Those are the turns where "what did we actually hear?" matters most; end-of-path recording would have left every one of them blank.

`cleaned`/`condensed` record whether a stage **changed** the text, not whether it ran — both stages fail open and return their input unchanged, so `cleaned === raw` is the ordinary case on a healthy turn.

## One defect found and corrected inside this cut

The first version stored `voice_text_for_brain` under a comment claiming it was "what the handlers routed on". It is not: `media.ts` calls `handleMessage` with `forBrain + "\n\n[LANGUAGE NOTE: …]"`. A column holding something other than its label — exactly the defect revert case 2 of this cut's own red-on-revert exists to catch one stage earlier.

Corrected with the existing JSONB, **no schema change**: `media.ts` composes the input once into `brainInput`, records that variable and passes that variable, so the record cannot drift from the call. The note lives beside the verbatim `handlerInput`, making the append reversible in both directions. `condensed` is computed from the **base** text — comparing against the handler input would report every language-note turn as condensed, which is a claim about the client's speech derived from a sentence of ours.

## Real audio and STT were NOT executed

Stated plainly rather than implied. The audio download and the transcription call cannot run offline: `assertSafeMediaUrl` requires an https URL on an allow-listed **public** host — it is an SSRF guard, and weakening it to make a test pass would be a far worse trade — and transcription needs network access the sandbox does not have.

What **is** driven for real: both model stages (`cleanSATranscript`, `condenseVoiceRamble`) against a stub client with `OFFLINE_AI=0`, including their fail-open guards; the recorder; the ledger write; the transport; and the read-back from PostgreSQL.

What is covered by **source-order assertion** instead: the `media.ts` wiring — specifically that the raw capture sits *above* the line where `cleanSATranscript` reassigns `transcribedText`. Revert cases 1–3 are where that limitation is paid for.

## Constraints held

No model selection, handler, coaching copy, echo behaviour, parsing or architecture changed. Nothing reads these columns back into a routing or coaching decision, and that must stay true — the moment a handler consults the raw transcript it stops being a record and becomes a second input. `media.ts` is net-zero lines and remains exactly at its 1550 budget. No governor raised.

## Evidence

| Gate | Result |
|---|---|
| `pg-voice-provenance-acceptance` | **31/31**, post-transport, read back from PostgreSQL |
| `voice-provenance-tests` | **all green** |
| `red-on-revert-voice-provenance.sh` | **9/9 graded red**, incl. 2 opposite-defect controls |
| `npm test` | **38/38**, none skipped |
| PostgreSQL acceptance runner | **29/29 green, 0 red** |
| `tsc` | clean |
| architecture · schema-safety · file-size · names · SAST · reach | green, at budget |

## Note for whoever merges

Migration `0013` must be verified as **applied** after deploy, not assumed. While building this, `db:migrate` reported success while silently skipping it — drizzle orders by the journal's `when`, and the timestamp originally written fell behind `0012`. Fixed here; the general trap is the subject of the next cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_