### PR TITLE
Revert scripts read DATABASE_URL and fail loudly instead of silently resetting nothing

### DIFF
--- a/script/lib/db-safety-check.ts
+++ b/script/lib/db-safety-check.ts
@@ -1,0 +1,24 @@
+/**
+ * "MAY THIS DATABASE BE TRUNCATED?" — asked of the owner, answered for bash.
+ *
+ * The red-on-revert scripts truncate every table before each case. They must never do that to a
+ * database that is not a local throwaway, and the rule for deciding that already has an owner:
+ * `testDatabaseSafety` in script/pg-acceptance-runner.ts (loopback hosts only, never
+ * NODE_ENV=production, CI or an explicit PG_ACCEPTANCE_ALLOW_RESET=1).
+ *
+ * This is a two-line adapter so six shell scripts can consult that owner instead of each
+ * reimplementing its rules — six copies of a destructive-operation guard is five chances for one
+ * to drift without anything failing.
+ *
+ * It is a FILE rather than an inline `tsx -e` because inline eval is transformed as CommonJS and
+ * the runner uses top-level await, which fails the transform. That failure was silent behind
+ * `2>/dev/null` and made every database report "safety check could not run" — fail-closed, but
+ * refusing the valid case too, which is a guard that grades nothing.
+ *
+ * Prints exactly `SAFE` or `UNSAFE: <reason>` on stdout. Exit code is not the signal; the caller
+ * reads the line.
+ */
+import { testDatabaseSafety } from "../pg-acceptance-runner";
+
+const verdict = testDatabaseSafety(process.env.DATABASE_URL, process.env as any);
+process.stdout.write(verdict.safe ? "SAFE" : `UNSAFE: ${verdict.reason}`);

--- a/script/lib/revert-db.sh
+++ b/script/lib/revert-db.sh
@@ -1,0 +1,70 @@
+# shellcheck shell=bash
+#
+# THE DATABASE CONTRACT FOR RED-ON-REVERT SCRIPTS (Cut 1B, 2026-09-11).
+#
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# WHY THIS EXISTS
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+#
+# Six revert scripts each carried their own copy of this line:
+#
+#     PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c "…TRUNCATE…" >/dev/null 2>&1
+#
+# Three defects in one line, repeated six times.
+#
+#   1. THE DATABASE NAME IS HARDCODED. CI runs `kamlife`, not `journeylab`. Every one of those
+#      calls fails in CI.
+#   2. THE FAILURE IS SWALLOWED. `>/dev/null 2>&1` with no return check, so a reset that never
+#      happened looks identical to one that did. Proven on 2026-09-11: the voice-provenance revert
+#      script — the only one registered in the CI inventory — reset NOTHING in nine consecutive
+#      CI cases and still reported 9/9. It passed because the acceptance happens to clean up after
+#      itself, which is luck, not isolation.
+#   3. NOTHING CHECKS WHAT IT IS POINTED AT. These scripts TRUNCATE EVERY TABLE. A DATABASE_URL
+#      aimed at a real database would be a data-loss event with no confirmation step.
+#
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# ONE OWNER, NOT SIX COPIES
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+#
+# This file is sourced by all six. A safety rule copied six times is a safety rule that drifts in
+# five of them without anything failing — which is the same shape as the defect above, one layer
+# out. The safety QUESTION itself is not re-answered here either: `testDatabaseSafety` in
+# script/pg-acceptance-runner.ts already owns "may this database be reset?" (loopback host only,
+# never NODE_ENV=production, CI or an explicit opt-in), and this asks that owner rather than
+# reimplementing its rules in bash.
+#
+# EVERY FAILURE IS LOUD AND FATAL. There is no path through this file that lets a script keep
+# grading after the database it grades against was not prepared.
+
+# Fail fatally unless DATABASE_URL is set AND the existing owner says it is safe to truncate.
+# Call once, before any case runs.
+revert_db_require_safe () {
+  if [[ -z "${DATABASE_URL:-}" ]]; then
+    echo "FATAL: DATABASE_URL is not set. These cases truncate the database and grade against it;"
+    echo "       without one they would grade nothing and report success. Refusing to run." >&2
+    exit 1
+  fi
+  local verdict
+  # Stderr is NOT suppressed: a safety check that cannot run must be visible, not mistaken for a
+  # verdict. Silencing it is what made every database report "could not run" while the real cause
+  # was a CommonJS transform error.
+  verdict="$(npx tsx "$(dirname "$0")/lib/db-safety-check.ts")"
+  if [[ "$verdict" != "SAFE" ]]; then
+    echo "FATAL: refusing to truncate this database — ${verdict:-safety check could not run}." >&2
+    echo "       These cases TRUNCATE EVERY TABLE. Point DATABASE_URL at a local throwaway" >&2
+    echo "       database and set PG_ACCEPTANCE_ALLOW_RESET=1 (CI sets CI=true)." >&2
+    exit 1
+  fi
+}
+
+# Truncate every table except the two migration ledgers. Returns non-zero on ANY failure, so the
+# caller can fail its case instead of grading against a database it did not prepare.
+#
+# schema_migrations is preserved alongside __drizzle_migrations: the boot runner tracks applied
+# migrations there, and emptying it would make every migration re-run mid-suite. Three of these six
+# scripts previously truncated it; that was never deliberate.
+revert_db_reset () {
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q -c \
+    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" \
+    >/dev/null
+}

--- a/script/red-on-revert-221-owner.sh
+++ b/script/red-on-revert-221-owner.sh
@@ -6,14 +6,17 @@
 # testing its mechanism, and is reported as such rather than dressed up.
 set -u
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 ACC=script/pg-session-owner-acceptance.ts
 
 run_case () {
   local name="$1" patch="$2"
   cp -r server /tmp/221o-server-backup
   python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221o-server-backup; return 1; }
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; rm -rf /tmp/221o-server-backup; return 1
+  fi
   local out; out="$(npx tsx "$ACC" 2>&1)"
   echo "── REVERT: $name"
   echo "   $(echo "$out" | grep -E '^pg-session-owner-acceptance:' || echo '(no verdict — crashed)')"

--- a/script/red-on-revert-221-recap.sh
+++ b/script/red-on-revert-221-recap.sh
@@ -6,14 +6,17 @@
 # red on the checks that mouth exists to hold.
 set -u
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 ACC=script/pg-session-recap-acceptance.ts
 
 run_case () {
   local name="$1" patch="$2"
   cp -r server /tmp/221r-server-backup
   python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221r-server-backup; return 1; }
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; rm -rf /tmp/221r-server-backup; return 1
+  fi
   local out; out="$(npx tsx "$ACC" 2>&1)"
   echo "── REVERT: $name"
   echo "   $(echo "$out" | grep -E '^pg-session-recap-acceptance:' || echo '(no verdict — crashed)')"

--- a/script/red-on-revert-221.sh
+++ b/script/red-on-revert-221.sh
@@ -9,6 +9,8 @@
 # Usage:  DATABASE_URL=... bash script/red-on-revert-221.sh
 set -u
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 ACC=script/pg-comeback-clock-acceptance.ts
 TRUNC="DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;"
 
@@ -18,7 +20,9 @@ run_case () {
   python3 "$patch" || { echo "  !! patch failed to apply: $name"; rm -rf /tmp/221-server-backup; return 1; }
   # Truncate before EVERY run — these suites are not isolated from each other, and treating them
   # as if they were is exactly what produced a false four-acceptance regression report on #220.
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c "$TRUNC" >/dev/null 2>&1
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; rm -rf /tmp/221-server-backup; return 1
+  fi
   local out; out="$(npx tsx "$ACC" 2>&1)"
   echo "── REVERT: $name"
   echo "   $(echo "$out" | grep -E '^pg-comeback-clock-acceptance:' || echo '(no verdict — crashed)')"

--- a/script/red-on-revert-233-outbound.sh
+++ b/script/red-on-revert-233-outbound.sh
@@ -2,13 +2,16 @@
 # RED-ON-REVERT — #233 outbound, one mechanism at a time.
 set -u
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 ACC=script/pg-missed-session-outbound-acceptance.ts
 run_case () {
   local name="$1" patch="$2"
   cp -r server /tmp/233-server-backup
   python3 "$patch" || { echo "  !! patch failed: $name"; rm -rf /tmp/233-server-backup; return 1; }
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename <> '__drizzle_migrations' LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; rm -rf /tmp/233-server-backup; return 1
+  fi
   local out; out="$(npx tsx "$ACC" 2>&1)"
   echo "── REVERT: $name"
   echo "   $(echo "$out" | grep -E '^pg-missed-session-outbound-acceptance:' || echo '(no verdict — crashed)')"

--- a/script/red-on-revert-cut1-interaction.sh
+++ b/script/red-on-revert-cut1-interaction.sh
@@ -10,6 +10,8 @@
 # not go red, the acceptance is not protecting what it claims to protect.
 set -uo pipefail
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 ACC=script/pg-interaction-truth-acceptance.ts
 WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cut1-revert.XXXXXX")"
 BACKUP="$WORK_ROOT/backup"
@@ -42,8 +44,7 @@ run_case () {
     restore_case
     return 1
   fi
-  if ! PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1; then
+  if ! revert_db_reset; then
     echo "  !! database reset failed: $name"
     restore_case
     return 1

--- a/script/red-on-revert-voice-provenance.sh
+++ b/script/red-on-revert-voice-provenance.sh
@@ -16,6 +16,8 @@
 # passed that text plus an internal language note.
 set -uo pipefail
 cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
 
 WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/voiceprov-revert.XXXXXX")"
 BACKUP="$WORK_ROOT/backup"
@@ -30,10 +32,6 @@ restore_case () {
 cleanup () { restore_case; rm -rf "$WORK_ROOT"; }
 trap cleanup EXIT INT TERM
 
-reset_db () {
-  PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c \
-    "DO \$\$ DECLARE t text; BEGIN FOR t IN SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT IN ('__drizzle_migrations','schema_migrations') LOOP EXECUTE format('TRUNCATE TABLE %I CASCADE', t); END LOOP; END \$\$;" >/dev/null 2>&1
-}
 
 run_case () {
   local name="$1" patch="$2" suite="$3" label="$4"
@@ -44,7 +42,9 @@ run_case () {
   if ! python3 "$patch"; then
     echo "  !! patch failed: $name"; restore_case; return 1
   fi
-  reset_db
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; restore_case; return 1
+  fi
   out="$(npx tsx "$suite" 2>&1)"
   status=$?
   verdict="$(printf '%s\n' "$out" | grep -E "^${label}:" | tail -1 || true)"


### PR DESCRIPTION
Cut 1B. Base `ad5e9ad5cd58f0291317bd7f0067552ab610e19e`. Head `a145f8911db3007d593a972f370f14e9b784e453`.

Infrastructure only. **Zero `server/` files. No runtime code, no product behaviour, no schema, no governor moved.**

## The defect

Six red-on-revert scripts each carried their own copy of this line:

```
PGPASSWORD=kam psql -h 127.0.0.1 -U kam -d journeylab -q -c "…TRUNCATE…" >/dev/null 2>&1
```

Three defects in one line, repeated six times.

1. **The database name is hardcoded.** CI runs `kamlife`. Every one of those calls fails in CI.
2. **The failure is swallowed.** `>/dev/null 2>&1`, no return check. A reset that never happened looks identical to one that did.
3. **Nothing checks what it is pointed at.** These scripts TRUNCATE EVERY TABLE.

Reproduced on the base, not inferred: `red-on-revert-voice-provenance.sh` is the one of the six registered in the CI acceptance inventory. On `ad5e9ad` in CI it reset **nothing** across nine consecutive cases and still reported 9/9. It passed because that acceptance happens to clean up after itself — luck, not isolation. The other five never run in CI at all, so their reset has been a no-op wherever `journeylab` does not exist.

## One owner, not six copies

`script/lib/revert-db.sh`, sourced by all six.

The safety *question* is not re-answered there either. `testDatabaseSafety` in `script/pg-acceptance-runner.ts` already owns "may this database be reset?" — loopback host only, never `NODE_ENV=production`, `CI=true` or an explicit opt-in. `script/lib/db-safety-check.ts` is a 24-line ESM adapter that asks that owner and prints `SAFE` or `UNSAFE: <reason>`. No rule is reimplemented in bash.

Six copies of a destructive-operation guard is five chances to drift with nothing failing — the same shape as the defect above, one layer out.

## Every failure path is loud and fatal — all four proven, each exit 1

| condition | behaviour |
|---|---|
| `DATABASE_URL` unset | `FATAL: DATABASE_URL is not set… Refusing to run.` — no case runs |
| non-loopback host | `UNSAFE: host db.prod.example.com is not a local throwaway database` |
| loopback, no opt-in, not CI | `UNSAFE: not CI, and PG_ACCEPTANCE_ALLOW_RESET=1 was not given` |
| reset fails (Postgres stopped) | every case fails: `!! database reset failed: 1 (raw never captured)` |

`psql "$DATABASE_URL" -v ON_ERROR_STOP=1`, return value checked, no silent no-op anywhere.

**Stderr from the safety check is deliberately not suppressed.** Silencing it is what made every database report "safety check could not run" while the real cause was a CommonJS transform error — a check that cannot run must be visible, not mistaken for a verdict.

## Six revert scripts, all still red-on-revert

```
red-on-revert-voice-provenance    9/9 graded red
red-on-revert-cut1-interaction    7/7 graded red
red-on-revert-233-outbound        6 cases, all RED  (6,5,5,1,3,3 checks failed)
red-on-revert-221                 7 cases, all RED  (1,5,3,2,3,1,1)
red-on-revert-221-owner           3 cases, all RED  (3,2,2)
red-on-revert-221-recap           3 cases, all RED  (3,1,3)
```

Each restores the tree afterwards; the worktree was verified clean after the full run.

## Two judgement calls, disclosed rather than buried

1. **Eight files, not the six named.** The two additions are the shared contract and its adapter. The alternative was six edited copies of the same guard, which is the defect being fixed.
2. **`schema_migrations` is now preserved by all six.** Three previously truncated it. The boot runner tracks applied migrations there; emptying it makes every migration re-run mid-suite. That was never deliberate, and the three that did it differed from the three that did not for no stated reason.

## Gates on this head

```
tsc --noEmit                 clean
npm test                     38/38 green, none skipped
pg-acceptance-runner         30/30 green, 0 red   (journey-lab GREEN, 266 checks)
six revert scripts           all cases graded red
governors                    none raised, none moved
```

## What this does not claim

It does not claim the six scripts were previously *wrong about the product* — their assertions were unchanged and are unchanged here. It claims their isolation was fictional, and that the one of them CI actually runs was grading against a database it had not prepared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_