### PR TITLE
The clock may not name a meal the client did not name

### DIFF
--- a/script/check-sast.ts
+++ b/script/check-sast.ts
@@ -21,7 +21,7 @@ const CANONICAL = ["server/sast.ts"];
 
 // Today's count, 2026-07-28. LOWER THIS as call sites migrate. Never raise it: a rise means a
 // new hand-rolled day boundary was written, which is the exact bug this exists to stop.
-const BUDGET = 59;  // 2026-09-03: utils temporal attribution moved to canonical sast.ts
+const BUDGET = 55;  // 2026-09-11 (Cut 2): the clock-derived meal-slot inference is gone — 59 → 55
                     // 2026-08-13: client-snapshot dropped its local SAST key for sast.sastDayKey
 
 const RAW_OFFSET = /\b2\s*\*\s*3[_,]?600[_,]?000\b|\b7[_,]?200[_,]?000\b/g;

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -4,7 +4,6 @@
  *
  * Functions tested here:
  *   scalePortionDescription  (food-context.ts)
- *   extractMealLabel         (food-context.ts)
  *   assessWeightRate         (weight.ts)
  *   parseMealDate            (utils.ts) — edge cases beyond routing-audit coverage
  *   isRetroactiveMeal        (utils.ts)
@@ -32,7 +31,6 @@ process.env.TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN || "test";
 process.env.TWILIO_WHATSAPP_NUMBER = process.env.TWILIO_WHATSAPP_NUMBER || "+27000000000";
 
 // Dynamic imports — execute after env vars above, unlike static imports which are hoisted.
-const { extractMealLabel } = await import("../server/handlers/food-context");
 const { scalePortionDescription, adjustFoodsForSegment } = await import("../server/portion-memory");
 const { assessWeightRate, weeklyTrendSlopeKg } = await import("../server/handlers/weight");
 const { parseMealDate, isRetroactiveMeal, mealDateLabel } = await import("../server/utils");
@@ -746,71 +744,79 @@ test("scalePortionDescription: no numbers in desc — returns desc unchanged", (
 });
 
 // ============================================================
-// extractMealLabel — meal time extraction from message text
+// THE MEAL SLOT COMES FROM THE CLIENT'S WORDS, OR FROM NOWHERE (Cut 2, 2026-09-11).
+//
+// `extractMealLabel` was graded here. It is gone: its only truthful branch was explicitMealSlot,
+// which this repository already declares the one owner of "did the client name a slot?", and the
+// branches around it answered from the send clock, from the calorie count, and from a time the
+// client had typed. All three wrote a meal name into meal_logs.meal_label as a fact.
+//
+// EVERY KEYWORD ASSERTION BELOW IS THE ORIGINAL ONE, re-pointed at the surviving owner — the
+// promise "if they said it, we store it" is unchanged. The two clock tests are INVERTED, and the
+// inversion is stricter than what they asserted:
+//
+//   was: "caption wins over the clock"        -> still true, and now the clock has no claim at all
+//   was: "no caption at 1pm -> lunch"         -> at 1pm, saying nothing means nothing is claimed
+//   was: "no time signal -> any valid label"  -> that test could not fail; it accepted null AND
+//                                                every invented label. Now it demands null.
 // ============================================================
 
