### PR TITLE
The migration journal cannot silently skip a migration

### DIFF
--- a/script/check-schema-safety.ts
+++ b/script/check-schema-safety.ts
@@ -89,7 +89,7 @@ if (uncreatable.length > 0) {
   );
 }
 
-// 5. THE JOURNAL MUST BE ORDERED, COMPLETE AND UNAMBIGUOUS (2026-09-11).
+// 5. THE JOURNAL MUST BE PRESENT, WELL-FORMED, ORDERED, COMPLETE AND UNAMBIGUOUS (2026-09-11).
 //
 // A SUCCESSFUL COMMAND THAT SKIPPED A MIGRATION. While building the raw-voice-provenance cut,
 // `npm run db:migrate` printed "migrations applied successfully" and did not run 0013. The four
@@ -101,64 +101,139 @@ if (uncreatable.length > 0) {
 //
 // That is the worst shape a deploy step can have: not a wrong answer, but no answer wearing the
 // same colour as one. Production's own boot runner (server/index.ts phase 3) reads the DIRECTORY
-// in filename order, so the two systems would also disagree about what is applied — one of them
-// silently right, the other silently wrong, with no signal either way.
+// in filename order, so the two systems can also disagree about what is applied — one silently
+// right, the other silently wrong, with no signal either way. That is why rule (f) below requires
+// the two ORDERS to match, not merely the two sets.
 //
-// So the journal is checked here, where the other schema-shaped traps already live. Read-only:
-// this adds no runtime behaviour and no second migration runner.
+// FAIL CLOSED, and this is the correction to the first version of this guard. It opened with
+// `if (existsSync(JOURNAL_PATH))`, so deleting the journal skipped every rule below it and the
+// build stayed green — a guard that can be silenced by removing its subject is not a guard. The
+// same applies one level in: a missing or non-numeric `when` slipped past the monotonic
+// comparison, because `undefined <= undefined` is false. Shape is therefore validated BEFORE any
+// rule that depends on it.
+//
+// Read-only: no runtime behaviour, no second migration runner.
 const JOURNAL_PATH = "migrations/meta/_journal.json";
-if (existsSync(JOURNAL_PATH)) {
+if (!existsSync(JOURNAL_PATH)) {
+  problems.push(
+    `${JOURNAL_PATH} is missing — "db:migrate" has no list to apply and will do nothing, silently.`
+    + `\n     This file is the deploy path's only record of what has run. It is never optional.`,
+  );
+} else {
+  let journal: any = null;
   try {
-    const journal = JSON.parse(readFileSync(JOURNAL_PATH, "utf-8"));
-    const entries: Array<{ idx: number; when: number; tag: string }> = journal.entries || [];
+    journal = JSON.parse(readFileSync(JOURNAL_PATH, "utf-8"));
+  } catch (e: any) {
+    problems.push(`${JOURNAL_PATH} could not be parsed: ${e?.message || e}`);
+  }
 
-    // a. Indexes contiguous and ordered. A gap or a repeat means two authors edited the journal
-    //    without seeing each other, which is exactly when the rest of these rules start to matter.
+  const entries: any[] | null = journal && Array.isArray(journal.entries) ? journal.entries : null;
+  if (journal && !entries) {
+    problems.push(`${JOURNAL_PATH} has no "entries" array — nothing can be verified about what will run.`);
+  }
+
+  if (entries) {
+    // a. EVERY ENTRY IS THE SHAPE THE LATER RULES ASSUME. Checked first and tracked, because a
+    //    comparison against undefined does not throw — it quietly evaluates false, which is how a
+    //    missing `when` walked through the monotonic check.
+    let wellFormed = true;
     entries.forEach((e, i) => {
-      if (e.idx !== i) {
-        problems.push(`${JOURNAL_PATH} entry ${i} has idx ${e.idx} — indexes must be contiguous and in order.`);
+      if (!e || typeof e !== "object") {
+        problems.push(`${JOURNAL_PATH} entry ${i} is not an object.`); wellFormed = false; return;
+      }
+      if (!Number.isInteger(e.idx) || e.idx < 0) {
+        problems.push(`${JOURNAL_PATH} entry ${i} has idx ${JSON.stringify(e.idx)} — must be a non-negative integer.`);
+        wellFormed = false;
+      }
+      if (typeof e.when !== "number" || !Number.isFinite(e.when)) {
+        problems.push(
+          `${JOURNAL_PATH} entry ${i} ("${e.tag ?? "?"}") has when=${JSON.stringify(e.when)} — must be a finite number.`
+          + `\n     drizzle orders by this field; a missing or non-numeric value cannot be compared,`
+          + `\n     so the ordering rule below would pass while the ordering itself is undefined.`,
+        );
+        wellFormed = false;
+      }
+      if (typeof e.tag !== "string" || !e.tag.trim()) {
+        problems.push(`${JOURNAL_PATH} entry ${i} has tag ${JSON.stringify(e.tag)} — must be a non-empty string.`);
+        wellFormed = false;
       }
     });
 
-    // b. `when` STRICTLY increasing. This is the rule whose violation skipped 0013 in silence.
-    for (let i = 1; i < entries.length; i++) {
-      if (entries[i].when <= entries[i - 1].when) {
-        problems.push(
-          `${JOURNAL_PATH}: "${entries[i].tag}" has when=${entries[i].when}, not after "${entries[i - 1].tag}" (${entries[i - 1].when}).`
-          + `\n     drizzle orders by this field, so a migration stamped behind its predecessor is`
-          + `\n     reported as applied and never runs. Stamp it later than every existing entry.`,
-        );
+    // b. Indexes contiguous and in order. A gap or a repeat means two authors edited the journal
+    //    without seeing each other, which is exactly when the rest of these rules start to matter.
+    if (wellFormed) {
+      entries.forEach((e, i) => {
+        if (e.idx !== i) {
+          problems.push(`${JOURNAL_PATH} entry ${i} has idx ${e.idx} — indexes must be contiguous and in order.`);
+        }
+      });
+    }
+
+    // c. `when` STRICTLY increasing. This is the rule whose violation skipped 0013 in silence.
+    if (wellFormed) {
+      for (let i = 1; i < entries.length; i++) {
+        if (entries[i].when <= entries[i - 1].when) {
+          problems.push(
+            `${JOURNAL_PATH}: "${entries[i].tag}" has when=${entries[i].when}, not after "${entries[i - 1].tag}" (${entries[i - 1].when}).`
+            + `\n     drizzle orders by this field, so a migration stamped behind its predecessor is`
+            + `\n     reported as applied and never runs. Stamp it later than every existing entry.`,
+          );
+        }
       }
     }
 
-    // c. Tags unique. Two entries naming one file is ambiguous about which was applied.
+    // d. Tags unique. Two entries naming one file is ambiguous about which was applied.
     const seen = new Set<string>();
     for (const e of entries) {
-      if (seen.has(e.tag)) problems.push(`${JOURNAL_PATH}: duplicate tag "${e.tag}".`);
-      seen.add(e.tag);
+      const tag = typeof e?.tag === "string" ? e.tag : "";
+      if (!tag) continue;
+      if (seen.has(tag)) problems.push(`${JOURNAL_PATH}: duplicate tag "${tag}".`);
+      seen.add(tag);
     }
 
-    // d. Every journal entry has the SQL file it names.
+    // e. Every journal entry has the SQL file it names.
     for (const e of entries) {
-      if (!existsSync(join("migrations", `${e.tag}.sql`))) {
-        problems.push(`${JOURNAL_PATH} names "${e.tag}" but migrations/${e.tag}.sql does not exist.`);
+      const tag = typeof e?.tag === "string" ? e.tag : "";
+      if (!tag) continue;
+      if (!existsSync(join("migrations", `${tag}.sql`))) {
+        problems.push(`${JOURNAL_PATH} names "${tag}" but migrations/${tag}.sql does not exist.`);
       }
     }
 
-    // e. Every NUMBERED migration appears in the journal. Scoped to the `NNNN_` shape on purpose:
-    //    the repo carries two legacy unnumbered files (add_client_intelligence_profiles.sql,
-    //    add_shadow_replies.sql) that the boot runner executes by directory order and that drizzle
-    //    has never journaled. Failing them here would make this guard red on the day it ships,
-    //    which teaches people to disable it — the one outcome worse than not having it.
-    for (const f of migrations) {
-      if (!/^\d{4}_/.test(f)) continue;
-      const tag = f.replace(/\.sql$/, "");
-      if (!seen.has(tag)) {
-        problems.push(`migrations/${f} is a numbered migration with no journal entry — "db:migrate" will never run it.`);
-      }
+    // f. THE TWO ORDERS MUST MATCH, not merely the two sets.
+    //
+    //    drizzle applies in JOURNAL order; the boot runner applies in FILENAME order. Checking
+    //    membership alone lets two valid tags be swapped — every other rule here still passes,
+    //    and the two systems then apply the same migrations in different orders. For DDL that is
+    //    a schema that depends on which runner touched the database first.
+    //
+    //    Scoped to the `NNNN_` shape on purpose: the repo carries two legacy unnumbered files
+    //    (add_client_intelligence_profiles.sql, add_shadow_replies.sql) that the boot runner
+    //    executes by directory order and that drizzle has never journaled. Failing them here would
+    //    make this guard red on the day it ships, which teaches people to disable it — the one
+    //    outcome worse than not having it.
+    const NUMBERED = /^\d{4}_/;
+    const journalNumbered = entries
+      .map(e => (typeof e?.tag === "string" ? e.tag : ""))
+      .filter(t => NUMBERED.test(t));
+    const fileNumbered = migrations
+      .filter(f => NUMBERED.test(f))
+      .map(f => f.replace(/\.sql$/, ""))
+      .sort();
+    if (journalNumbered.join("\n") !== fileNumbered.join("\n")) {
+      const firstDiff = journalNumbered.findIndex((t, i) => t !== fileNumbered[i]);
+      problems.push(
+        `${JOURNAL_PATH}: the numbered journal order does not match the numbered migration files.`
+        + `\n     journal: ${journalNumbered.join(", ") || "(none)"}`
+        + `\n     files  : ${fileNumbered.join(", ") || "(none)"}`
+        + (firstDiff >= 0
+          ? `\n     first divergence at position ${firstDiff}: journal has "${journalNumbered[firstDiff] ?? "(nothing)"}",`
+            + ` files have "${fileNumbered[firstDiff] ?? "(nothing)"}".`
+          : "")
+        + `\n     drizzle applies in journal order and the boot runner in filename order; when those`
+        + `\n     disagree the two deploy paths produce different schemas from the same commit.`,
+      );
     }
-  } catch (e: any) {
-    problems.push(`${JOURNAL_PATH} could not be parsed: ${e?.message || e}`);
   }
 }
 

--- a/script/check-schema-safety.ts
+++ b/script/check-schema-safety.ts
@@ -89,6 +89,79 @@ if (uncreatable.length > 0) {
   );
 }
 
+// 5. THE JOURNAL MUST BE ORDERED, COMPLETE AND UNAMBIGUOUS (2026-09-11).
+//
+// A SUCCESSFUL COMMAND THAT SKIPPED A MIGRATION. While building the raw-voice-provenance cut,
+// `npm run db:migrate` printed "migrations applied successfully" and did not run 0013. The four
+// columns did not exist; the acceptance is what caught it, not this guard.
+//
+// The cause is that drizzle orders and records by the journal's `when`, not by filename. 0012 had
+// been stamped with a real epoch (1789056000000) and 0013 with a smaller hand-written one, so
+// drizzle treated 0013 as already applied and moved on. Nothing failed. Nothing warned.
+//
+// That is the worst shape a deploy step can have: not a wrong answer, but no answer wearing the
+// same colour as one. Production's own boot runner (server/index.ts phase 3) reads the DIRECTORY
+// in filename order, so the two systems would also disagree about what is applied — one of them
+// silently right, the other silently wrong, with no signal either way.
+//
+// So the journal is checked here, where the other schema-shaped traps already live. Read-only:
+// this adds no runtime behaviour and no second migration runner.
+const JOURNAL_PATH = "migrations/meta/_journal.json";
+if (existsSync(JOURNAL_PATH)) {
+  try {
+    const journal = JSON.parse(readFileSync(JOURNAL_PATH, "utf-8"));
+    const entries: Array<{ idx: number; when: number; tag: string }> = journal.entries || [];
+
+    // a. Indexes contiguous and ordered. A gap or a repeat means two authors edited the journal
+    //    without seeing each other, which is exactly when the rest of these rules start to matter.
+    entries.forEach((e, i) => {
+      if (e.idx !== i) {
+        problems.push(`${JOURNAL_PATH} entry ${i} has idx ${e.idx} — indexes must be contiguous and in order.`);
+      }
+    });
+
+    // b. `when` STRICTLY increasing. This is the rule whose violation skipped 0013 in silence.
+    for (let i = 1; i < entries.length; i++) {
+      if (entries[i].when <= entries[i - 1].when) {
+        problems.push(
+          `${JOURNAL_PATH}: "${entries[i].tag}" has when=${entries[i].when}, not after "${entries[i - 1].tag}" (${entries[i - 1].when}).`
+          + `\n     drizzle orders by this field, so a migration stamped behind its predecessor is`
+          + `\n     reported as applied and never runs. Stamp it later than every existing entry.`,
+        );
+      }
+    }
+
+    // c. Tags unique. Two entries naming one file is ambiguous about which was applied.
+    const seen = new Set<string>();
+    for (const e of entries) {
+      if (seen.has(e.tag)) problems.push(`${JOURNAL_PATH}: duplicate tag "${e.tag}".`);
+      seen.add(e.tag);
+    }
+
+    // d. Every journal entry has the SQL file it names.
+    for (const e of entries) {
+      if (!existsSync(join("migrations", `${e.tag}.sql`))) {
+        problems.push(`${JOURNAL_PATH} names "${e.tag}" but migrations/${e.tag}.sql does not exist.`);
+      }
+    }
+
+    // e. Every NUMBERED migration appears in the journal. Scoped to the `NNNN_` shape on purpose:
+    //    the repo carries two legacy unnumbered files (add_client_intelligence_profiles.sql,
+    //    add_shadow_replies.sql) that the boot runner executes by directory order and that drizzle
+    //    has never journaled. Failing them here would make this guard red on the day it ships,
+    //    which teaches people to disable it — the one outcome worse than not having it.
+    for (const f of migrations) {
+      if (!/^\d{4}_/.test(f)) continue;
+      const tag = f.replace(/\.sql$/, "");
+      if (!seen.has(tag)) {
+        problems.push(`migrations/${f} is a numbered migration with no journal entry — "db:migrate" will never run it.`);
+      }
+    }
+  } catch (e: any) {
+    problems.push(`${JOURNAL_PATH} could not be parsed: ${e?.message || e}`);
+  }
+}
+
 if (problems.length > 0) {
   console.error("schema safety: FAILED\n" + problems.map(p => `  ✗ ${p}`).join("\n"));
   console.error("\nWhy this guard exists: a bad `push` corrupts the day-ledger and the only way back\nis the 6-hourly backup — up to half a day of client food logs lost.\n");

--- a/script/check-schema-safety.ts
+++ b/script/check-schema-safety.ts
@@ -114,22 +114,49 @@ if (uncreatable.length > 0) {
 //
 // Read-only: no runtime behaviour, no second migration runner.
 const JOURNAL_PATH = "migrations/meta/_journal.json";
+/**
+ * THE ONLY TWO UNNUMBERED MIGRATIONS, BY EXACT NAME. Both predate the journal and are executed by
+ * the boot runner in directory order; drizzle has never recorded either. Listed literally rather
+ * than matched by shape so the exemption cannot grow: a new unnumbered file is a mistake, not a
+ * third legacy case.
+ */
+const LEGACY_UNNUMBERED = new Set(["add_client_intelligence_profiles.sql", "add_shadow_replies.sql"]);
 if (!existsSync(JOURNAL_PATH)) {
   problems.push(
     `${JOURNAL_PATH} is missing — "db:migrate" has no list to apply and will do nothing, silently.`
     + `\n     This file is the deploy path's only record of what has run. It is never optional.`,
   );
 } else {
-  let journal: any = null;
+  let journal: any;
+  let parsed = false;
   try {
     journal = JSON.parse(readFileSync(JOURNAL_PATH, "utf-8"));
+    parsed = true;
   } catch (e: any) {
     problems.push(`${JOURNAL_PATH} could not be parsed: ${e?.message || e}`);
   }
 
-  const entries: any[] | null = journal && Array.isArray(journal.entries) ? journal.entries : null;
-  if (journal && !entries) {
-    problems.push(`${JOURNAL_PATH} has no "entries" array — nothing can be verified about what will run.`);
+  // THE ROOT MUST BE A REAL OBJECT, and this is the third fail-open hole found in this guard.
+  // `JSON.parse("null")` SUCCEEDS and yields null; so do `false`, `0` and `""`. The previous
+  // version tested `journal && Array.isArray(journal.entries)`, so every one of those scalars made
+  // `entries` null, skipped the "no entries array" branch because `journal` was falsy, skipped
+  // every rule below it, and left the build green. Replacing the journal with the four characters
+  // `null` silenced the entire guard. An array root is rejected for the same reason: it carries no
+  // `entries` and is not the shape drizzle writes.
+  let entries: any[] | null = null;
+  if (parsed) {
+    const isPlainObject = journal !== null && typeof journal === "object" && !Array.isArray(journal);
+    if (!isPlainObject) {
+      problems.push(
+        `${JOURNAL_PATH} root is ${Array.isArray(journal) ? "an array" : JSON.stringify(journal)} — must be an object with an "entries" array.`
+        + `\n     JSON.parse accepts null, false, 0 and "" as valid documents, so a scalar here is a`
+        + `\n     parseable file that describes no migrations at all.`,
+      );
+    } else if (!Array.isArray(journal.entries)) {
+      problems.push(`${JOURNAL_PATH} has no "entries" array — nothing can be verified about what will run.`);
+    } else {
+      entries = journal.entries;
+    }
   }
 
   if (entries) {
@@ -213,6 +240,28 @@ if (!existsSync(JOURNAL_PATH)) {
     //    make this guard red on the day it ships, which teaches people to disable it — the one
     //    outcome worse than not having it.
     const NUMBERED = /^\d{4}_/;
+
+    // g. NO NEW UNNUMBERED MIGRATIONS, AND NO UNNUMBERED JOURNAL TAGS.
+    //
+    //    The NNNN_ scoping above exists to grandfather two files that predate the journal. It was
+    //    written as a SHAPE test, which means any future unnumbered file would inherit the
+    //    exemption and bypass journal membership, ordering and file-existence checking entirely —
+    //    the grandfather clause would quietly become a bypass. So the exemption is now EXACTLY
+    //    those two names, and everything else must be numbered.
+    for (const f of migrations) {
+      if (LEGACY_UNNUMBERED.has(f) || NUMBERED.test(f)) continue;
+      problems.push(
+        `migrations/${f} is not numbered — every migration after the two grandfathered legacy files`
+        + `\n     must use the NNNN_ prefix, or it bypasses journal membership and ordering entirely.`
+        + `\n     Grandfathered, by exact name: ${[...LEGACY_UNNUMBERED].join(", ")}`,
+      );
+    }
+    for (const e of entries) {
+      const tag = typeof e?.tag === "string" ? e.tag : "";
+      if (!tag || NUMBERED.test(tag)) continue;
+      problems.push(`${JOURNAL_PATH}: tag "${tag}" is not numbered — journal tags must use the NNNN_ prefix.`);
+    }
+
     const journalNumbered = entries
       .map(e => (typeof e?.tag === "string" ? e.tag : ""))
       .filter(t => NUMBERED.test(t));

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -195,6 +195,13 @@ export const ACCEPTANCES: Acceptance[] = [
     // in prepareOutbound and sendFinal, past every handler.
     command: ["npx", "tsx", "script/pg-interaction-truth-acceptance.ts"] },
 
+  { id: "journal-guard", title: "The migration journal cannot silently skip a migration",
+    // A SUCCESSFUL COMMAND THAT SKIPPED A MIGRATION (2026-09-11). `db:migrate` reported success and
+    // did not run 0013, because drizzle orders by the journal's `when` and 0013 was stamped behind
+    // 0012. No database is needed — the guard reads files — but it lives in this runner because
+    // this is the inventory that is actually authoritative, and a guard nobody runs is a comment.
+    command: ["bash", "script/red-on-revert-journal-guard.sh"] },
+
   { id: "voice-provenance", title: "The words the client actually spoke are durable",
     // RAW VOICE PROVENANCE (2026-09-10). A voice note becomes three strings — STT output, cleaned,
     // condensed — and only the last reached the ledger, so "did we mis-hear them, or hear them and

--- a/script/red-on-revert-journal-guard.sh
+++ b/script/red-on-revert-journal-guard.sh
@@ -12,6 +12,9 @@
 # Case 1 is the EXACT defect: a timestamp behind its predecessor.
 # Cases 2-5 are the other four ways the journal can lie about what will run.
 # Case 7 proves the unique-index rule the order names explicitly.
+# Cases 8-11 are the FAIL-CLOSED holes: a deleted journal skipped every rule; a missing or
+# non-numeric `when` evaded the monotonic comparison; and two valid tags could be swapped
+# because membership was checked but ORDER was not. All three passed the first version.
 # The CONTROL at the end: the unmodified tree must pass, or every case above is meaningless.
 #
 # No database is required — the guard reads files only, which is why it can run in any job.
@@ -106,6 +109,45 @@ d["entries"][-1]["idx"] = d["entries"][-2]["idx"]
 json.dump(d, open(p,"w"), indent=2)
 PY2
 
+# 8. THE JOURNAL IS DELETED ENTIRELY. The first version of this guard opened with
+#    `if (existsSync(...))`, so removing the file skipped every rule below it and the build stayed
+#    green. A guard that can be silenced by deleting its subject is not a guard.
+cat > "$PATCH_DIR/8.py" <<'PY2'
+import os
+os.remove("migrations/meta/_journal.json")
+PY2
+
+# 9. `when` REMOVED from an entry. `undefined <= undefined` is false, so the monotonic rule passed
+#    while the ordering it claims to enforce was undefined.
+cat > "$PATCH_DIR/9.py" <<'PY2'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+del d["entries"][-1]["when"]
+json.dump(d, open(p,"w"), indent=2)
+PY2
+
+# 10. `when` PRESENT BUT NON-NUMERIC. String comparison would silently "work" for some values and
+#     not others; the field must be a finite number or the ordering means nothing.
+cat > "$PATCH_DIR/10.py" <<'PY2'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+d["entries"][-1]["when"] = "1789061218646"
+json.dump(d, open(p,"w"), indent=2)
+PY2
+
+# 11. TWO VALID NUMBERED TAGS SWAPPED. Indexes stay contiguous, timestamps stay strictly
+#     increasing, tags stay unique, every file still exists — every other rule passes. Only the
+#     ORDER rule can catch it, and without that rule drizzle and the boot runner would apply the
+#     same commit's migrations in different orders.
+cat > "$PATCH_DIR/11.py" <<'PY2'
+import json, re
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+nums=[i for i,e in enumerate(d["entries"]) if re.match(r"^\d{4}_", e.get("tag",""))]
+i,j = nums[-2], nums[-1]
+d["entries"][i]["tag"], d["entries"][j]["tag"] = d["entries"][j]["tag"], d["entries"][i]["tag"]
+json.dump(d, open(p,"w"), indent=2)
+PY2
+
 echo "RED-ON-REVERT — migration journal guard. Every case below must report FAILED."
 failed=0
 run_case "1 (when behind its predecessor — the real defect)" "$PATCH_DIR/1.py" || failed=$((failed+1))
@@ -115,6 +157,10 @@ run_case "4 (duplicate tag)"                                 "$PATCH_DIR/4.py" |
 run_case "5 (numbered migration absent from journal)"        "$PATCH_DIR/5.py" || failed=$((failed+1))
 run_case "6 (journal entry with no SQL file)"                "$PATCH_DIR/6.py" || failed=$((failed+1))
 run_case "7 (duplicate index, tags still unique)"           "$PATCH_DIR/7.py" || failed=$((failed+1))
+run_case "8 (journal deleted entirely)"                     "$PATCH_DIR/8.py" || failed=$((failed+1))
+run_case "9 (when field removed)"                           "$PATCH_DIR/9.py" || failed=$((failed+1))
+run_case "10 (when present but non-numeric)"                "$PATCH_DIR/10.py" || failed=$((failed+1))
+run_case "11 (two valid numbered tags swapped)"             "$PATCH_DIR/11.py" || failed=$((failed+1))
 
 # CONTROL — the unmodified tree must pass. Without this every red above could come from a guard
 # that simply always fails, and the whole script would grade nothing.
@@ -129,4 +175,4 @@ if [[ $failed -ne 0 ]]; then
   echo "RED-ON-REVERT: FAILED — $failed case(s) did not behave as required."
   exit 1
 fi
-echo "RED-ON-REVERT: GREEN — 7/7 breakages caught, and the real journal passes."
+echo "RED-ON-REVERT: GREEN — 11/11 breakages caught, and the real journal passes."

--- a/script/red-on-revert-journal-guard.sh
+++ b/script/red-on-revert-journal-guard.sh
@@ -11,7 +11,8 @@
 #
 # Case 1 is the EXACT defect: a timestamp behind its predecessor.
 # Cases 2-5 are the other four ways the journal can lie about what will run.
-# Case 6 is the CONTROL: the unmodified tree must pass, or every case above is meaningless.
+# Case 7 proves the unique-index rule the order names explicitly.
+# The CONTROL at the end: the unmodified tree must pass, or every case above is meaningless.
 #
 # No database is required — the guard reads files only, which is why it can run in any job.
 set -uo pipefail
@@ -95,6 +96,16 @@ d["entries"].append({"idx": len(d["entries"]), "version": last["version"],
 json.dump(d, open(p,"w"), indent=2)
 PY
 
+# 7. A DUPLICATED INDEX with tags left unique. Contiguity already implies uniqueness, but
+#    "implied" is not proof — this demonstrates the rule the order names explicitly, so nobody has
+#    to reason about whether it holds.
+cat > "$PATCH_DIR/7.py" <<'PY2'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+d["entries"][-1]["idx"] = d["entries"][-2]["idx"]
+json.dump(d, open(p,"w"), indent=2)
+PY2
+
 echo "RED-ON-REVERT — migration journal guard. Every case below must report FAILED."
 failed=0
 run_case "1 (when behind its predecessor — the real defect)" "$PATCH_DIR/1.py" || failed=$((failed+1))
@@ -103,6 +114,7 @@ run_case "3 (index gap)"                                     "$PATCH_DIR/3.py" |
 run_case "4 (duplicate tag)"                                 "$PATCH_DIR/4.py" || failed=$((failed+1))
 run_case "5 (numbered migration absent from journal)"        "$PATCH_DIR/5.py" || failed=$((failed+1))
 run_case "6 (journal entry with no SQL file)"                "$PATCH_DIR/6.py" || failed=$((failed+1))
+run_case "7 (duplicate index, tags still unique)"           "$PATCH_DIR/7.py" || failed=$((failed+1))
 
 # CONTROL — the unmodified tree must pass. Without this every red above could come from a guard
 # that simply always fails, and the whole script would grade nothing.
@@ -117,4 +129,4 @@ if [[ $failed -ne 0 ]]; then
   echo "RED-ON-REVERT: FAILED — $failed case(s) did not behave as required."
   exit 1
 fi
-echo "RED-ON-REVERT: GREEN — 6/6 breakages caught, and the real journal passes."
+echo "RED-ON-REVERT: GREEN — 7/7 breakages caught, and the real journal passes."

--- a/script/red-on-revert-journal-guard.sh
+++ b/script/red-on-revert-journal-guard.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — the migration journal guard. One rule at a time.
+#
+# The guard this exercises exists because `npm run db:migrate` printed "migrations applied
+# successfully" and silently did not run 0013 — drizzle orders by the journal's `when`, and 0013
+# had been stamped behind 0012. Nothing failed. Nothing warned. The four columns simply were not
+# there.
+#
+# So every rule below must be able to turn the build red on its own. A rule that cannot is a
+# comment, and a comment would not have caught the thing that actually happened.
+#
+# Case 1 is the EXACT defect: a timestamp behind its predecessor.
+# Cases 2-5 are the other four ways the journal can lie about what will run.
+# Case 6 is the CONTROL: the unmodified tree must pass, or every case above is meaningless.
+#
+# No database is required — the guard reads files only, which is why it can run in any job.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+GUARD=script/check-schema-safety.ts
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/journal-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/migrations"
+PATCH_DIR="$WORK_ROOT/patches"
+
+restore () { if [[ -d "$BACKUP" ]]; then rm -rf migrations && mv "$BACKUP" migrations; fi; }
+cleanup () { restore; rm -rf "$WORK_ROOT"; }
+trap cleanup EXIT INT TERM
+
+run_case () {
+  local name="$1" patch="$2"
+  local out status
+  restore
+  cp -a migrations "$BACKUP"
+  if ! python3 "$patch"; then echo "  !! patch failed: $name"; restore; return 1; fi
+  out="$(npx tsx "$GUARD" 2>&1)"; status=$?
+  echo "── BREAK: $name"
+  printf '%s\n' "$out" | grep -E "schema safety|✗" | sed 's/^/   /' | head -3
+  restore
+  if [[ $status -eq 0 ]]; then echo "  !! guard stayed green: $name"; return 1; fi
+}
+
+mkdir -p "$PATCH_DIR"
+
+# 1. THE EXACT DEFECT — a migration stamped behind its predecessor. drizzle reports it applied and
+#    never runs it; the columns never appear; the deploy says success.
+cat > "$PATCH_DIR/1.py" <<'PY'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+d["entries"][-1]["when"] = d["entries"][-2]["when"] - 1000
+json.dump(d, open(p,"w"), indent=2)
+PY
+
+# 2. Equal timestamps — the same ambiguity, one step subtler, and "strictly increasing" is the
+#    only phrasing that catches it.
+cat > "$PATCH_DIR/2.py" <<'PY'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+d["entries"][-1]["when"] = d["entries"][-2]["when"]
+json.dump(d, open(p,"w"), indent=2)
+PY
+
+# 3. A gap in the indexes — two authors edited the journal without seeing each other.
+cat > "$PATCH_DIR/3.py" <<'PY'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+d["entries"][-1]["idx"] += 5
+json.dump(d, open(p,"w"), indent=2)
+PY
+
+# 4. A duplicated tag — ambiguous about which file was applied.
+cat > "$PATCH_DIR/4.py" <<'PY'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+last = dict(d["entries"][-1]); last["idx"] = len(d["entries"]); last["when"] = last["when"] + 1000
+d["entries"].append(last)
+json.dump(d, open(p,"w"), indent=2)
+PY
+
+# 5. A numbered migration committed with no journal entry — `db:migrate` will never run it, which
+#    is the same silent skip arriving from the other direction.
+cat > "$PATCH_DIR/5.py" <<'PY'
+open("migrations/0099_orphan_migration.sql","w").write(
+    "-- red-on-revert fixture: a numbered migration deliberately absent from the journal\n"
+    "ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS red_on_revert_fixture TEXT;\n")
+PY
+
+# 6. A journal entry naming a SQL file that does not exist.
+cat > "$PATCH_DIR/6.py" <<'PY'
+import json
+p="migrations/meta/_journal.json"; d=json.load(open(p))
+last = d["entries"][-1]
+d["entries"].append({"idx": len(d["entries"]), "version": last["version"],
+                     "when": last["when"] + 1000, "tag": "0100_file_that_does_not_exist",
+                     "breakpoints": True})
+json.dump(d, open(p,"w"), indent=2)
+PY
+
+echo "RED-ON-REVERT — migration journal guard. Every case below must report FAILED."
+failed=0
+run_case "1 (when behind its predecessor — the real defect)" "$PATCH_DIR/1.py" || failed=$((failed+1))
+run_case "2 (equal timestamps)"                              "$PATCH_DIR/2.py" || failed=$((failed+1))
+run_case "3 (index gap)"                                     "$PATCH_DIR/3.py" || failed=$((failed+1))
+run_case "4 (duplicate tag)"                                 "$PATCH_DIR/4.py" || failed=$((failed+1))
+run_case "5 (numbered migration absent from journal)"        "$PATCH_DIR/5.py" || failed=$((failed+1))
+run_case "6 (journal entry with no SQL file)"                "$PATCH_DIR/6.py" || failed=$((failed+1))
+
+# CONTROL — the unmodified tree must pass. Without this every red above could come from a guard
+# that simply always fails, and the whole script would grade nothing.
+echo "── CONTROL: the committed journal, unmodified"
+if npx tsx "$GUARD" >/dev/null 2>&1; then
+  echo "   schema safety: OK — the real journal passes"
+else
+  echo "   !! the committed journal FAILS its own guard"; failed=$((failed+1))
+fi
+
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) did not behave as required."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 6/6 breakages caught, and the real journal passes."

--- a/script/red-on-revert-journal-guard.sh
+++ b/script/red-on-revert-journal-guard.sh
@@ -15,6 +15,8 @@
 # Cases 8-11 are the FAIL-CLOSED holes: a deleted journal skipped every rule; a missing or
 # non-numeric `when` evaded the monotonic comparison; and two valid tags could be swapped
 # because membership was checked but ORDER was not. All three passed the first version.
+# Cases 12-13 close the last two: a journal of `null` is VALID JSON and silenced every rule,
+# and the NNNN_ exemption was a shape test, so any future unnumbered file would inherit it.
 # The CONTROL at the end: the unmodified tree must pass, or every case above is meaningless.
 #
 # No database is required — the guard reads files only, which is why it can run in any job.
@@ -148,6 +150,24 @@ d["entries"][i]["tag"], d["entries"][j]["tag"] = d["entries"][j]["tag"], d["entr
 json.dump(d, open(p,"w"), indent=2)
 PY2
 
+# 12. THE JOURNAL REPLACED WITH JSON `null`. `JSON.parse("null")` SUCCEEDS, so the file is valid
+#     JSON describing no migrations at all. The previous version tested `journal && ...`, which is
+#     falsy for null, so every rule below was skipped and the build stayed green — the whole guard
+#     silenced by four characters. `false`, `0` and `""` are the same hole.
+cat > "$PATCH_DIR/12.py" <<'PY2'
+open("migrations/meta/_journal.json","w").write("null")
+PY2
+
+# 13. A HARMLESS NEW UNNUMBERED MIGRATION. It looks like the two grandfathered legacy files, so a
+#     shape-based exemption would wave it through — and an unnumbered file is checked for journal
+#     membership, ordering and file existence by nothing at all. The exemption must be two exact
+#     names, not a pattern, or it becomes a bypass for every future migration.
+cat > "$PATCH_DIR/13.py" <<'PY2'
+open("migrations/add_a_harmless_looking_thing.sql","w").write(
+    "-- red-on-revert fixture: an unnumbered migration that must NOT inherit the legacy exemption\n"
+    "ALTER TABLE turn_ledger ADD COLUMN IF NOT EXISTS red_on_revert_unnumbered TEXT;\n")
+PY2
+
 echo "RED-ON-REVERT — migration journal guard. Every case below must report FAILED."
 failed=0
 run_case "1 (when behind its predecessor — the real defect)" "$PATCH_DIR/1.py" || failed=$((failed+1))
@@ -161,6 +181,8 @@ run_case "8 (journal deleted entirely)"                     "$PATCH_DIR/8.py" ||
 run_case "9 (when field removed)"                           "$PATCH_DIR/9.py" || failed=$((failed+1))
 run_case "10 (when present but non-numeric)"                "$PATCH_DIR/10.py" || failed=$((failed+1))
 run_case "11 (two valid numbered tags swapped)"             "$PATCH_DIR/11.py" || failed=$((failed+1))
+run_case "12 (journal replaced with JSON null)"             "$PATCH_DIR/12.py" || failed=$((failed+1))
+run_case "13 (new unnumbered migration file)"               "$PATCH_DIR/13.py" || failed=$((failed+1))
 
 # CONTROL — the unmodified tree must pass. Without this every red above could come from a guard
 # that simply always fails, and the whole script would grade nothing.
@@ -175,4 +197,4 @@ if [[ $failed -ne 0 ]]; then
   echo "RED-ON-REVERT: FAILED — $failed case(s) did not behave as required."
   exit 1
 fi
-echo "RED-ON-REVERT: GREEN — 11/11 breakages caught, and the real journal passes."
+echo "RED-ON-REVERT: GREEN — 13/13 breakages caught, and the real journal passes."


### PR DESCRIPTION
## A successful command that skipped a migration

While building the raw-voice-provenance cut, `npm run db:migrate` printed **"migrations applied successfully"** and did not run `0013`. The four columns did not exist. The acceptance caught it; the schema guard did not.

The cause: drizzle orders and records by the journal's `when`, not by filename. `0012` carried a real epoch (`1789056000000`), `0013` a smaller hand-written one, so drizzle treated `0013` as already applied and moved on. Nothing failed. Nothing warned.

That is the worst shape a deploy step can have — **not a wrong answer, but no answer wearing the same colour as one**.

Production's boot runner (`server/index.ts` phase 3) reads the *directory* in filename order, so the two systems can also disagree about what is applied: one silently right, the other silently wrong.

## Where it lives

`script/check-schema-safety.ts` — the existing owner, where the other schema-shaped traps already are. **No new migration system. No runtime behaviour. No governor raised.** Read-only file checks, which is why it needs no database.

## The rules

| | Rule |
|---|---|
| a | Journal file **must exist** — missing is a failure, not a skip |
| b | Root must be a **non-null, non-array object** with an `entries` array |
| c | Per entry: `idx` non-negative integer, `when` finite number, `tag` non-empty string |
| d | Indexes **contiguous and in order** |
| e | `when` **strictly increasing** |
| f | Tags **unique** |
| g | Every journal tag has its **SQL file** |
| h | Numbered journal tags **equal numbered filenames, in order** — not merely as sets |
| i | Only **two exact** grandfathered unnumbered files; everything else must be `NNNN_` |

Shape (c) is validated **before** any rule that depends on it, because a comparison against `undefined` does not throw — it quietly evaluates false.

Rule (h) compares *sequences*, not sets: drizzle applies in journal order and the boot runner in filename order, so two swapped tags would let one commit produce different schemas depending on which path ran.

Rule (i) is a list of two literal filenames rather than a pattern. As a shape test it would have exempted every future unnumbered file, each bypassing membership, ordering and existence checks — the grandfather clause would have become a bypass.

## Red-on-revert — 13/13, plus control

```
 1  when behind its predecessor (the real defect)   FAILED
 2  equal timestamps                                FAILED
 3  index gap                                       FAILED
 4  duplicate tag                                   FAILED
 5  numbered migration absent from journal          FAILED
 6  journal entry with no SQL file                  FAILED
 7  duplicate index, tags still unique              FAILED
 8  journal deleted entirely                        FAILED
 9  when field removed                              FAILED
10  when present but non-numeric                    FAILED
11  two valid numbered tags swapped                 FAILED
12  journal replaced with JSON null                 FAILED
13  new unnumbered migration file                   FAILED
CONTROL: committed journal, unmodified              OK
```

**Cases 8–13 were all green in earlier versions of this guard.** Each is a way the guard could be silenced rather than a way the journal could be wrong:

- **8** — it opened with `if (existsSync(...))`. Deleting the journal skipped every rule. A guard that can be silenced by removing its subject is not a guard.
- **9, 10** — `undefined <= undefined` is false, so a missing or non-numeric `when` passed the monotonic rule while the ordering it claims to enforce was undefined.
- **11** — membership was checked, order was not.
- **12** — `JSON.parse("null")` *succeeds*. Four characters silenced the whole guard.
- **13** — the `NNNN_` exemption was a shape test, so a new unnumbered file inherited it.

Case 11 is the one proving rule (h) stands alone: indexes contiguous, timestamps increasing, tags unique, every file present — every other rule passes.

The control matters as much as the reds. Without it, a guard that always failed would look identical to this one.

## Evidence

| Gate | Result |
|---|---|
| Red-on-revert | **13/13 + control** |
| `npm test` | **38/38 green**, none skipped |
| PG acceptance inventory | **30/30 green, 0 red** |
| `tsc` | clean |
| schema-safety · file-size · names · SAST · reach · architecture | green, at budget, **none raised** |

Head: `1bcfb78dbdd3eb07976cbc9a16e01687fe7ec764`

## Honest note on this PR's history

Three earlier heads on this branch each claimed to be finished and each had a fail-open hole found on review: `c49fa27`/`d21f446` (6/6, then 7/7) missed the deleted journal, the malformed `when` and the tag swap; `2730c50` (11/11) missed the `null` root and the unnumbered-file bypass. The evidence table above is the amended total, not the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa