### PR TITLE
The information-value acceptance is deterministic on every day of the week

### DIFF
--- a/script/pg-acceptance-runner.ts
+++ b/script/pg-acceptance-runner.ts
@@ -117,6 +117,12 @@ export const ACCEPTANCES: Acceptance[] = [
     // later backdated answer are all real rows; this grades the one canonical INVESTIGATE owner.
     command: ["npx", "tsx", "script/pg-information-value-acceptance.ts"] },
 
+  { id: "information-value-clock", title: "The information-value acceptance is deterministic on every day",
+    // It was green every weekday and red every weekend, and it blocked PR #244 — a cut that
+    // touches none of this code — on a Saturday. Case 1 reproduces those four failures on demand
+    // by pinning the file to that Saturday, so the defect is provable on a Tuesday.
+    command: ["bash", "script/red-on-revert-information-value-clock.sh"] },
+
   { id: "behaviour-patterns", title: "Evidence-backed behavioural patterns",
     // BEHAVIOURAL PATTERN STATE (#217). Repetition, attributed outcomes, user isolation and
     // contradiction are properties of longitudinal rows. The profile must then be read by the

--- a/script/pg-information-value-acceptance.ts
+++ b/script/pg-information-value-acceptance.ts
@@ -17,6 +17,48 @@ process.env.TWILIO_AUTH_TOKEN = "test";
 process.env.TWILIO_WHATSAPP_NUMBER = "+27000000000";
 process.env.NODE_ENV = "production";
 
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+// THE CLOCK IS PINNED, AND THAT IS THE WHOLE SUBCUT (2026-09-12).
+// ══════════════════════════════════════════════════════════════════════════════════════════════
+//
+// THIS ACCEPTANCE WAS GREEN ON WEEKDAYS AND RED ON THE WEEKEND. Measured on unmodified
+// 017efd9 on Saturday 12 September 2026 — four checks fail, on a build that passed the same four
+// in CI the previous afternoon:
+//
+//     FAIL  the real customer front door delivers the authorized weekend question
+//     FAIL  the reactive question becomes durable only after it is included in the reply
+//     FAIL  'I was travelling and didn't track' durably closes the open question
+//     FAIL  'it was normal' is accepted as the bounded answer to the question actually open
+//
+// THE MECHANISM, not a guess: the fixture seeds meals on WEEKDAYS ONLY so the weekend is the
+// unknown under test, then sends "Dinner is rice, mince and mixed veggies" through the real front
+// door. That message logs a meal for TODAY. On a Saturday, today IS a weekend day — so the live
+// turn manufactures the very weekend evidence the section exists to find missing, the INVESTIGATE
+// owner correctly stops asking, and four checks fail against a product that is behaving correctly.
+//
+// The defect was never in the product. It was an acceptance whose fixture depended on which day
+// of the week CI happened to start, exactly as #240's depended on the hour — and it was found the
+// same way, by a cut that touched none of this code being blocked by it.
+//
+// SO THE DAY IS CHOSEN RATHER THAN INHERITED. Everything below runs on a fixed Wednesday, which
+// makes every `ago(n)` offset, every seeded row and every live turn deterministic on every run at
+// every hour of every day. Date.now() alone is not enough — `new Date()` reads the system clock
+// directly and never consults it, so both move together or the pin is decorative.
+//
+// Installed BEFORE the server modules are imported, because they capture the clock as they load.
+const RealDate = Date;
+const PINNED_WEDNESDAY = RealDate.UTC(2026, 8, 9, 10, 0, 0);   // 2026-09-09 12:00 SAST, a Wednesday
+const PINNED_SATURDAY = RealDate.UTC(2026, 8, 12, 10, 0, 0);   // 2026-09-12 12:00 SAST, a Saturday
+const PINNED_SUNDAY = RealDate.UTC(2026, 8, 13, 10, 0, 0);     // 2026-09-13 12:00 SAST, a Sunday
+let PINNED_AT = PINNED_WEDNESDAY;
+class PinnedDate extends RealDate {
+  constructor(...args: any[]) { super(...(args.length === 0 ? [PINNED_AT] : args) as [any]); }
+  static now() { return PINNED_AT; }
+}
+(globalThis as any).Date = PinnedDate;
+/** Move the pinned day. Section E uses it to grade the Saturday the old fixture could only fail. */
+const pinTo = (at: number) => { PINNED_AT = at; };
+
 const REAL = console.log.bind(console);
 console.log = console.warn = console.error = () => {};
 
@@ -268,6 +310,67 @@ const isolatedMove = await canonicalNextMove(isolated, { hour: 14 });
 check(isolatedMove.action.investigation?.missingFact === "weekend_food",
   "one client's answer never fills another client's missing fact",
   JSON.stringify(isolatedMove.action));
+
+REAL("\n=== E — THE SATURDAY THIS SUITE COULD ONLY EVER FAIL ===");
+// NOT A REPAIR OF THE PIN — THE CASE THE PIN REVEALED. Everything above runs on a Wednesday, so
+// without this section the weekend day is simply never graded, which is the state that let the
+// old fixture be green for months and then red on a Saturday morning with nothing changed.
+//
+// THE PROMISE: the coach must not ask for a fact it already holds. On a weekend day the client's
+// own live log IS weekend evidence, so the weekend question must stop being selected — the exact
+// behaviour that looked like four failures when the fixture assumed a weekday.
+{
+  pinTo(PINNED_SATURDAY);
+  // OFFSETS DERIVED FROM THE PINNED DAY, NOT INHERITED. `weekdayOffsets` at the top of this file
+  // is computed under the Wednesday pin, and reusing it here seeded a meal on the Saturday itself
+  // — the fixture manufacturing the evidence the section exists to find missing, which is the
+  // very defect this subcut repairs. It failed on the first run and said so.
+  const satWeekdayOffsets = Array.from({ length: 7 }, (_, i) => i).filter(i => !isWeekend(ago(i))).slice(0, 3);
+  check(satWeekdayOffsets.every(o => !isWeekend(ago(o))) && satWeekdayOffsets.length === 3,
+    "the Saturday fixture seeds weekdays only", JSON.stringify(satWeekdayOffsets));
+  const sat = await freshUser();
+  await seedMeals(sat.id, satWeekdayOffsets);
+  await seedWeights(sat.id, stalled);
+
+  const beforeLog = await canonicalNextMove(sat, { hour: 14 });
+  check(beforeLog.action.investigation?.missingFact === "weekend_food",
+    "on a Saturday with weekday-only evidence the weekend is still the missing fact",
+    JSON.stringify(beforeLog.action));
+
+  _resetOutboundDedupe();
+  await say(sat.phoneNumber, "Dinner is rice, mince and mixed veggies");
+  const afterTruth = await getProgressTruth(await reload(sat.id), { days: 7 });
+  check(weekendLoggedDays(afterTruth.window.perDay) > 0,
+    "a meal logged ON a weekend day IS weekend evidence — this is why the day matters",
+    JSON.stringify(afterTruth.window.perDay));
+
+  const afterLog = await canonicalDecision(await reload(sat.id), "how am I doing?");
+  check(afterLog.investigation?.missingFact !== "weekend_food",
+    "…so the coach stops asking for the weekend it can now see",
+    `missing=${JSON.stringify(afterLog.investigation?.missingFact)} todo=${JSON.stringify(afterLog.todo)}`);
+
+  // SUNDAY, THE OTHER HALF OF THE WEEKEND. Saturday alone would leave the same class of gap one
+  // day wide: a fixture that happens to be right on one weekend day and never runs on the other.
+  pinTo(PINNED_SUNDAY);
+  const sunWeekdayOffsets = Array.from({ length: 7 }, (_, i) => i).filter(i => !isWeekend(ago(i))).slice(0, 3);
+  check(sunWeekdayOffsets.every(o => !isWeekend(ago(o))) && sunWeekdayOffsets.length === 3,
+    "the Sunday fixture seeds weekdays only", JSON.stringify(sunWeekdayOffsets));
+  const sun = await freshUser();
+  await seedMeals(sun.id, sunWeekdayOffsets);
+  await seedWeights(sun.id, stalled);
+  const sunBefore = await canonicalNextMove(sun, { hour: 14 });
+  check(sunBefore.action.investigation?.missingFact === "weekend_food",
+    "on a Sunday with weekday-only evidence the weekend is still the missing fact",
+    JSON.stringify(sunBefore.action));
+  _resetOutboundDedupe();
+  await say(sun.phoneNumber, "Dinner is rice, mince and mixed veggies");
+  const sunAfter = await canonicalDecision(await reload(sun.id), "how am I doing?");
+  check(sunAfter.investigation?.missingFact !== "weekend_food",
+    "…and a Sunday log closes it for the same reason a Saturday one does",
+    `missing=${JSON.stringify(sunAfter.investigation?.missingFact)}`);
+
+  pinTo(PINNED_WEDNESDAY);
+}
 
 for (const id of ids) await db.delete(schema.users).where(eq(schema.users.id, id)).catch(() => {});
 await pool.end();

--- a/script/red-on-revert-information-value-clock.sh
+++ b/script/red-on-revert-information-value-clock.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# RED-ON-REVERT — the information-value acceptance is deterministic on every day of the week.
+#
+# THE DEFECT THIS GUARDS is not in the product. It is an acceptance that inherited the day CI
+# happened to start on: green every weekday, red every weekend, for a build nobody had changed.
+# Found on Saturday 12 September 2026 when it blocked PR #244, a cut that touches none of this code.
+#
+# Case 1 REPRODUCES that deterministically, on any day, by pinning the whole file to the Saturday
+# it used to fail on. Case 2 breaks section E's own day-derived fixture — a bug this section had on
+# its first run, which is the same defect one level in. Case 3 is the opposite-defect control: the
+# suite must still be grading the PRODUCT, not the calendar.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+source "$(dirname "$0")/lib/revert-db.sh"
+revert_db_require_safe
+ACC=script/pg-information-value-acceptance.ts
+WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ivclock-revert.XXXXXX")"
+BACKUP="$WORK_ROOT/backup"
+PATCH_DIR="$WORK_ROOT/patches"
+
+restore_case () {
+  if [[ -d "$BACKUP/server" && -f "$BACKUP/acc.ts" ]]; then
+    rm -rf server; mv "$BACKUP/server" server
+    cp "$BACKUP/acc.ts" "$ACC"
+  fi
+  rm -rf "$BACKUP"
+}
+cleanup () { restore_case; rm -rf "$WORK_ROOT"; }
+trap cleanup EXIT INT TERM
+
+run_case () {
+  local name="$1" patch="$2" out status verdict
+  restore_case
+  mkdir -p "$BACKUP"
+  cp -a server "$BACKUP/server"
+  cp "$ACC" "$BACKUP/acc.ts"
+  if ! python3 "$patch"; then echo "  !! patch failed: $name"; restore_case; return 1; fi
+  if ! revert_db_reset; then echo "  !! database reset failed: $name"; restore_case; return 1; fi
+  out="$(npx tsx "$ACC" 2>&1)"; status=$?
+  verdict="$(printf '%s\n' "$out" | grep -E '^pg-information-value-acceptance:' | tail -1 || true)"
+  echo "── REVERT: $name"
+  echo "   ${verdict:-'(no verdict — crashed)'}"
+  printf '%s\n' "$out" | grep '^  FAIL' | sed 's/^/   /' | head -4 || true
+  restore_case
+  if [[ $status -eq 0 ]]; then echo "  !! acceptance stayed green: $name"; return 1; fi
+  if [[ ! "$verdict" =~ ^pg-information-value-acceptance:\ RED ]]; then
+    echo "  !! acceptance did not reach a graded red verdict: $name (exit $status)"; return 1
+  fi
+}
+
+mkdir -p "$PATCH_DIR"
+
+# THE UNMODIFIED CONTROL RUNS FIRST. Without it a harness can report every case "caught" while the
+# acceptance was failing for a reason that has nothing to do with the mutation — a dead database, a
+# bad import, a timeout. Detection only means something if the same command passes untouched.
+if ! revert_db_reset; then echo "!! database reset failed before the control"; exit 1; fi
+control_out="$(npx tsx "$ACC" 2>&1)"; control_status=$?
+control_verdict="$(printf '%s\n' "$control_out" | grep -E '^pg-information-value-acceptance:' | tail -1 || true)"
+if [[ $control_status -ne 0 || ! "$control_verdict" =~ GREEN ]]; then
+  echo "!! CONTROL FAILED — the unmodified acceptance does not pass, so nothing below proves anything."
+  echo "   ${control_verdict:-'(no verdict — crashed)'}"
+  printf '%s\n' "$control_out" | grep '^  FAIL' | sed 's/^/   /' | head -5 || true
+  exit 1
+fi
+echo "CONTROL: the unmodified acceptance is GREEN — detections below are real."
+
+
+# 1. THE WHOLE FILE RUNS ON A SATURDAY — what an unpinned run did yesterday, reproduced on demand
+#    rather than once a week. Sections A-D fail because the live turn's own meal lands on a weekend
+#    day and supplies the evidence they exist to find missing.
+cat > "$PATCH_DIR/1.py" <<'PYEOF'
+p="script/pg-information-value-acceptance.ts"; s=open(p).read(); b=s
+s=s.replace("let PINNED_AT = PINNED_WEDNESDAY;", "let PINNED_AT = PINNED_SATURDAY;")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 2. SECTION E REUSES THE WEDNESDAY OFFSETS. This is the bug section E had on its first run: the
+#    fixture seeds a meal on the Saturday itself, so the weekend is not missing and the section
+#    grades nothing. A day-dependent fixture inside the fix for day-dependent fixtures.
+cat > "$PATCH_DIR/2.py" <<'PYEOF'
+p="script/pg-information-value-acceptance.ts"; s=open(p).read(); b=s
+s=s.replace("  await seedMeals(sat.id, satWeekdayOffsets);", "  await seedMeals(sat.id, weekdayOffsets);")
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+# 3. OPPOSITE DEFECT — the INVESTIGATE owner stops selecting the weekend fact at all. Every check
+#    about "the coach stops asking" is trivially satisfied by a coach that never asks, which is the
+#    cheapest wrong way to make a day-sensitive suite deterministic.
+cat > "$PATCH_DIR/3.py" <<'PYEOF'
+import re
+p="server/day-ledger-core.ts"; s=open(p).read(); b=s
+m=re.search(r"export function weekendLoggedDays\([^)]*\)[^{]*\{", s)
+assert m, "weekendLoggedDays not found"
+s = s[:m.end()] + "\n  return 1;" + s[m.end():]
+assert s!=b, "no match"; open(p,"w").write(s)
+PYEOF
+
+echo "RED-ON-REVERT — information-value clock. Every case below must report RED."
+failed=0
+for i in 1 2 3; do
+  if ! run_case "$i" "$PATCH_DIR/$i.py"; then failed=$((failed + 1)); fi
+done
+if [[ $failed -ne 0 ]]; then
+  echo "RED-ON-REVERT: FAILED — $failed case(s) were green, crashed, or would not patch."
+  exit 1
+fi
+echo "RED-ON-REVERT: GREEN — 3/3 cases reached a graded red verdict."


### PR DESCRIPTION
Base `017efd9d38e39c38a59d9247d7c58ad533ea6dd2`. Head `06e2e6009be6175db78efd25af914377c15ab0cf`.

**The CI unblocker for #244.** Test-only: no runtime file is touched, and no production policy is changed to satisfy a fixture.

## The defect, and it is not in the product

`pg-information-value-acceptance` was green every weekday and red every weekend. Nobody knew, because it had never run on a Saturday — it ran on one today and blocked #244, a cut that touches none of this code.

Measured on **unmodified main `017efd9`** in a separate worktree, Saturday 12 September — the same four checks that passed in CI the previous afternoon:

```
FAIL  the real customer front door delivers the authorized weekend question
FAIL  the reactive question becomes durable only after it is included in the reply
FAIL  'I was travelling and didn't track' durably closes the open question
FAIL  'it was normal' is accepted as the bounded answer to the question actually open
```

**The mechanism.** The fixture seeds meals on weekdays only, so the weekend is the unknown under test, then sends `"Dinner is rice, mince and mixed veggies"` through the real front door. That logs a meal for **today**. On a Saturday, today *is* a weekend day — so the live turn manufactures the very evidence the section exists to find missing, the INVESTIGATE owner correctly stops asking for a weekend it can now see, and four checks fail against correct behaviour.

## The repair

The day is **chosen rather than inherited**: everything runs on a fixed Wednesday, which makes every `ago(n)` offset, every seeded row and every live turn deterministic at every hour of every day. `Date.now()` alone is not enough — `new Date()` reads the system clock directly and never consults it — and the pin is installed *before* the server modules load, because they capture the clock as they come up. Same pattern as #240, one axis over: that one was the hour, this is the day.

**All four original durability assertions are kept verbatim.** Nothing is relaxed; they now run on every day instead of five in seven.

## And the weekend is now graded, which it never was

Section E pins a **Saturday** and a **Sunday** and asserts the promise the old fixture could only ever fail:

```
PASS  the Saturday fixture seeds weekdays only
PASS  on a Saturday with weekday-only evidence the weekend is still the missing fact
PASS  a meal logged ON a weekend day IS weekend evidence — this is why the day matters
PASS  …so the coach stops asking for the weekend it can now see
PASS  the Sunday fixture seeds weekdays only
PASS  on a Sunday with weekday-only evidence the weekend is still the missing fact
PASS  …and a Sunday log closes it for the same reason a Saturday one does
```

Both days, because being right on Saturday and never running on Sunday is the same defect one day wide.

**Section E had exactly that bug on its first run**, and it is kept as revert case 2: it reused the Wednesday-derived offsets, seeded a meal on the Saturday itself, and graded nothing. The offsets are derived from the pinned day now.

## red-on-revert 3/3

```
CONTROL  the unmodified acceptance is GREEN — detections below are real

1  the whole file pinned to that Saturday    RED — the original 4 failures, on demand
2  section E reuses the Wednesday offsets    RED — 1
3  CONTROL: weekendLoggedDays always says    RED — 16; the suite still grades the
   the weekend is covered                          product, not the calendar
```

**The harness runs an unmodified control first.** Without it, every case can report "caught" while the acceptance was failing for a reason unrelated to the mutation — a dead database, a bad import, a timeout. Detection means nothing unless the same command passes untouched. A missing verdict (a crash) fails the harness rather than counting as a detection.

## Gates

```
tsc --noEmit          clean
npm test              38/38 green
pg-acceptance-runner  33 run, 33 green, 0 red
red-on-revert         3/3, with the control
governors             unmoved — no runtime file touched
```

## Changed files

```
M  script/pg-information-value-acceptance.ts
M  script/pg-acceptance-runner.ts          (registers the revert script)
A  script/red-on-revert-information-value-clock.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Uu7DNH8b5xNB9VCV6iJa)_