-test("extractMealLabel: 'for breakfast' → breakfast", () => {
-  assert.equal(extractMealLabel("I had eggs for breakfast"), "breakfast");
+test("meal slot: 'for breakfast' → breakfast", () => {
+  assert.equal(explicitMealSlot("I had eggs for breakfast"), "breakfast");
 });
 
-test("extractMealLabel: 'for lunch' → lunch", () => {
-  assert.equal(extractMealLabel("rice and chicken for lunch"), "lunch");
+test("meal slot: 'for lunch' → lunch", () => {
+  assert.equal(explicitMealSlot("rice and chicken for lunch"), "lunch");
 });
 
-test("extractMealLabel: 'for dinner' → dinner", () => {
-  assert.equal(extractMealLabel("had pap for dinner"), "dinner");
+test("meal slot: 'for dinner' → dinner", () => {
+  assert.equal(explicitMealSlot("had pap for dinner"), "dinner");
 });
 
-test("extractMealLabel: 'for supper' → dinner (supper maps to dinner)", () => {
-  assert.equal(extractMealLabel("had pap for supper"), "dinner");
+test("meal slot: 'for supper' → dinner (supper maps to dinner)", () => {
+  assert.equal(explicitMealSlot("had pap for supper"), "dinner");
 });
 
-test("extractMealLabel: 'snack' keyword → snack", () => {
-  assert.equal(extractMealLabel("afternoon snack — apple"), "snack");
+test("meal slot: 'snack' keyword → snack", () => {
+  assert.equal(explicitMealSlot("afternoon snack — apple"), "snack");
 });
 
-test("extractMealLabel: bare 'Lunch' at start of message → lunch", () => {
-  assert.equal(extractMealLabel("Lunch rice and beef"), "lunch");
+test("meal slot: bare 'Lunch' at start of message → lunch", () => {
+  assert.equal(explicitMealSlot("Lunch rice and beef"), "lunch");
 });
 
-test("extractMealLabel: bare 'Dinner' at start → dinner", () => {
-  assert.equal(extractMealLabel("Dinner pap and wors"), "dinner");
+test("meal slot: bare 'Dinner' at start → dinner", () => {
+  assert.equal(explicitMealSlot("Dinner pap and wors"), "dinner");
 });
 
-test("extractMealLabel: bare 'Breakfast' at start → breakfast", () => {
-  assert.equal(extractMealLabel("Breakfast 2 eggs and toast"), "breakfast");
+test("meal slot: bare 'Breakfast' at start → breakfast", () => {
+  assert.equal(explicitMealSlot("Breakfast 2 eggs and toast"), "breakfast");
 });
 
-test("extractMealLabel: 'breakfast was' → breakfast", () => {
-  assert.equal(extractMealLabel("breakfast was oats with milk"), "breakfast");
+test("meal slot: 'breakfast was' → breakfast", () => {
+  assert.equal(explicitMealSlot("breakfast was oats with milk"), "breakfast");
 });
 
-// BONOLO'S LOG (2026-07-14): a photo captioned "Breakfast" sent at 1pm was stamped
-// LUNCH because the PHOTO path used slotFromSastHour(now), ignoring her caption. The
-// caption keyword must win over the clock at any time of day — a batch-logger who
-// eats early and logs at midday must not have her whole morning dumped into LUNCH.
-test("extractMealLabel: caption wins over the clock — 'Breakfast' at 1pm → breakfast", () => {
-  const onePm = new Date("2026-07-14T13:00:00+02:00"); // SAST lunchtime
-  assert.equal(extractMealLabel("Breakfast", onePm), "breakfast");
-  assert.equal(extractMealLabel("Snack", onePm), "snack");
-  assert.equal(extractMealLabel("Dinner", onePm), "dinner");
+test("meal slot: 'dinner was' → dinner", () => {
+  assert.equal(explicitMealSlot("dinner was chicken and rice"), "dinner");
 });
 
-test("extractMealLabel: no caption at 1pm → clock fallback (lunch)", () => {
-  const onePm = new Date("2026-07-14T13:00:00+02:00");
-  assert.equal(extractMealLabel("", onePm, { kcal: 600, protein: 30 }), "lunch");
+// BONOLO'S LOG (2026-07-14): a photo captioned "Breakfast" sent at 1pm was stamped LUNCH because
+// the PHOTO path used slotFromSastHour(now), ignoring her caption. Her caption still wins — and
+// as of Cut 2 there is no longer a competing claim for it to win against.
+test("meal slot: the caption's own word stands at any hour", () => {
+  assert.equal(explicitMealSlot("Breakfast"), "breakfast");
+  assert.equal(explicitMealSlot("Snack"), "snack");
+  assert.equal(explicitMealSlot("Dinner"), "dinner");
 });
 
-test("extractMealLabel: 'dinner was' → dinner", () => {
-  assert.equal(extractMealLabel("dinner was chicken and rice"), "dinner");
-});
-
-test("extractMealLabel: no time signal — returns null (falls back to time-of-day)", () => {
-  // Pure message with no meal keyword — result depends on server clock, just check it's
-  // a valid label or null (not an unexpected string)
-  const result = extractMealLabel("oats and milk");
-  const VALID = new Set(["breakfast", "lunch", "dinner", "snack", null]);
-  assert.ok(VALID.has(result), `unexpected label: ${result}`);
+// THE INVERTED ONE. This asserted `extractMealLabel("", 1pm, 600kcal) === "lunch"` — a client who
+// said nothing, answered with "lunch" because of the hour their phone sent the message.
+test("meal slot: saying nothing at 1pm claims nothing", () => {
+  assert.equal(explicitMealSlot(""), null);
+  assert.equal(explicitMealSlot("chicken and rice"), null, "a 600-kcal plate is still not a named meal");
+  assert.equal(explicitMealSlot("I had a pear"), null, "the 22:00 pear — the named failure of Cut 2");
+  assert.equal(explicitMealSlot("oats and milk"), null);
 });
 
 // ============================================================

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -215,6 +215,19 @@ export const ACCEPTANCES: Acceptance[] = [
     // suite must turn red. A crash or an absent verdict is itself red.
     command: ["bash", "script/red-on-revert-voice-provenance.sh"] },
 
+  { id: "meal-slot-truth", title: "The clock may not name a meal the client did not name",
+    // CUT 2 (2026-09-11). At 06:00/13:00/22:00 SAST a client who names no meal must get no meal
+    // name written to their record. Needs a real database and the real front door: every claim is
+    // about which STRING landed in meal_logs.meal_label and what the post-transport body said
+    // about it, and the repeat case needs two turns of one client's real day to exist at all.
+    command: ["npx", "tsx", "script/pg-meal-slot-truth-acceptance.ts"] },
+
+  { id: "meal-slot-reverts", title: "Every removed meal-slot invention turns the acceptance red",
+    // The send clock, the calorie rule, a typed time, the photo path's own clock, the repeat
+    // target and the duplicate-guard sentence are each restored independently, plus two
+    // opposite-defect controls. A crash or an absent verdict is itself red.
+    command: ["bash", "script/red-on-revert-cut2-meal-slot.sh"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-meal-slot-truth-acceptance.ts
+++ b/script/pg-meal-slot-truth-acceptance.ts
@@ -1,0 +1,325 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — the clock may not name a meal the client did not name (Cut 2).
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT WAS PROVEN BROKEN ON a3731ee, BEFORE A LINE OF THIS CUT WAS WRITTEN
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * Measured through extractMealLabel with the macros the live path passes:
+ *
+ *     06:00  "chicken and rice"   ->  "breakfast"     the send clock
+ *     13:00  "chicken and rice"   ->  "lunch"         the send clock
+ *     22:00  "chicken and rice"   ->  "night meal"    the send clock
+ *     22:00  "I had a pear"       ->  "snack"         the calorie count
+ *     13:00  "had this at 1pm"    ->  "lunch"         a time they typed, read as a meal name
+ *
+ * Not one of those clients said breakfast, lunch, dinner, snack or night meal. Every string was
+ * written to meal_logs.meal_label as a fact about them and read back by the morning job, by
+ * meal-repeat, by the slot memory that then demoted their next plate, and by the model's snapshot.
+ *
+ * HONEST CORRECTION TO THE ORDER'S NAMED CASE, recorded rather than quietly worked around: at
+ * 22:00 exactly, "I had a pear" did NOT come back breakfast/lunch/dinner — the low-calorie rule
+ * fired first and returned "snack". It is still a slot the client never said, and it is still
+ * stored as one, so the defect is real; the 22:00 pear reaches it through the macro rule, and the
+ * clock's main-slot invention is reached by the same client's plate of chicken and rice. Both are
+ * graded below at all three hours rather than only the one that happened to reproduce verbatim.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHY THE CLOCK IS FROZEN HERE
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * The order names three fixed SAST times, and the reason is the lesson of PR #240: an acceptance
+ * that reads the real clock grades whichever hour CI happened to start in, and is green for a year
+ * of afternoons. Every case below pins 06:00, 13:00 and 22:00 SAST explicitly, so a revert is red
+ * at every hour of the day rather than at the hours someone was lucky enough to run it.
+ *
+ * GRADED POST-TRANSPORT. Each case drives processTextAsync — the reactive path through sendFinal,
+ * prepareOutbound, the truth floor and the delivery owner — then reads meal_logs (stored truth)
+ * and shadow_replies (the body the client would have received). A handler return proves neither.
+ *
+ * WHAT IS NOT EXECUTED HERE, stated rather than implied: real audio and the STT call. The voice
+ * path cannot run offline (assertSafeMediaUrl requires an https allow-listed host; transcription
+ * needs the network). Section 3 drives the exact re-entry media.ts uses — the transcript handed
+ * back to handleMessage as text — and section 6 asserts the photo path's own label line by source,
+ * because that line is the one place a second clock authority could reappear.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-meal-slot-truth-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { processTextAsync } = await import("../server/routes/whatsapp");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+const { _resetInteractionCorrelation } = await import("../server/handlers/chat-log");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+// ── THE FROZEN CLOCK ─────────────────────────────────────────────────────────────────────────
+// Date.now() alone is not enough: slotFromSastHour's default parameter is `new Date()`, which
+// reads the system clock directly and never consults Date.now. Both have to move together or a
+// case "pinned" at 22:00 grades the hour CI started in — which is exactly the defect #240 fixed.
+const RealDate = Date;
+const SAST_DAY = [2026, 8, 11] as const;            // 11 September 2026
+function freezeSast(hour: number): () => void {
+  const fixed = RealDate.UTC(SAST_DAY[0], SAST_DAY[1], SAST_DAY[2], hour - 2, 30, 0);
+  class FrozenDate extends RealDate {
+    constructor(...args: any[]) {
+      super(...(args.length === 0 ? [fixed] : args) as [any]);
+    }
+    static now() { return fixed; }
+  }
+  (globalThis as any).Date = FrozenDate;
+  return () => { (globalThis as any).Date = RealDate; };
+}
+
+const phone = "whatsapp:+27820000955";
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+const [user] = await db.insert(schema.users).values({
+  phoneNumber: phone, name: "Naledi Slot", onboardingState: "COMPLETE", popiConsent: true,
+  popiConsentAt: new RealDate(), subscriptionStatus: "active", goalType: "fat_loss",
+  currentWeight: "88", startWeight: "92", targetWeight: "80", heightCm: 165, age: 31,
+  gender: "female", trainingMode: "gym", proteinTarget: 130, calorieTarget: 1900,
+  dailyCalorieTarget: 1900, dailyStepTarget: 8000, stepsTarget: 8000,
+} as any).returning();
+
+type Meal = { meal_label: string | null; raw_message: string | null; logged_at: Date; kcal_int: number | null };
+// ORDER BY logged_at, NOT BY id. meal_logs.id is a gen_random_uuid(), so ordering by it is
+// ordering by a random number — which is exactly how section 4b's two rows came back in a
+// different order on roughly one run in three, failing an assertion about a defect that was not
+// there. A flaky acceptance is worse than none: it teaches people that red means nothing.
+const meals = async (): Promise<Meal[]> => (await pool.query<Meal>(
+  `SELECT meal_label, raw_message, logged_at, kcal_int FROM meal_logs
+    WHERE user_id = $1 ORDER BY logged_at, raw_message`, [user.id])).rows;
+const wire = async (): Promise<string[]> => (await pool.query<{ body: string }>(
+  "SELECT body FROM shadow_replies WHERE phone = $1 ORDER BY id", [phone])).rows.map(r => r.body);
+const clear = async () => {
+  await pool.query("DELETE FROM meal_logs WHERE user_id = $1", [user.id]);
+  await pool.query("DELETE FROM chat_history WHERE user_id = $1", [user.id]);
+  await pool.query("DELETE FROM turn_ledger WHERE user_id = $1", [user.id]);
+  await pool.query("DELETE FROM shadow_replies WHERE phone = $1", [phone]);
+  _resetOutboundDedupe();
+  _resetInteractionCorrelation();
+};
+const settle = () => new Promise(r => setTimeout(r, 900));
+
+/** One turn, at a pinned SAST hour, through the real reactive front door. */
+async function turnAt(hour: number, text: string, sid: string): Promise<{ rows: Meal[]; bodies: string[] }> {
+  await clear();
+  const unfreeze = freezeSast(hour);
+  try {
+    await processTextAsync(phone, text, null, null, [], handleMessage as any, sid);
+    await settle();
+  } finally { unfreeze(); }
+  return { rows: await meals(), bodies: await wire() };
+}
+
+/** Every meal name the product could put on a plate. A stored slot is one of these or null. */
+const SLOT_WORDS = /\b(breakfast|lunch|dinner|supper|night meal|brunch)\b/i;
+
+REAL("\npg-meal-slot-truth-acceptance — the clock may not name a meal the client did not name\n");
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("1. THE NAMED FAILURE — \"I had a pear\" at 06:00, 13:00 and 22:00 SAST");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+for (const hour of [6, 13, 22]) {
+  const { rows, bodies } = await turnAt(hour, "I had a pear", `sid-pear-${hour}`);
+  const label = rows[0]?.meal_label ?? "(no row)";
+  chk(rows.length === 1, `${hour}:00 — the pear is stored`, `got ${rows.length} row(s)`);
+  chk(rows.length === 1 && rows[0].meal_label === null,
+    `${hour}:00 — stored with NO invented meal slot`, `meal_label=${JSON.stringify(label)}`);
+  chk(bodies.length > 0, `${hour}:00 — the client got an answer`, `got ${bodies.length} bodies`);
+  chk(!SLOT_WORDS.test(bodies.join("\n")),
+    `${hour}:00 — the final body names no breakfast, lunch or dinner`,
+    `body=${JSON.stringify(bodies.join(" | ").slice(0, 160))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n2. THE SAME CLIENT'S FULL PLATE — the case where the clock invented a MAIN slot");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// "I had a pear" reached a fabricated slot through the calorie rule; "chicken and rice" reached
+// one through the clock itself, and at all three hours it was a different main meal. Both routes
+// into the same defect are graded, so closing one of them cannot make this section green.
+for (const hour of [6, 13, 22]) {
+  const { rows, bodies } = await turnAt(hour, "I had chicken and rice", `sid-plate-${hour}`);
+  chk(rows.length >= 1, `${hour}:00 — the plate is stored`, `got ${rows.length} row(s)`);
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === null),
+    `${hour}:00 — a 600-kcal plate is still not a named meal`,
+    `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+  chk(!SLOT_WORDS.test(bodies.join("\n")),
+    `${hour}:00 — the final body names no meal either`,
+    `body=${JSON.stringify(bodies.join(" | ").slice(0, 160))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n2b. A TIME THEY TYPED IS NOT A MEAL THEY NAMED");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// The third invention, and the one this acceptance did not grade until its own red-on-revert case
+// stayed green and said so. slotFromCaptionTime read "1pm" out of a caption and returned "lunch".
+// People eat lunch at 11:00 and dinner at 17:00; an hour is not a meal name in anybody's mouth.
+{
+  const { rows } = await turnAt(22, "I had chicken and rice at 1pm", "sid-caption-time");
+  chk(rows.length >= 1, "22:00 — a plate reported with a typed time is still stored",
+    `got ${rows.length} row(s)`);
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === null),
+    "22:00 — \"at 1pm\" names an hour, so no meal is claimed",
+    `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+}
+{
+  const { rows } = await turnAt(13, "I had eggs at 8am", "sid-caption-time-am");
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === null),
+    "13:00 — and \"at 8am\" is not breakfast either",
+    `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n3. VOICE AND TYPED AGREE — the transcript re-enters as text, so it must land identically");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// media.ts hands the cleaned transcript back to handleMessage as TEXT (the recursion Cut 0 made
+// durable). This drives that same entry with the same words at the same hour as section 1, and
+// compares the stored truth of the two paths directly rather than asserting they "should" match.
+{
+  const typed = await turnAt(22, "I had a pear", "sid-typed-22");
+  const voice = await turnAt(22, "I had a pear", "sid-voice-22");
+  chk(typed.rows[0]?.meal_label === voice.rows[0]?.meal_label,
+    "22:00 — voice re-entry stores the same slot as the typed path",
+    `typed=${JSON.stringify(typed.rows[0]?.meal_label)} voice=${JSON.stringify(voice.rows[0]?.meal_label)}`);
+  chk(voice.rows[0]?.meal_label === null, "22:00 — and that slot is null, on both");
+  chk(!SLOT_WORDS.test(voice.bodies.join("\n")), "22:00 — the voice turn's body names no meal",
+    `body=${JSON.stringify(voice.bodies.join(" | ").slice(0, 160))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n4. WHAT THE CLIENT SAID IS STILL AUTHORITATIVE — the controls that make section 1 mean something");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// A build that stored null for EVERY meal would pass every check above. These are the opposite
+// defect: the client named the meal, at an hour the clock disagrees with, and their word must win.
+{
+  const { rows, bodies } = await turnAt(22, "I had pap for breakfast", "sid-said-breakfast");
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === "breakfast"),
+    "22:00 — \"for breakfast\" is stored as breakfast, at an hour the clock calls a night meal",
+    `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+  chk(/breakfast/i.test(bodies.join("\n")) || bodies.length > 0,
+    "22:00 — and the turn still answers", `body=${JSON.stringify(bodies.join(" | ").slice(0, 120))}`);
+}
+{
+  const { rows } = await turnAt(6, "Yesterday at dinner I had chicken", "sid-retro-dinner");
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === "dinner"),
+    "06:00 — a retroactive named slot survives", `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+  const sastDay = (d: Date) => new RealDate(new RealDate(d).getTime() + 2 * 3_600_000).toISOString().slice(0, 10);
+  chk(rows.length >= 1 && sastDay(rows[0].logged_at) === "2026-09-10",
+    "06:00 — and it is still filed to YESTERDAY: the clock keeps the day, it only loses the meal name",
+    `logged_at=${rows[0] ? sastDay(rows[0].logged_at) : "(none)"}`);
+}
+{
+  const { rows } = await turnAt(13, "I had an apple as a snack", "sid-said-snack");
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === "snack"),
+    "13:00 — a snack they CALLED a snack is stored as one", `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+}
+{
+  const { rows } = await turnAt(13, "This morning I had 3 eggs and 2 slices of toast", "sid-174");
+  chk(rows.length >= 1 && rows.every(r => r.meal_label === "breakfast"),
+    "13:00 — #174 stays answered: saying WHEN you ate is saying WHICH meal it was",
+    `labels=${JSON.stringify(rows.map(r => r.meal_label))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n4b. \"THE SAME AS MY LUNCH\" NAMES THE SOURCE, NOT THIS PLATE");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Two turns, one client, one day — the only way to express this claim at all. The copy is made at
+// 19:10, when the clock says dinner and the client's own sentence says lunch. Neither is a
+// statement about the plate in front of them, and the record must say neither.
+{
+  await clear();
+  const unfreeze = freezeSast(13);
+  try {
+    await processTextAsync(phone, "I had rice and chicken for lunch", null, null, [], handleMessage as any, "sid-rep-src");
+    await settle();
+  } finally { unfreeze(); }
+  const seeded = await meals();
+  chk(seeded.length >= 1 && seeded[0].meal_label === "lunch",
+    "13:00 — the source meal is stored as the lunch they called it",
+    `labels=${JSON.stringify(seeded.map(r => r.meal_label))}`);
+
+  const unfreeze2 = freezeSast(19);
+  let bodies: string[] = [];
+  try {
+    await processTextAsync(phone, "I had the same as my lunch", null, null, [], handleMessage as any, "sid-rep-copy");
+    await settle();
+  } finally { unfreeze2(); }
+  const after = await meals();
+  bodies = await wire();
+  // BY THE HOUR THEY WERE WRITTEN AT, not by their place in the list: the source was logged at
+  // 13:00 and the copy at 19:10, and those are facts about the rows rather than about the query.
+  const sastHour = (d: Date) => new RealDate(new RealDate(d).getTime() + 2 * 3_600_000).getUTCHours();
+  const copy = after.find(r => sastHour(r.logged_at) === 19);
+  const source = after.find(r => sastHour(r.logged_at) === 13);
+  chk(after.length === seeded.length + 1, "19:10 — the copy is logged",
+    `rows before=${seeded.length} after=${after.length}`);
+  chk(!!copy, "19:10 — and it is the 19:10 row", `hours=${JSON.stringify(after.map(r => sastHour(r.logged_at)))}`);
+  chk(!!copy && copy.meal_label === null,
+    "19:10 — the copy carries no slot: not the clock's dinner, and not the source's lunch",
+    `copy label=${JSON.stringify(copy?.meal_label)}`);
+  chk(!!source && source.meal_label === "lunch",
+    "19:10 — and the original lunch still says lunch",
+    `labels=${JSON.stringify(after.map(r => [sastHour(r.logged_at), r.meal_label]))}`);
+  chk(!/\*Lunch logged\*|\*Dinner logged\*/i.test(bodies.join("\n")),
+    "19:10 — the body does not tell them a second lunch, or a dinner, was recorded",
+    `body=${JSON.stringify(bodies.join(" | ").slice(0, 200))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n5. NOTHING IS SILENTLY DROPPED — the food itself still lands");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Losing the slot must not cost the client the log. The opposite defect for the whole cut.
+{
+  const { rows } = await turnAt(13, "I had chicken and rice", "sid-still-logs");
+  chk(rows.length >= 1 && rows.some(r => (r.kcal_int || 0) > 0),
+    "13:00 — the meal is still priced and written", `rows=${JSON.stringify(rows.map(r => r.kcal_int))}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n6. NO SECOND CLOCK AUTHORITY SURVIVES ON A WRITE PATH (source-graded, and it says so)");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// The photo and album writes cannot be executed offline, and they are exactly where a clock
+// fallback would be re-added — both lines read `extractMealLabel(...) || slotFromSastHour(...)`,
+// so a null from the owner was overruled one character later. Graded by source, deliberately.
+{
+  const { readFileSync } = await import("node:fs");
+  const media = readFileSync("server/handlers/media.ts", "utf-8");
+  const foodCtx = readFileSync("server/handlers/food-context.ts", "utf-8");
+  const mealSelect = readFileSync("server/meal-select.ts", "utf-8");
+  const live = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
+  chk(!/slotFromSastHour/.test(live(media)), "media.ts no longer asks the clock for a meal name");
+  chk((live(media).match(/explicitMealSlot\(/g) || []).length >= 2,
+    "both photo writes ask the client's words instead");
+  chk(!/slotFromSastHour|slotFromCaptionTime|resolveInferredSlot/.test(live(foodCtx)),
+    "food-context.ts has no clock or caption slot authority left");
+  chk(!/extractMealLabel/.test(live(foodCtx)), "extractMealLabel is gone, not merely unused");
+  chk(!/slotFromSastHour/.test(live(mealSelect)),
+    "meal-select.ts no longer names the target slot of a repeat from the clock");
+}
+
+REAL(`\n${failed === 0 ? "pg-meal-slot-truth-acceptance: GREEN" : `pg-meal-slot-truth-acceptance: ${failed} FAILED`}\n`);
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/red-on-revert-cut2-meal-slot.sh
+++ b/script/red-on-revert-cut2-meal-slot.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — Cut 2, the clock may not name a meal the client did not name.
+#
+# Each case restores exactly ONE of the removed inventions and re-runs the acceptance. A case that
+# stays green is a check that grades nothing.
+#
+# Cases 1-3 are the three answers extractMealLabel gave when the client had said nothing: the send
+# clock, the calorie count, and a time they had typed. Cases 4-5 are the two OTHER write paths that
+# each carried their own copy of the clock, and which would have quietly overruled a null from the
+# owner. Case 6 is the laundering route — a slot invented for the record, then spoken back to the
+# client as the phrase that would store it again. Case 9 is the repeat path storing the slot of the
+# meal that was COPIED FROM, which is a statement about a different plate at a different hour.
+#
+# CASE 3 IS WHY THIS FILE EXISTS. It was GREEN on the first run: the acceptance had no fixture
+# carrying a typed time, so the caption-time invention could have been restored with every check
+# still passing. Section 2b was written because this script said so, not the other way round.
+#
+# Cases 7 and 8 are OPPOSITE-DEFECT controls. They do not restore anything this cut removed; they
+# break what it must NOT have broken — a named meal keeping its name, and the food being logged at
+# all. A build that simply stored null for everything, or stopped logging food, would satisfy every
+# check in sections 1-3 and is the cheapest wrong way to pass this cut.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
+ACC=script/pg-meal-slot-truth-acceptance.ts
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cut2-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/backup"
+PATCH_DIR="$WORK_ROOT/patches"
+
+restore_case () {
+  if [[ -d "$BACKUP/server" ]]; then
+    rm -rf server
+    mv "$BACKUP/server" server
+  fi
+  rm -rf "$BACKUP"
+}
+
+cleanup () {
+  restore_case
+  rm -rf "$WORK_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+run_case () {
+  local name="$1" patch="$2"
+  local out status verdict
+  restore_case
+  mkdir -p "$BACKUP"
+  cp -a server "$BACKUP/server"
+  if ! python3 "$patch"; then
+    echo "  !! patch failed: $name"
+    restore_case
+    return 1
+  fi
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"
+    restore_case
+    return 1
+  fi
+  out="$(npx tsx "$ACC" 2>&1)"
+  status=$?
+  verdict="$(printf '%s\n' "$out" | grep -E '^pg-meal-slot-truth-acceptance:' | tail -1 || true)"
+  echo "── REVERT: $name"
+  echo "   ${verdict:-'(no verdict — crashed)'}"
+  printf '%s\n' "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4 || true
+  restore_case
+  if [[ $status -eq 0 ]]; then
+    echo "  !! acceptance stayed green: $name"
+    return 1
+  fi
+  if [[ ! "$verdict" =~ ^pg-meal-slot-truth-acceptance:\ [1-9][0-9]*\ FAILED$ ]]; then
+    echo "  !! acceptance did not reach a graded red verdict: $name (exit $status)"
+    return 1
+  fi
+}
+
+mkdir -p "$PATCH_DIR"
+
+# 1. THE SEND CLOCK NAMES THE MEAL AGAIN — the defect itself. A client who said nothing gets
+#    breakfast at 06:00, lunch at 13:00 and a night meal at 22:00, written to their record.
+cat > "$PATCH_DIR/1.py" <<'PY'
+p="server/handlers/food-context.ts"; s=open(p).read(); b=s
+s=s.replace('import { explicitMealSlot } from "../understanding/actions";',
+            'import { explicitMealSlot } from "../understanding/actions";\n'
+            'import { slotFromSastHour as _clock } from "../utils";\n'
+            'const _slot = (m: string, at?: Date, k?: number) => explicitMealSlot(m)\n'
+            '  || _clock(at, { substantial: (k ?? 0) >= 300 });')
+s=s.replace("""      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || explicitMealSlot(message);""",
+            """      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || _slot(message, undefined, totalCals);""")
+assert s!=b and "_slot(message, undefined, totalCals)" in s, "no match"; open(p,"w").write(s)
+PY
+
+# 2. THE CALORIE COUNT NAMES THE MEAL AGAIN — the route the 22:00 pear actually took. A light log
+#    becomes somebody's "snack" because of its kcal, not because they said so.
+cat > "$PATCH_DIR/2.py" <<'PY'
+p="server/handlers/food-context.ts"; s=open(p).read(); b=s
+s=s.replace('import { explicitMealSlot } from "../understanding/actions";',
+            'import { explicitMealSlot } from "../understanding/actions";\n'
+            'const _slot = (m: string, k?: number, pr?: number) => explicitMealSlot(m)\n'
+            '  || ((k != null && k < 250 && (pr ?? 0) <= 4) ? "snack" : null);')
+s=s.replace("""      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || explicitMealSlot(message);""",
+            """      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || _slot(message, totalCals, Math.round(totalProtein));""")
+assert s!=b and "_slot(message, totalCals" in s, "no match"; open(p,"w").write(s)
+PY
+
+# 3. A TYPED TIME IS READ AS A MEAL NAME AGAIN — slotFromCaptionTime, restored inline. "had this at
+#    1pm" becomes lunch; the client named an hour, not a meal.
+cat > "$PATCH_DIR/3.py" <<'PY'
+p="server/handlers/food-context.ts"; s=open(p).read(); b=s
+s=s.replace('import { explicitMealSlot } from "../understanding/actions";',
+            'import { explicitMealSlot } from "../understanding/actions";\n'
+            'const _caption = (m: string): string | null => {\n'
+            '  const t = (m || "").toLowerCase().match(/\\b(\\d{1,2})\\s*(am|pm)\\b/);\n'
+            '  if (!t) return null;\n'
+            '  let h = parseInt(t[1], 10);\n'
+            '  if (t[2] === "pm" && h < 12) h += 12;\n'
+            '  return h <= 11 ? "breakfast" : h <= 15 ? "lunch" : "dinner";\n'
+            '};\n'
+            'const _slot = (m: string) => explicitMealSlot(m) || _caption(m);')
+s=s.replace("""      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || explicitMealSlot(message);""",
+            """      const firstSegLabel = mealSegments.find(s => s.label)?.label
+        || _slot(message);""")
+assert s!=b and "|| _slot(message);" in s, "no match"; open(p,"w").write(s)
+PY
+
+# 4. THE PHOTO PATH GETS ITS OWN CLOCK BACK. Both media.ts writes read
+#    `extractMealLabel(...) || slotFromSastHour(photoLoggedAt)` — a null from the owner was
+#    overruled one character later, so fixing only food-context would have changed nothing here.
+cat > "$PATCH_DIR/4.py" <<'PY'
+p="server/handlers/media.ts"; s=open(p).read(); b=s
+s=s.replace('import { explicitMealSlot } from "../understanding/actions";',
+            'import { explicitMealSlot } from "../understanding/actions";\n'
+            'import { slotFromSastHour } from "../utils";')
+s=s.replace('const photoLabel = explicitMealSlot(message || "");',
+            'const photoLabel = explicitMealSlot(message || "") || slotFromSastHour(photoLoggedAt);')
+assert s!=b and "|| slotFromSastHour(photoLoggedAt)" in s, "no match"; open(p,"w").write(s)
+PY
+
+# 5. THE REPEAT TARGET IS NAMED BY THE CLOCK AGAIN. "I had the same as my lunch" said at 19:10
+#    stored the copy as the client's "dinner" — a slot they never used, from the send hour.
+cat > "$PATCH_DIR/5.py" <<'PY'
+p="server/meal-select.ts"; s=open(p).read(); b=s
+s=s.replace('import { parseMealDate }', 'import { slotFromSastHour } from "./utils";\nimport { parseMealDate }')
+if "slotFromSastHour" not in s:
+    s = 'import { slotFromSastHour } from "./utils";\n' + s
+s=s.replace("    : sameAsMealM ? null", "    : sameAsMealM ? slotFromSastHour()")
+assert s!=b and "sameAsMealM ? slotFromSastHour()" in s, "no match"; open(p,"w").write(s)
+PY
+
+# 6. THE INVENTION IS LAUNDERED THROUGH THE CLIENT. findDuplicateMealToday returns "lunch" for a
+#    row that has no slot, and the photo-duplicate reply tells them to say "same as lunch" — which
+#    would then store the copy as lunch. A guess, spoken back until it becomes a fact.
+cat > "$PATCH_DIR/6.py" <<'PY'
+p="server/handlers/food-scanner.ts"; s=open(p).read(); b=s
+s=s.replace('slot: (r.mealLabel || "").toString(),', 'slot: (r.mealLabel || "lunch").toString(),')
+assert s!=b, "no match"; open(p,"w").write(s)
+p2="server/handlers/food-context.ts"; s2=open(p2).read(); b2=s2
+s2=s2.replace("        || explicitMealSlot(message);", '        || "lunch";')
+assert s2!=b2, "no match (food-context)"; open(p2,"w").write(s2)
+PY
+
+# 7. OPPOSITE DEFECT — the client names the meal and it is thrown away. Every check in sections 1-3
+#    still passes, because null is what they assert. Section 4 is the only thing standing between
+#    this cut and a product that has simply stopped recording which meal anything was.
+cat > "$PATCH_DIR/7.py" <<'PY'
+p="server/understanding/actions.ts"; s=open(p).read(); b=s
+s=s.replace('export function explicitMealSlot(msg: string): "breakfast" | "lunch" | "dinner" | "snack" | null {',
+            'export function explicitMealSlot(msg: string): "breakfast" | "lunch" | "dinner" | "snack" | null {\n  if (msg) return null;')
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 8. OPPOSITE DEFECT — the meal stops being logged at all. A row that never exists has no invented
+#    slot either, which is the other cheap way to be green on a cut about what gets stored.
+cat > "$PATCH_DIR/8.py" <<'PY'
+p="server/day-ledger.ts"; s=open(p).read(); b=s
+s=s.replace("export async function commitFoodLog(params: CommitFoodLogParams): Promise<CommitFoodLogResult> {",
+            "export async function commitFoodLog(params: CommitFoodLogParams): Promise<CommitFoodLogResult> {\n"
+            "  if (params) return { ok: true, runningCals: 0, runningProtein: 0, prevCals: 0 } as any;")
+assert s!=b, "no match"; open(p,"w").write(s)
+PY
+
+# 9. THE REPEAT PATH STORES THE SOURCE'S SLOT AGAIN. "I had the same as my lunch" at 19:10 named
+#    the meal they COPIED FROM; the row it writes is a different plate, hours later. Restoring the
+#    fallback chain records a second "lunch" and tells the client "*Lunch logged*".
+cat > "$PATCH_DIR/9.py" <<'PYEOF'
+p="server/handlers/meal-repeat.ts"; s=open(p).read(); b=s
+s=s.replace("      mealLabel: targetLabel || null,   // only what they called THIS meal (Cut 2)",
+            "      mealLabel: targetLabel || sourceHint || match.mealLabel || null,")
+s=s.replace('    const labelDisplay = (targetLabel || "Meal").replace(/\b\w/g, c => c.toUpperCase());',
+            '    const labelDisplay = (targetLabel || sourceHint || match.mealLabel || "Meal").replace(/\b\w/g, c => c.toUpperCase());')
+assert s!=b and "targetLabel || sourceHint || match.mealLabel || null," in s, "no match"; open(p,"w").write(s)
+PYEOF
+
+echo "RED-ON-REVERT — Cut 2. Every case below must report FAILED."
+failed=0
+for i in 1 2 3 4 5 6 7 8 9; do
+  if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
+done
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) were green, crashed, or ungraded."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 9/9 cases reached a graded red verdict."

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -21,7 +21,7 @@ import { classifyLoggedFood, buildGroceryPersonalization, loggerType, type FoodP
 import { computeProgressScore } from "../server/progress-score";
 import { computeClientRisk, sortByRisk } from "../server/client-triage";
 import { classifyWorkoutFeedback } from "../server/workout-feedback";
-import { normaliseMsisdn, buildContentVariables, stripInventedRetroDate, parseQuantityCorrection, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, parseMealDate, sastDayStart, hasGoalChangeVocabulary, timeGreeting, slotFromCaptionTime, effectiveMealLoggedAt } from "../server/utils";
+import { normaliseMsisdn, buildContentVariables, stripInventedRetroDate, parseQuantityCorrection, looksLikeStepsReport, looksLikeWaterReport, looksLikeWeightReport, parseMealDate, sastDayStart, hasGoalChangeVocabulary, timeGreeting, effectiveMealLoggedAt } from "../server/utils";
 import { getSleepResponse } from "../server/handlers/sleep";
 import { selectMealToCopy, parseMealRepeatTarget, type CopyableMeal } from "../server/meal-select";
 import { getGoalProfile, usesMacroTargets, GOAL_KEYS, looksLikeGoalAnswer, classifyGoalFromText } from "../server/goal-profiles";
@@ -1273,31 +1273,36 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
   });
 }
 
-// PERSONAL MEAL-SLOT LEARNING (2026-07-17, Review #7 items 3b + gap-heuristic +
-// behavioural shift detection). The client's own hour-pattern beats the clock;
-// a light second meal on a used slot demotes to snack; weak patterns change nothing.
+// PERSONAL MEAL-SLOT LEARNING IS GONE, AND MUST STAY GONE (Cut 2, 2026-09-11).
+//
+// Three tests stood here proving that a client's own hour-pattern beat the clock, that a light
+// second plate on a used slot demoted to "snack", and that a weak pattern changed nothing. Every
+// one of them graded an INVENTION: the client had named no meal, and all three paths ended in a
+// string written to meal_logs.meal_label as a fact about them.
+//
+// They are not weakened, they are inverted — the capability they graded no longer exists, and
+// what replaces them is stricter than what they asserted. The old tests permitted a label on a
+// message that named none; this permits none.
 {
-  const { dominantSlotByHour, resolveInferredSlot } = await import("../server/portion-memory");
-  const at = (sastHour: number, label: string) => ({ loggedAt: new Date(Date.UTC(2026, 6, 10, (sastHour - 2 + 24) % 24, 15)), mealLabel: label });
-  test("slot learning: hour qualifies at >=3 logs and >=70% share — never on noise", async () => {
-    const strong = dominantSlotByHour([at(10, "lunch"), at(10, "lunch"), at(10, "lunch"), at(10, "breakfast")]);
-    assert.equal(strong.get(10), "lunch", "3/4 lunch at 10:00 = personal lunch hour");
-    const weak = dominantSlotByHour([at(10, "lunch"), at(10, "lunch"), at(10, "breakfast"), at(10, "breakfast")]);
-    assert.ok(!weak.has(10), "50/50 split teaches nothing");
-    const thin = dominantSlotByHour([at(10, "lunch"), at(10, "lunch")]);
-    assert.ok(!thin.has(10), "2 logs is not a pattern");
+  const { explicitMealSlot } = await import("../server/understanding/actions");
+  const { getPortionMemory } = await import("../server/portion-memory");
+  const pm = await import("../server/portion-memory");
+  test("slot inference: the hour-learning apparatus is not merely unused, it is absent", async () => {
+    for (const gone of ["dominantSlotByHour", "resolveInferredSlot", "getSlotContext"]) {
+      assert.ok(!(gone in pm), `${gone} is back in portion-memory — the clock is naming meals again`);
+    }
+    const sast = await import("../server/sast");
+    assert.ok(!("slotFromCaptionTime" in sast), "slotFromCaptionTime is back — a typed time is not a meal name");
+    assert.equal(typeof getPortionMemory, "function", "portion memory is a different question and must survive");
   });
-  test("slot learning: personal hour beats the clock; shift worker learned without a flag", async () => {
-    const ctx = { personalByHour: new Map([[10, "lunch"], [2, "night meal"]]), todaySlots: [] };
-    assert.equal(resolveInferredSlot("breakfast", 10, ctx, 600), "lunch", "the reviewer's 10:00 case");
-    assert.equal(resolveInferredSlot("snack", 2, ctx, 250), "night meal", "02:00 history wins, no onboarding flag needed");
-    assert.equal(resolveInferredSlot("breakfast", 7, ctx, 400), "breakfast", "no pattern for 07:00 = clock stands");
-  });
-  test("slot learning: light second meal on a used slot = snack; a real plate keeps its slot", async () => {
-    const ctx = { personalByHour: new Map<number, string>(), todaySlots: ["breakfast"] };
-    assert.equal(resolveInferredSlot("breakfast", 9, ctx, 180), "snack", "09:30 fruit after 07:30 breakfast");
-    assert.equal(resolveInferredSlot("breakfast", 9, ctx, 650), "breakfast", "a second full plate is honestly a second breakfast");
-    assert.equal(resolveInferredSlot("breakfast", 9, undefined, 180), "breakfast", "no context = old behaviour, fail-open");
+  test("slot inference: only the client's own words name a meal, at any hour", async () => {
+    for (const said of ["I had a pear", "chicken and rice", "2 eggs and toast", "had this at 1pm", "500ml water"]) {
+      assert.equal(explicitMealSlot(said), null, `"${said}" names no meal, so nothing may claim one`);
+    }
+    assert.equal(explicitMealSlot("I had pap for breakfast"), "breakfast");
+    assert.equal(explicitMealSlot("Yesterday at dinner I had chicken"), "dinner");
+    assert.equal(explicitMealSlot("afternoon snack - apple"), "snack");
+    assert.equal(explicitMealSlot("This morning I had 3 eggs"), "breakfast", "#174 stays answered");
   });
 }
 
@@ -7123,24 +7128,34 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
 }
 
 // ============================================================
-// PHOTO DIARY — CAPTION TIME SETS THE MEAL SLOT (2026-07-22, Puntsa's screenshots: she
-// photographs each meal but batch-sends the whole day in the evening. "11:00" breakfast
-// arriving at 19:49 must NOT be labelled dinner from the send-clock.)
+// PHOTO DIARY — A CAPTION TIME NO LONGER SETS THE MEAL SLOT (Cut 2, 2026-09-11; the block
+// here graded slotFromCaptionTime, added 2026-07-22 for Puntsa, who photographs each meal and
+// batch-sends the whole day at 19:49).
+//
+// THE DEFECT IT WAS BUILT FOR IS FIXED MORE COMPLETELY THAN IT FIXED IT. It stopped the SEND
+// clock calling an 11:00 breakfast "dinner" by having a SECOND clock — the one she typed — name
+// the meal instead. Cut 2 removes the send clock's claim outright, so there is nothing left to
+// out-rank, and "I ate at 11:00" is still not "I ate breakfast": people eat lunch at 11:00.
+//
+// NOT A SILENT LOSS. Four of that block's six captions still resolve, because in those four she
+// NAMED the meal — her words were always doing the work, and the clock was reading over her
+// shoulder. The two that no longer resolve are the two where she named only a time.
 // ============================================================
 {
-  test("caption-time: a time in the caption maps to the right slot", () => {
-    assert.equal(slotFromCaptionTime("11:00"), "breakfast");
-    assert.equal(slotFromCaptionTime("8am tea and eggs"), "breakfast");
-    assert.equal(slotFromCaptionTime("had this at 1pm"), "lunch");
-    assert.equal(slotFromCaptionTime("2:30pm snack"), "lunch");
-    assert.equal(slotFromCaptionTime("dinner at 19:30"), "dinner");
-    assert.equal(slotFromCaptionTime("supper 8pm"), "dinner");
+  const { explicitMealSlot } = await import("../server/understanding/actions");
+  test("caption: the client's own meal word still decides, exactly as before", () => {
+    assert.equal(explicitMealSlot("dinner at 19:30"), "dinner");
+    assert.equal(explicitMealSlot("supper 8pm"), "dinner");
+    assert.equal(explicitMealSlot("2:30pm snack"), "snack", "her word, not the 14:30 the old rule read as lunch");
+    assert.equal(explicitMealSlot("Lunch time"), "lunch");
   });
-  test("caption-time: quantities and plain text are NOT read as times", () => {
-    assert.equal(slotFromCaptionTime("2 eggs and toast"), null);
-    assert.equal(slotFromCaptionTime("500ml water"), null);
-    assert.equal(slotFromCaptionTime("Lunch time"), null); // no clock — the keyword path handles this
-    assert.equal(slotFromCaptionTime(""), null);
+  test("caption: a bare time names no meal, and nothing may fill that in", () => {
+    assert.equal(explicitMealSlot("11:00"), null, "people eat lunch at 11:00");
+    assert.equal(explicitMealSlot("8am tea and eggs"), null);
+    assert.equal(explicitMealSlot("had this at 1pm"), null);
+    assert.equal(explicitMealSlot("2 eggs and toast"), null);
+    assert.equal(explicitMealSlot("500ml water"), null);
+    assert.equal(explicitMealSlot(""), null);
   });
 }
 

--- a/server/handlers/food-context.ts
+++ b/server/handlers/food-context.ts
@@ -26,9 +26,9 @@ import { gptFoodFallback, gptFoodSupplement, type GptFoodItem, askCoachK } from 
 import { logChat, withTimeout, turnMutation } from "./chat-log";
 import { unloggedFoodNotice, carriesFeelingClause } from "../unlogged-notice";
 import { enforceReplyContract, clientAskedForDetail } from "../reply-contract";
-import { sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, SAYS_TODAY_RE, mealDateLabel, statedWhen, slotFromSastHour, slotFromCaptionTime, isNightWorker, looksLikeDeepEmotionalShare, effectiveMealLoggedAt, spaceName, isAskingNotReporting } from "../utils";
+import { sastDayStart, sastToday, parseMealDate, isRetroactiveMeal, SAYS_TODAY_RE, mealDateLabel, statedWhen, looksLikeDeepEmotionalShare, effectiveMealLoggedAt, spaceName, isAskingNotReporting } from "../utils";
 import { explicitMealSlot } from "../understanding/actions";
-import { getPortionMemory, getSlotContext, resolveInferredSlot, adjustFoodsForSegment, type SlotContext } from "../portion-memory";
+import { getPortionMemory, adjustFoodsForSegment } from "../portion-memory";
 import { invalidatePatternCache } from "../cache";
 import { educationNote, remainingInMeals } from "../education";
 import { firstActionCelebration } from "../activation";
@@ -51,22 +51,39 @@ function gateFoodReply(reply: string, message: string, user: any): string {
 
 const TREAT_WORDS = /\b(dessert|treat|pudding|cake|chocolate|ice cream|biscuit|cookie)\b/i;
 
-export function extractMealLabel(msg: string, atDate?: Date, macros?: { kcal?: number | null; protein?: number | null }, user?: any, slotCtx?: SlotContext): string | null {
-  const lo = msg.toLowerCase();
-  const explicit = explicitMealSlot(msg);
-  if (explicit) return explicit;
-  // A light, low-protein log with no keyword is a SNACK — clock-slotting it steals a main slot
-  // and lets a later "same breakfast" copy it (bug 2026-07-01).
-  if (macros && macros.kcal != null && macros.kcal < 250 && (macros.protein ?? 0) <= 4) return "snack";
-  // CAPTION TIME beats the send-clock (a diary shot at 11:00, batch-sent at 19:49, read dinner).
-  const captionSlot = slotFromCaptionTime(msg);
-  if (captionSlot) return captionSlot;
-  // No keyword: night-shift/substantial late plate → "night meal", never a demoted "snack".
-  // Their own hour-pattern beats the clock; a light second meal on a used slot demotes to snack.
-  const fallback = slotFromSastHour(atDate, { nightWorker: isNightWorker(user), substantial: (macros?.kcal ?? 0) >= 300 });
-  const sastHour = new Date((atDate ? atDate.getTime() : Date.now()) + 2 * 3_600_000).getUTCHours();
-  return resolveInferredSlot(fallback, sastHour, slotCtx, macros?.kcal);
-}
+/**
+ * THE CLOCK MAY NOT NAME A MEAL THE CLIENT DID NOT NAME (Cut 2, 2026-09-11).
+ *
+ * `extractMealLabel` stood here and answered "which meal was this?" four different ways when the
+ * client had not said. Measured on a3731ee, through this function, with the macros the live path
+ * passes:
+ *
+ *     06:00  "chicken and rice"   ->  "breakfast"      the send clock
+ *     13:00  "chicken and rice"   ->  "lunch"          the send clock
+ *     22:00  "chicken and rice"   ->  "night meal"     the send clock
+ *     22:00  "I had a pear"       ->  "snack"          the macro rule
+ *     13:00  "had this at 1pm"    ->  "lunch"          a time they typed, read as a meal name
+ *
+ * Not one of those clients said breakfast, lunch, dinner, snack or night meal. Every one of those
+ * strings was written to meal_logs.meal_label as a fact about them, and read back by the morning
+ * job ("did they eat breakfast?"), by meal-repeat ("same as my lunch"), by the day-slot memory
+ * that then demoted their NEXT plate, and by the model's own snapshot of the client's day.
+ *
+ * A guess that is stored is indistinguishable from something they told us. That is the defect —
+ * not the accuracy of the guess.
+ *
+ * SO THE FUNCTION IS GONE, not corrected. Its only remaining branch was `explicitMealSlot`, which
+ * this repository already declares the single owner of "did the client name a slot?" — the
+ * comment on that function says so in those words. A wrapper whose whole body is a call to the
+ * declared owner is a second name for one answer, and the next clock branch would be added to it.
+ * The eleven callers ask the owner directly and store `null` when the client said nothing, which
+ * is what shared/schema.ts has always documented meal_label's null to mean.
+ *
+ * WHAT THE CLOCK STILL DOES, unchanged: it decides the calendar DAY (sastDayStart,
+ * effectiveMealLoggedAt, parseMealDate), and it still selects which of today's rows a client means
+ * by "the same as my lunch" (meal-repeat). Deciding when something happened is not the same as
+ * claiming what they called it.
+ */
 
 /**
  * WHERE ONE EATING EVENT ENDS AND THE NEXT BEGINS.
@@ -407,7 +424,7 @@ export async function handleFoodContext(ctx: {
           const cv = await commitFoodLog({
             userId: user.id, phone, rawMessage: "[Photo — checked first, then eaten]", source: "photo",
             kcalInt: vKcal, proteinInt: vProt, carbsInt: 0, fatInt: 0, items: [],
-            mealLabel: extractMealLabel(message, undefined, { kcal: vKcal, protein: vProt }, user, await getSlotContext(user.id)),
+            mealLabel: explicitMealSlot(message),
             loggedAt: new Date(), sourceMessageId: eventGroupId,
           });
           const vReply = `Logged ✅ ~${vKcal} kcal | ${vProt}g protein.\n\n_Today: ${cv.runningCals} kcal | ${cv.runningProtein}g protein_`;
@@ -434,7 +451,7 @@ export async function handleFoodContext(ctx: {
           const cs = await commitFoodLog({
             userId: user.id, phone, rawMessage: lastUnloggedFood.messageIn || "", source: "text",
             kcalInt: totalCals, proteinInt: totalProt2, carbsInt: 0, fatInt: 0, items: [],
-            mealLabel: extractMealLabel(lastUnloggedFood.messageIn || "", undefined, { kcal: totalCals, protein: totalProt2 }, user, await getSlotContext(user.id)),
+            mealLabel: explicitMealSlot(lastUnloggedFood.messageIn || ""),
             loggedAt: new Date(), sourceMessageId: eventGroupId,
           });
           return `Logged! ✅\n${parts.join("\n")}\n\n_Today: ${cs.runningCals} kcal | ${cs.runningProtein}g protein_`;
@@ -738,7 +755,7 @@ export async function handleFoodContext(ctx: {
   if (isFutureEating && !isQuestion && !isFrustration && hasActualFood) {
     const junkPlanned = foodsInMsg.filter(f => f.category === "junk");
     const plannedNames = foodsInMsg.map(f => f.name).join(", ");
-    const plannedLabel = extractMealLabel(message);
+    const plannedLabel = explicitMealSlot(message);
     const swapNote = junkPlanned.length > 0
       ? `\n\nIf you want to swap anything out later, I can suggest alternatives — just ask.`
       : `\n\nGood plan — solid choices in there.`;
@@ -806,7 +823,6 @@ export async function handleFoodContext(ctx: {
     }
 
     if (multiPlan.length >= 2) {
-      const slotCtxMulti = await getSlotContext(user.id);
       // Through the one write door — one per day, sequential so today's recompute doesn't race.
       let recomp = { calories: 0, protein: 0 };
       for (const p of multiPlan) {
@@ -821,7 +837,7 @@ export async function handleFoodContext(ctx: {
           // and event-bucket rows already use.
           kcalInt: p.kcal, proteinInt: p.prot, carbsInt: 0, fatInt: 0,
           items: itemsFromAdjusted(p.foods),
-          mealLabel: extractMealLabel(p.raw, p.date, { kcal: p.kcal, protein: p.prot }, user, slotCtxMulti),
+          mealLabel: explicitMealSlot(p.raw),
           loggedAt: p.date, sourceMessageId: eventGroupId,
         });
         recomp = { calories: c.runningCals, protein: c.runningProtein };
@@ -1105,7 +1121,7 @@ export async function handleFoodContext(ctx: {
       };
       const { carbs: totalCarbs, fat: totalFat } = carbsFatOf(allAdjustedFoods);
       const firstSegLabel = mealSegments.find(s => s.label)?.label
-        || extractMealLabel(message, undefined, { kcal: totalCals, protein: Math.round(totalProtein) }, user, await getSlotContext(user.id));
+        || explicitMealSlot(message);
       const scannerItems = itemsFromAdjusted(allAdjustedFoods);
       // ── ONE ROW PER EATING EVENT (2026-08-17, migration 0004) ───────────────────────────────
       // "eggs in the morning, pap at lunch" is TWO events, stored as one row with one date and one
@@ -1131,7 +1147,6 @@ export async function handleFoodContext(ctx: {
         : Math.round(totalProtein);
       let committed!: Awaited<ReturnType<typeof commitFoodLog>>;
       if (splitIntoEvents) {
-        const slotCtx = await getSlotContext(user.id);
         for (const bucket of eventBuckets) {
           const kcal = bucket.foods.reduce((t, f: any) => t + (f.adjustedCalories || 0), 0);
           const prot = Math.round(bucket.foods.reduce((t, f: any) => t + (f.adjustedProtein || 0), 0));
@@ -1147,7 +1162,7 @@ export async function handleFoodContext(ctx: {
             kcalInt: kcal, proteinInt: prot, carbsInt: carbs, fatInt: fat,
             items: itemsFromAdjusted(bucket.foods),
             mealLabel: bucket.label
-              || extractMealLabel(bucket.text, ownDate, { kcal, protein: prot }, user, slotCtx),
+              || explicitMealSlot(bucket.text),
             loggedAt: ownDate,
             sourceMessageId: eventGroupId,
           });
@@ -1267,7 +1282,7 @@ export async function handleFoodContext(ctx: {
             name: f.name, grams: 0, kcal: f.kcal, protein: f.protein_g, category: f.category,
             origin: "ai",
           })),
-          mealLabel: extractMealLabel(message, undefined, { kcal: gptFallbackResult.totalKcal, protein: gptFallbackResult.totalProtein }, user, await getSlotContext(user.id)),
+          mealLabel: explicitMealSlot(message),
           loggedAt: gptLoggedAt, sourceMessageId: eventGroupId,
         });
         const { prevCals: fbPrevCals, runningCals, runningProtein } = committed;
@@ -1355,7 +1370,7 @@ export async function handleFoodContext(ctx: {
         items: gptFallbackResult.foods.map((f: any) => ({
           name: f.name, grams: 0, kcal: f.kcal, protein: f.protein_g, category: f.category,
         })),
-        mealLabel: extractMealLabel(message, undefined, { kcal: gptFallbackResult.totalKcal, protein: gptFallbackResult.totalProtein }, user, await getSlotContext(user.id)),
+        mealLabel: explicitMealSlot(message),
         loggedAt: fb2LoggedAt, sourceMessageId: eventGroupId,
       });
       const { prevCals: fb2PrevCals, runningCals, runningProtein } = committed2;

--- a/server/handlers/food-scanner.ts
+++ b/server/handlers/food-scanner.ts
@@ -724,8 +724,12 @@ export async function findDuplicateMealToday(userId: string, desc: string): Prom
     for (const r of rows) {
       if (mealsOverlap(desc, r.rawMessage || "")) {
         return {
+          // "" WHEN THE ROW HAS NO NAMED SLOT (Cut 2). This read `|| "lunch"`, so a meal nobody
+          // called lunch was described back to the client as their lunch — and the sentence it
+          // feeds tells them to SAY "same as lunch", which would then store the copy as lunch too.
+          // An invention laundered through the client's own mouth. The caller words it truthfully.
           desc: (r.rawMessage || "that meal").replace(/\s+/g, " ").trim().slice(0, 70),
-          slot: (r.mealLabel || "lunch").toString(),
+          slot: (r.mealLabel || "").toString(),
         };
       }
     }

--- a/server/handlers/meal-repeat.ts
+++ b/server/handlers/meal-repeat.ts
@@ -161,7 +161,12 @@ export async function handleMealRepeat(ctx: {
     // kcal, different slot), then told the client dinner was "already counted" while
     // it was never written (2026-07-05 audit). A dup = same kcal AND same slot.
     const dupWindow = new Date(Date.now() - 4 * 60_000);
-    const newLabel = String(targetLabel || sourceHint || match.mealLabel || "").toLowerCase();
+    // THE SLOT THIS MEAL IS BEING LOGGED AS — the one the client named for THIS meal, or none.
+    // `sourceHint` names the meal they copied FROM ("the same as my lunch") and `match.mealLabel`
+    // is that older row's own label; neither is a statement about the plate in front of them now.
+    // This must be the value actually stored below, or the guard compares a label the row will
+    // never carry and a webhook retry logs the meal twice (Cut 2).
+    const newLabel = String(targetLabel || "").toLowerCase();
     const recentRows = await db.select({ kcalInt: mealLogs.kcalInt, mealLabel: mealLogs.mealLabel }).from(mealLogs)
       .where(and(eq(mealLogs.userId, user.id), gte(mealLogs.loggedAt, dupWindow)));
     if (recentRows.some(r => (r.kcalInt || 0) === (match.kcalInt || 0) && String(r.mealLabel || "").toLowerCase() === newLabel)) {
@@ -187,7 +192,7 @@ export async function handleMealRepeat(ctx: {
       proteinInt: match.proteinInt || 0,
       carbsInt: match.carbsInt || 0,
       fatInt: match.fatInt || 0,
-      mealLabel: targetLabel || sourceHint || match.mealLabel || null,
+      mealLabel: targetLabel || null,   // only what they called THIS meal (Cut 2)
       items: repeatedItems,
       loggedAt: new Date(),
       sourceMessageId: ctx.sourceMessageId,
@@ -196,7 +201,9 @@ export async function handleMealRepeat(ctx: {
     if (!committed.ok) return `I found that meal but couldn't save the copy just now. Send that again in a moment.`;
     if (committed.wasDup) return `Already logged ✅ — that meal is counted in today's total.`;
 
-    const labelDisplay = (targetLabel || sourceHint || match.mealLabel || "Meal").replace(/\b\w/g, c => c.toUpperCase());
+    // "*Lunch logged*" for a 19:10 copy of lunch told the client we had recorded a second lunch.
+    // The source still appears, truthfully, in fromNote below: "copied from lunch" (Cut 2).
+    const labelDisplay = (targetLabel || "Meal").replace(/\b\w/g, c => c.toUpperCase());
     const mealWasToday = match.loggedAt && new Date(match.loggedAt) >= todayStart;
     // Never say "copied from breakfast" ON a breakfast log — use a time reference instead.
     const fromNote = crossish && sourceHint && sourceHint !== targetLabel ? `copied from ${sourceHint}`

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -36,10 +36,10 @@ import { buildFormCheckPrompt, extractFormExercise } from "../form-check-prompt"
 // photo saves immediately, timer resets, one job processes the whole set 15s after the last.
 const _progressBurst = new Map<string, ReturnType<typeof setTimeout>>();
 import { getTodayWorkoutState } from "../workout-state";
-import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, slotFromSastHour, stripFoodLoggedClaim, isAskingNotReporting , getDisplayName, transcriptMustPassWhole } from "../utils";
+import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, stripFoodLoggedClaim, isAskingNotReporting , getDisplayName, transcriptMustPassWhole } from "../utils";
 import { stripVoiceDenial } from "../reply-hygiene";
 import { detectVoiceLanguageNote } from "../voice-language";
-import { extractMealLabel } from "./food-context";
+import { explicitMealSlot } from "../understanding/actions";
 import { getNumbersMode, stripNumbersFromProse } from "../numbers-mode";
 import { cardWillAttach } from "../card-policy";
 import { remainingInMeals, goalStatusLine } from "../education";
@@ -1065,7 +1065,7 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
             const extraKcal = extractKcal(extraText);
             const extraProt = extractProt(extraText);
             if (!(/^NOT_FOOD\b/i.test(extraText)) && (extraKcal > 0 || extraProt > 0)) {
-              const extraLabel = extractMealLabel(message || "", photoLoggedAt, { kcal: extraKcal, protein: extraProt }, user, await (await import("../portion-memory")).getSlotContext(user.id)) || slotFromSastHour(photoLoggedAt);
+              const extraLabel = explicitMealSlot(message || "");   // null unless the caption NAMES it
               const extraCommit = await commitFoodLog({
                 userId: user.id, phone, rawMessage: `[Album photo ${extraIndex + 2}]`, source: "photo",
                 kcalInt: extraKcal, proteinInt: extraProt, carbsInt: 0, fatInt: 0,
@@ -1123,13 +1123,13 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
         // NAME-overlap dupe guard: a photo of a meal ALREADY logged today must not double-log.
         const dupe = extraImageUrls.length === 0 ? await findDuplicateMealToday(user.id, photoDesc) : null;
         if (dupe) {
-          const dupeReply = `📸 That looks like the *${dupe.desc}* you already logged today — I have NOT logged it again, your totals are safe.\n\nIf this is a second helping, say *"same as ${dupe.slot}"* and I'll log it properly.`;
+          const dupeReply = `📸 That looks like the *${dupe.desc}* you already logged today — I have NOT logged it again, your totals are safe.\n\nIf this is a second helping, ${dupe.slot ? `say *"same as ${dupe.slot}"*` : `name the meal — *"same for lunch"*, or whichever it is`} and I'll log it properly.`;
           await logChat(user.id, "[Food Photo — duplicate held]", dupeReply, "FOOD_PHOTO_DUPE");
           return dupeReply;
         }
-        // ONE WRITE DOOR (Box 2): commitFoodLog dedups + guarantees complete macros;
-        // caption wins over the clock for the slot.
-        const photoLabel = extractMealLabel(message || "", photoLoggedAt, { kcal: primaryPhotoKcal, protein: primaryPhotoProt }, user, await (await import("../portion-memory")).getSlotContext(user.id)) || slotFromSastHour(photoLoggedAt);
+        // ONE WRITE DOOR (Box 2): commitFoodLog dedups; the slot is the caption's when it NAMES
+        // one, else null — a 19:49 batch-send says nothing about when the plate was eaten (Cut 2).
+        const photoLabel = explicitMealSlot(message || "");
         // Structured items from the vision reply — names in "my meals", scalable corrections.
         photoCommit = await commitFoodLog({
           userId: user.id, phone, rawMessage: extraImageUrls.length > 0 ? `[Album photo 1] ${photoDesc}` : photoDesc, source: "photo",

--- a/server/handlers/referent-log.ts
+++ b/server/handlers/referent-log.ts
@@ -27,13 +27,13 @@ export async function tryLogReferent(ctx: { phone: string; message: string; user
   await db.update(users).set({ profileNotes: cleared }).where(eq(users.id, user.id));
   user.profileNotes = cleared;
 
-  const { commitFoodLog, extractMealLabel } = await import("./food-context");
-  const { getSlotContext } = await import("../portion-memory");
+  const { commitFoodLog } = await import("./food-context");
+  const { explicitMealSlot } = await import("../understanding/actions");
   const committed = await commitFoodLog({
     userId: user.id, phone, rawMessage: `${ref.mult}x ${pending.name}`.slice(0, 200),
     source: "referent", kcalInt: kcal, proteinInt: protein, carbsInt: 0, fatInt: 0,
     items: [{ name: pending.name, grams: 0, kcal, protein, category: "referent" }],
-    mealLabel: extractMealLabel(message, undefined, { kcal, protein }, user, await getSlotContext(user.id)),
+    mealLabel: explicitMealSlot(message),
     loggedAt: new Date(),
   });
   const amt = ref.mult === 1 ? "" : ref.mult === 0.5 ? "half of " : `${ref.mult}× `;

--- a/server/meal-select.ts
+++ b/server/meal-select.ts
@@ -11,7 +11,6 @@
  * fabricating.
  */
 
-import { slotFromSastHour } from "./utils";
 
 /**
  * Which meal is being REPEATED and where does it go — pure, so it's unit-testable
@@ -38,8 +37,11 @@ export function parseMealRepeatTarget(m: string): { crossish: boolean; targetLab
   const sameBeM = !crossMealM && !sameAsMealM && !sameForM
     && m.match(/\b(breakfast|lunch|dinner|supper|snack)\b[^.!?]{0,40}?\b(?:will\s+be|is|are|gonna\s+be|be|stays?|remains?)\b[^.!?]{0,20}?\bthe\s+same\b/i);
   const crossish = !!(crossMealM || sameAsMealM || sameForM || sameBeM);
+  // "same as my lunch" NAMES THE SOURCE, NOT THE TARGET (Cut 2). This asked the send clock what
+  // to call the copy, so a 16:40 repeat of lunch was stored as somebody's "snack" and a 19:10 one
+  // as their "dinner" — a slot they never said, written as a fact about them. Unknown is null.
   const targetLabel = crossMealM ? crossMealM[1].toLowerCase().replace("supper", "dinner")
-    : sameAsMealM ? slotFromSastHour()
+    : sameAsMealM ? null
     : sameForM ? sameForM[1].toLowerCase().replace("supper", "dinner")
     : sameBeM ? sameBeM[1].toLowerCase().replace("supper", "dinner")
     : null;

--- a/server/portion-memory.ts
+++ b/server/portion-memory.ts
@@ -77,7 +77,6 @@ const CACHE_TTL_MS = 60_000;
 /** Invalidate after any meal insert/correction so the next log learns immediately. */
 export function invalidatePortionMemory(userId: string): void {
   _cache.delete(userId);
-  _slotCache.delete(userId); // slot memory learns from the same rows
 }
 
 export async function getPortionMemory(userId: string): Promise<Map<string, PortionStat>> {
@@ -99,74 +98,20 @@ export async function getPortionMemory(userId: string): Promise<Map<string, Port
   }
 }
 
-// ── PERSONAL MEAL-SLOT LEARNING (Review #7 items 3b + gap-heuristic + behavioural
-// shift detection, built 2026-07-17). The clock says 10:00 = breakfast; this client's
-// own history may say 10:00 = lunch. Their pattern wins once it's strong enough —
-// which also catches rotating/irregular shift workers the onboarding flag misses:
-// eleven 02:00 "night meal" logs teach the system regardless of any flag. ──────────
-
-export type SlotContext = { personalByHour: Map<number, string>; todaySlots: string[] };
-
-const MAIN_SLOTS = ["breakfast", "lunch", "dinner"];
-
-/** Pure: dominant meal label per SAST hour — qualifies at >=3 logs and >=70% share. */
-export function dominantSlotByHour(rows: Array<{ loggedAt: Date | string | null; mealLabel: string | null }>): Map<number, string> {
-  const byHour = new Map<number, Map<string, number>>();
-  for (const r of rows) {
-    const label = (r.mealLabel || "").toLowerCase().trim();
-    if (!label || !r.loggedAt) continue;
-    const h = new Date(new Date(r.loggedAt).getTime() + 2 * 3_600_000).getUTCHours();
-    const counts = byHour.get(h) || new Map<string, number>();
-    counts.set(label, (counts.get(label) || 0) + 1);
-    byHour.set(h, counts);
-  }
-  const out = new Map<number, string>();
-  for (const [h, counts] of byHour) {
-    let total = 0, topLabel = "", topN = 0;
-    for (const [label, n] of counts) { total += n; if (n > topN) { topN = n; topLabel = label; } }
-    if (topN >= 3 && topN / total >= 0.7) out.set(h, topLabel);
-  }
-  return out;
-}
-
-/**
- * Pure: the final inferred slot. Personal hour-pattern beats the clock fallback;
- * then the collision rule — a LIGHT (<300 kcal) second meal landing on a main slot
- * already used today is a snack, not a duplicate "breakfast" (a real second plate
- * keeps its slot honestly: two breakfasts happened). Explicit keywords never reach
- * this function — it only runs when the client said nothing about the meal.
- */
-export function resolveInferredSlot(fallback: string, hour: number, ctx: SlotContext | undefined, kcal?: number | null): string {
-  let slot = ctx?.personalByHour?.get(hour) || fallback;
-  if (ctx?.todaySlots?.includes(slot) && MAIN_SLOTS.includes(slot) && kcal != null && kcal < 300) slot = "snack";
-  return slot;
-}
-
-const _slotCache = new Map<string, { at: number; ctx: SlotContext }>();
-
-export async function getSlotContext(userId: string): Promise<SlotContext> {
-  const empty: SlotContext = { personalByHour: new Map(), todaySlots: [] };
-  try {
-    const c = _slotCache.get(userId);
-    if (c && Date.now() - c.at < CACHE_TTL_MS) return c.ctx;
-    const sixtyDaysAgo = new Date(Date.now() - 60 * 86_400_000);
-    const rows = await db.select({ loggedAt: mealLogs.loggedAt, mealLabel: mealLogs.mealLabel }).from(mealLogs)
-      .where(and(eq(mealLogs.userId, userId), gte(mealLogs.loggedAt, sixtyDaysAgo)))
-      .orderBy(desc(mealLogs.loggedAt))
-      .limit(300);
-    const sastMidnight = new Date(new Date(Date.now() + 2 * 3_600_000).setUTCHours(0, 0, 0, 0) - 2 * 3_600_000);
-    const todaySlots = [...new Set(rows
-      .filter(r => r.loggedAt && new Date(r.loggedAt) >= sastMidnight)
-      .map(r => (r.mealLabel || "").toLowerCase().trim()).filter(Boolean))];
-    const ctx: SlotContext = { personalByHour: dominantSlotByHour(rows), todaySlots };
-    if (_slotCache.size > 2000) _slotCache.clear();
-    _slotCache.set(userId, { at: Date.now(), ctx });
-    return ctx;
-  } catch (e) {
-    console.warn("[SLOT_MEMORY] non-fatal:", (e as Error)?.message);
-    return empty; // fail-open: clock fallback, exactly as before
-  }
-}
+// ── PERSONAL MEAL-SLOT LEARNING — REMOVED (Cut 2, 2026-09-11) ───────────────────────────────
+//
+// `dominantSlotByHour`, `resolveInferredSlot` and `getSlotContext` stood here. They learned which
+// meal a client "usually" has at a given SAST hour and applied it to a message that named no meal
+// at all — then demoted the next light plate to "snack" because the slot they had inferred for an
+// earlier one was already taken. Both answers were written to meal_logs.meal_label as facts.
+//
+// The whole apparatus existed to make a clock-derived guess sharper. Cut 2 removes the guess: when
+// the client does not name a meal, the label is null. A better-informed invention is still an
+// invention, so there is nothing left here to sharpen, and this is deleted rather than left
+// unreachable for the next caller to rediscover.
+//
+// PORTION memory below is untouched — it answers a different question ("how much is a spoon of pap
+// FOR THIS CLIENT?") from the client's own corrected logs, and it never names a meal.
 
 // ── PORTION UNITS: what does "2 spoons of pap" actually mean? ────────────────────────────────
 // (2026-08-13, measured: "2 spoons of pap" logged 660 kcal — roughly five times the truth, and

--- a/server/sast.ts
+++ b/server/sast.ts
@@ -118,30 +118,16 @@ export function effectiveMealLoggedAt(loggedAt: Date, rawMessage: string, mealLa
   return new Date(loggedAt.getTime() - 24 * 3_600_000); // → the day that just ended
 }
 
-// A clock time written in a caption tells us the meal SLOT even when the photo is batch-sent
-// hours later (2026-07-22, Puntsa's photo diary: shot at "11:00", the whole day sent at 19:49
-// — the send-clock mislabelled it dinner). Requires a colon-time or am/pm so it never fires on
-// a quantity ("2 eggs", "500ml"). Returns null when there's no time to read.
-export function slotFromCaptionTime(msg: string): "breakfast" | "lunch" | "dinner" | "snack" | null {
-  const lo = (msg || "").toLowerCase();
-  let hour: number | null = null;
-  const hm = lo.match(/\b(\d{1,2}):(\d{2})\s*(am|pm)?\b/);
-  const ap = lo.match(/\b(\d{1,2})\s*(am|pm)\b/);
-  if (hm) {
-    hour = parseInt(hm[1], 10);
-    if (hm[3] === "pm" && hour < 12) hour += 12;
-    if (hm[3] === "am" && hour === 12) hour = 0;
-  } else if (ap) {
-    hour = parseInt(ap[1], 10);
-    if (ap[2] === "pm" && hour < 12) hour += 12;
-    if (ap[2] === "am" && hour === 12) hour = 0;
-  }
-  if (hour === null || hour < 0 || hour > 23) return null;
-  if (hour <= 11) return "breakfast"; // includes late-morning brunch (11:00 eggs)
-  if (hour <= 15) return "lunch";
-  if (hour <= 16) return "snack";
-  return "dinner";
-}
+// A CAPTION TIME IS A TIME, NOT A MEAL NAME — `slotFromCaptionTime` REMOVED (Cut 2, 2026-09-11).
+//
+// It read "11:00" or "1pm" out of a caption and returned breakfast/lunch/dinner. It was added so a
+// photo diary batch-sent at 19:49 would not have its whole morning stamped "dinner" by the SEND
+// clock — a real defect, for two named clients. Cut 2 removes the send-clock claim itself, so the
+// thing this defended against cannot happen, and what is left is a second clock naming a meal the
+// client never named. "I ate at 11:00" is not "I ate breakfast": people eat lunch at 11:00.
+//
+// A caption that NAMES the meal ("Breakfast", "for lunch") is unaffected — explicitMealSlot in
+// server/understanding/actions.ts reads the client's words and remains authoritative.
 
 // Does this client work nights? Read from the onboarding answers we already hold —
 // the same data that steers their programme timing.

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -27,13 +27,13 @@ export function buildContentVariables(vars?: Record<string, string | number | nu
 // Day boundaries live in server/sast.ts (ledger D6) — ONE definition of a SAST day for the whole
 // codebase. These two stay as re-exports so the existing call sites keep working unchanged while
 // they migrate; new code should import from ./sast directly.
-import { sastDayKey, sastDayStart, slotFromSastHour, effectiveMealLoggedAt, slotFromCaptionTime, isNightWorker, parseMealDate, statedWhen, SAYS_TODAY_RE, isRetroactiveMeal, stripInventedRetroDate, isFutureIntent } from "./sast";
+import { sastDayKey, sastDayStart, slotFromSastHour, effectiveMealLoggedAt, isNightWorker, parseMealDate, statedWhen, SAYS_TODAY_RE, isRetroactiveMeal, stripInventedRetroDate, isFutureIntent } from "./sast";
 import { clausesOf } from "./understanding/messy-intake";
 export { sastDayStart };
 export const sastToday = sastDayKey;
 
 // Temporal attribution lives in sast.ts. These re-exports preserve existing callers while they migrate.
-export { slotFromSastHour, effectiveMealLoggedAt, slotFromCaptionTime, isNightWorker, parseMealDate, statedWhen, SAYS_TODAY_RE, isRetroactiveMeal, stripInventedRetroDate, isFutureIntent };
+export { slotFromSastHour, effectiveMealLoggedAt, isNightWorker, parseMealDate, statedWhen, SAYS_TODAY_RE, isRetroactiveMeal, stripInventedRetroDate, isFutureIntent };
 
 /**
  * CANONICAL "HOW MANY TRAINING SESSIONS DOES THIS TEXT ASSERT?" (2026-08-22). Two callers, one


### PR DESCRIPTION
Cut 2. Base `a3731ee5f026ab047703b3625f6739eccd1b0653`. Head `9f89e31bfd7183837f8c0915130ae7b1b84ff8c1`.

## Reproduced on the base, and the named case needs one correction

Measured on `a3731ee` through `extractMealLabel`, with the macros the live path actually passes:

| SAST | message | stored `meal_label` | who decided |
|---|---|---|---|
| 06:00 | "chicken and rice" | `breakfast` | the send clock |
| 13:00 | "chicken and rice" | `lunch` | the send clock |
| 22:00 | "chicken and rice" | `night meal` | the send clock |
| 22:00 | "I had a pear" | `snack` | the calorie count |
| 13:00 | "had this at 1pm" | `lunch` | a time they typed |

**At 22:00 the pear does NOT come back breakfast/lunch/dinner.** The low-calorie rule fires first and returns `"snack"`. It is still a slot the client never said and still stored as a fact about them, so the named defect is real — it just reaches it through the macro rule rather than the clock, and the clock's main-slot invention is reached by the same client's full plate. Both routes are graded at all three hours rather than only the one that reproduced verbatim. Recording this rather than quietly reshaping the case to fit.

## Why it is worse than a wrong label

`meal_label` is read back by the morning job ("did they eat breakfast?"), by meal-repeat ("same as my lunch"), by the day-slot memory that then **demoted their next plate** because the slot it had invented for an earlier one was taken, and by the model's snapshot of their day. A guess that is stored is indistinguishable from something they told us.

## The owner is deleted, not corrected

`extractMealLabel`'s only truthful branch was `explicitMealSlot`, which this repository already declares the single owner of "did the client name a slot?" — that function's own comment says so in those words. A wrapper whose whole body is a call to the declared owner is a second name for one answer, and the next clock branch gets added to it. All eleven callers ask the owner directly and store `null`, which is what `shared/schema.ts` has documented `meal_label`'s null to mean since it was written. Every consumer already handled null (`|| ""`, `.filter(Boolean)`, `|| "that meal"`, `|| "Meal"`).

## Six mouths, not one

Fixing food-context alone would have changed nothing on the photo path, which read `extractMealLabel(...) || slotFromSastHour(photoLoggedAt)` and overruled the null one character later.

| file | what changed |
|---|---|
| `food-context.ts` | the clock, the calorie rule and the caption time, all gone |
| `portion-memory.ts` | `getSlotContext` / `resolveInferredSlot` / `dominantSlotByHour` deleted |
| `sast.ts` | `slotFromCaptionTime` deleted — an hour is not a meal name |
| `media.ts` | both photo writes lose their `\|\| slotFromSastHour(...)` |
| `meal-select.ts` | "same as my lunch" no longer takes its **target** from the clock |
| `meal-repeat.ts` | and no longer stores the **source's** slot on the new plate |
| `food-scanner.ts` | the duplicate guard stops reporting an unlabelled meal as "lunch" — that string was spoken back to the client as the phrase that would then store the copy as lunch |

**What the clock still does, unchanged:** it decides the calendar **day** (`sastDayStart`, `effectiveMealLoggedAt`, `parseMealDate`), and it still **selects** which of today's rows a client means by "the same as my lunch". Deciding when something happened is not claiming what they called it.

**What survives, graded as hard as what was removed:** "I had pap for breakfast" at 22:00 is breakfast. "Yesterday at dinner I had chicken" is dinner, still filed to yesterday. "an apple as a snack" is a snack. #174's "this morning" is still breakfast. No clarifying question was added — an unnamed meal is logged silently, as before.

## Evidence

`script/pg-meal-slot-truth-acceptance.ts` — real PostgreSQL, real front door, graded **post-transport** on `meal_logs` and on the delivered body, with the SAST clock frozen at 06:00, 13:00 and 22:00.

Frozen because of PR #240: an acceptance that reads the real clock grades whichever hour CI started in and stays green for a year of afternoons. `Date.now()` alone is not enough — `slotFromSastHour`'s default parameter is `new Date()`, which never consults it.

**red-on-revert 9/9**, each restoring one mechanism:

```
1  the send clock             10 checks red     6  the laundered "lunch"        13 red
2  the calorie rule            6 checks red     7  CONTROL: named meals lost     6 red
3  a typed time                2 checks red     8  CONTROL: nothing logged      26 red
4  the photo path's clock      3 checks red     9  the repeat's source slot      1 red
5  the repeat target clock     4 checks red
```

## Two defects found in the acceptance itself, and fixed rather than lived with

1. **Case 3 was GREEN on its first run.** The acceptance carried no fixture with a typed time, so the caption-time invention could have been restored with every check still passing. Section 2b exists because the revert script said so, not the other way round.
2. **The acceptance was flaky — about one run in three.** It used `ORDER BY id` on a table whose id is a `gen_random_uuid()`; that is ordering by a random number. Rows are now identified by the hour they were written at. Five consecutive green runs since.

## Gates

```
tsc --noEmit              clean
npm test                  38/38 green, none skipped
pg-acceptance-runner      32/32 green, 0 red   (30 + the two new entries)
red-on-revert             9/9 graded red
governors                 architecture at budget and unmoved; media.ts exactly 1550
check-sast                LOWERED 59 -> 55 — no budget raised
```

`check-sast` fails on a **drop** and demands the win be locked in; the deleted inference took four raw day-offset uses with it.

## Regraded assertions, disclosed

Three test blocks graded the behaviour this cut removes. None is weakened — each is inverted, and the inversion is stricter than what it asserted:

- `gap-tests` "no caption at 1pm → clock fallback (lunch)" → at 1pm, saying nothing claims nothing.
- `gap-tests` "no time signal → returns null (falls back to time-of-day)" accepted null **and** every invented label, so it could not fail. It now demands null.
- `unit-tests` slot-learning and caption-time blocks → the capability is asserted absent, and four of the six caption fixtures still resolve because in those four the client **named** the meal. Their words were always doing the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_