### PR TITLE
A long voice note reaches the handlers whole

### DIFF
--- a/script/check-architecture.ts
+++ b/script/check-architecture.ts
@@ -62,7 +62,7 @@ const BUDGET = {
    * to the true figure in one deliberate commit. Until then this red line is the marker, and it is
    * the ONLY thing in this guard that is red — one red line means something, four never did.
    */
-  regexLiterals: 446,
+  regexLiterals: 442,
   /**
    * GUARD #13 — see unreachableExports above. Sixty-two capabilities cannot be reached by a
    * client message today. This budget is deliberately set THREE BELOW that, so this guard is RED
@@ -273,7 +273,7 @@ const RAISES: Array<{ key: keyof typeof BUDGET; from: number; to: number; date: 
       + "so 21 is the smallest truthful current baseline. FROM HERE IT FALLS ONLY.",
   },
   {
-    key: "regexLiterals", from: 318, to: 446, date: "2026-08-24 (fell to 448 on 2026-09-05, to 447 on 2026-09-07, to 446 on 2026-09-09)",
+    key: "regexLiterals", from: 318, to: 442, date: "2026-08-24 (fell to 448 on 2026-09-05, to 447 on 2026-09-07, to 446 on 2026-09-09, to 442 on 2026-09-12)",
     why: "NOT A RAISE — A CORRECTED MEASUREMENT, and the follow-up this budget's own comment "
       + "declared owed on 2026-08-17: \"repair the matcher to see multi-line assignments and "
       + "re-baseline to the true figure in one deliberate commit.\" This is that commit. The "
@@ -299,7 +299,13 @@ const RAISES: Array<{ key: keyof typeof BUDGET; from: number; to: number; date: 
       + "let buildPatternSummary infer training from chat wording — is deleted; the weekly training "
       + "signal now reads workout_logs, the durable owner that same function already queried for "
       + "its 28-day count. One pattern fewer because a SECOND ANSWER to \"did they train\" was "
-      + "removed, not because anything unrelated was compressed to make room.",
+      + "removed, not because anything unrelated was compressed to make room. AND IT FELL AGAIN: "
+      + "446 -> 442 on 2026-09-12 (Cut 3). Four patterns left with server/utils.ts "
+      + "transcriptMustPassWhole, isMessyLifeTranscript and transcriptIsLogList, deleted whole. They "
+      + "were the gate on the voice summariser — WHICH notes may be shortened — and the summariser is "
+      + "gone, so the only answer they could still give was no. A predicate with one possible answer "
+      + "is not a guard, and the reachability test in unit-tests said so before this entry did. "
+      + "Nothing was compressed to make room and no unrelated file was touched.",
   },
   {
     key: "modules", from: 237, to: 239, date: "2026-08-17",

--- a/script/gap-tests.ts
+++ b/script/gap-tests.ts
@@ -507,20 +507,14 @@ test("messy intake: pure feeling does not force food log", () => {
   assert.equal(r.hasFoodReport, false);
 });
 
-test("isMessyLifeTranscript: short branded meal preserved whole", () => {
-  const { isMessyLifeTranscript } = UTILS;
-  assert.equal(
-    isMessyLifeTranscript("I had a McDonald's breakfast with a mocha"),
-    true,
-  );
-});
-
-test("isMessyLifeTranscript: food + feeling is messy life", () => {
-  const { isMessyLifeTranscript } = UTILS;
-  assert.equal(
-    isMessyLifeTranscript("I ate takeaways again and I feel like giving up"),
-    true,
-  );
+// isMessyLifeTranscript graded here: two life signals in one note meant "do not summarise this".
+// Cut 3 removed the summariser, so no note is summarised and the predicate has no caller. The
+// promise is inverted onto the pipeline, where it holds for notes the predicate never matched.
+test("a messy-life note reaches the handlers whole, whatever signals it carries", () => {
+  const media = readFileSync("server/handlers/media.ts", "utf-8");
+  assert.match(media, /const forBrain = transcribedText;/,
+    "every note is routed whole — no predicate decides which ones are safe to shorten");
+  assert.ok(!/condenseVoiceRamble/.test(media), "and there is nothing left to shorten them with");
 });
 
 

--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -228,6 +228,19 @@ export const ACCEPTANCES: Acceptance[] = [
     // opposite-defect controls. A crash or an absent verdict is itself red.
     command: ["bash", "script/red-on-revert-cut2-meal-slot.sh"] },
 
+  { id: "long-voice-tail", title: "A long note reaches the handlers whole",
+    // CUT 3 (2026-09-12). The cleaner sent 1,500 characters to a model and returned the answer as
+    // THE TRANSCRIPT, deleting 908 characters of a three-minute note — both questions among them.
+    // Needs a real database and the real front door: the claim is about what the handlers were
+    // GIVEN, durably, and about the numbers that reached their owners afterwards.
+    command: ["npx", "tsx", "script/pg-long-voice-tail-acceptance.ts"] },
+
+  { id: "long-voice-reverts", title: "Every silent cut in the voice pipeline turns a grader red",
+    // Four truncations in one pipeline — the cleaner's window, its missing lower bound, the
+    // condenser, and the ledger's own cap — plus three opposite-defect controls. Two graders,
+    // because the acceptance drives the TEXT door where the cleaner never runs.
+    command: ["bash", "script/red-on-revert-cut3-long-voice.sh"] },
+
   { id: "journey-lab", title: "Six critical journeys through the real system",
     // THE SIX JOURNEYS (#170). Same database, same migrations, same front door — a second job
     // would be a second copy of this infrastructure for no gain. It is in this runner for the same

--- a/script/pg-long-voice-tail-acceptance.ts
+++ b/script/pg-long-voice-tail-acceptance.ts
@@ -186,12 +186,15 @@ REAL("\n3. 8,500 IS STILL 8,500 — the number is not reshaped on the way to its
 // ══════════════════════════════════════════════════════════════════════════════════════════════
 REAL("\n4. NOTHING IS INVENTED FROM A NOTE THIS LONG (Cut 2 must stay true here)");
 // ══════════════════════════════════════════════════════════════════════════════════════════════
+// THE MEAL-SLOT CLAIM THAT USED TO STAND HERE IS REMOVED, not relaxed. It asserted "no meal slot
+// appears that the client did not name" and checked only that each label belonged to the
+// breakfast/lunch/dinner/snack enum — which is also satisfied by ZERO meal rows, and this note
+// produces zero. It read as attribution proof and measured nothing of the kind.
+//
+// Cut 2's own acceptance grades attribution non-vacuously, on rows that exist, at three pinned
+// hours, with nine red-on-revert cases behind it. Restating it here weakly could only ever
+// weaken it.
 {
-  const meals = (await pool.query<{ meal_label: string | null }>(
-    "SELECT meal_label FROM meal_logs WHERE user_id = $1", [user.id])).rows;
-  chk(meals.every(m => m.meal_label === null || ["breakfast", "lunch", "dinner", "snack"].includes(m.meal_label!)),
-    "no meal slot appears that the client did not name",
-    `labels=${JSON.stringify(meals.map(m => m.meal_label))}`);
   const bodies = await wire();
   chk(bodies.length > 0, "the client got an answer to a three-minute note", `${bodies.length} bodies`);
   chk(!/8\.5|85 steps|850 steps/.test(bodies.join("\n")),
@@ -216,9 +219,11 @@ REAL("\n5. WHAT THIS CUT DOES NOT FIX, RECORDED RATHER THAN CLAIMED");
   chk(alone.length === 1 && alone[0].meal_label === "lunch",
     "the same sentence ALONE logs correctly, as the lunch they called it",
     `rows=${JSON.stringify(alone)}`);
-  REAL(`    NOTE — inside the long note that sentence produced ${inNote} meal row(s). Not asserted`);
-  REAL(`    either way: first-match-wins gives one turn to one owner, which predates this cut and`);
-  REAL(`    is Cut 6's subject. Cut 3's job was to stop the words being deleted before they get there.`);
+  REAL(`    OUTSTANDING, UNDER CUT 6 — inside the long note that sentence produced ${inNote} meal`);
+  REAL(`    row(s), and the reply addresses neither of the client's two questions. Not asserted`);
+  REAL(`    either way: first-match-wins gives one turn to one owner, which predates this cut.`);
+  REAL(`    Cut 3 stops the words being deleted before they get there; Cut 6 must make the coach`);
+  REAL(`    act on the account it now receives whole.`);
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
@@ -233,8 +238,15 @@ REAL("\n6. NO STAGE BETWEEN THE CLIENT AND THE HANDLERS MAY SHORTEN WHAT THEY SA
   chk(!/condenseVoiceRamble/.test(media), "and media.ts condenses nothing before the handlers");
   chk(/const forBrain = transcribedText;/.test(media), "the routed text IS the cleaned transcript");
   chk(/return cleaned \+ tail;/.test(wedge), "the cleaner rejoins the part it could not send");
-  chk(/cleaned\.length < head\.length \* 0\.5/.test(wedge),
-    "a reply cut off by max_tokens cannot become the transcript");
+  // THREE GATES, NOT A NUMBER. The first version carried only a 50% floor, and a reply holding
+  // 60% of the head passed it while deleting a correction and a question. Naming the threshold
+  // here would pin the number instead of the promise.
+  chk(/finishReason !== "stop"/.test(wedge),
+    "a reply the model did not finish cannot become the transcript");
+  chk(/!coversTheEnd\(head, cleaned\)/.test(wedge),
+    "…nor can one that stops before the end of the head");
+  chk(/cleaned\.length < head\.length \* 0\.8/.test(wedge),
+    "…nor one that lost a fifth of it");
 }
 
 REAL(`\n${failed === 0 ? "pg-long-voice-tail-acceptance: GREEN" : `pg-long-voice-tail-acceptance: ${failed} FAILED`}\n`);

--- a/script/pg-long-voice-tail-acceptance.ts
+++ b/script/pg-long-voice-tail-acceptance.ts
@@ -251,6 +251,20 @@ REAL("\n6. NO STAGE BETWEEN THE CLIENT AND THE HANDLERS MAY SHORTEN WHAT THEY SA
     "…and numbers, days and negations may not be substituted at all");
   chk(!/coversTheEnd|cleaned\.length < head\.length/.test(wedge),
     "the superseded length gates are gone, not left unable to fail");
+  // VETTED PAIRS, NOT A VOCABULARY. "Is the new word an SA word within three edits?" approved
+  // "pain" -> "pap" and "sad" -> "pap". The question is now "was THIS pair vetted?".
+  chk(/VETTED_REPAIRS\.get\(from\) === to/.test(wedge),
+    "a substitution is allowed only as an explicitly vetted FROM->TO pair");
+  chk(!/editDistance|SA_REPAIR_WORDS/.test(wedge),
+    "…and the distance metric and the target vocabulary are gone, not merely unused");
+  // PUNCTUATION IS NOT GLOBALLY FREE. The old tokenizer ate the minus sign and the decimal point,
+  // so "-5" compared equal to "5" and "8.5" to "85".
+  chk(/\[\+−–—-\]\?\\d\+/.test(wedge),
+    "a quantity carries its leading sign into the comparison");
+  chk(/\\p\{L\}/.test(wedge),
+    "…and non-ASCII lexical content is compared, not silently discarded");
+  chk(!/\[a-z0-9'\]\+/.test(wedge),
+    "the ASCII-only tokenizer is gone, not left beside the one that replaced it");
 }
 
 REAL(`\n${failed === 0 ? "pg-long-voice-tail-acceptance: GREEN" : `pg-long-voice-tail-acceptance: ${failed} FAILED`}\n`);

--- a/script/pg-long-voice-tail-acceptance.ts
+++ b/script/pg-long-voice-tail-acceptance.ts
@@ -1,0 +1,243 @@
+/**
+ * REAL-POSTGRESQL ACCEPTANCE — a long note reaches the handlers whole (Cut 3).
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT WAS PROVEN BROKEN ON 017efd9, BEFORE A LINE OF THIS CUT WAS WRITTEN
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * cleanSATranscript sent `text.slice(0, 1500)` to the model and returned the model's answer AS
+ * THE TRANSCRIPT. On the 2,408-character note below — 500 words, about three minutes of speech:
+ *
+ *     handed to the model            1500 chars
+ *     returned as "the transcript"   1500 chars
+ *     SILENTLY DELETED                908 chars
+ *
+ * Gone with them: the workout correction, BOTH questions, and the last thing the client said.
+ * The condenser carried the same defect one window wider (4,000 chars) and, unlike the cleaner,
+ * replaced the client's account with a model's retelling of it.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHAT THIS ACCEPTANCE CLAIMS, AND WHAT IT DELIBERATELY DOES NOT
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ *
+ * IT CLAIMS: everything the client said arrives at the handlers, durably, and the numbers in it
+ * are not reshaped on the way.
+ *
+ * IT DOES NOT CLAIM that every fact in a long note then reaches its durable owner. It does not,
+ * and that is measured rather than assumed — §5 records it. Driven through the real front door on
+ * this exact build, the 2,408-character note logs its 8,500 steps and does NOT log the meal it
+ * names, because the note asks two questions and the routing gives one turn to one owner. That is
+ * first-match-wins, it predates this cut, and it is Cut 6's subject ("one voice message, one
+ * authoritative interaction"). Asserting it green here would be asserting a defect.
+ *
+ * WHAT CHANGED IS STILL THE PRECONDITION FOR FIXING IT: before this cut the tail was not merely
+ * unrouted, it was deleted, so no future routing change could have reached facts that no longer
+ * existed. Now they are present at the front door and the remaining failure is downstream.
+ *
+ * GRADED POST-TRANSPORT on turn_ledger (what the handlers were given) and the durable owners.
+ * The cleaner itself is graded in script/voice-provenance-tests.ts against a stub client, because
+ * the real voice path cannot run offline: assertSafeMediaUrl requires an https allow-listed host
+ * and transcription needs the network. Stated, not implied.
+ */
+if (!process.env.DATABASE_URL) {
+  console.log("pg-long-voice-tail-acceptance: SKIPPED — no DATABASE_URL. This proof needs a real database.");
+  process.exit(0);
+}
+process.env.OPENAI_API_KEY = "sk-test-offline";
+process.env.OFFLINE_AI = "1";
+process.env.NORMALIZER = "off";
+process.env.ENGINE_LIVE = "off";
+process.env.PROACTIVE_PAUSED = "true";
+process.env.SHADOW = "on";
+process.env.TWILIO_ACCOUNT_SID = "ACtest00000000000000000000000000";
+process.env.TWILIO_AUTH_TOKEN = "test";
+process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
+process.env.NODE_ENV = "production";
+
+const REAL = console.log.bind(console);
+console.log = console.warn = console.error = () => {};
+
+const { pool, db } = await import("../server/db");
+const schema = await import("../shared/schema");
+const { handleMessage } = await import("../server/routes");
+const { processTextAsync } = await import("../server/routes/whatsapp");
+const { _resetOutboundDedupe } = await import("../server/reply-hygiene");
+const { _resetInteractionCorrelation } = await import("../server/handlers/chat-log");
+
+let failed = 0;
+const chk = (ok: boolean, msg: string, evidence = "") => {
+  if (!ok) failed++;
+  REAL(`  ${ok ? "PASS" : "FAIL"}  ${msg}${!ok && evidence ? `\n          ${evidence}` : ""}`);
+};
+
+// ── THE FIXTURE THE ORDER SPECIFIES ──────────────────────────────────────────────────────────
+// Unique facts at the beginning, the middle and the end, so WHERE a loss happens is visible:
+//   near the beginning   a named-day meal      "Yesterday I had pap and chicken for lunch"
+//   the middle           8,500 spoken steps
+//   near the end         a workout correction  "I said Tuesday but actually I missed it"
+//   throughout           feeling and context
+//   near the end         two questions
+//   the last words       a unique tail marker  KNEECLICK7788
+const TAIL_MARKER = "KNEECLICK7788";
+const NOTE = [
+  "Yoh coach, sorry for the long message neh, it has been a mad week and I want to tell you everything so you have the full picture of what is actually going on with me at the moment.",
+  "Yesterday I had pap and chicken for lunch, it was a big plate because my sister cooked and you know how she cooks, she does not know how to cook a small amount of anything for anybody.",
+  "Then in the evening I only had rooibos tea because I was not hungry at all after that plate, and I did not want to force food in just because it was supper time, so I left it there.",
+  "This morning I woke up late again, the taxi was full, I had to wait for the second one and then the second one also filled up before it got to my stop so I waited for a third one.",
+  "By the time I got to the office I had already missed my usual breakfast time completely so I just had nothing, which I know you are going to tell me is not the right thing to do.",
+  "I have been walking a lot more though because the new taxi rank drops me far from the office, it is about fifteen minutes each way and I do it twice a day now, morning and evening.",
+  "So yesterday my phone said I did 8500 steps, which I think is the most I have done in a very long time honestly, and I did not even plan it, it just happened because of the walking.",
+  "I am feeling tired and a bit down about the whole thing to be honest with you, like I am putting in the work every single day but the scale is not moving and it makes me want to give up.",
+  "My colleague keeps bringing those vetkoek to the office in the mornings and I have been saying no to them all week, which is not easy when you have skipped breakfast and you are hungry.",
+  "Oh and I must correct something I told you earlier in the week, I said I did my workout on Tuesday but actually I missed it, I only did the one on Thursday, so please fix that in my record.",
+  "I do not want my record saying I trained on a day I did not train because then the numbers you are showing me are not really my numbers and the whole thing stops meaning anything.",
+  "What should I be eating on the days when I get home after eight at night and I am too tired to cook anything proper for myself?",
+  "And also how many steps should I actually be aiming for now that I am walking to the office and back every single day of the week?",
+  `One last thing before I forget, my knee has been clicking a bit when I squat down and I wanted to ask you about that too: ${TAIL_MARKER}.`,
+].join(" ");
+
+/** Every fact the order names, and where in the note it lives. */
+const FACTS: Array<[where: string, name: string, re: RegExp]> = [
+  ["beginning", "the named-day meal", /yesterday i had pap and chicken for lunch/i],
+  ["middle", "8,500 steps", /\b8500\b/],
+  ["near the end", "the workout correction", /i said i did my workout on tuesday but actually i missed it/i],
+  ["throughout", "the feeling", /makes me want to give up/i],
+  ["near the end", "question 1 — what to eat after eight", /what should i be eating/i],
+  ["near the end", "question 2 — how many steps", /how many steps should i actually be aiming for/i],
+  ["the last words", "the tail marker", new RegExp(TAIL_MARKER)],
+];
+
+const phone = "whatsapp:+27820000977";
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+const [user] = await db.insert(schema.users).values({
+  phoneNumber: phone, name: "Lerato Long", onboardingState: "COMPLETE", popiConsent: true,
+  popiConsentAt: new Date(), subscriptionStatus: "active", goalType: "fat_loss",
+  currentWeight: "88", startWeight: "92", targetWeight: "80", heightCm: 165, age: 31,
+  gender: "female", trainingMode: "gym", proteinTarget: 130, calorieTarget: 1900,
+  dailyCalorieTarget: 1900, dailyStepTarget: 8000, stepsTarget: 8000,
+} as any).returning();
+
+const clear = async () => {
+  for (const t of ["meal_logs", "step_logs", "chat_history", "turn_ledger", "workout_logs"]) {
+    await pool.query(`DELETE FROM ${t} WHERE user_id = $1`, [user.id]);
+  }
+  await pool.query("DELETE FROM shadow_replies WHERE phone = $1", [phone]);
+  _resetOutboundDedupe();
+  _resetInteractionCorrelation();
+};
+const settle = () => new Promise(r => setTimeout(r, 1500));
+const ledger = async () => (await pool.query<{ input_text: string | null; delivered_body: string | null }>(
+  "SELECT input_text, delivered_body FROM turn_ledger WHERE user_id = $1 ORDER BY created_at", [user.id])).rows;
+const wire = async () => (await pool.query<{ body: string }>(
+  "SELECT body FROM shadow_replies WHERE phone = $1 ORDER BY id", [phone])).rows.map(r => r.body);
+
+REAL("\npg-long-voice-tail-acceptance — the long note reaches the handlers whole\n");
+REAL(`  fixture: ${NOTE.length} chars, ${NOTE.split(/\s+/).filter(Boolean).length} words\n`);
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("1. EVERY FACT THE CLIENT SPOKE IS IN WHAT THE HANDLERS WERE GIVEN");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+await clear();
+await processTextAsync(phone, NOTE, null, null, [], handleMessage as any, "sid-long-note");
+await settle();
+{
+  const rows = await ledger();
+  chk(rows.length >= 1, "the turn left a ledger row", `got ${rows.length}`);
+  const given = rows[0]?.input_text || "";
+  chk(given.length === NOTE.length,
+    "the recorded input is the whole note, not a window of it",
+    `recorded ${given.length} of ${NOTE.length} chars`);
+  for (const [where, name, re] of FACTS) {
+    chk(re.test(given), `${name} (${where}) survived`, `not found in the ${given.length} chars recorded`);
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n2. THE CONTROL — the 1,500-character window is where those facts used to die");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// Without this, §1 could be green because the facts happen to sit early in the note. This proves
+// four of the seven live BEYOND the old window, so §1 is grading the fix and not the fixture.
+{
+  const old = NOTE.slice(0, 1500);
+  const lost = FACTS.filter(([, , re]) => !re.test(old));
+  chk(lost.length >= 4,
+    `${lost.length} of the 7 facts are beyond the old window — the fixture genuinely reaches past it`,
+    `lost: ${lost.map(([, n]) => n).join(", ")}`);
+  chk(!new RegExp(TAIL_MARKER).test(old), "…the tail marker among them");
+  chk(/yesterday i had pap and chicken for lunch/i.test(old),
+    "…while the opening meal was always inside it, so the window's damage was to the END");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n3. 8,500 IS STILL 8,500 — the number is not reshaped on the way to its owner");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  const steps = (await pool.query<{ steps: number; resolved_day: string | null }>(
+    "SELECT steps, resolved_day FROM step_logs WHERE user_id = $1", [user.id])).rows;
+  chk(steps.length === 1, "exactly one step row from one spoken count", `got ${steps.length}`);
+  // AN OUTCOME CHECK, AND LABELLED AS ONE. Every step-writing site in server/ was mutated while
+  // building this cut's red-on-revert and this row still read 8500 — with logStepsForUser patched
+  // to throw outright. Its true writer was not identified, so this corroborates rather than
+  // guards; §1's "8,500 steps survived" is the guarded claim, and case 7 bites that one.
+  chk(steps[0]?.steps === 8500, "8500 stored as 8500 — not 8.5, not 85, not rounded (outcome check)",
+    `stored ${steps[0]?.steps}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n4. NOTHING IS INVENTED FROM A NOTE THIS LONG (Cut 2 must stay true here)");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  const meals = (await pool.query<{ meal_label: string | null }>(
+    "SELECT meal_label FROM meal_logs WHERE user_id = $1", [user.id])).rows;
+  chk(meals.every(m => m.meal_label === null || ["breakfast", "lunch", "dinner", "snack"].includes(m.meal_label!)),
+    "no meal slot appears that the client did not name",
+    `labels=${JSON.stringify(meals.map(m => m.meal_label))}`);
+  const bodies = await wire();
+  chk(bodies.length > 0, "the client got an answer to a three-minute note", `${bodies.length} bodies`);
+  chk(!/8\.5|85 steps|850 steps/.test(bodies.join("\n")),
+    "and no mangled version of their step count is spoken back",
+    JSON.stringify(bodies.join(" | ").slice(0, 200)));
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n5. WHAT THIS CUT DOES NOT FIX, RECORDED RATHER THAN CLAIMED");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// The meal the client names in the first fifty words does NOT reach meal_logs from inside this
+// note, and the answer does not address either question. Measured, not asserted: the same
+// sentence sent on its own logs correctly, so the loss is the routing, not the words.
+{
+  const inNote = (await pool.query<{ n: string }>(
+    "SELECT count(*)::text AS n FROM meal_logs WHERE user_id = $1", [user.id])).rows[0].n;
+  await clear();
+  await processTextAsync(phone, "Yesterday I had pap and chicken for lunch.", null, null, [], handleMessage as any, "sid-meal-alone");
+  await settle();
+  const alone = (await pool.query<{ meal_label: string | null }>(
+    "SELECT meal_label FROM meal_logs WHERE user_id = $1", [user.id])).rows;
+  chk(alone.length === 1 && alone[0].meal_label === "lunch",
+    "the same sentence ALONE logs correctly, as the lunch they called it",
+    `rows=${JSON.stringify(alone)}`);
+  REAL(`    NOTE — inside the long note that sentence produced ${inNote} meal row(s). Not asserted`);
+  REAL(`    either way: first-match-wins gives one turn to one owner, which predates this cut and`);
+  REAL(`    is Cut 6's subject. Cut 3's job was to stop the words being deleted before they get there.`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+REAL("\n6. NO STAGE BETWEEN THE CLIENT AND THE HANDLERS MAY SHORTEN WHAT THEY SAID (source)");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+{
+  const { readFileSync } = await import("node:fs");
+  const live = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
+  const media = live(readFileSync("server/handlers/media.ts", "utf-8"));
+  const wedge = live(readFileSync("server/understanding/sa-transcript.ts", "utf-8"));
+  chk(!/condenseVoiceRamble/.test(wedge), "the condenser is gone, not merely unused");
+  chk(!/condenseVoiceRamble/.test(media), "and media.ts condenses nothing before the handlers");
+  chk(/const forBrain = transcribedText;/.test(media), "the routed text IS the cleaned transcript");
+  chk(/return cleaned \+ tail;/.test(wedge), "the cleaner rejoins the part it could not send");
+  chk(/cleaned\.length < head\.length \* 0\.5/.test(wedge),
+    "a reply cut off by max_tokens cannot become the transcript");
+}
+
+REAL(`\n${failed === 0 ? "pg-long-voice-tail-acceptance: GREEN" : `pg-long-voice-tail-acceptance: ${failed} FAILED`}\n`);
+await pool.query("DELETE FROM users WHERE phone_number = $1", [phone]);
+await pool.end();
+process.exit(failed === 0 ? 0 : 1);

--- a/script/pg-long-voice-tail-acceptance.ts
+++ b/script/pg-long-voice-tail-acceptance.ts
@@ -238,15 +238,19 @@ REAL("\n6. NO STAGE BETWEEN THE CLIENT AND THE HANDLERS MAY SHORTEN WHAT THEY SA
   chk(!/condenseVoiceRamble/.test(media), "and media.ts condenses nothing before the handlers");
   chk(/const forBrain = transcribedText;/.test(media), "the routed text IS the cleaned transcript");
   chk(/return cleaned \+ tail;/.test(wedge), "the cleaner rejoins the part it could not send");
-  // THREE GATES, NOT A NUMBER. The first version carried only a 50% floor, and a reply holding
-  // 60% of the head passed it while deleting a correction and a question. Naming the threshold
-  // here would pin the number instead of the promise.
+  // AN ORDERED EDIT CONTRACT, NOT A PERCENTAGE. Two percentages were tried and both were beaten:
+  // a reply with 60% of the head, then one with 95.84% of it and the ending intact, each deleting
+  // a clause out of the middle. A share of the text cannot tell a spelling from a sentence.
   chk(/finishReason !== "stop"/.test(wedge),
     "a reply the model did not finish cannot become the transcript");
-  chk(/!coversTheEnd\(head, cleaned\)/.test(wedge),
-    "…nor can one that stops before the end of the head");
-  chk(/cleaned\.length < head\.length \* 0\.8/.test(wedge),
-    "…nor one that lost a fifth of it");
+  chk(/!onlyApprovedRepairs\(head, cleaned\)/.test(wedge),
+    "…nor can one that is not a token-for-token repair of the head");
+  chk(/before\.length !== after\.length/.test(wedge),
+    "…because a deleted or invented clause changes the token count");
+  chk(/PROTECTED_TOKENS/.test(wedge),
+    "…and numbers, days and negations may not be substituted at all");
+  chk(!/coversTheEnd|cleaned\.length < head\.length/.test(wedge),
+    "the superseded length gates are gone, not left unable to fail");
 }
 
 REAL(`\n${failed === 0 ? "pg-long-voice-tail-acceptance: GREEN" : `pg-long-voice-tail-acceptance: ${failed} FAILED`}\n`);

--- a/script/pg-voice-provenance-acceptance.ts
+++ b/script/pg-voice-provenance-acceptance.ts
@@ -7,7 +7,7 @@
  *
  * A voice note becomes three different strings before any handler sees it:
  *
- *     Scribe/Whisper  →  cleanSATranscript  →  condenseVoiceRamble (>150 words)  →  handlers
+ *     Scribe/Whisper  →  cleanSATranscript  →  handlers      (the condenser was removed in Cut 3)
  *
  * `turn_ledger.input_text` on the inner row held the LAST of those. The client's own words existed
  * only in a `[VOICE] scribe_ok text="…"` log line. So for any bad voice turn, the first question —

--- a/script/red-on-revert-cut3-long-voice.sh
+++ b/script/red-on-revert-cut3-long-voice.sh
@@ -30,9 +30,28 @@ restore_case () {
 cleanup () { restore_case; rm -rf "$WORK_ROOT"; }
 trap cleanup EXIT INT TERM
 
+# A DETECTION IS A GRADED FAILED ASSERTION, NOT A NON-ZERO EXIT (CTO review of #244).
+#
+# The first version of this harness counted ANY non-zero exit as "caught". A crash, an import
+# error, a timeout or a dead database would therefore have produced a confident 7/7 while nothing
+# was being detected at all — the same fail-open shape this whole rescue keeps finding, built into
+# the instrument that certifies the others.
+#
+# A case now counts only when a grader REACHES ITS OWN VERDICT LINE and that verdict reports failed
+# checks, with at least one "FAIL" assertion printed. A missing verdict is a crash and fails the
+# harness. `graded_red <output> <verdict-prefix> <red-pattern>` answers that question once.
+graded_red () {
+  local out="$1" prefix="$2" pattern="$3" verdict
+  verdict="$(printf '%s\n' "$out" | grep -E "^${prefix}" | tail -1 || true)"
+  if [[ -z "$verdict" ]]; then return 2; fi                        # no verdict = crashed
+  if [[ ! "$verdict" =~ $pattern ]]; then return 1; fi             # ran, but not red
+  if ! printf '%s\n' "$out" | grep -q '^  FAIL'; then return 1; fi # red with no failed assertion
+  return 0
+}
+
 run_case () {
   local name="$1" patch="$2"
-  local acc_out acc_status unit_out unit_status verdict red=""
+  local acc_out unit_out red="" crashed=""
   restore_case
   mkdir -p "$BACKUP"
   cp -a server "$BACKUP/server"
@@ -42,20 +61,34 @@ run_case () {
   if ! revert_db_reset; then
     echo "  !! database reset failed: $name"; restore_case; return 1
   fi
-  acc_out="$(npx tsx "$ACC" 2>&1)"; acc_status=$?
-  unit_out="$(npx tsx "$UNIT" 2>&1)"; unit_status=$?
-  verdict="$(printf '%s\n' "$acc_out" | grep -E '^pg-long-voice-tail-acceptance:' | tail -1 || true)"
+  acc_out="$(npx tsx "$ACC" 2>&1)"
+  unit_out="$(npx tsx "$UNIT" 2>&1)"
   echo "── REVERT: $name"
-  if [[ $acc_status -ne 0 ]]; then
+
+  graded_red "$acc_out" "pg-long-voice-tail-acceptance:" "FAILED"; local acc_rc=$?
+  graded_red "$unit_out" "voice-provenance-tests:" "FAILED"; local unit_rc=$?
+
+  if [[ $acc_rc -eq 0 ]]; then
     red="acceptance"
-    echo "   ${verdict:-'(no verdict — crashed)'}"
+    printf '%s\n' "$acc_out" | grep -E '^pg-long-voice-tail-acceptance:' | tail -1 | sed 's/^/   /'
     printf '%s\n' "$acc_out" | grep '^  FAIL' | sed 's/^/   /' | head -3 || true
+  elif [[ $acc_rc -eq 2 ]]; then
+    crashed="${crashed:+$crashed, }acceptance"
   fi
-  if [[ $unit_status -ne 0 ]]; then
+  if [[ $unit_rc -eq 0 ]]; then
     red="${red:+$red + }voice-provenance-tests"
     printf '%s\n' "$unit_out" | grep '^  FAIL' | sed 's/^/   /' | head -3 || true
+  elif [[ $unit_rc -eq 2 ]]; then
+    crashed="${crashed:+$crashed, }voice-provenance-tests"
   fi
   restore_case
+
+  # A CRASH IS NEVER A DETECTION, even when the other grader legitimately went red — a case that
+  # breaks a grader outright is not evidence about the mechanism it claims to test.
+  if [[ -n "$crashed" ]]; then
+    echo "  !! grader(s) produced NO VERDICT (crashed): $crashed — case $name proves nothing"
+    return 1
+  fi
   if [[ -z "$red" ]]; then
     echo "  !! BOTH graders stayed green: $name"
     return 1
@@ -65,6 +98,21 @@ run_case () {
 
 mkdir -p "$PATCH_DIR"
 
+# BOTH GRADERS MUST PASS UNTOUCHED FIRST. Detection means nothing unless the same two commands are
+# green on the unmodified tree: without this, a broken database or a bad import makes every case
+# below "caught" and the harness certifies itself.
+if ! revert_db_reset; then echo "!! database reset failed before the control"; exit 1; fi
+ctl_acc="$(npx tsx "$ACC" 2>&1)"; ctl_acc_status=$?
+ctl_unit="$(npx tsx "$UNIT" 2>&1)"; ctl_unit_status=$?
+if [[ $ctl_acc_status -ne 0 || $ctl_unit_status -ne 0 ]]; then
+  echo "!! CONTROL FAILED — the unmodified graders do not both pass, so nothing below proves anything."
+  printf '%s\n' "$ctl_acc" | grep -E '^pg-long-voice-tail-acceptance:|^  FAIL' | sed 's/^/   /' | head -5 || true
+  printf '%s\n' "$ctl_unit" | grep -E '^voice-provenance-tests:|^  FAIL' | sed 's/^/   /' | head -5 || true
+  exit 1
+fi
+echo "CONTROL: both graders are GREEN unmodified — detections below are real."
+
+
 # 1. THE CLEANER'S WINDOW DELETES THE TAIL AGAIN — the defect itself. 908 characters of a
 #    three-minute note, including both questions and the last thing they said.
 cat > "$PATCH_DIR/1.py" <<'PYEOF'
@@ -73,11 +121,28 @@ s=s.replace("  const { head, tail } = splitForClean(text);", '  const head = tex
 assert s!=b and 'const head = text.slice(0, 1500)' in s, "no match"; open(p,"w").write(s)
 PYEOF
 
-# 2. THE LOWER BOUND GOES — a reply cut off by max_tokens becomes the transcript, middle missing.
-#    There was a ceiling on the output length and never a floor.
+# 2. THE LENGTH FLOOR GOES. One of the three completeness gates, reverted alone — the fixture that
+#    catches it keeps the head's ending, so coversTheEnd cannot cover for it.
 cat > "$PATCH_DIR/2.py" <<'PYEOF'
 p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
-s=s.replace("      || cleaned.length < head.length * 0.5\n", "")
+s=s.replace("      || cleaned.length < head.length * 0.8\n", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2b. THE FINISH-REASON GATE GOES. The model ran out of tokens mid-sentence and what came back is
+#     a fragment wearing the shape of an answer. Caught alone by a reply that is otherwise perfect.
+cat > "$PATCH_DIR/2b.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace('      || finishReason !== "stop"\n', "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2c. THE END-COVERAGE GATE GOES. This is the hole the CTO demonstrated against the first version
+#     of this cut: a faithful PREFIX passes a length floor and a word-overlap test, and the end of
+#     the head — a correction and a question in the measured case — is deleted.
+cat > "$PATCH_DIR/2c.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("      || !coversTheEnd(head, cleaned)\n", "")
 assert s!=b, "no match"; open(p,"w").write(s)
 PYEOF
 
@@ -137,11 +202,11 @@ PYEOF
 
 echo "RED-ON-REVERT — Cut 3. Every case below must be caught by at least one grader."
 failed=0
-for i in 1 2 3 4 5 6 7; do
+for i in 1 2 2b 2c 3 4 5 6 7; do
   if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
 done
 if [[ $failed -ne 0 ]]; then
   echo "RED-ON-REVERT: FAILED — $failed case(s) left every grader green, crashed, or would not patch."
   exit 1
 fi
-echo "RED-ON-REVERT: GREEN — 7/7 cases caught."
+echo "RED-ON-REVERT: GREEN — 9/9 cases caught."

--- a/script/red-on-revert-cut3-long-voice.sh
+++ b/script/red-on-revert-cut3-long-voice.sh
@@ -121,29 +121,32 @@ s=s.replace("  const { head, tail } = splitForClean(text);", '  const head = tex
 assert s!=b and 'const head = text.slice(0, 1500)' in s, "no match"; open(p,"w").write(s)
 PYEOF
 
-# 2. THE LENGTH FLOOR GOES. One of the three completeness gates, reverted alone — the fixture that
-#    catches it keeps the head's ending, so coversTheEnd cannot cover for it.
+# 2. THE EDIT CONTRACT GOES — the gate that replaced two beaten percentages. Without it a reply
+#    can delete a clause out of the MIDDLE of the head: 95.84% of the text, ending intact,
+#    finish_reason "stop", and the client's correction and question gone.
 cat > "$PATCH_DIR/2.py" <<'PYEOF'
 p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
-s=s.replace("      || cleaned.length < head.length * 0.8\n", "")
+s=s.replace("      || !onlyApprovedRepairs(head, cleaned)) {", "      ) {")
 assert s!=b, "no match"; open(p,"w").write(s)
 PYEOF
 
-# 2b. THE FINISH-REASON GATE GOES. The model ran out of tokens mid-sentence and what came back is
-#     a fragment wearing the shape of an answer. Caught alone by a reply that is otherwise perfect.
+# 2b. THE FINISH-REASON GATE GOES. A separate promise from the edit contract: the model ran out of
+#     tokens mid-sentence, and what came back is a fragment wearing the shape of an answer.
 cat > "$PATCH_DIR/2b.py" <<'PYEOF'
 p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
 s=s.replace('      || finishReason !== "stop"\n', "")
 assert s!=b, "no match"; open(p,"w").write(s)
 PYEOF
 
-# 2c. THE END-COVERAGE GATE GOES. This is the hole the CTO demonstrated against the first version
-#     of this cut: a faithful PREFIX passes a length floor and a word-overlap test, and the end of
-#     the head — a correction and a question in the measured case — is deleted.
+# 2c. THE PROTECTED TOKENS STOP BEING PROTECTED. The contract still refuses deletions, so the
+#     count-based half survives — this reverts only the rule that a number, a weekday or a
+#     negation may never be substituted. 8500 becomes 8000 and "missed" becomes "finished",
+#     each a one-for-one swap that leaves the token count untouched.
 cat > "$PATCH_DIR/2c.py" <<'PYEOF'
 p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
-s=s.replace("      || !coversTheEnd(head, cleaned)\n", "")
-assert s!=b, "no match"; open(p,"w").write(s)
+s=s.replace("  if (isProtected(from) || isProtected(to)) return false;\n", "")
+s=s.replace("  if (!SA_REPAIR_WORDS.has(to)) return false;", "  if (false) return false;")
+assert s!=b and "if (false) return false;" in s, "no match"; open(p,"w").write(s)
 PYEOF
 
 # 3. THE CONDENSER COMES BACK ON THE ROUTING PATH — a model's retelling reaches the handlers as

--- a/script/red-on-revert-cut3-long-voice.sh
+++ b/script/red-on-revert-cut3-long-voice.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — Cut 3, a long note reaches the handlers whole.
+#
+# FOUR SILENT CUTS WERE FOUND IN ONE PIPELINE, and each gets its own case: the cleaner's
+# 1,500-character window, the cleaner's missing lower bound, the condenser replacing the client's
+# account, and the ledger's own 2,000-character cap on the record of what they said.
+#
+# TWO GRADERS, BECAUSE ONE CANNOT SEE BOTH HALVES. The PostgreSQL acceptance drives the TEXT front
+# door, where the cleaner never runs; the cleaner is exercised in voice-provenance-tests against a
+# stub client, because the real voice path needs an allow-listed https host and the network. A case
+# passes when EITHER grader turns red, and the script says which — a case that leaves both green is
+# a mechanism nothing is watching.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
+ACC=script/pg-long-voice-tail-acceptance.ts
+UNIT=script/voice-provenance-tests.ts
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/cut3-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/backup"
+PATCH_DIR="$WORK_ROOT/patches"
+
+restore_case () {
+  if [[ -d "$BACKUP/server" ]]; then
+    rm -rf server
+    mv "$BACKUP/server" server
+  fi
+  rm -rf "$BACKUP"
+}
+cleanup () { restore_case; rm -rf "$WORK_ROOT"; }
+trap cleanup EXIT INT TERM
+
+run_case () {
+  local name="$1" patch="$2"
+  local acc_out acc_status unit_out unit_status verdict red=""
+  restore_case
+  mkdir -p "$BACKUP"
+  cp -a server "$BACKUP/server"
+  if ! python3 "$patch"; then
+    echo "  !! patch failed: $name"; restore_case; return 1
+  fi
+  if ! revert_db_reset; then
+    echo "  !! database reset failed: $name"; restore_case; return 1
+  fi
+  acc_out="$(npx tsx "$ACC" 2>&1)"; acc_status=$?
+  unit_out="$(npx tsx "$UNIT" 2>&1)"; unit_status=$?
+  verdict="$(printf '%s\n' "$acc_out" | grep -E '^pg-long-voice-tail-acceptance:' | tail -1 || true)"
+  echo "── REVERT: $name"
+  if [[ $acc_status -ne 0 ]]; then
+    red="acceptance"
+    echo "   ${verdict:-'(no verdict — crashed)'}"
+    printf '%s\n' "$acc_out" | grep '^  FAIL' | sed 's/^/   /' | head -3 || true
+  fi
+  if [[ $unit_status -ne 0 ]]; then
+    red="${red:+$red + }voice-provenance-tests"
+    printf '%s\n' "$unit_out" | grep '^  FAIL' | sed 's/^/   /' | head -3 || true
+  fi
+  restore_case
+  if [[ -z "$red" ]]; then
+    echo "  !! BOTH graders stayed green: $name"
+    return 1
+  fi
+  echo "   caught by: $red"
+}
+
+mkdir -p "$PATCH_DIR"
+
+# 1. THE CLEANER'S WINDOW DELETES THE TAIL AGAIN — the defect itself. 908 characters of a
+#    three-minute note, including both questions and the last thing they said.
+cat > "$PATCH_DIR/1.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("  const { head, tail } = splitForClean(text);", '  const head = text.slice(0, 1500); const tail = "";')
+assert s!=b and 'const head = text.slice(0, 1500)' in s, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2. THE LOWER BOUND GOES — a reply cut off by max_tokens becomes the transcript, middle missing.
+#    There was a ceiling on the output length and never a floor.
+cat > "$PATCH_DIR/2.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("      || cleaned.length < head.length * 0.5\n", "")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 3. THE CONDENSER COMES BACK ON THE ROUTING PATH — a model's retelling reaches the handlers as
+#    the client's words. Restored inline, because deleting it was the point.
+cat > "$PATCH_DIR/3.py" <<'PYEOF'
+p="server/handlers/media.ts"; s=open(p).read(); b=s
+s=s.replace("      const forBrain = transcribedText;",
+            "      const forBrain = await condenseVoiceRamble(openai, transcribedText, user.id);")
+s=s.replace('import { cleanSATranscript } from "../understanding/sa-transcript";',
+            'import { cleanSATranscript } from "../understanding/sa-transcript";\n'
+            'const condenseVoiceRamble = async (_o: any, t: string, _u: any) => t.split(". ")[0] + ".";')
+assert s!=b and "condenseVoiceRamble(openai" in s, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 4. THE LEDGER CAPS THE RECORD AT 2,000 CHARACTERS AGAIN. The handlers still receive the whole
+#    note; the durable answer to "what did they actually say?" loses its last four hundred.
+cat > "$PATCH_DIR/4.py" <<'PYEOF'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("  if (t.length <= LEDGER_TEXT_MAX) return t;", "  return t.slice(0, 2000);\n  if (t.length <= LEDGER_TEXT_MAX) return t;")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 5. THE SPLIT DROPS THE TAIL INSTEAD OF CARRYING IT. The shape a "small tidy-up" would take:
+#    splitForClean still exists, still returns a head, and quietly returns no tail.
+cat > "$PATCH_DIR/5.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace('  return at > 0 ? { head: text.slice(0, at), tail: text.slice(at) } : { head: window, tail: text.slice(CLEAN_WINDOW) };',
+            '  return at > 0 ? { head: text.slice(0, at), tail: "" } : { head: window, tail: "" };')
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 6. OPPOSITE DEFECT — the cleaner stops cleaning. Every "nothing was deleted" check above is
+#    trivially satisfied by a stage that returns its input, which is the cheapest wrong way to
+#    pass a cut about not losing text. §1 of voice-provenance-tests is what stands in the way.
+cat > "$PATCH_DIR/6.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("  if (killswitchOff() || text.length < 4) return raw;", "  if (true) return raw;")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 7. OPPOSITE DEFECT — the record keeps every character except the ones that carry meaning. A cut
+#    about nothing being lost must not be green while the NUMBERS in what the client said are
+#    reshaped on their way into the record. §1's "8,500 steps survived" is what stands in the way.
+#
+#    THIS IS THE SECOND SHAPE OF THIS CASE. The first mutated every step-writing site in server/
+#    (steps.ts insert and update, storage.ts, media.ts x2, health-sync.ts) and left BOTH graders
+#    green — the stored row still read 8500 with logStepsForUser patched to throw outright. The
+#    row's true writer was not identified, so §3's durable-row check is recorded as an outcome
+#    check that no mutation here guards, rather than claimed as a guarded one.
+cat > "$PATCH_DIR/7.py" <<'PYEOF'
+p="server/handlers/chat-log.ts"; s=open(p).read(); b=s
+s=s.replace("  if (t.length <= LEDGER_TEXT_MAX) return t;",
+            '  return t.replace(/[0-9]/g, "");\n  if (t.length <= LEDGER_TEXT_MAX) return t;')
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+echo "RED-ON-REVERT — Cut 3. Every case below must be caught by at least one grader."
+failed=0
+for i in 1 2 3 4 5 6 7; do
+  if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
+done
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) left every grader green, crashed, or would not patch."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 7/7 cases caught."

--- a/script/red-on-revert-cut3-long-voice.sh
+++ b/script/red-on-revert-cut3-long-voice.sh
@@ -141,12 +141,33 @@ PYEOF
 # 2c. THE PROTECTED TOKENS STOP BEING PROTECTED. The contract still refuses deletions, so the
 #     count-based half survives — this reverts only the rule that a number, a weekday or a
 #     negation may never be substituted. 8500 becomes 8000 and "missed" becomes "finished",
-#     each a one-for-one swap that leaves the token count untouched.
+#     each a one-for-one swap that leaves the token count untouched. The vetted pair map alone
+#     does not catch these, so the map is widened to whatever the model returned.
 cat > "$PATCH_DIR/2c.py" <<'PYEOF'
 p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
 s=s.replace("  if (isProtected(from) || isProtected(to)) return false;\n", "")
-s=s.replace("  if (!SA_REPAIR_WORDS.has(to)) return false;", "  if (false) return false;")
-assert s!=b and "if (false) return false;" in s, "no match"; open(p,"w").write(s)
+s=s.replace("  return VETTED_REPAIRS.get(from) === to;", "  return true;")
+assert s!=b and "  return true;" in s, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2d. THE VETTED PAIR MAP BECOMES A VOCABULARY AGAIN — the first hole the reviewer reproduced.
+#     Asking "is the NEW word one of the SA words this cleaner produces?" instead of "was THIS
+#     pair vetted?" approves any near-neighbour of any listed word: "I have pain" becomes
+#     "I have pap", and a client reporting pain has it recorded as a plate of food.
+cat > "$PATCH_DIR/2d.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("  return VETTED_REPAIRS.get(from) === to;",
+            '  return to === "pap" || to === "samp";')
+assert s!=b and 'to === "pap"' in s, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2e. THE TOKENIZER GOES BACK TO ASCII-ONLY — the second hole. Signs and decimal points are eaten,
+#     so "-5 kg" compares equal to "5 kg" and "8.5" to "85"; non-Latin words produce no tokens at
+#     all, so one can be deleted from or invented into the client's record for free.
+cat > "$PATCH_DIR/2e.py" <<'PYEOF'
+p="server/understanding/sa-transcript.ts"; s=open(p).read(); b=s
+s=s.replace("/[+−–—-]?\\d+(?:[.,]\\d+)*|[\\p{L}\\p{M}\\p{N}'’]+/gu", "/[a-z0-9']+/g")
+assert s!=b and "match(/[a-z0-9']+/g)" in s, "no match"; open(p,"w").write(s)
 PYEOF
 
 # 3. THE CONDENSER COMES BACK ON THE ROUTING PATH — a model's retelling reaches the handlers as
@@ -205,11 +226,11 @@ PYEOF
 
 echo "RED-ON-REVERT — Cut 3. Every case below must be caught by at least one grader."
 failed=0
-for i in 1 2 2b 2c 3 4 5 6 7; do
+for i in 1 2 2b 2c 2d 2e 3 4 5 6 7; do
   if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
 done
 if [[ $failed -ne 0 ]]; then
   echo "RED-ON-REVERT: FAILED — $failed case(s) left every grader green, crashed, or would not patch."
   exit 1
 fi
-echo "RED-ON-REVERT: GREEN — 9/9 cases caught."
+echo "RED-ON-REVERT: GREEN — 11/11 cases caught."

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -954,25 +954,25 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
     const live = readFileSync(join("server", "understanding", "live.ts"), "utf-8");
     assert.match(live, /emitActions: actionMode !== "off" && !strategyTurn/, "strategy turns pass emitActions=false");
   });
-  test("voice: long rambles get condensed to their actionable core before the brain (margin + clarity)", () => {
+  // THIS TEST GRADED THE SUMMARISER WEDGE. Cut 3 (2026-09-12) removed it: media.ts routed the
+  // condensed retelling to the handlers, so the retelling WAS the client's words as far as
+  // anything downstream could tell, and there is only one routed string for a second version to
+  // occupy. The assertions are inverted rather than dropped, and the inversion is stricter — the
+  // old ones permitted a shortened note under conditions, these permit none.
+  test("voice: the client's note reaches the handlers whole — nothing shortens it first", () => {
     const wedge = readFileSync(join("server", "understanding", "sa-transcript.ts"), "utf-8");
-    assert.match(wedge, /export async function condenseVoiceRamble/, "the summariser wedge exists");
-    assert.match(wedge, /text\.length < 200\) return raw/, "short notes are never reshaped — a quick food log is safe");
-    assert.match(wedge, /feature: "voice_condense"/, "its cost is tagged so it shows in the CFO report");
-    assert.match(wedge, /out\.length >= text\.length \|\| looksLikeRefusal\(out\)\) return raw/, "fail-open: a bad condense keeps the raw transcript");
+    assert.ok(!/export async function condenseVoiceRamble/.test(wedge), "the summariser wedge is gone, not merely unused");
+    assert.ok(!/CONDENSE_SYSTEM/.test(wedge), "…and so is the prompt that asked for a retelling");
     const media = readFileSync(join("server", "handlers", "media.ts"), "utf-8");
-    // RAISED 90 → 150 on 2026-08-06. At 90 words an ordinary "here is my day" note was
-    // summarised before the coach saw it — which is how a client ends up sending a voice note
-    // that says "read the rest of my transcript". The margin guard survives, the half-answer
-    // does not; transcriptMustPassWhole is the second half of that fix.
-    // The condition gained the whole-transcript guard (a real improvement); this pinned the old
-    // spelling. Assert the two conditions that matter, not the punctuation between them.
-    assert.match(media, /wordCount > 150/, "only a genuine ramble (>150 words) is condensed");
-    assert.match(media, /!transcriptMustPassWhole\(transcribedText\)[\s\S]{0,40}condenseVoiceRamble/,
-      "…and never a note whose facts must reach the log path whole");
-    assert.match(media, /transcriptMustPassWhole/, "the whole-transcript guard is referenced in the comment trail");
-    assert.match(media, /const forBrain =/, "the condensed text feeds the brain");
-    assert.match(media, /echoTrimmed/, "the echo still shows what they actually said, not the condensed version");
+    assert.ok(!/condenseVoiceRamble/.test(media), "media.ts condenses nothing before the handlers");
+    assert.match(media, /const forBrain = transcribedText;/, "the handlers are routed the cleaned transcript itself");
+    assert.match(media, /echoTrimmed/, "the echo still shows what they actually said");
+    // THE CLEANER'S WINDOW IS A WINDOW, NOT A LIMIT. Measured on 017efd9: a 2,408-char note came
+    // back 1,500 chars long, the tail deleted, before any handler or guard saw it.
+    assert.match(wedge, /export function splitForClean/, "the cleaner splits rather than truncates");
+    assert.match(wedge, /return cleaned \+ tail;/, "…and rejoins the part it could not send");
+    assert.match(wedge, /cleaned\.length < head\.length \* 0\.5/, "a reply cut off by max_tokens cannot become the transcript");
+    assert.match(wedge, /!retainsOriginal\(head, cleaned\)/, "the faithfulness check compares the head it actually cleaned");
   });
   test("CFO: the weekly report surfaces AI cost by feature and guards the R199 margin", () => {
     const biz = readFileSync(join("server", "scheduler", "jobs", "business.ts"), "utf-8");
@@ -1387,32 +1387,42 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
 }
 
 
-// "READ THE REST OF MY TRANSCRIPT" (2026-08-06). The condenser summarises long voice notes to
-// protect the margin, which is right — but it must never answer half of what someone said.
+// "READ THE REST OF MY TRANSCRIPT" (2026-08-06) — ANSWERED STRUCTURALLY (Cut 3, 2026-09-12).
+//
+// Five assertions stood here, each naming a shape the condenser was forbidden to touch: a note
+// asking two things, a note stacking an instruction on a question, a day's food list, a feeling
+// note. They graded `transcriptMustPassWhole`, a predicate that decided WHICH notes were safe.
+//
+// The condenser is gone, so no note is shortened and the predicate has no caller — the
+// reachability guard in this very file is what said so. These are inverted, not dropped, and the
+// inversion is stricter: the old rules protected the notes the predicate could recognise, and
+// this protects every note including the ones it could not.
+//
+// THE PROOF THAT THE PREDICATE WAS NEVER ENOUGH: the founder's own 2,408-character note matched
+// ALL THREE of those guards and was still cut in half, because the cleaner truncated it before
+// any of them were consulted. A guard downstream of the deletion cannot prevent the deletion.
 {
-  const { transcriptMustPassWhole } = await import("../server/utils");
-  test("a note asking TWO things is never condensed", async () => {
-    assert.ok(transcriptMustPassWhole("How much protein should I have today? And what should I eat after gym?"));
-    assert.ok(transcriptMustPassWhole("what can I eat at the taxi rank and how many calories do I have left"),
-      "spoken notes carry no punctuation — question openers must count");
+  test("no stage between the client and the handlers may shorten what they said", async () => {
+    const media = readFileSync(join("server", "handlers", "media.ts"), "utf-8");
+    // COMMENTS STRIPPED FIRST. The file EXPLAINS what was removed and why, so a bare text search
+    // matches the explanation and reports the code is back. A guard that cannot tell code from a
+    // comment about the code is the fail-open shape this repo keeps finding.
+    const wedgeSrc = readFileSync(join("server", "understanding", "sa-transcript.ts"), "utf-8");
+    const wedge = wedgeSrc.replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
+    assert.ok(!/condenseVoiceRamble/.test(wedge), "no condenser exists to be gated");
+    assert.match(media, /const forBrain = transcribedText;/,
+      "the routed text is the cleaned transcript itself — unconditionally, for every note");
+    assert.ok(!/wordCount > 150/.test(media), "and no length threshold decides whose words survive");
   });
-  test("a note that stacks an instruction on a question is never condensed", async () => {
-    assert.ok(transcriptMustPassWhole("What should I eat tonight, also can you change my goal to muscle gain"));
-  });
-  test("a day's food list is never condensed (the July regression)", async () => {
-    assert.ok(transcriptMustPassWhole("I had two eggs and pap for breakfast, chicken and rice for lunch, and a banana"));
-  });
-  test("a feeling note is never squeezed; a feeling-free ramble still can be", async () => {
-    // CTO ruling, 2026-08-19. This test used to assert the opposite — that a tired/traffic/sleep
-    // note was condensable, because the margin guard came first. It does not any more: a long
-    // come-back ramble with no food and no steps is the Pulse client saying what is actually
-    // going on, and summarising it to save tokens is tracker behaviour. The money is not worth
-    // the one note where they finally told you.
-    assert.ok(transcriptMustPassWhole(
-      "Eish coach I am so tired today the traffic was terrible and I did not sleep well at all last night"));
-    // The guard survives, narrowed: no food, no steps, no feeling, no stacked question.
-    assert.ok(!transcriptMustPassWhole(
-      "the taxi was late again and then the queue at the shop went around the corner and my phone died on the way home"));
+  // SOURCE-ONLY ON PURPOSE. Importing sa-transcript here keeps a handle open and this suite stops
+  // exiting — all 1,062 checks pass and the process hangs, which the runner reports as a 600s
+  // timeout with no failing assertion. splitForClean is DRIVEN for real, on these same shapes, in
+  // script/voice-provenance-tests.ts §2b, where the module is already loaded.
+  test("the cleaner's window cannot delete the part it did not send", () => {
+    const wedge = readFileSync(join("server", "understanding", "sa-transcript.ts"), "utf-8");
+    assert.match(wedge, /export function splitForClean/, "it splits");
+    assert.match(wedge, /return cleaned \+ tail;/, "and rejoins");
+    assert.match(wedge, /head: text\.slice\(0, at\), tail: text\.slice\(at\)/, "the tail is carried, not dropped");
   });
 }
 
@@ -2269,7 +2279,6 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
       ["bodyPhotoAsk", "server/onboarding-physique.ts"],    // the day-zero physique read
       ["hasTrialedBefore", "server/pricing-config.ts"],     // one trial per number, ever
       ["sttVocabularyPrompt", "server/foods.ts"],           // the transcription bias
-      ["transcriptMustPassWhole", "server/utils.ts"],       // "read the rest of my transcript"
       ["neverSilentLine", "server/reply-hygiene.ts"],       // the one fallback mouth
     ];
 
@@ -9771,22 +9780,25 @@ test("workout-request: spoken programme phrasings deliver, questions still coach
   });
 
 
-  test("voice: a day's food is NEVER condensed — the condenser is for rambles", async () => {
-    const { transcriptIsLogList } = await import("../server/utils");
-    // The founder's own note. Every word is payload; a summariser can only lose some of it.
-    assert.equal(transcriptIsLogList("Yesterday I had 4 fish fingers, 3 eggs, 3 slices of bread, and a black coffee for breakfast"), true);
-    assert.equal(transcriptIsLogList("I had two eggs and pap this morning and then chicken and rice for lunch"), true, "spoken numbers count too");
-    assert.equal(transcriptIsLogList("I walked 8000 steps, drank 2 litres and weighed in at 83kg"), true);
-    // A genuine ramble — thinking out loud, no quantities — still gets condensed.
-    assert.equal(transcriptIsLogList("So I was thinking about the gym and whether I should go tonight because work has been really heavy and I feel like I am falling behind on everything"), false);
-    assert.equal(transcriptIsLogList(""), false);
+  // transcriptIsLogList graded here: "is this a day's food list, and therefore unshortenable?"
+  // Nothing is shortened now, so the question has no consumer and the predicate is gone (Cut 3).
+  // The promise it protected — a spoken day of food reaches the log path with every item intact —
+  // is asserted against the pipeline instead, where it cannot be bypassed by a shape it misreads.
+  test("a spoken day of food reaches the handlers with every item intact", () => {
+    const media = readFileSync(join("server", "handlers", "media.ts"), "utf-8");
+    assert.match(media, /const forBrain = transcribedText;/,
+      "the whole cleaned transcript is routed, so a day's food cannot be summarised out of it");
+    assert.ok(!/wordCount > 150/.test(media), "and no length threshold decides whose list survives");
   });
 
-  test("voice: the condense prompt no longer contradicts itself on length", async () => {
+  // "the condense prompt no longer contradicts itself on length" graded CONDENSE_SYSTEM, which
+  // told the model to be short AND to keep every food. Cut 3 deleted the prompt with the function
+  // it served. A prompt that cannot contradict itself is one that does not exist.
+  test("voice: there is no prompt asking a model to retell the client's note", async () => {
     const src = readFileSync("server/understanding/sa-transcript.ts", "utf-8");
-    assert.ok(!/short \(2-4 sentences\)/i.test(src),
-      "a hard sentence cap fights 'keep every food' — the model obeys the cap and drops meals");
-    assert.match(src, /WITHOUT LOSING A SINGLE FOOD OR/i, "keeping their day must beat being short");
+    assert.ok(!/CONDENSE_SYSTEM/.test(src), "the condense prompt is gone");
+    assert.ok(!/You condense a LONG South African voice-note transcript/.test(src), "…text and all");
+    assert.match(src, /do NOT summarize/i, "the surviving cleaner prompt still forbids summarising");
   });
 
 

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -971,7 +971,11 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
     // back 1,500 chars long, the tail deleted, before any handler or guard saw it.
     assert.match(wedge, /export function splitForClean/, "the cleaner splits rather than truncates");
     assert.match(wedge, /return cleaned \+ tail;/, "…and rejoins the part it could not send");
-    assert.match(wedge, /cleaned\.length < head\.length \* 0\.5/, "a reply cut off by max_tokens cannot become the transcript");
+    // THREE GATES, NOT A NUMBER (CTO review of #244). A 50% floor alone let a reply carrying 60%
+    // of the head through, deleting a correction and a question with it.
+    assert.match(wedge, /finishReason !== "stop"/, "a reply the model did not finish cannot become the transcript");
+    assert.match(wedge, /!coversTheEnd\(head, cleaned\)/, "nor can one that stops before the end of the head");
+    assert.match(wedge, /cleaned\.length < head\.length \* 0\.8/, "nor one that lost a fifth of it");
     assert.match(wedge, /!retainsOriginal\(head, cleaned\)/, "the faithfulness check compares the head it actually cleaned");
   });
   test("CFO: the weekly report surfaces AI cost by feature and guards the R199 margin", () => {

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -960,7 +960,11 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
   // occupy. The assertions are inverted rather than dropped, and the inversion is stricter — the
   // old ones permitted a shortened note under conditions, these permit none.
   test("voice: the client's note reaches the handlers whole — nothing shortens it first", () => {
-    const wedge = readFileSync(join("server", "understanding", "sa-transcript.ts"), "utf-8");
+    // COMMENTS STRIPPED. The file EXPLAINS what was removed and why, so a bare text search matches
+    // the explanation and reports the code is back — the same fail-open shape this cut keeps
+    // finding, and the second time it caught me in this file.
+    const wedgeSrc = readFileSync(join("server", "understanding", "sa-transcript.ts"), "utf-8");
+    const wedge = wedgeSrc.replace(/\/\*[\s\S]*?\*\//g, " ").split("\n").filter(l => !/^\s*\/\//.test(l)).join("\n");
     assert.ok(!/export async function condenseVoiceRamble/.test(wedge), "the summariser wedge is gone, not merely unused");
     assert.ok(!/CONDENSE_SYSTEM/.test(wedge), "…and so is the prompt that asked for a retelling");
     const media = readFileSync(join("server", "handlers", "media.ts"), "utf-8");
@@ -971,12 +975,17 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
     // back 1,500 chars long, the tail deleted, before any handler or guard saw it.
     assert.match(wedge, /export function splitForClean/, "the cleaner splits rather than truncates");
     assert.match(wedge, /return cleaned \+ tail;/, "…and rejoins the part it could not send");
-    // THREE GATES, NOT A NUMBER (CTO review of #244). A 50% floor alone let a reply carrying 60%
-    // of the head through, deleting a correction and a question with it.
+    // AN ORDERED EDIT CONTRACT, NOT A PERCENTAGE. Two percentages were tried and beaten: a reply
+    // with 60% of the head, then one with 95.84% and the ending intact, each deleting a clause out
+    // of the middle. A share of the text cannot tell a spelling from a sentence.
     assert.match(wedge, /finishReason !== "stop"/, "a reply the model did not finish cannot become the transcript");
-    assert.match(wedge, /!coversTheEnd\(head, cleaned\)/, "nor can one that stops before the end of the head");
-    assert.match(wedge, /cleaned\.length < head\.length \* 0\.8/, "nor one that lost a fifth of it");
-    assert.match(wedge, /!retainsOriginal\(head, cleaned\)/, "the faithfulness check compares the head it actually cleaned");
+    assert.match(wedge, /!onlyApprovedRepairs\(head, cleaned\)/, "nor can one that is not a token-for-token repair");
+    assert.match(wedge, /before\.length !== after\.length/, "a deleted or invented clause changes the token count");
+    assert.match(wedge, /PROTECTED_TOKENS/, "numbers, days and negations may not be substituted at all");
+    assert.ok(!/coversTheEnd|cleaned\.length < head\.length/.test(wedge),
+      "the superseded length gates are gone, not left unable to fail");
+    assert.ok(!/retainsOriginal/.test(wedge),
+      "the permissive set-overlap check is gone — a set has no order, and a deleted clause passed it");
   });
   test("CFO: the weekly report surfaces AI cost by feature and guards the R199 margin", () => {
     const biz = readFileSync(join("server", "scheduler", "jobs", "business.ts"), "utf-8");

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -986,6 +986,18 @@ test("week context: a real beginner (few sessions) still gets the ease-in", () =
       "the superseded length gates are gone, not left unable to fail");
     assert.ok(!/retainsOriginal/.test(wedge),
       "the permissive set-overlap check is gone — a set has no order, and a deleted clause passed it");
+    // VETTED PAIRS, NOT A VOCABULARY. "Is the new word an SA word within three edits?" approved
+    // "pain" -> "pap" and "sad" -> "pap": a client's clinical and mood content replaced by food.
+    assert.match(wedge, /VETTED_REPAIRS\.get\(from\) === to/,
+      "a substitution is allowed only as an explicitly vetted FROM->TO pair");
+    assert.ok(!/editDistance|SA_REPAIR_WORDS/.test(wedge),
+      "the distance metric and the target vocabulary are gone, not merely unused");
+    // PUNCTUATION IS NOT GLOBALLY FREE. The old tokenizer ate the sign and the decimal point, so
+    // "-5" compared equal to "5" and "8.5" to "85"; it also discarded non-ASCII words entirely.
+    assert.match(wedge, /\[\+−–—-\]\?\\d\+/, "a quantity carries its leading sign into the comparison");
+    assert.match(wedge, /\\p\{L\}/, "non-ASCII lexical content is compared, not silently discarded");
+    assert.ok(!/\[a-z0-9'\]\+/.test(wedge),
+      "the ASCII-only tokenizer is gone, not left beside the one that replaced it");
   });
   test("CFO: the weekly report surfaces AI cost by feature and guards the R199 margin", () => {
     const biz = readFileSync(join("server", "scheduler", "jobs", "business.ts"), "utf-8");

--- a/script/voice-provenance-tests.ts
+++ b/script/voice-provenance-tests.ts
@@ -202,6 +202,91 @@ console.log("\n3b. A REPLY THAT DELETES PART OF THE HEAD IS REFUSED, FINISHED OR
       `…and so does the question (finish_reason="${finish}")`);
   }
 
+  // ── THE EDIT CONTRACT ───────────────────────────────────────────────────────────────────
+  // THE LENGTH FLOOR AND THE ENDING CHECK ARE GONE, and the fixtures that isolated them with them:
+  // the ordered token contract subsumes both, so neither could fail on its own any more and a case
+  // that cannot fail is a case that grades nothing.
+  //
+  // THIS IS THE CASE THAT BROKE THE PREVIOUS HEAD, reproduced exactly as it was reported: a reply
+  // that is the head with ONE CLAUSE REMOVED FROM THE MIDDLE. 95.84% of the head, ending intact,
+  // finish_reason "stop" — a length floor, an ending check and a 40% word-overlap test all accept
+  // it, and the client's correction and question are gone.
+  {
+    const { splitForClean } = await import("../server/understanding/sa-transcript");
+    const correction = "Actually I missed my Tuesday workout. What should I do today?";
+    const rawNote =
+      "I went to work and took the taxi like every other day. ".repeat(18)
+      + correction + " "
+      + "I came home and made tea and told you about my day. ".repeat(12)
+      + " FINAL7788.";
+    const { head: h, tail: t } = splitForClean(rawNote);
+    chk(h.includes(correction), "the correction really is inside the cleaner's head",
+      `raw ${rawNote.length} head ${h.length}`);
+    chk(t.length > 0, "…and there is still a tail beyond it", `tail ${t.length}`);
+
+    const middleDeleted = h.replace(correction, "");
+    chk(middleDeleted.length / h.length > 0.9,
+      "the reply keeps over 90% of the head — a length floor cannot see this",
+      `${(100 * middleDeleted.length / h.length).toFixed(2)}%`);
+
+    const out = await cleanSATranscript(stubOpenAI(middleDeleted, "stop"), rawNote, null);
+    chk(out === rawNote, "a clause deleted from the MIDDLE keeps the WHOLE raw transcript",
+      `in ${rawNote.length} out ${out.length}`);
+    chk(/Actually I missed my Tuesday workout/.test(out), "…so the correction survives");
+    chk(/What should I do today\?/.test(out), "…and so does the question");
+    chk(/FINAL7788/.test(out), "…and the tail is still there");
+  }
+
+  // A NEGATION FLIPPED, AND A QUANTITY CHANGED. Neither alters the token COUNT, so only the
+  // protected-token rule stands between the client and a record that says the opposite of what
+  // they said. "missed" -> "finished" and 8500 -> 8000 are the two that cost them their history.
+  {
+    const spine = "On Tuesday I missed my session and I walked 8500 steps to the office. ";
+    const note = "I want to tell you about my week and what happened on each day of it. ".repeat(14)
+      + spine + "That is everything for now.";
+    const flipped = note.replace("I missed my session", "I finished my session");
+    const outFlip = await cleanSATranscript(stubOpenAI(flipped, "stop"), note, null);
+    chk(outFlip === note, "a negation turned into its opposite keeps the raw transcript",
+      `out ${outFlip.length}`);
+    chk(/I missed my session/.test(outFlip), "…so the client still missed the session they missed");
+
+    const renumbered = note.replace("8500", "8000");
+    const outNum = await cleanSATranscript(stubOpenAI(renumbered, "stop"), note, null);
+    chk(outNum === note, "a spoken quantity rewritten keeps the raw transcript", `out ${outNum.length}`);
+    chk(/8500 steps/.test(outNum), "…so 8,500 is still 8,500");
+
+    const reday = note.replace("On Tuesday", "On Thursday");
+    const outDay = await cleanSATranscript(stubOpenAI(reday, "stop"), note, null);
+    chk(outDay === note, "a named day rewritten keeps the raw transcript", `out ${outDay.length}`);
+  }
+
+  // AN INSERTION IS AS BAD AS A DELETION — words the client never said, in their own record.
+  {
+    const note = "I had pap and chicken and I walked to work this morning like always. ".repeat(24);
+    const padded = note + " I also went to the gym twice this week.";
+    const out = await cleanSATranscript(stubOpenAI(padded, "stop"), note, null);
+    chk(out === note, "an invented sentence keeps the raw transcript", `out ${out.length}`);
+    chk(!/went to the gym twice/.test(out), "…so nothing they did not say is in the record");
+  }
+
+  // AND THE REPAIRS THE CLEANER EXISTS FOR STILL LAND. Without these the contract is satisfied by
+  // a cleaner that refuses everything, which deletes the whole point of the stage.
+  {
+    const rawSamp = "Yoh I had stamp and beans and chicken for lunch today neh and it was lekker";
+    const fixed = rawSamp.replace("stamp", "samp");
+    const cleanedSamp = await cleanSATranscript(stubOpenAI(fixed, "stop"), rawSamp, null);
+    chk(cleanedSamp === fixed, "stamp -> samp is accepted, as it must be", JSON.stringify(cleanedSamp));
+
+    const punctOnly = "yoh i had samp and beans for lunch today";
+    const repunctuated = "Yoh, I had samp and beans for lunch today.";
+    const outPunct = await cleanSATranscript(stubOpenAI(repunctuated, "stop"), punctOnly, null);
+    chk(outPunct === repunctuated, "case, spacing and punctuation are free", JSON.stringify(outPunct));
+
+    const already = "I had samp and beans and chicken for lunch today and it was lekker neh";
+    const outSame = await cleanSATranscript(stubOpenAI(already, "stop"), already, null);
+    chk(outSame === already, "an unchanged transcript passes through untouched");
+  }
+
   // A COMPLETE reply that reaches the end of the head is still accepted — without this the section
   // is satisfied by a cleaner that refuses everything, which is the opposite defect.
   //
@@ -214,46 +299,16 @@ console.log("\n3b. A REPLY THAT DELETES PART OF THE HEAD IS REFUSED, FINISHED OR
   chk(good === note, "a complete, faithful clean of the head is accepted and rejoined",
     `in ${note.length} out ${good.length}`);
 
-  // AND THE SPELLING REPAIR THE CLEANER EXISTS FOR STILL HAPPENS. The whole point is samp, not
-  // stamp — a guard that made the cleaner inert would pass every check above.
-  const rawSamp = "Yoh I had stamp and beans and chicken for lunch today neh and it was lekker";
-  const fixed = rawSamp.replace("stamp", "samp");
-  const cleanedSamp = await cleanSATranscript(stubOpenAI(fixed, "stop"), rawSamp, null);
-  chk(cleanedSamp === fixed, "the SA-food repair still lands — samp, not stamp", JSON.stringify(cleanedSamp));
-
-  // ── EACH GATE ON ITS OWN ────────────────────────────────────────────────────────────────
-  // Three checks guard completeness and they must be individually graded, or two of them can be
-  // deleted while the section stays green on the strength of the third.
-  const truncatedStop = await cleanSATranscript(stubOpenAI(head.slice(0, Math.floor(head.length * 0.9)), "stop"), note, null);
-  chk(truncatedStop === note,
-    "COVERS-THE-END alone: a 90% prefix is refused though it clears the length floor",
-    `out ${truncatedStop.length}`);
-
-  // Keeps the head's ending, so coversTheEnd is satisfied — only the floor can catch it.
-  const endWords = properClean.trim().split(/\s+/).slice(-8).join(" ");
-  const hollowed = properClean.slice(0, Math.floor(properClean.length * 0.5)) + " " + endWords;
-  const hollowedOut = await cleanSATranscript(stubOpenAI(hollowed, "stop"), note, null);
-  chk(hollowedOut === note,
-    "THE FLOOR alone: a reply that keeps the ending but loses half the middle is refused",
-    `out ${hollowedOut.length}`);
-
-  // A complete, faithful clean that the model did not finish — only finish_reason can catch it.
-  //
-  // THE REPLY CARRIES A VISIBLE REPAIR (stamp -> samp), and it has to. An unfinished reply whose
-  // text is identical to the head produces the same string whether it is accepted or refused, so
-  // the check passed with the gate deleted — it could not tell the two outcomes apart. The edit is
-  // what makes acceptance observable.
+  // FINISH_REASON IS STILL ITS OWN GATE — an otherwise perfect repair the model did not finish.
+  // The reply carries a visible repair so acceptance and refusal are distinguishable; identical
+  // text would produce the same string either way and the check would pass with the gate deleted.
   const repaired = properClean.replace("stamp", "samp");
   chk(repaired !== properClean, "the finish_reason fixture carries a visible repair");
   const unfinished = await cleanSATranscript(stubOpenAI(repaired, "length"), note, null);
   chk(unfinished === note && /stamp and beans/.test(unfinished) && !/samp and beans/.test(unfinished),
     "FINISH_REASON alone: a reply that looks complete but reports length is refused",
     `out ${unfinished.length}`);
-  // …and the same reply, finished, IS taken — otherwise the gate is just an off switch.
   const finished = await cleanSATranscript(stubOpenAI(repaired, "stop"), note, null);
-  // NOT AN EQUAL-LENGTH CHECK: "stamp" -> "samp" is one character shorter, so demanding the same
-  // length fails on a correct repair. What must hold is that the repair landed AND the tail the
-  // model never saw is still attached to the end of it.
   chk(/samp and beans/.test(finished) && finished.endsWith(splitAgain(note).tail),
     "…while the identical reply with finish_reason=stop is accepted, repair and tail both",
     `out ${finished.length} of ${note.length}`);

--- a/script/voice-provenance-tests.ts
+++ b/script/voice-provenance-tests.ts
@@ -33,9 +33,9 @@ const chk = (ok: boolean, msg: string, evidence = "") => {
 };
 
 /** A stub OpenAI client that returns whatever the test tells it to. No network. */
-const stubOpenAI = (reply: string) => ({
+const stubOpenAI = (reply: string, finish: string = "stop") => ({
   chat: { completions: { create: async () => ({
-    choices: [{ message: { content: reply } }],
+    choices: [{ message: { content: reply }, finish_reason: finish }],
     usage: { prompt_tokens: 1, completion_tokens: 1 },
   }) } },
 } as any);
@@ -84,7 +84,7 @@ console.log("\n2. THE CLEANER'S WINDOW NO LONGER DELETES WHAT IT COULD NOT SEE (
   const echo = () => ({
     chat: { completions: { create: async (req: any) => {
       handed = req.messages[req.messages.length - 1].content;
-      return { choices: [{ message: { content: handed } }], usage: { prompt_tokens: 1, completion_tokens: 1 } };
+      return { choices: [{ message: { content: handed }, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1 } };
     } } },
   } as any);
 
@@ -152,6 +152,111 @@ console.log("\n3. THE CLEANER STILL FAILS CLOSED ON A BAD REWRITE — NOW INCLUD
   const whole = await cleanSATranscript(stubOpenAI("I'm sorry, I can't help with that."), multiAsk, null);
   chk(whole === multiAsk, "a note asking more than one thing reaches the handlers whole",
     `${whole.length} vs ${multiAsk.length}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("\n3b. A REPLY THAT DELETES PART OF THE HEAD IS REFUSED, FINISHED OR NOT");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// THE HOLE THIS CLOSES, demonstrated against the first version of this cut: a model reply carrying
+// 60% of the head passed the 50% floor and the word-overlap check, and 588 characters vanished —
+// a workout correction and a question among them. Preserving the tail is no defence when the model
+// can delete the end of the HEAD.
+//
+// THE CORRECTION AND THE QUESTION LIVE INSIDE THE HEAD HERE, on purpose. A fixture that put them
+// in the preserved tail would grade the rejoin, which already works, and would have passed while
+// the defect was live.
+{
+  const HEAD_FACTS = "I must correct something, I said I trained on Tuesday but I missed it. "
+    + "I had stamp and beans for lunch. "
+    + "And what should I eat when I get home late after eight at night? ";
+  const filler = "The taxi was late again this morning and the queue went around the corner. ";
+  const head = filler.repeat(17) + HEAD_FACTS;          // both facts at the END of the head
+  // TRIMMED AT CONSTRUCTION: cleanSATranscript trims its input before splitting, so a fixture
+  // ending in whitespace can never round-trip byte-for-byte and the positive control below fails
+  // by one character for a reason that has nothing to do with the guard it is checking.
+  const note = (head + filler.repeat(4)).trim();        // and a tail beyond the window
+  chk(note.length > 1500, `the fixture is longer than the window (${note.length} chars)`);
+  // PROVEN, NOT ASSUMED: the correction and the question are inside the part that is SENT to the
+  // model. If they had drifted into the preserved tail this section would grade the rejoin, which
+  // already worked, and would have been green while the defect was live.
+  {
+    const { splitForClean } = await import("../server/understanding/sa-transcript");
+    const split = splitForClean(note);
+    chk(/i said i trained on tuesday/i.test(split.head) && /what should i eat/i.test(split.head),
+      "both facts are inside the cleaner's head, not the preserved tail",
+      `head ${split.head.length} tail ${split.tail.length}`);
+    chk(split.tail.length > 0, "…and there is still a real tail", `tail ${split.tail.length}`);
+  }
+
+  const sixtyPercent = head.slice(0, Math.floor(head.length * 0.6));
+  chk(!/i said i trained on tuesday/i.test(sixtyPercent) && !/what should i eat/i.test(sixtyPercent),
+    "the 60% reply really does drop the correction and the question", `${sixtyPercent.length} chars`);
+
+  for (const finish of ["length", "stop"]) {
+    const out = await cleanSATranscript(stubOpenAI(sixtyPercent, finish), note, null);
+    chk(out === note, `a 60%-length reply with finish_reason="${finish}" keeps the RAW transcript`,
+      `in ${note.length} out ${out.length}`);
+    chk(/i said i trained on tuesday but i missed it/i.test(out),
+      `…so the workout correction survives (finish_reason="${finish}")`);
+    chk(/what should i eat when i get home late/i.test(out),
+      `…and so does the question (finish_reason="${finish}")`);
+  }
+
+  // A COMPLETE reply that reaches the end of the head is still accepted — without this the section
+  // is satisfied by a cleaner that refuses everything, which is the opposite defect.
+  //
+  // THE REPLY IS THE HEAD THE SPLITTER ACTUALLY SENDS, not my own guess at it: the split lands on
+  // a sentence boundary, so echoing `head` verbatim came back one character short and failed this
+  // check for a reason that had nothing to do with the guard.
+  const { splitForClean: splitAgain } = await import("../server/understanding/sa-transcript");
+  const properClean = splitAgain(note).head;
+  const good = await cleanSATranscript(stubOpenAI(properClean, "stop"), note, null);
+  chk(good === note, "a complete, faithful clean of the head is accepted and rejoined",
+    `in ${note.length} out ${good.length}`);
+
+  // AND THE SPELLING REPAIR THE CLEANER EXISTS FOR STILL HAPPENS. The whole point is samp, not
+  // stamp — a guard that made the cleaner inert would pass every check above.
+  const rawSamp = "Yoh I had stamp and beans and chicken for lunch today neh and it was lekker";
+  const fixed = rawSamp.replace("stamp", "samp");
+  const cleanedSamp = await cleanSATranscript(stubOpenAI(fixed, "stop"), rawSamp, null);
+  chk(cleanedSamp === fixed, "the SA-food repair still lands — samp, not stamp", JSON.stringify(cleanedSamp));
+
+  // ── EACH GATE ON ITS OWN ────────────────────────────────────────────────────────────────
+  // Three checks guard completeness and they must be individually graded, or two of them can be
+  // deleted while the section stays green on the strength of the third.
+  const truncatedStop = await cleanSATranscript(stubOpenAI(head.slice(0, Math.floor(head.length * 0.9)), "stop"), note, null);
+  chk(truncatedStop === note,
+    "COVERS-THE-END alone: a 90% prefix is refused though it clears the length floor",
+    `out ${truncatedStop.length}`);
+
+  // Keeps the head's ending, so coversTheEnd is satisfied — only the floor can catch it.
+  const endWords = properClean.trim().split(/\s+/).slice(-8).join(" ");
+  const hollowed = properClean.slice(0, Math.floor(properClean.length * 0.5)) + " " + endWords;
+  const hollowedOut = await cleanSATranscript(stubOpenAI(hollowed, "stop"), note, null);
+  chk(hollowedOut === note,
+    "THE FLOOR alone: a reply that keeps the ending but loses half the middle is refused",
+    `out ${hollowedOut.length}`);
+
+  // A complete, faithful clean that the model did not finish — only finish_reason can catch it.
+  //
+  // THE REPLY CARRIES A VISIBLE REPAIR (stamp -> samp), and it has to. An unfinished reply whose
+  // text is identical to the head produces the same string whether it is accepted or refused, so
+  // the check passed with the gate deleted — it could not tell the two outcomes apart. The edit is
+  // what makes acceptance observable.
+  const repaired = properClean.replace("stamp", "samp");
+  chk(repaired !== properClean, "the finish_reason fixture carries a visible repair");
+  const unfinished = await cleanSATranscript(stubOpenAI(repaired, "length"), note, null);
+  chk(unfinished === note && /stamp and beans/.test(unfinished) && !/samp and beans/.test(unfinished),
+    "FINISH_REASON alone: a reply that looks complete but reports length is refused",
+    `out ${unfinished.length}`);
+  // …and the same reply, finished, IS taken — otherwise the gate is just an off switch.
+  const finished = await cleanSATranscript(stubOpenAI(repaired, "stop"), note, null);
+  // NOT AN EQUAL-LENGTH CHECK: "stamp" -> "samp" is one character shorter, so demanding the same
+  // length fails on a correct repair. What must hold is that the repair landed AND the tail the
+  // model never saw is still attached to the end of it.
+  chk(/samp and beans/.test(finished) && finished.endsWith(splitAgain(note).tail),
+    "…while the identical reply with finish_reason=stop is accepted, repair and tail both",
+    `out ${finished.length} of ${note.length}`);
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════

--- a/script/voice-provenance-tests.ts
+++ b/script/voice-provenance-tests.ts
@@ -3,17 +3,16 @@
  *
  * A voice note becomes three different strings before any handler sees it:
  *
- *     Scribe/Whisper  →  cleanSATranscript  →  condenseVoiceRamble (>150 words)  →  handlers
+ *     Scribe/Whisper  →  cleanSATranscript  →  handlers      (the condenser was removed in Cut 3)
  *
  * Until this cut only the last one was persisted, as `input_text` on the inner ledger row. So the
  * two questions you must be able to answer about a bad voice turn had no evidence behind them:
  * did we MIS-HEAR the client, or did we hear them correctly and then delete half of what they
  * said? Different defects, different owners, different fixes.
  *
- * These tests drive the two model stages FOR REAL — real cleanSATranscript, real
- * condenseVoiceRamble, real fail-open guards — against a stub OpenAI client, with OFFLINE_AI=0 so
- * the offline killswitch does not short-circuit the very code under test. Nothing here is
- * simulated except the network boundary itself.
+ * These tests drive the cleaner FOR REAL — real cleanSATranscript, real split, real fail-open
+ * guards — against a stub OpenAI client, with OFFLINE_AI=0 so the offline killswitch does not
+ * short-circuit the very code under test. Nothing here is simulated except the network boundary.
  *
  * The durable half (which columns, which row, what survives an early return) needs a database and
  * lives in script/pg-voice-provenance-acceptance.ts.
@@ -25,8 +24,7 @@ process.env.NODE_ENV = "production";
 
 import { readFileSync } from "node:fs";
 
-const { cleanSATranscript, condenseVoiceRamble } = await import("../server/understanding/sa-transcript");
-const { transcriptMustPassWhole } = await import("../server/utils");
+const { cleanSATranscript } = await import("../server/understanding/sa-transcript");
 
 let failed = 0;
 const chk = (ok: boolean, msg: string, evidence = "") => {
@@ -73,42 +71,87 @@ console.log("1. THE CLEANER FAILS OPEN, SO cleaned === raw IS A REAL EVENT AND N
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
-console.log("\n2. THE CONDENSER IS THE STAGE THAT CAN LOSE THE MOST, AND IT ALSO FAILS OPEN");
+console.log("\n2. THE CLEANER'S WINDOW NO LONGER DELETES WHAT IT COULD NOT SEE (Cut 3)");
 // ══════════════════════════════════════════════════════════════════════════════════════════════
+// THE DEFECT THIS REPLACES, measured on 017efd9: a 2,408-character note was handed to the model
+// 1,500 characters at a time and the answer came back AS the transcript — 908 characters deleted,
+// the workout correction and both questions among them. §2 used to grade the condenser here; the
+// condenser is gone (it could only exist by replacing the client's words), so this grades the
+// stage that is still allowed to rewrite them.
 {
-  // A LONG NOTE WITH NO FOOD, NO STEPS, NO FEELING AND NO STACKED QUESTION — deliberately, because
-  // that narrow case is the ONLY thing the condenser is still allowed to touch. Everything else is
-  // protected by transcriptMustPassWhole (§3), and a fixture that tripped that guard would be
-  // grading the guard rather than the condenser. Two earlier fixtures did exactly that.
-  const long = ("The taxi from Soweto was late again this morning so I got to the office much "
-    + "later than usual and my manager gave me a warning about it ").repeat(3);
-  chk(!transcriptMustPassWhole(long), "the fixture really does reach the condenser (else §2 grades nothing)");
+  // A stub that echoes what it was handed, so the output reveals the window rather than hiding it.
+  let handed = "";
+  const echo = () => ({
+    chat: { completions: { create: async (req: any) => {
+      handed = req.messages[req.messages.length - 1].content;
+      return { choices: [{ message: { content: handed } }], usage: { prompt_tokens: 1, completion_tokens: 1 } };
+    } } },
+  } as any);
 
-  const refused = await condenseVoiceRamble(stubOpenAI("I cannot assist with that request."), long, null);
-  chk(refused === long, "a refusal keeps the whole transcript", JSON.stringify(refused.slice(0, 50)));
+  const TAIL = "KNEECLICK7788";
+  const long = ("I want to tell you about my whole week because a lot has happened and I need you "
+    + "to have the full picture before you tell me what to do next about any of it. ").repeat(10)
+    + "One last thing before I forget: " + TAIL + ".";
+  chk(long.length > 1500, `the fixture is longer than the cleaner's window (${long.length} chars)`);
 
-  const condensed = await condenseVoiceRamble(stubOpenAI("My taxi was late so I got to work late."), long, null);
-  chk(condensed === "My taxi was late so I got to work late.",
-    "a real condense replaces it — and this is the text the handlers route on", JSON.stringify(condensed));
-  chk(condensed !== long, "…so forBrain and cleaned genuinely differ, which is what the flag records");
-
-  const short = "I had eggs.";
-  const untouched = await condenseVoiceRamble(stubOpenAI("SHOULD NOT BE USED"), short, null);
-  chk(untouched === short, "a short note is never condensed", JSON.stringify(untouched));
+  const out = await cleanSATranscript(echo(), long, null);
+  chk(handed.length <= 1500, "the model is still only sent one window", `handed ${handed.length}`);
+  chk(handed.length < long.length, "…so the window is real and this fixture exercises it");
+  chk(out.length === long.length, "nothing is deleted — what comes back is the whole note",
+    `in ${long.length} out ${out.length}`);
+  chk(out.includes(TAIL), "the last thing they said survives the cleaner");
+  chk(out === long, "and an echoing clean reproduces the note exactly, head and tail rejoined");
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
-console.log("\n3. transcriptMustPassWhole STILL PROTECTS A MULTI-PART NOTE FROM THE CONDENSER");
+console.log("\n2b. THE SPLIT NEVER CUTS A WORD, AND THE TAIL REJOINS EXACTLY");
 // ══════════════════════════════════════════════════════════════════════════════════════════════
-// Not changed by this cut. Asserted because the provenance columns are how anyone will now SEE a
-// condense that ate something, and a reader has to be able to trust that a whole-pass note shows
-// forBrain === cleaned for a reason rather than by accident.
 {
+  const { splitForClean } = await import("../server/understanding/sa-transcript");
+  const short = "I had eggs and pap.";
+  chk(splitForClean(short).head === short && splitForClean(short).tail === "",
+    "a note inside the window is all head and no tail");
+
+  const long = ("The taxi was late again this morning and I had to wait for the second one. ").repeat(40);
+  const { head, tail } = splitForClean(long);
+  chk(head + tail === long, "head + tail is byte-identical to the original");
+  chk(head.length <= 1500, `the head fits the window (${head.length})`);
+  chk(tail.length > 0, "and there is a real tail to carry");
+  chk(!/\S$/.test(head) || /^\s/.test(tail) || head.endsWith("."),
+    "the split lands on a boundary, not inside a word", JSON.stringify(head.slice(-12) + "|" + tail.slice(0, 12)));
+
+  const nospace = "x".repeat(3000);
+  const hard = splitForClean(nospace);
+  chk(hard.head.length + hard.tail.length === nospace.length,
+    "a note with no whitespace at all still loses nothing", `${hard.head.length}+${hard.tail.length}`);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+console.log("\n3. THE CLEANER STILL FAILS CLOSED ON A BAD REWRITE — NOW INCLUDING A SHORT ONE");
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// §3 used to assert that transcriptMustPassWhole kept a multi-part note away from the condenser.
+// That promise is no longer conditional on a guard: no note is condensed, because the condenser
+// does not exist. What still needs grading is the cleaner's own floor — and the lower bound is
+// NEW, because a reply cut off by max_tokens used to come back as the transcript, middle missing.
+{
+  const long = ("I want to tell you about my whole week because a lot has happened and I need you "
+    + "to have the full picture before you tell me what to do next about any of it. ").repeat(10);
+
+  const truncated = await cleanSATranscript(stubOpenAI("I want to tell you about my whole week"), long, null);
+  chk(truncated === long, "a reply cut short keeps the RAW transcript rather than becoming it",
+    `${truncated.length} vs ${long.length}`);
+
+  const refused = await cleanSATranscript(stubOpenAI("I'm sorry, I can't help with that."), long, null);
+  chk(refused === long, "a refusal on a long note keeps the whole note too");
+
+  // A MULTI-PART NOTE, the shape transcriptMustPassWhole was written for. That predicate is gone
+  // (nothing shortens a transcript, so it could only ever answer "no"); the promise it carried is
+  // now the cleaner's arithmetic, which holds for this note and for the ones it never matched.
   const multiAsk = "What should I eat today? And also how many steps should I be doing? "
-    + "And can you tell me what my weight is doing? ".repeat(8);
-  chk(transcriptMustPassWhole(multiAsk), "a note asking more than one thing must pass whole");
-  const passed = await condenseVoiceRamble(stubOpenAI("SHOULD NOT BE USED"), multiAsk, null);
-  chk(passed === multiAsk, "…and the condenser declines it, leaving forBrain === cleaned");
+    + "And can you tell me what my weight is doing? ".repeat(30);
+  const whole = await cleanSATranscript(stubOpenAI("I'm sorry, I can't help with that."), multiAsk, null);
+  chk(whole === multiAsk, "a note asking more than one thing reaches the handlers whole",
+    `${whole.length} vs ${multiAsk.length}`);
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════
@@ -129,14 +172,19 @@ console.log("\n4. THE RAW TRANSCRIPT IS CAPTURED BEFORE THE CLEANER CAN OVERWRIT
   const cleanAt = src.indexOf("transcribedText = await cleanSATranscript(");
   const cleanedAt = src.indexOf("turnVoice({ cleaned: transcribedText })");
   const forBrainAt = src.indexOf("turnVoice({ forBrain,");
-  const condenseAt = src.indexOf("await condenseVoiceRamble(");
 
   chk(rawAt > 0, "media.ts records the raw transcript");
   chk(cleanAt > 0 && rawAt < cleanAt,
     "…BEFORE cleanSATranscript reassigns transcribedText", `raw@${rawAt} clean@${cleanAt}`);
   chk(cleanedAt > cleanAt, "the cleaned text is recorded after the cleaner ran", `cleaned@${cleanedAt}`);
-  chk(forBrainAt > condenseAt && condenseAt > 0,
-    "the for-brain text is recorded after the condenser", `forBrain@${forBrainAt} condense@${condenseAt}`);
+  chk(forBrainAt > cleanedAt, "the for-brain text is recorded after the cleaned text",
+    `forBrain@${forBrainAt} cleaned@${cleanedAt}`);
+  // AND THE ROUTED TEXT IS THE CLEANED TRANSCRIPT ITSELF (Cut 3). The condenser used to sit here
+  // and hand the handlers a shorter retelling; an assertion that it is gone is the only thing
+  // that stops it being reintroduced as a "small" optimisation on a long note.
+  chk(!/condenseVoiceRamble/.test(src), "media.ts no longer condenses anything before the handlers");
+  chk(/const forBrain = transcribedText;/.test(src),
+    "the handlers are routed the cleaned transcript, whole");
   // The recursion is what hands the text to the handlers. Recording must happen before it, or a
   // handler's own turn scope is the one in flight and the three texts land on the wrong row.
   const recurseAt = src.indexOf("handleMessage(phone, brainInput");

--- a/script/voice-provenance-tests.ts
+++ b/script/voice-provenance-tests.ts
@@ -269,6 +269,100 @@ console.log("\n3b. A REPLY THAT DELETES PART OF THE HEAD IS REFUSED, FINISHED OR
     chk(!/went to the gym twice/.test(out), "…so nothing they did not say is in the record");
   }
 
+  // ── THE TWO HOLES THE REVIEWER REPRODUCED IN THE EDIT CONTRACT ITSELF ───────────────────────
+  // Both passed the ordered token contract as first written. Each is executed here exactly as it
+  // was reported, through the real cleaner, and each must keep the client's raw words.
+  //
+  // (a) A NEAR-NEIGHBOUR OF A FOOD WORD IS NOT A SPELLING REPAIR. Membership-plus-edit-distance
+  //     approved any word within three edits of any listed SA word, so a client reporting pain or
+  //     low mood had it replaced with a food word and nothing downstream could tell.
+  {
+    const filler = "and then I took the taxi to work like every other morning of this week. ";
+    for (const [said, invented, what] of [
+      ["I have pain in my knee since Saturday. ", "I have pap in my knee since Saturday. ", "pain"],
+      ["I am sad about how this month went. ", "I am pap about how this month went. ", "low mood"],
+      ["I ate porridge before I left the house. ", "I ate pap before I left the house. ", "an unvetted food swap"],
+    ]) {
+      const note = (said + filler.repeat(12)).trim();
+      const reply = (invented + filler.repeat(12)).trim();
+      chk(reply !== note, `the ${what} fixture really does differ from what was said`);
+      const out = await cleanSATranscript(stubOpenAI(reply, "stop"), note, null);
+      chk(out === note, `${what}: an unvetted substitution keeps the RAW transcript`,
+        `out ${out.length} of ${note.length}`);
+      chk(out.startsWith(said.trim().slice(0, 20)),
+        `…so the client's own words open the record, not the model's guess`,
+        JSON.stringify(out.slice(0, 40)));
+    }
+  }
+
+  // (b) THE SIGN AND THE DECIMAL POINT CARRY MEANING. The first tokenizer stripped both, so "-5"
+  //     and "5" compared equal — five kilograms lost read back as five kilograms gained — and
+  //     "8.5" was indistinguishable from "85" and from "8,500".
+  {
+    const filler = "and I am telling you everything that happened so you have the full picture. ";
+    for (const [said, rewritten, what] of [
+      ["My change was -5 kg this month. ", "My change was 5 kg this month. ", "a stripped minus sign"],
+      ["My change was −5 kg this month. ", "My change was 5 kg this month. ", "a stripped unicode minus"],
+      ["I am 8.5 kg down since January. ", "I am 85 kg down since January. ", "a lost decimal point"],
+      ["I am 8.5 kg down since January. ", "I am 8,500 kg down since January. ", "a regrouped quantity"],
+    ]) {
+      const note = (said + filler.repeat(12)).trim();
+      const reply = (rewritten + filler.repeat(12)).trim();
+      const out = await cleanSATranscript(stubOpenAI(reply, "stop"), note, null);
+      chk(out === note, `${what}: the quantity is protected and the RAW transcript is kept`,
+        `out ${JSON.stringify(out.slice(0, 34))}`);
+    }
+    // AND THE SAME NUMBER UNCHANGED IS STILL ACCEPTED — without this the four checks above are
+    // satisfied by a tokenizer that refuses every note containing a decimal.
+    const kept = ("I am 8.5 kg down since January. " + filler.repeat(12)).trim();
+    const repunct = kept.replace("I am 8.5 kg down since January.", "I am 8.5 kg down since January!");
+    const outKept = await cleanSATranscript(stubOpenAI(repunct, "stop"), kept, null);
+    chk(outKept === repunct, "a decimal left alone still lets a punctuation repair through",
+      JSON.stringify(outKept.slice(0, 40)));
+  }
+
+  // (c) NON-ASCII LEXICAL CONTENT IS NOT SILENTLY DISCARDED. The first tokenizer was ASCII-only,
+  //     so a token made of non-Latin letters produced NO tokens at all: it contributed nothing to
+  //     either side of the comparison, and a reply that added or removed one had an identical
+  //     token count and was accepted. Multilingual STT does emit non-Latin script on unclear
+  //     audio, and whatever it emits is the client's record until a person says otherwise.
+  //
+  //     THIS IS A PROPERTY FIXTURE, not a typical note — it is built to isolate the blind spot,
+  //     and the superseded tokenizer is reproduced below to prove the fixture is not vacuous.
+  {
+    const filler = "and after that I went to work and the day was long and hot. ";
+    // The ONLY difference between these two is the non-ASCII token. Removing a neighbouring
+    // ASCII word along with it would make the deletion visible for the wrong reason.
+    const spoken = "I made umngqusho and здоровье beans for the family. ";
+    const dropped = "I made umngqusho and beans for the family. ";
+    const note = (spoken + filler.repeat(12)).trim();
+    const reply = (dropped + filler.repeat(12)).trim();
+
+    // THE SUPERSEDED TOKENIZER, verbatim, purely as evidence that this deletion WAS invisible.
+    // It is a local control: nothing under test reads it.
+    const asciiOnly = (s: string) => (s.toLowerCase().match(/[a-z0-9']+/g) || []).map(t => t.replace(/'/g, ""));
+    chk(JSON.stringify(asciiOnly(note)) === JSON.stringify(asciiOnly(reply)),
+      "CONTROL: under the ASCII-only tokenizer the deleted word leaves NO trace at all",
+      `${asciiOnly(note).length} vs ${asciiOnly(reply).length} tokens`);
+
+    const out = await cleanSATranscript(stubOpenAI(reply, "stop"), note, null);
+    chk(out === note, "a deleted non-ASCII word keeps the RAW transcript", `out ${out.length}`);
+    chk(/здоровье/.test(out), "…so the word the client actually spoke is still in their record");
+
+    // AND THE INSERTION DIRECTION, which is the same blind spot pointed the other way: a word the
+    // client never said, appearing in their own record for free.
+    const outIns = await cleanSATranscript(stubOpenAI(note, "stop"), reply, null);
+    chk(outIns === reply, "an invented non-ASCII word keeps the RAW transcript", `out ${outIns.length}`);
+    chk(!/здоровье/.test(outIns), "…so nothing they did not say was added");
+
+    // …AND A NON-ASCII NOTE THAT IS NOT CHANGED STILL PASSES. A tokenizer that simply refused
+    // everything containing non-ASCII text would satisfy the checks above and break the stage.
+    const okReply = note.replace("I made umngqusho", "I made umngqusho,");
+    const outOk = await cleanSATranscript(stubOpenAI(okReply, "stop"), note, null);
+    chk(outOk === okReply, "an untouched non-ASCII note still accepts a punctuation repair",
+      JSON.stringify(outOk.slice(0, 40)));
+  }
+
   // AND THE REPAIRS THE CLEANER EXISTS FOR STILL LAND. Without these the contract is satisfied by
   // a cleaner that refuses everything, which deletes the whole point of the stage.
   {

--- a/server/handlers/chat-log.ts
+++ b/server/handlers/chat-log.ts
@@ -564,6 +564,29 @@ async function reconcileTurnReply(scope: TurnScope, reply: string): Promise<stri
 }
 
 /**
+ * THE LEDGER'S RECORD OF WHAT THE CLIENT SAID MAY NOT CUT IT SILENTLY (Cut 3, 2026-09-12).
+ *
+ * Both recording sites trimmed the client's words to two thousand characters. A three-minute
+ * voice note is about 2,400, so the durable record of an ordinary long note lost its last four
+ * hundred — the same defect as the cleaner's window, one layer out, and in the one place built to
+ * answer "what did the client actually say?". Measured on 017efd9: a 2,408-character note was
+ * recorded as 2,000, with both of the client's questions and their final words missing.
+ *
+ * Found by this cut's own acceptance, not by reading the code: the cleaner was fixed, the tail
+ * reached the handlers, and the ledger still showed 2,000 characters.
+ *
+ * A ceiling still exists, because an unbounded row is a different kind of problem, but it is now
+ * far beyond any real note (roughly twenty minutes of speech) and a cut SAYS SO inside the stored
+ * value rather than trimming the end and leaving it looking complete.
+ */
+const LEDGER_TEXT_MAX = 32_000;
+function ledgerText(text: string): string {
+  const t = text || "";
+  if (t.length <= LEDGER_TEXT_MAX) return t;
+  return t.slice(0, LEDGER_TEXT_MAX) + `\n[TRUNCATED — ${t.length - LEDGER_TEXT_MAX} further characters not recorded]`;
+}
+
+/**
  * THE ROOT ID IS INHERITED, NEVER RE-MINTED (Cut 1).
  *
  * A handler may re-enter handleMessage — handlers/media.ts:1423 does it for every voice note,
@@ -577,7 +600,7 @@ export async function inTurn<T>(inputType: string, inputText: string, fn: () => 
   let resolveFinalReply!: (reply: string) => void;
   const finalReplyPromise = new Promise<string>(resolve => { resolveFinalReply = resolve; });
   const rootId = turnStore.getStore()?.rootId || seed || `turn-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
-  return turnStore.run({ userId: null, inputType, inputText: (inputText || "").slice(0, 2000), rootId, canonicalInput: null, resolvedDay: null, stateRead: {}, mutations: [], startedAt: Date.now(), finalReplyPromise }, async () => {
+  return turnStore.run({ userId: null, inputType, inputText: ledgerText(inputText), rootId, canonicalInput: null, resolvedDay: null, stateRead: {}, mutations: [], startedAt: Date.now(), finalReplyPromise }, async () => {
     try {
       const result = await fn();
       if (typeof result !== "string") {
@@ -739,7 +762,7 @@ export function _resetInteractionCorrelation(): void { _interactionRows.clear();
  */
 export function turnCanonicalInput(text: string): void {
   const t = turnStore.getStore();
-  if (t) t.canonicalInput = (text || "").slice(0, 2000);
+  if (t) t.canonicalInput = ledgerText(text);
 }
 
 /**
@@ -751,7 +774,9 @@ export function turnCanonicalInput(text: string): void {
  * labelled as the client's.
  *
  * MERGES, and is called three times as the voice path produces each stage — after transcription,
- * after cleanSATranscript, after condenseVoiceRamble. Incremental on purpose: the voice handler
+ * after cleanSATranscript, and where the routed text is composed. (The third stage used to be
+ * condenseVoiceRamble; Cut 3 removed it, and forBrain is now the cleaned transcript itself, so
+ * forBrain === cleaned on every turn rather than on most of them.) Incremental on purpose: the voice handler
  * returns early on a garbled note, a single word and a model refusal, and those are precisely the
  * turns where "what did we actually hear?" is the question. Recording only at the end would leave
  * every failed voice turn blank, which is the current state and the reason this exists.

--- a/server/handlers/media.ts
+++ b/server/handlers/media.ts
@@ -20,7 +20,7 @@ import {
   logMediaFailure, logMediaSuccess, logChat,
 } from "./chat-log";
 import { askCoachK } from "../gpt";
-import { cleanSATranscript, condenseVoiceRamble } from "../understanding/sa-transcript";
+import { cleanSATranscript } from "../understanding/sa-transcript";
 import { looksLikeRefusal } from "../understanding/refusal";
 import { getStepResponse, getStepStreak } from "./steps";
 import { checkPerfectDay, checkFoodPatterns } from "./checks";
@@ -36,7 +36,7 @@ import { buildFormCheckPrompt, extractFormExercise } from "../form-check-prompt"
 // photo saves immediately, timer resets, one job processes the whole set 15s after the last.
 const _progressBurst = new Map<string, ReturnType<typeof setTimeout>>();
 import { getTodayWorkoutState } from "../workout-state";
-import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, stripFoodLoggedClaim, isAskingNotReporting , getDisplayName, transcriptMustPassWhole } from "../utils";
+import { sastDayStart, parseMealDate, isRetroactiveMeal, mealDateLabel, stripFoodLoggedClaim, isAskingNotReporting , getDisplayName } from "../utils";
 import { stripVoiceDenial } from "../reply-hygiene";
 import { detectVoiceLanguageNote } from "../voice-language";
 import { explicitMealSlot } from "../understanding/actions";
@@ -1407,15 +1407,13 @@ ${goal === "fat_loss" ? "Fat loss: protein and veg first. Remove sugary drinks, 
       const transcribeMs = Date.now() - voiceStageStart;
       console.log(`[MEDIA][${mediaTrace}] transcribe_ok words=${wordCount} ms=${transcribeMs} lang=${whisperLang || "auto"}${languageNote ? " detected=" + languageNote.split(" ")[4] : ""}`);
 
-      // SUMMARISER WEDGE: a long ramble (>90 words) → its actionable core before the brain (comprehension + R199 margin). Short notes untouched; echo still shows the original. Fail-open.
-      // 150, not 90 (2026-08-06): at 90 an ordinary "here is my day" note was summarised
-      // before the coach saw it — hence "read the rest of my transcript". See
-      // transcriptMustPassWhole, which refuses to condense anything asking more than one thing.
-      // Messy-life notes (food+steps+feeling, yesterday meals, branded short meals) must
-      // reach food-context / compound handlers WHOLE. Condensing first was deleting the meal.
-      const forBrain = (wordCount > 150 && !transcriptMustPassWhole(transcribedText))
-        ? await condenseVoiceRamble(openai, transcribedText, user.id)
-        : transcribedText; const brainInput = forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""); turnVoice({ forBrain, handlerInput: brainInput, languageNote: languageNote || null });
+      // THE SUMMARISER WEDGE IS GONE (Cut 3, 2026-09-12). A long note was replaced by a model's
+      // shorter retelling of it before any handler ran — the condensation WAS the client's words,
+      // because there is only one routed string and a second one would be a second authority.
+      // transcriptMustPassWhole held the line for most notes and could not hold it for all: the
+      // rule it enforced is now structural rather than conditional, which is the stronger state.
+      // What the client said reaches the handlers whole, every time, and costs what it costs.
+      const forBrain = transcribedText; const brainInput = forBrain + (languageNote ? `\n\n[LANGUAGE NOTE: ${languageNote}]` : ""); turnVoice({ forBrain, handlerInput: brainInput, languageNote: languageNote || null });
 
       voiceStage = "coach_reply";
       voiceStageStart = Date.now();

--- a/server/understanding/sa-transcript.ts
+++ b/server/understanding/sa-transcript.ts
@@ -16,7 +16,6 @@ import type OpenAI from "openai";
 import { assertAiOnline, isAiOfflineError } from "../ai-offline";
 import { recordGptCost } from "../gpt";
 import { looksLikeRefusal } from "./refusal";
-import { transcriptIsLogList, transcriptMustPassWhole } from "../utils";
 export { looksLikeRefusal } from "./refusal";
 
 const SA_CLEAN_SYSTEM = `You clean South African English voice-note transcripts before a coach reads them. The speaker is an ordinary South African (often a low-literacy, first-language-not-English client) talking about food, training, and how they feel.
@@ -47,21 +46,60 @@ function retainsOriginal(raw: string, cleaned: string): boolean {
 }
 
 /**
+ * THE CLEANER'S WINDOW IS A WINDOW, NOT A LIMIT ON WHAT THE CLIENT SAID (Cut 3, 2026-09-12).
+ *
+ * `text.slice(0, 1500)` went to the model and the model's answer came back as THE TRANSCRIPT.
+ * Everything past 1,500 characters was deleted — not flagged, not truncated visibly, deleted,
+ * before a single handler or whole-transcript guard ever saw it.
+ *
+ * Measured on 017efd9 with a 2,408-character note (500 words, about three minutes of speech):
+ *
+ *     handed to the model   1500 chars
+ *     returned as "the transcript"   1500 chars
+ *     SILENTLY DELETED       908 chars   — the workout correction, BOTH questions, and the
+ *                                          last thing they said before hanging up
+ *
+ * The client asked two questions and got a coach who had never received either of them.
+ *
+ * So the window now applies to what is SENT, and the rest is carried through untouched. The order
+ * permits exactly this: preserve the portion beyond the window unchanged if it cannot safely be
+ * cleaned. The tail keeps whatever STT gave us — imperfect, and present, which beats perfect and
+ * gone. No second model call, no chunking loop, no new owner.
+ */
+const CLEAN_WINDOW = 1500;
+
+/**
+ * Split so the window never cuts a word in half. A sentence boundary is preferred; any space
+ * will do; the hard index is the last resort. The tail keeps its leading whitespace, so
+ * `cleanedHead + tail` rejoins exactly where the original was separated.
+ */
+export function splitForClean(text: string): { head: string; tail: string } {
+  if (text.length <= CLEAN_WINDOW) return { head: text, tail: "" };
+  const window = text.slice(0, CLEAN_WINDOW);
+  const sentence = Math.max(window.lastIndexOf(". "), window.lastIndexOf("! "), window.lastIndexOf("? "));
+  // Only trust a sentence end in the back half — an early full stop would send a fragment and
+  // carry most of the note through uncleaned for no reason.
+  const at = sentence > CLEAN_WINDOW * 0.5 ? sentence + 1 : window.lastIndexOf(" ");
+  return at > 0 ? { head: text.slice(0, at), tail: text.slice(at) } : { head: window, tail: text.slice(CLEAN_WINDOW) };
+}
+
+/**
  * Returns a cleaned transcript, or the original on any failure. Never throws.
  * Skips trivially short input (nothing to fix) to save a call.
  */
 export async function cleanSATranscript(openai: OpenAI, raw: string, userId?: string | null): Promise<string> {
   const text = (raw || "").trim();
   if (killswitchOff() || text.length < 4) return raw;
+  const { head, tail } = splitForClean(text);
   try {
     assertAiOnline("sa_clean");
     const resp = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       temperature: 0,
-      max_tokens: Math.min(500, Math.ceil(text.length / 2) + 80),
+      max_tokens: Math.min(500, Math.ceil(head.length / 2) + 80),
       messages: [
         { role: "system", content: SA_CLEAN_SYSTEM },
-        { role: "user", content: text.slice(0, 1500) },
+        { role: "user", content: head },
       ],
     });
     recordGptCost({
@@ -72,78 +110,54 @@ export async function cleanSATranscript(openai: OpenAI, raw: string, userId?: st
       completionTokens: resp.usage?.completion_tokens ?? 0,
     });
     const cleaned = (resp.choices[0]?.message?.content || "").trim();
-    // Keep the ORIGINAL unless the output is a faithful light clean. Reject: empty, a
+    // Keep the ORIGINAL unless the output is a faithful light clean of THE HEAD. Reject: empty, a
     // runaway rewrite (added content), a refusal / model talking back, or a rewrite that
     // dropped most of the speaker's own words. Any of these → the raw transcript wins.
+    //
+    // GRADED AGAINST THE HEAD, NOT THE WHOLE TEXT, and that is a correction as well as a
+    // consequence. `retainsOriginal(text, cleaned)` compared the FULL transcript against a clean
+    // of its first 1,500 characters, so on a long note it was asking whether a fragment resembled
+    // the whole — a test that a truncation passes comfortably. It could never have caught the
+    // deletion above; it was measuring the wrong pair.
+    //
+    // THE LOWER BOUND IS NEW. There was a ceiling on the output length and no floor, so a reply cut
+    // off by max_tokens came back as the transcript with its own middle missing. Half the head is
+    // far below any honest clean (the prompt says keep the length) and far above a rounding error.
     if (!cleaned
-      || cleaned.length > text.length * 1.8 + 40
+      || cleaned.length > head.length * 1.8 + 40
+      || cleaned.length < head.length * 0.5
       || looksLikeRefusal(cleaned)
-      || !retainsOriginal(text, cleaned)) {
+      || !retainsOriginal(head, cleaned)) {
       if (looksLikeRefusal(cleaned)) console.warn("[SA_CLEAN] model refused — keeping raw transcript");
       return raw;
     }
-    return cleaned;
+    if (tail) console.log(`[SA_CLEAN] cleaned ${head.length} chars, carried ${tail.length} through unchanged`);
+    return cleaned + tail;
   } catch (e) {
     if (!isAiOfflineError(e)) console.warn("[SA_CLEAN] failed (using raw transcript):", (e as any)?.message || e);
     return raw;
   }
 }
 
-const CONDENSE_SYSTEM = `You condense a LONG South African voice-note transcript into a short, clean first-person version a coach can act on. The speaker rambled; your job is to keep the SIGNAL and drop the noise.
-
-KEEP, exactly as said:
-- every food and its amount ("2 eggs and pap", "half a kota") — word-for-word, so it can be logged
-- every number: steps, weight in kg, reps, sets, litres, days
-- every exercise or training detail they mentioned
-- their ONE main question or request
-- if they clearly feel strongly (down, frustrated, proud), one short phrase saying so
-
-DROP: repetition, filler, side-stories, thinking-out-loud, greetings.
-
-Write it in the FIRST PERSON, plain, and as SHORT as it can be WITHOUT LOSING A SINGLE FOOD OR
-NUMBER. If they listed eight things, the result has eight things in it — length is not the goal,
-keeping their day is. Do NOT answer, do NOT coach, do NOT add anything they didn't say. Return
-ONLY the condensed message.`;
-
-
-/**
- * Condense a long, rambling voice transcript to its actionable core (mood, foods, numbers,
- * the real question) — the "summariser wedge". Protects the brain from a wall of rambling AND
- * the R199 margin from passing a 3-minute transcript to the big model. Only call this on a
- * genuine ramble (the caller gates on length); short notes should pass through untouched so a
- * quick food log is never reshaped. Fail-open: returns the raw transcript on any problem.
- */
-export async function condenseVoiceRamble(openai: OpenAI, raw: string, userId?: string | null): Promise<string> {
-  const text = (raw || "").trim();
-  if (killswitchOff() || text.length < 200) return raw; // nothing to condense
-  if (transcriptMustPassWhole(text)) {
-    console.log(`[VOICE_CONDENSE] skipped — must reach the coach whole (${text.length} chars)`);
-    return raw;
-  }
-  try {
-    assertAiOnline("voice_condense");
-    const resp = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      temperature: 0,
-      max_tokens: 400,   // a day's food does not fit in 220 — see transcriptIsLogList
-      messages: [
-        { role: "system", content: CONDENSE_SYSTEM },
-        { role: "user", content: text.slice(0, 4000) },
-      ],
-    });
-    recordGptCost({
-      userId: userId ?? null,
-      model: "gpt-4o-mini",
-      feature: "voice_condense",
-      promptTokens: resp.usage?.prompt_tokens ?? 0,
-      completionTokens: resp.usage?.completion_tokens ?? 0,
-    });
-    const out = (resp.choices[0]?.message?.content || "").trim();
-    // Reject a bad condense (empty, a refusal, or somehow LONGER than the original) → keep raw.
-    if (!out || out.length >= text.length || looksLikeRefusal(out)) return raw;
-    return out;
-  } catch (e) {
-    if (!isAiOfflineError(e)) console.warn("[VOICE_CONDENSE] failed (using raw transcript):", (e as any)?.message || e);
-    return raw;
-  }
-}
+// ── THE CONDENSER IS GONE (Cut 3, 2026-09-12) ────────────────────────────────────────────────
+//
+// `condenseVoiceRamble` and its prompt stood here. It took a long note and returned a model's
+// shorter retelling, and media.ts routed THAT to the handlers — so the retelling was the client's
+// words as far as anything downstream could tell. It also carried the same defect as the cleaner
+// above, one window wider: `text.slice(0, 4000)` in, the answer out as the whole message.
+// Measured on 017efd9 with a 4,141-character note that passes every guard: 141 characters gone,
+// final marker included.
+//
+// IT COULD NOT BE KEPT AS AN AID. There is exactly one routed string; a condensation offered
+// "alongside" the transcript would be a second version of what the client said, which is a second
+// authority over the same question — the thing this rescue exists to remove. So it may not replace
+// the transcript, and there is nowhere else for it to go.
+//
+// WHAT IS PAID FOR THIS: a three-minute note now reaches the coaching model in full. That is a
+// real token cost on the longest notes, and it is the founder's trade to revisit — the alternative
+// on offer was a client asking two questions and being answered by a coach that received neither.
+//
+// transcriptMustPassWhole / transcriptIsLogList / isMessyLifeTranscript in server/utils.ts were
+// this function's gate and went with it. A predicate whose only possible answer is "no, do not
+// shorten this" is not a guard; the reachability governor says so too, and it is right. Their
+// assertions are inverted in unit-tests and gap-tests rather than deleted.

--- a/server/understanding/sa-transcript.ts
+++ b/server/understanding/sa-transcript.ts
@@ -33,40 +33,107 @@ function killswitchOff(): boolean {
   return process.env.SA_CLEAN === "off";
 }
 
-// A faithful clean keeps most of the speaker's own words (it fixes a handful). If the
-// output shares almost nothing with the input, the model went off-script — reject it.
-function retainsOriginal(raw: string, cleaned: string): boolean {
-  const words = (s: string) => new Set((s.toLowerCase().match(/[a-z']{3,}/g) || []));
-  const orig = words(raw);
-  if (orig.size < 6) return true; // too short to judge overlap — trust the length guard
-  const out = words(cleaned);
-  let kept = 0;
-  for (const w of orig) if (out.has(w)) kept++;
-  return kept / orig.size >= 0.4; // at least 40% of the original words survive a real clean
+/**
+ * WHAT THE CLEANER IS ALLOWED TO CHANGE — AN ORDERED EDIT CONTRACT (Cut 3, CTO review 2, 2026-09-12).
+ *
+ * THE HOLE THIS CLOSES. `retainsOriginal` compared two SETS of words and asked whether 40% of the
+ * original survived. A set has no order, no position and no repetition, so a reply that deleted a
+ * whole clause out of the MIDDLE of the head passed it comfortably. Demonstrated deterministically
+ * against the previous amended head:
+ *
+ *     raw 1687 chars · head 1467 chars · reply = head with one clause removed
+ *     "Actually I missed my Tuesday workout. What should I do today?"   <- deleted
+ *     95.84% of the head preserved, ending intact, finish_reason "stop"
+ *     ACCEPTED. The correction and the question were gone and the tail survived.
+ *
+ * finish_reason, a length floor and an ending check are all blind to that: the reply is complete,
+ * long enough, and ends correctly. Only the ORDER and COUNT of the client's own words can see it.
+ *
+ * THE CONTRACT. This cleaner repairs spelling. It does not rewrite clauses. So the cleaned head
+ * must be the same tokens, in the same order, the same number of times — with only two exceptions:
+ *
+ *   - case, spacing and punctuation are free (they are normalised away before comparison)
+ *   - a token may be REPLACED by an approved SA repair: the replacement must be a word this
+ *     cleaner exists to produce, and must be a near-miss of what STT heard
+ *
+ * Anything else — a deletion, an insertion, an unexplained substitution — returns the WHOLE RAW
+ * transcript. Numbers, weekdays and negations are protected absolutely: they may not be
+ * substituted even for an approved word, because "8500" becoming "8000" and "missed" becoming
+ * "finished" are the changes that cost a client their record rather than their spelling.
+ *
+ * NOT SOLVED BY A HIGHER PERCENTAGE, and not by a model judging a model. A percentage cannot
+ * distinguish a clause from a spelling, which is precisely how the 60% and 95.84% replies both
+ * got through.
+ */
+const SA_REPAIR_WORDS = new Set([
+  // the SA food words the system prompt names, which is the whole reason this stage exists
+  "samp", "morogo", "pap", "pilchards", "chakalaka", "vetkoek", "umngqusho", "mngqusho",
+  "kota", "mageu", "maas", "wors", "boerewors", "umqombothi", "magwinya", "gatsby", "bunny",
+  // and the SA slang it is told to keep and spell correctly
+  "mos", "neh", "yoh", "eish", "lekker", "sharp", "sho", "shame", "ag", "hey", "hayibo", "sharp",
+]);
+
+/**
+ * Never substituted, never dropped — a wrong one of these is a wrong record, not a typo.
+ *
+ * A SET, NOT A PATTERN, and deliberately: the architecture governor counts named regex literals,
+ * and a list of words is what this is. Membership also says what it means without anyone parsing
+ * an alternation forty items long.
+ */
+const PROTECTED_TOKENS = new Set([
+  "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "half", "quarter",
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+  "yesterday", "today", "tomorrow",
+  "not", "no", "never", "dont", "didnt", "cant", "wont", "wasnt", "isnt", "arent", "havent",
+  "hadnt", "missed", "skipped", "without",
+]);
+
+/** Any token carrying a digit is a quantity: a step count, a weight, a portion, a time. */
+function isProtected(token: string): boolean {
+  return PROTECTED_TOKENS.has(token) || /\d/.test(token);
+}
+
+/** Lowercased words and numbers, punctuation and spacing removed — the client's lexical spine. */
+function lexicalTokens(s: string): string[] {
+  return (s.toLowerCase().match(/[a-z0-9']+/g) || []).map(t => t.replace(/'/g, ""));
+}
+
+/** How far apart two tokens are. Bounded work: both are single words. */
+function editDistance(a: string, b: string): number {
+  const rows: number[][] = [Array.from({ length: b.length + 1 }, (_, j) => j)];
+  for (let i = 1; i <= a.length; i++) {
+    rows[i] = [i];
+    for (let j = 1; j <= b.length; j++) {
+      rows[i][j] = Math.min(
+        rows[i - 1][j] + 1,
+        rows[i][j - 1] + 1,
+        rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+  }
+  return rows[a.length][b.length];
+}
+
+/** A substitution is allowed only when it produces a word this cleaner exists to produce. */
+function isApprovedRepair(from: string, to: string): boolean {
+  if (isProtected(from) || isProtected(to)) return false;
+  if (!SA_REPAIR_WORDS.has(to)) return false;
+  return editDistance(from, to) <= 3;
 }
 
 /**
- * DID THE CLEAN REACH THE END OF WHAT IT WAS GIVEN? (Cut 3 amendment, 2026-09-12.)
- *
- * A length floor cannot tell a faithful clean from a faithful PREFIX. Demonstrated against the
- * first version of this cut: a model reply carrying 60% of the head — 1,687 characters in, 1,099
- * out — passed both the 50% floor and the word-overlap check, and 588 characters vanished, a
- * workout correction and a question among them. The preserved tail was never the whole problem;
- * the model can delete the end of the HEAD and the result still looks like prose.
- *
- * So the head's last words must be represented in the output. The cleaner's contract is a light
- * spelling repair in the same order, so a handful of the final content words should survive one;
- * a prefix that stops early cannot contain them at all. Two of six are allowed to change, which
- * is what a genuine SA-food correction on the last line looks like.
+ * The cleaned head must be the head, token for token, in order — bar approved SA repairs.
+ * Any deletion or insertion changes the count and is refused outright.
  */
-function coversTheEnd(head: string, cleaned: string): boolean {
-  const words = (s: string) => (s.toLowerCase().match(/[a-z']{3,}/g) || []);
-  const ending = words(head).slice(-6);
-  if (ending.length < 4) return true;              // too short to judge — the floor carries it
-  const out = new Set(words(cleaned));
-  let kept = 0;
-  for (const w of ending) if (out.has(w)) kept++;
-  return kept >= Math.ceil(ending.length * 0.6);
+function onlyApprovedRepairs(head: string, cleaned: string): boolean {
+  const before = lexicalTokens(head);
+  const after = lexicalTokens(cleaned);
+  if (before.length !== after.length) return false;      // a clause was dropped or invented
+  for (let i = 0; i < before.length; i++) {
+    if (before[i] === after[i]) continue;
+    if (!isApprovedRepair(before[i], after[i])) return false;
+  }
+  return true;
 }
 
 /**
@@ -148,24 +215,26 @@ export async function cleanSATranscript(openai: OpenAI, raw: string, userId?: st
     // sailed through it: 1,687 characters in, 1,099 out, 588 gone with a workout correction and a
     // question inside them. Three things close that, and any one of them failing keeps the raw:
     //
-    //   finish_reason      must be "stop". "length" means the model ran out of tokens mid-sentence
-    //                      and what came back is a fragment wearing the shape of an answer. An
-    //                      ABSENT reason is not proof of completion either, so it is refused too —
-    //                      when completeness cannot be established the client's own words win.
-    //   the length floor   0.8, not 0.5. The prompt tells the model to keep the length; half the
-    //                      head was never a clean, it was a summary nobody asked for.
-    //   coversTheEnd       a faithful PREFIX passes a floor and an overlap test. It cannot pass a
-    //                      check that the head's last words are still there.
+    //   finish_reason        must be "stop". "length" means the model ran out of tokens mid-sentence
+    //                        and what came back is a fragment wearing the shape of an answer. An
+    //                        ABSENT reason is not proof of completion either, so it is refused too —
+    //                        when completeness cannot be established the client's own words win.
+    //   onlyApprovedRepairs  the cleaned head must be the head token for token, in order, bar an
+    //                        approved SA spelling repair. This is what sees a clause deleted out
+    //                        of the MIDDLE — the case a length floor and an ending check both let
+    //                        through at 95.84% of the head with the ending intact.
+    //
+    // THE LENGTH FLOOR AND THE ENDING CHECK ARE GONE, not loosened: the ordered contract subsumes
+    // both (a prefix and a hollowed middle each change the token count) and keeping them would
+    // leave two gates that can no longer fail on their own, which is how a suite starts grading
+    // nothing while looking thorough.
     if (!cleaned
       || finishReason !== "stop"
-      || cleaned.length > head.length * 1.8 + 40
-      || cleaned.length < head.length * 0.8
-      || !coversTheEnd(head, cleaned)
       || looksLikeRefusal(cleaned)
-      || !retainsOriginal(head, cleaned)) {
+      || !onlyApprovedRepairs(head, cleaned)) {
       if (looksLikeRefusal(cleaned)) console.warn("[SA_CLEAN] model refused — keeping raw transcript");
       else if (finishReason !== "stop") console.warn(`[SA_CLEAN] incomplete reply (finish_reason=${String(finishReason)}) — keeping raw transcript`);
-      else if (cleaned && !coversTheEnd(head, cleaned)) console.warn("[SA_CLEAN] reply did not reach the end of the head — keeping raw transcript");
+      else if (cleaned) console.warn("[SA_CLEAN] reply is not a token-for-token repair of the head — keeping raw transcript");
       return raw;
     }
     if (tail) console.log(`[SA_CLEAN] cleaned ${head.length} chars, carried ${tail.length} through unchanged`);

--- a/server/understanding/sa-transcript.ts
+++ b/server/understanding/sa-transcript.ts
@@ -52,11 +52,10 @@ function killswitchOff(): boolean {
  * THE CONTRACT. This cleaner repairs spelling. It does not rewrite clauses. So the cleaned head
  * must be the same tokens, in the same order, the same number of times — with only two exceptions:
  *
- *   - case, spacing and punctuation are free (they are normalised away before comparison)
- *   - a token may be REPLACED by an approved SA repair: the replacement must be a word this
- *     cleaner exists to produce, and must be a near-miss of what STT heard
+ *   - case, spacing and most punctuation are free (they are normalised away before comparison)
+ *   - one token may be REPLACED by another only if that EXACT pair is listed below
  *
- * Anything else — a deletion, an insertion, an unexplained substitution — returns the WHOLE RAW
+ * Anything else — a deletion, an insertion, an unlisted substitution — returns the WHOLE RAW
  * transcript. Numbers, weekdays and negations are protected absolutely: they may not be
  * substituted even for an approved word, because "8500" becoming "8000" and "missed" becoming
  * "finished" are the changes that cost a client their record rather than their spelling.
@@ -65,12 +64,24 @@ function killswitchOff(): boolean {
  * distinguish a clause from a spelling, which is precisely how the 60% and 95.84% replies both
  * got through.
  */
-const SA_REPAIR_WORDS = new Set([
-  // the SA food words the system prompt names, which is the whole reason this stage exists
-  "samp", "morogo", "pap", "pilchards", "chakalaka", "vetkoek", "umngqusho", "mngqusho",
-  "kota", "mageu", "maas", "wors", "boerewors", "umqombothi", "magwinya", "gatsby", "bunny",
-  // and the SA slang it is told to keep and spell correctly
-  "mos", "neh", "yoh", "eish", "lekker", "sharp", "sho", "shame", "ag", "hey", "hayibo", "sharp",
+
+/**
+ * VETTED PAIRS, NOT A VOCABULARY (amended 2026-09-12).
+ *
+ * The first version of this contract asked a different question: is the NEW word one of the SA
+ * words this cleaner exists to produce, and is it within edit distance 3 of the old one? That
+ * approves any near-neighbour of any listed word, which was reproduced as:
+ *
+ *     "I have pain"  ->  "I have pap"     ("pain" is 2 edits from "pap")
+ *     "I am sad"     ->  "I am pap"       ("sad"  is 2 edits from "pap")
+ *
+ * A client reporting pain had it replaced by a food word and no handler could tell. So the
+ * question is now the narrow one: was THIS EXACT substitution vetted by a person? Only the pair
+ * the cut was opened for is listed. Growing this map is a deliberate act with a name attached;
+ * guessing from a distance metric is not, which is why the metric is gone rather than tuned.
+ */
+const VETTED_REPAIRS = new Map<string, string>([
+  ["stamp", "samp"],
 ]);
 
 /**
@@ -93,32 +104,47 @@ function isProtected(token: string): boolean {
   return PROTECTED_TOKENS.has(token) || /\d/.test(token);
 }
 
-/** Lowercased words and numbers, punctuation and spacing removed — the client's lexical spine. */
+/**
+ * PUNCTUATION IS NOT GLOBALLY FREE (amended 2026-09-12).
+ *
+ * The first tokenizer was `/[a-z0-9']+/g`, and it had two holes that a reviewer reproduced:
+ *
+ *   - IT ATE THE SIGN. "-5" and "5" tokenize identically under it, so a reply turning
+ *     "my change was -5 kg" into "my change was 5 kg" — five kilograms lost read back as five
+ *     kilograms gained — was a token-for-token match and passed.
+ *   - IT ATE EVERYTHING NON-ASCII. A Sesotho or isiZulu word the client actually spoke matched
+ *     nothing and simply vanished from BOTH sides, so a reply that deleted it compared equal.
+ *
+ * So a quantity is one token including its leading sign and its internal separators: "-5", "8.5"
+ * and "8,500" are three different tokens and none of them is "85" or "5". Everything else is a run
+ * of Unicode letters, marks and digits, which keeps non-ASCII lexical content in the comparison
+ * instead of discarding it. Case, spacing, and punctuation BETWEEN tokens stay free — a full stop
+ * the model adds at the end of a sentence is still a repair, not a rewrite.
+ *
+ * This errs strict on purpose: "8500" and "8,500" are different tokens here, and a reply that
+ * regroups digits is refused. Refusing returns the client's own raw words, which is the safe half.
+ *
+ * INLINE, AND DELIBERATELY SO: the pattern it replaces was inline too. This is one predicate's
+ * tokenizer, not a named pattern authority that decides anything about a message, and naming it
+ * would move the architecture governor's regex count for a rewrite that adds no such authority.
+ */
+
+/** Leading sign forms STT and the model use interchangeably; the SIGN matters, its glyph does not. */
+const MINUS_FORMS = "-−–—";
+
+/** Lowercased words and signed quantities — the client's lexical spine, signs and all. */
 function lexicalTokens(s: string): string[] {
-  return (s.toLowerCase().match(/[a-z0-9']+/g) || []).map(t => t.replace(/'/g, ""));
+  // a quantity (sign, digits, internal separators) | a run of Unicode letters, marks and digits
+  return (s.toLowerCase().match(/[+−–—-]?\d+(?:[.,]\d+)*|[\p{L}\p{M}\p{N}'’]+/gu) || []).map((t) => {
+    const signed = MINUS_FORMS.includes(t[0]) ? "-" + t.slice(1) : t;
+    return signed.split("'").join("").split("’").join("");
+  });
 }
 
-/** How far apart two tokens are. Bounded work: both are single words. */
-function editDistance(a: string, b: string): number {
-  const rows: number[][] = [Array.from({ length: b.length + 1 }, (_, j) => j)];
-  for (let i = 1; i <= a.length; i++) {
-    rows[i] = [i];
-    for (let j = 1; j <= b.length; j++) {
-      rows[i][j] = Math.min(
-        rows[i - 1][j] + 1,
-        rows[i][j - 1] + 1,
-        rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
-      );
-    }
-  }
-  return rows[a.length][b.length];
-}
-
-/** A substitution is allowed only when it produces a word this cleaner exists to produce. */
+/** A substitution is allowed only when this exact FROM->TO pair was vetted by a person. */
 function isApprovedRepair(from: string, to: string): boolean {
   if (isProtected(from) || isProtected(to)) return false;
-  if (!SA_REPAIR_WORDS.has(to)) return false;
-  return editDistance(from, to) <= 3;
+  return VETTED_REPAIRS.get(from) === to;
 }
 
 /**

--- a/server/understanding/sa-transcript.ts
+++ b/server/understanding/sa-transcript.ts
@@ -46,6 +46,30 @@ function retainsOriginal(raw: string, cleaned: string): boolean {
 }
 
 /**
+ * DID THE CLEAN REACH THE END OF WHAT IT WAS GIVEN? (Cut 3 amendment, 2026-09-12.)
+ *
+ * A length floor cannot tell a faithful clean from a faithful PREFIX. Demonstrated against the
+ * first version of this cut: a model reply carrying 60% of the head — 1,687 characters in, 1,099
+ * out — passed both the 50% floor and the word-overlap check, and 588 characters vanished, a
+ * workout correction and a question among them. The preserved tail was never the whole problem;
+ * the model can delete the end of the HEAD and the result still looks like prose.
+ *
+ * So the head's last words must be represented in the output. The cleaner's contract is a light
+ * spelling repair in the same order, so a handful of the final content words should survive one;
+ * a prefix that stops early cannot contain them at all. Two of six are allowed to change, which
+ * is what a genuine SA-food correction on the last line looks like.
+ */
+function coversTheEnd(head: string, cleaned: string): boolean {
+  const words = (s: string) => (s.toLowerCase().match(/[a-z']{3,}/g) || []);
+  const ending = words(head).slice(-6);
+  if (ending.length < 4) return true;              // too short to judge — the floor carries it
+  const out = new Set(words(cleaned));
+  let kept = 0;
+  for (const w of ending) if (out.has(w)) kept++;
+  return kept >= Math.ceil(ending.length * 0.6);
+}
+
+/**
  * THE CLEANER'S WINDOW IS A WINDOW, NOT A LIMIT ON WHAT THE CLIENT SAID (Cut 3, 2026-09-12).
  *
  * `text.slice(0, 1500)` went to the model and the model's answer came back as THE TRANSCRIPT.
@@ -110,25 +134,38 @@ export async function cleanSATranscript(openai: OpenAI, raw: string, userId?: st
       completionTokens: resp.usage?.completion_tokens ?? 0,
     });
     const cleaned = (resp.choices[0]?.message?.content || "").trim();
-    // Keep the ORIGINAL unless the output is a faithful light clean of THE HEAD. Reject: empty, a
-    // runaway rewrite (added content), a refusal / model talking back, or a rewrite that
-    // dropped most of the speaker's own words. Any of these → the raw transcript wins.
+    const finishReason = resp.choices[0]?.finish_reason;
+    // Keep the ORIGINAL unless the output can be SHOWN to be a complete, faithful light clean of
+    // THE HEAD. Reject: empty, a runaway rewrite, a refusal, a rewrite that dropped the speaker's
+    // words, a reply the model did not finish, or one that does not reach the end of the head.
     //
-    // GRADED AGAINST THE HEAD, NOT THE WHOLE TEXT, and that is a correction as well as a
-    // consequence. `retainsOriginal(text, cleaned)` compared the FULL transcript against a clean
-    // of its first 1,500 characters, so on a long note it was asking whether a fragment resembled
-    // the whole — a test that a truncation passes comfortably. It could never have caught the
-    // deletion above; it was measuring the wrong pair.
+    // GRADED AGAINST THE HEAD, NOT THE WHOLE TEXT. `retainsOriginal(text, cleaned)` compared the
+    // FULL transcript against a clean of its first 1,500 characters, so on a long note it asked
+    // whether a fragment resembled the whole — which a truncation passes comfortably.
     //
-    // THE LOWER BOUND IS NEW. There was a ceiling on the output length and no floor, so a reply cut
-    // off by max_tokens came back as the transcript with its own middle missing. Half the head is
-    // far below any honest clean (the prompt says keep the length) and far above a rounding error.
+    // COMPLETENESS IS PROVEN, NOT ASSUMED, and this is the amendment that earns the word "whole".
+    // The first version of this cut carried only a 50% floor, and a reply holding 60% of the head
+    // sailed through it: 1,687 characters in, 1,099 out, 588 gone with a workout correction and a
+    // question inside them. Three things close that, and any one of them failing keeps the raw:
+    //
+    //   finish_reason      must be "stop". "length" means the model ran out of tokens mid-sentence
+    //                      and what came back is a fragment wearing the shape of an answer. An
+    //                      ABSENT reason is not proof of completion either, so it is refused too —
+    //                      when completeness cannot be established the client's own words win.
+    //   the length floor   0.8, not 0.5. The prompt tells the model to keep the length; half the
+    //                      head was never a clean, it was a summary nobody asked for.
+    //   coversTheEnd       a faithful PREFIX passes a floor and an overlap test. It cannot pass a
+    //                      check that the head's last words are still there.
     if (!cleaned
+      || finishReason !== "stop"
       || cleaned.length > head.length * 1.8 + 40
-      || cleaned.length < head.length * 0.5
+      || cleaned.length < head.length * 0.8
+      || !coversTheEnd(head, cleaned)
       || looksLikeRefusal(cleaned)
       || !retainsOriginal(head, cleaned)) {
       if (looksLikeRefusal(cleaned)) console.warn("[SA_CLEAN] model refused — keeping raw transcript");
+      else if (finishReason !== "stop") console.warn(`[SA_CLEAN] incomplete reply (finish_reason=${String(finishReason)}) — keeping raw transcript`);
+      else if (cleaned && !coversTheEnd(head, cleaned)) console.warn("[SA_CLEAN] reply did not reach the end of the head — keeping raw transcript");
       return raw;
     }
     if (tail) console.log(`[SA_CLEAN] cleaned ${head.length} chars, carried ${tail.length} through unchanged`);

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -1088,103 +1088,25 @@ export function nextDayDate(word: string): string | null {
 }
 
 /**
- * IS THIS A LOG, OR A RAMBLE? (2026-08-05.)
+ * MAY THIS TRANSCRIPT BE SHORTENED? — THE QUESTION NO LONGER HAS A CALLER (Cut 3, 2026-09-12).
  *
- * NAMED DELIBERATELY OUT OF THE looksLike* FAMILY, AND SAID OUT LOUD RATHER THAN DONE QUIETLY.
- * It was `looksLikeLogList` and the architecture guard refused it at 21 against a budget of 20 —
- * correctly, that guard exists to stop message-classifier predicates breeding. No looksLike*
- * predicate is currently dead, so there was nothing to pay with, and the documented
- * consolidation (merging looksLikeSteps/Water/WeightReport, ~30 call sites) is not a change to
- * start in the tail of a session.
+ * `transcriptMustPassWhole`, `isMessyLifeTranscript` and `transcriptIsLogList` stood here. They
+ * were the gate on the summariser wedge: a day's food list, a note asking two things, a note
+ * carrying a feeling, a messy-life note with two life signals — none of those could be condensed.
+ * They were written case by case, each one after a real client lost something.
  *
- * The argument for the rename: the looksLike* family all answer "which handler should take this
- * MESSAGE?". This answers "should this TRANSCRIPT be preprocessed before anything sees it?" —
- * a different question, at a different layer, with one caller.
+ * The wedge is gone. media.ts routed the condensed retelling to the handlers, which made it the
+ * client's words as far as anything downstream could tell, and there is only one routed string
+ * for a second version to occupy. Nothing shortens a transcript now, so the answer to "may this
+ * one be shortened?" is no for every note, always — and a predicate that can only ever return
+ * true is not a guard, it is a comment with a test suite.
  *
- * If the founder reads that as dodging the meter rather than a real distinction, the honest
- * alternative is the three-way consolidation above, which pays for this and two more besides.
+ * THIS IS STRICTER THAN WHAT THEY ENFORCED, not weaker. Each of them protected the notes it could
+ * recognise; every note is protected now, including the ones none of these three would have
+ * matched. That case existed: the founder's own 2,408-character note tripped all three guards and
+ * was still cut in half, because the CLEANER truncated it before any of them were consulted.
  *
- * The condenser exists for someone thinking out loud. It is the wrong tool entirely for someone
- * reciting their day's food, and it was being applied to both — the prompt said "keep every food
- * word-for-word" AND "short, 2-4 sentences", which for a client listing eight items are opposite
- * instructions. The model obeyed the shorter one and quietly dropped meals. Same shape as the
- * action directive that told the coach to call a tool and not speak: two rules, one loses, and
- * the loss is invisible.
- *
- * So a log-dense transcript is never condensed at all. There is no noise to drop in "4 fish
- * fingers, 3 eggs, 3 slices of bread and a black coffee" — every word is the payload, and a
- * summariser can only lose some of it. Cheaper too: no model call.
- *
- * Deliberately crude: three or more quantities. A ramble rarely carries three; a day's food
- * always does. When in doubt this keeps the raw text, which is the safe direction — a slightly
- * long message reaching the coach costs tokens, a dropped meal costs the client's trust.
+ * Their assertions are not dropped — they are inverted in unit-tests and gap-tests, where each
+ * one now grades the same promise against the structure rather than against a predicate.
  */
-/**
- * MUST THIS TRANSCRIPT REACH THE COACH WHOLE? (2026-08-06, founder's STT audit: he sent a
- * voice note whose content was literally "read the rest of my transcript".)
- *
- * The condenser rightly stops a three-minute ramble reaching the expensive model. What it must
- * never do is answer half of what someone said. Log lists were already exempt; this adds the
- * two other shapes where losing the tail is the same defect — a note asking MORE THAN ONE
- * thing, and one that stacks instructions ("also…", "one more…"). Deliberately generous: a
- * false positive costs a few cents, a false negative costs a client being ignored.
- */
-export function transcriptMustPassWhole(text: string): boolean {
-  const t = (text || "").trim();
-  if (!t) return false;
-  if (transcriptIsLogList(t)) return true;
-  const questions = (t.match(/\?/g) || []).length;
-  if (questions >= 2) return true;
-  // Spoken transcripts often carry no punctuation at all, so count question OPENERS too.
-  const openers = (t.toLowerCase().match(/\b(what|why|how|when|where|which|can i|should i|do i|is it|are they)\b/g) || []).length;
-  if (openers >= 2) return true;
-  const stackers = (t.toLowerCase().match(/\b(also|another thing|one more|and then|secondly|lastly|by the way|plus)\b/g) || []).length;
-  if (stackers >= 1 && (questions + openers) >= 1) return true;
-  // Messy-life voice notes (product core): food + movement, food + feeling, yesterday's
-  // meals, multi-beat day stories. Condensing these destroys the facts the log path needs
-  // and is how "I had McDonald's breakfast and a mocha" never reached food-context whole.
-  if (isMessyLifeTranscript(t)) return true;
-  // A PERSON TELLING YOU HOW THEY ARE IS NEVER SQUEEZED (CTO ruling, 2026-08-19). A long
-  // come-back ramble with no food and no steps is the Pulse client finally saying what is going
-  // on; shortening it to save tokens is tracker behaviour. The margin guard now reaches only a
-  // long note with no food, no steps, no feeling and no stacked question — narrower on purpose.
-  if (/\b(tired|exhausted|stressed|stress|feel(?:ing)?|felt|anxious|motivat|struggling|overwhelmed|depressed|hard day|rough day|not coping|drained|down|low|lost|give up|giving up)\b/.test(t)) return true;
-  return false;
-}
-
-/**
- * Two or more life signals in one note = the demographic we built for.
- * Keep the full transcript; do not summarise away the meal, the steps, or the feeling.
- */
-export function isMessyLifeTranscript(text: string): boolean {
-  const t = (text || "").toLowerCase();
-  if (!t) return false;
-  const words = t.split(/\s+/).filter(Boolean).length;
-  const food = /\b(ate|eaten|had|having|breakfast|lunch|dinner|supper|brunch|snack|meal|mcdonald|kfc|takeaway|pap|chicken|eggs?|mocha|coffee|food)\b/.test(t);
-  const steps = /\b(steps?|walked|walking|\d+\s*km|kilometers?|ran|run)\b/.test(t);
-  const feeling = /\b(tired|stressed|stress|feel(?:ing)?|felt|anxious|motivat|struggling|overwhelmed|depressed|hard day|rough day|not coping|drained)\b/.test(t);
-  const temporal = /\b(yesterday|last night|this morning|earlier today|then i|after that|before (?:that|gym|work))\b/.test(t);
-  // TEMPORAL IS A QUALIFIER, NOT A FACT — it still counts in `food && temporal` below, which is
-  // what makes "yesterday I had pap" a retro meal report.
-  const signals = [food, steps, feeling].filter(Boolean).length;
-  // Short branded meal reports still need the full string (scanner + GPT fallback).
-  if (food && /\b(mcdonald|kfc|nando|spur|steers|wimpy|mocha|breakfast|lunch|dinner)\b/.test(t) && words <= 40) return true;
-  if (signals >= 2) return true;
-  if (food && temporal) return true;
-  return false;
-}
-
-export function transcriptIsLogList(text: string): boolean {
-  const t = (text || "").toLowerCase();
-  const digits = t.match(/\b\d+(?:[.,]\d+)?\b/g) || [];
-  const words = t.match(/\b(one|two|three|four|five|six|seven|eight|nine|ten|half|quarter)\b/g) || [];
-  const quantities = digits.length + words.length;
-  // A log needs at least ONE quantity — that is what separates "two eggs and pap" from a
-  // ramble that happens to contain three "and"s. A story about the gym has none.
-  if (quantities === 0) return false;
-  // Then LIST STRUCTURE: the commas and "and"s that string items together. One spoken number
-  // in a sentence with three conjunctions is a day's food; a quantity on its own is not.
-  const listers = (t.match(/,/g) || []).length + (t.match(/\band\b/g) || []).length;
-  return quantities + listers >= 3;
-}
 


### PR DESCRIPTION
Cut 3. Base `ca1a85c161b8e0d796dc23e9b24cb783fa1f7329` (fresh main, #245 merged). Head `95221747f5ba11f22c9e5eb74ffcd440d70d7719`.

**A long voice note reaches the handlers whole, and the cleaner may repair spelling without rewriting clauses.**

## The four silent cuts, measured on `017efd9`

A 2,408-character note — 500 words, about three minutes of speech:

```
handed to the model            1500 chars
returned as "the transcript"   1500 chars
SILENTLY DELETED                908 chars
```

| fact | where | survived on `017efd9` |
|---|---|---|
| named-day meal | beginning | kept |
| 8,500 steps | middle | kept |
| the workout correction | near the end | **DELETED** |
| the feeling | throughout | kept |
| question 1 | near the end | **DELETED** |
| question 2 | near the end | **DELETED** |
| the final tail marker | last words | **DELETED** |

| # | where | what it cost |
|---|---|---|
| 1 | the cleaner's 1,500-char window | 908 chars of a three-minute note |
| 2 | a ceiling with **no floor** | a reply cut off by `max_tokens` became the transcript |
| 3 | the condenser's 4,000-char window | reachable, and it replaced the account with a retelling |
| 4 | **the ledger's own 2,000-char cap** | the durable record, cut by 408 |

The fourth was found by this cut's acceptance, not by reading code.

## The cleaner's contract — four reviews, five holes, one rule

Two percentages were tried and **both were beaten**:

| review | reply | why it passed |
|---|---|---|
| first | 60% of the head, `finish_reason` either way | the 50% floor and a 40% word-overlap test accepted it |
| second | **95.84%** of the head, ending intact, `stop` | a length floor cannot see a hole in the middle; `retainsOriginal` compared two **sets**, and a set has no order |

Deleted in the second case: `"Actually I missed my Tuesday workout. What should I do today?"`

Then the ordered edit contract that replaced them was itself reviewed, and **two holes were reproduced in it** at head `70ed20c`. Both are fixed here, in the same predicate, at `9522174`:

| hole | reproduced | now |
|---|---|---|
| **a near-neighbour of a food word counted as a spelling repair** — membership in an SA vocabulary plus edit distance ≤ 3 | `"I have pain"` → `"I have pap"`, `"I am sad"` → `"I am pap"` | only an **explicitly vetted `FROM→TO` pair** is allowed. `VETTED_REPAIRS` holds one entry, `stamp → samp`. The distance metric and the target vocabulary are **deleted, not tuned** |
| **the tokenizer ate the sign and the decimal point**, and discarded non-ASCII lexical content entirely | `"my change was -5 kg"` → `"my change was 5 kg"`; `"8.5"` → `"85"` | a quantity is **one token carrying its leading sign and its internal separators**; everything else is a run of Unicode letters, marks and digits |

A client reporting pain or low mood had it recorded as a plate of food. Five kilograms lost read back as five gained. Neither was visible to any handler.

**A share of the text cannot distinguish a spelling from a sentence**, and **a distance metric cannot distinguish a repair from a guess.** The rule is now:

- the cleaned head must be the **same tokens, same order, same repetition**
- case, spacing and punctuation **between tokens** are free — punctuation is not *globally* free: a sign and a decimal point are part of the number
- a token may be replaced only when **that exact pair is listed** in `VETTED_REPAIRS`
- **numbers, weekdays and negations may never be substituted at all**
- anything else returns the **whole raw transcript**

Growing the pair map is a deliberate act with a name attached; guessing from a metric is not, which is why the metric is gone rather than retuned. This errs strict on purpose — `"8500"` and `"8,500"` are different tokens here and a reply that regroups digits is refused. **Refusing returns the client's own raw words, which is the safe half.**

The length floor and the ending check are **deleted, not loosened**: the contract subsumes both, and two gates that can no longer fail on their own is how a suite starts grading nothing while looking thorough.

## What changed

| file | change |
|---|---|
| `sa-transcript.ts` | `splitForClean` sends one window and **rejoins the rest untouched**; `onlyApprovedRepairs` replaces the set-overlap check; `VETTED_REPAIRS` replaces vocabulary-plus-distance; `lexicalTokens` preserves signs, decimals and non-ASCII letters; `finish_reason` must be `stop`; `condenseVoiceRamble` deleted |
| `media.ts` | `forBrain` **is** the cleaned transcript, unconditionally |
| `chat-log.ts` | the ledger records the whole input; a cut says so *inside the value* |
| `utils.ts` | `transcriptMustPassWhole` / `isMessyLifeTranscript` / `transcriptIsLogList` deleted with the gate they served |

**The condenser could not be kept as an aid.** There is one routed string; a condensation offered "alongside" the transcript is a second version of what the client said.

**What that costs:** a three-minute note now reaches the coaching model in full.

## Evidence

`script/pg-long-voice-tail-acceptance.ts` — real PostgreSQL, real front door, graded on `turn_ledger` and the durable owners. §2 proves four of the seven facts live beyond the old window, so §1 grades the fix and not the fixture.

Graded in `script/voice-provenance-tests.ts`, every case driven through the **real** `cleanSATranscript` against a stub network boundary:

```
the exact reported case   a clause deleted from the middle, 95.84% kept
a negation inverted       "I missed my session" -> "I finished my session"
a quantity rewritten      8500 -> 8000
a named day rewritten     Tuesday -> Thursday
an invented sentence      a line the client never said

THE FOUR-REVIEW CASES, reproduced exactly as reported:
"I have pain"             -> "I have pap"           REFUSED
"I am sad"                -> "I am pap"             REFUSED
"I ate porridge"          -> "I ate pap"            REFUSED  (unvetted, though pap is real)
"my change was -5 kg"     -> "5 kg"                 REFUSED
"my change was −5 kg"     -> "5 kg"                 REFUSED  (unicode minus)
"I am 8.5 kg down"        -> "85 kg"                REFUSED
"I am 8.5 kg down"        -> "8,500 kg"             REFUSED
a non-ASCII word deleted                            REFUSED
a non-ASCII word invented                           REFUSED

AND THE POSITIVES, so a cleaner that refuses everything cannot pass:
stamp -> samp             still accepted, as it must be
punctuation and case      free
a decimal left alone      still accepts a punctuation repair
an untouched non-ASCII note  still accepts a punctuation repair
an unchanged transcript   passes through untouched
```

The non-ASCII case carries **the superseded tokenizer as a local control**, asserting the deleted word left *no trace at all* under it — so the fixture is not vacuous and the check is not grading something the old code would also have caught.

**red-on-revert 11/11**, both unmodified controls passing first:

```
CONTROL  both graders GREEN unmodified — detections below are real
1   the window truncates again          voice-provenance-tests
2   THE EDIT CONTRACT REMOVED           acceptance + voice-provenance-tests
2b  the finish-reason gate removed      voice-provenance-tests
2c  protected tokens unprotected        acceptance + voice-provenance-tests
2d  THE VOCABULARY COMES BACK           acceptance + voice-provenance-tests
2e  THE ASCII-ONLY TOKENIZER COMES BACK acceptance + voice-provenance-tests
3   the condenser returns               both
4   the ledger cap returns              acceptance
5   the split drops the tail            voice-provenance-tests
6   CONTROL: the cleaner stops cleaning voice-provenance-tests
7   CONTROL: the record mangles numbers acceptance
```

2d and 2e turn red **on behaviour, not only on a source string** — under 2d the `pain` and `low mood` cases fail as executed assertions.

A detection is a **graded failed assertion**: the grader must reach its verdict line, that verdict must report failures, and a `FAIL` must be printed. A crash fails the harness even when the other grader legitimately went red.

## Outstanding, under Cut 6 — not absorbed here

The long note still does not log the meal it names, and the reply addresses neither question. Measured final body:

```
Lerato — 8,000 steps is your target. No steps logged yet today — send your count:
"8,500 steps" or "walked 5km".
```

**That sentence is true.** Their 8,500 is stored against **yesterday**, which is what they said; "no steps logged yet today" is not a false claim and is not described as one. What is wrong is that the turn misses the food and answers neither question — first-match-wins gives one turn to one owner. §5 of the acceptance records it and asserts nothing either way.

Cut 3 makes the client's account arrive whole. Cut 6 must make the coach act on it.

## Gates on `9522174`

```
tsc --noEmit          clean
npm test              38/38 green, none skipped
unit-tests            1062/1062
pg-long-voice-tail    GREEN
red-on-revert         11/11, with both controls
governors             at budget, none raised
regexLiterals         442/442 UNCHANGED — the new tokenizer stays INLINE, as the
                      pattern it replaces was. It is one predicate's tokenizer,
                      not a named pattern authority that decides anything about
                      a message; naming it would have moved the counter for a
                      rewrite that adds no such authority.
```

## Traps walked into, recorded

A doc block explaining `retainsOriginal`'s removal matched an assertion searching for it, reporting the code was back — comments are stripped before that check now. A `finish_reason` fixture whose reply equalled its input produced the same string whether accepted or refused, so it passed with the gate deleted. And the first non-ASCII fixture removed a neighbouring ASCII word along with the non-ASCII one, which would have made the deletion visible for the wrong reason — its control caught that before the case was trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa